### PR TITLE
Add Qualtrics API smoke workflow

### DIFF
--- a/.github/workflows/qualtrics-api-smoke.yml
+++ b/.github/workflows/qualtrics-api-smoke.yml
@@ -1,0 +1,108 @@
+name: Qualtrics API Smoke Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Qualtrics base URL, e.g. https://yourdatacenter.qualtrics.com (overrides environment var QUALTRICS_BASE_URL)"
+        required: false
+        type: string
+      survey_id:
+        description: "Qualtrics Survey ID to fetch (overrides environment var QUALTRICS_SURVEY_ID)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  qualtrics-smoke:
+    name: Qualtrics API smoke
+    runs-on: ubuntu-latest
+    environment: QUALTRICS-prod
+    env:
+      QUALTRICS_API_TOKEN: ${{ secrets.QUALTRICS_API_TOKEN }}
+      QUALTRICS_USERID: ${{ secrets.QUALTRICS_USERID }}
+      QUALTRICS_USERNAME: ${{ secrets.QUALTRICS_USERNAME }}
+      QUALTRICS_BASE_URL: ${{ vars.QUALTRICS_BASE_URL }}
+      QUALTRICS_SURVEY_ID: ${{ vars.QUALTRICS_SURVEY_ID }}
+      INPUT_BASE_URL: ${{ inputs.base_url }}
+      INPUT_SURVEY_ID: ${{ inputs.survey_id }}
+    steps:
+      - name: Validate configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${QUALTRICS_API_TOKEN:-}" ]]; then
+            echo "Missing secret QUALTRICS_API_TOKEN in environment QUALTRICS-prod"
+            exit 1
+          fi
+
+          if [[ -z "${QUALTRICS_USERID:-}" ]]; then
+            echo "Missing secret QUALTRICS_USERID in environment QUALTRICS-prod"
+            exit 1
+          fi
+
+          if [[ -z "${QUALTRICS_USERNAME:-}" ]]; then
+            echo "Missing secret QUALTRICS_USERNAME in environment QUALTRICS-prod"
+            exit 1
+          fi
+
+          BASE_URL="${INPUT_BASE_URL:-${QUALTRICS_BASE_URL:-}}"
+          SURVEY_ID="${INPUT_SURVEY_ID:-${QUALTRICS_SURVEY_ID:-}}"
+
+          if [[ -z "${BASE_URL}" ]]; then
+            echo "Missing Qualtrics base URL. Set env var QUALTRICS_BASE_URL in GitHub Environment QUALTRICS-prod (Variables), or pass workflow input base_url."
+            exit 1
+          fi
+
+          if [[ -z "${SURVEY_ID}" ]]; then
+            echo "Missing survey id. Set env var QUALTRICS_SURVEY_ID in GitHub Environment QUALTRICS-prod (Variables), or pass workflow input survey_id."
+            exit 1
+          fi
+
+          echo "BASE_URL=${BASE_URL}" >> "$GITHUB_ENV"
+          echo "SURVEY_ID=${SURVEY_ID}" >> "$GITHUB_ENV"
+
+      - name: List surveys (connectivity check)
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="${BASE_URL%/}/API/v3/surveys"
+
+          http_code=$(curl -sS -o surveys.json -w "%{http_code}" \
+            -H "X-API-TOKEN: ${QUALTRICS_API_TOKEN}" \
+            -H "Accept: application/json" \
+            "$url")
+
+          if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+            echo "Request failed (HTTP $http_code): $url"
+            head -c 4000 surveys.json || true
+            exit 1
+          fi
+
+          echo "::group::Survey list summary"
+          jq '{meta, resultCount: (.result.elements | length), firstFive: (.result.elements[0:5] | map({id, name, ownerId}))}' surveys.json
+          echo "::endgroup::"
+
+      - name: Fetch survey metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="${BASE_URL%/}/API/v3/surveys/${SURVEY_ID}"
+
+          http_code=$(curl -sS -o survey.json -w "%{http_code}" \
+            -H "X-API-TOKEN: ${QUALTRICS_API_TOKEN}" \
+            -H "Accept: application/json" \
+            "$url")
+
+          if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+            echo "Request failed (HTTP $http_code): $url"
+            head -c 4000 survey.json || true
+            exit 1
+          fi
+
+          echo "::group::Survey response summary"
+          jq '{meta, resultKeys: (.result | keys), result: (.result | {id, name, ownerId, creationDate, lastModified})}' survey.json
+          echo "::endgroup::"


### PR DESCRIPTION
Closes #18\n\nAdds a manual GitHub Actions workflow that uses the QUALTRICS-prod environment to call the Qualtrics API and print a safe summary of survey metadata.\n\nRun it via Actions  'Qualtrics API Smoke Test'  Run workflow, providing base_url and survey_id (or set QUALTRICS_BASE_URL / QUALTRICS_SURVEY_ID as Environment variables).