### PR TITLE
feat: Qualtrics survey stats chart

### DIFF
--- a/.github/workflows/qualtrics-metrics-update.yml
+++ b/.github/workflows/qualtrics-metrics-update.yml
@@ -1,0 +1,115 @@
+name: Update Qualtrics Survey Metrics
+
+on:
+  workflow_dispatch:
+    inputs:
+      survey_id:
+        description: 'Optional Survey ID (defaults to QUALTRICS_SURVEY_ID env var, else first survey returned by /surveys)'
+        required: false
+        type: string
+  schedule:
+    - cron: '17 3 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-metrics:
+    runs-on: ubuntu-latest
+    environment: qualtrics-prod
+    env:
+      QUALTRICS_API_TOKEN: ${{ secrets.QUALTRICS_API_TOKEN }}
+      QUALTRICS_BASE_URL: ${{ vars.QUALTRICS_BASE_URL }}
+      QUALTRICS_SURVEY_ID: ${{ vars.QUALTRICS_SURVEY_ID }}
+      INPUT_SURVEY_ID: ${{ inputs.survey_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch metrics from Qualtrics
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${QUALTRICS_API_TOKEN:-}" ]]; then
+            echo "Missing secret QUALTRICS_API_TOKEN in environment qualtrics-prod"
+            exit 1
+          fi
+
+          if [[ -z "${QUALTRICS_BASE_URL:-}" ]]; then
+            echo "Missing env var QUALTRICS_BASE_URL in environment qualtrics-prod"
+            exit 1
+          fi
+
+          BASE_URL="${QUALTRICS_BASE_URL%/}"
+          SURVEY_ID="${INPUT_SURVEY_ID:-${QUALTRICS_SURVEY_ID:-}}"
+
+          if [[ -z "${SURVEY_ID}" ]]; then
+            url="${BASE_URL}/API/v3/surveys"
+            http_code=$(curl -sS -o surveys.json -w "%{http_code}" \
+              -H "X-API-TOKEN: ${QUALTRICS_API_TOKEN}" \
+              -H "Accept: application/json" \
+              "$url")
+
+            if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+              echo "Request failed (HTTP $http_code): $url"
+              head -c 4000 surveys.json || true
+              exit 1
+            fi
+
+            SURVEY_ID=$(jq -r '.result.elements[0].id // empty' surveys.json)
+            if [[ -z "$SURVEY_ID" ]]; then
+              echo "Could not auto-select a survey id from /surveys. Set QUALTRICS_SURVEY_ID or pass workflow input survey_id."
+              exit 1
+            fi
+          fi
+
+          url="${BASE_URL}/API/v3/surveys/${SURVEY_ID}"
+          http_code=$(curl -sS -o survey.json -w "%{http_code}" \
+            -H "X-API-TOKEN: ${QUALTRICS_API_TOKEN}" \
+            -H "Accept: application/json" \
+            "$url")
+
+          if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+            echo "Request failed (HTTP $http_code): $url"
+            head -c 4000 survey.json || true
+            exit 1
+          fi
+
+          collected_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          survey_name=$(jq -r '.result.name // ""' survey.json)
+          org_id=$(jq -r '.result.organizationId // ""' survey.json)
+          response_counts=$(jq -c '.result.responseCounts // {}' survey.json)
+
+          mkdir -p src/data
+          jq -n \
+            --arg collectedAt "$collected_at" \
+            --arg baseUrl "$BASE_URL" \
+            --arg surveyId "$SURVEY_ID" \
+            --arg surveyName "$survey_name" \
+            --arg orgId "$org_id" \
+            --argjson responseCounts "$response_counts" \
+            '{
+              collectedAt: $collectedAt,
+              baseUrl: $baseUrl,
+              survey: {
+                id: $surveyId,
+                name: $surveyName,
+                organizationId: $orgId
+              },
+              responseCounts: $responseCounts,
+              metrics: ($responseCounts | to_entries | map({metric: .key, value: .value}) | sort_by(.metric))
+            }' > src/data/qualtrics-metrics.json
+
+      - name: Create pull request with updated metrics
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'Update Qualtrics survey metrics'
+          title: 'Update Qualtrics survey metrics'
+          body: |
+            Automated update of `src/data/qualtrics-metrics.json` from the Qualtrics API.
+
+            Each response count type is stored as its own metric for charting.
+          branch: chore/qualtrics-metrics
+          delete-branch: true

--- a/src/app/barriers/survey-stats/page.tsx
+++ b/src/app/barriers/survey-stats/page.tsx
@@ -1,0 +1,21 @@
+import Header from '@/components/header'
+import Footer from '@/components/footer'
+import QualtricsSurveyStats from '@/components/survey-stats/qualtrics-survey-stats'
+
+export default function SurveyStatsPage() {
+  return (
+    <>
+      <Header />
+      <main className="pt-[80px]">
+        <div className="bg-blue-600 py-[60px] text-center text-white">
+          <h1 className="text-[48px] font-bold">Survey stats</h1>
+          <p className="text-[20px] opacity-90">
+            Metrics pulled from Qualtrics via GitHub Actions.
+          </p>
+        </div>
+        <QualtricsSurveyStats />
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/components/survey-stats/qualtrics-survey-stats.tsx
+++ b/src/components/survey-stats/qualtrics-survey-stats.tsx
@@ -1,0 +1,78 @@
+import metricsData from '@/data/qualtrics-metrics.json'
+
+type QualtricsMetrics = typeof metricsData
+
+function formatMetricName(metric: string): string {
+  return metric.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+export default function QualtricsSurveyStats() {
+  const metrics = metricsData.metrics
+  const maxValue = Math.max(1, ...metrics.map((m) => m.value))
+
+  return (
+    <section className="mx-auto w-full max-w-5xl px-6 py-10">
+      <header className="mb-8">
+        <h2 className="text-3xl font-bold text-slate-900">Survey stats</h2>
+        <p className="mt-2 text-slate-700">
+          Source: Qualtrics API (cached via GitHub Actions). Last updated{' '}
+          <span className="font-medium">{metricsData.collectedAt}</span>.
+        </p>
+        <div className="mt-4 rounded-lg border border-slate-200 bg-white p-4">
+          <div className="text-sm text-slate-600">Survey</div>
+          <div className="mt-1 flex flex-col gap-1">
+            <div className="text-lg font-semibold text-slate-900">{metricsData.survey.name}</div>
+            <div className="text-sm text-slate-700">
+              <span className="font-medium">Survey ID:</span> {metricsData.survey.id}
+            </div>
+            <div className="text-sm text-slate-700">
+              <span className="font-medium">Org:</span> {metricsData.survey.organizationId}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-6">
+        <div className="mb-4 flex items-end justify-between gap-4">
+          <h3 className="text-xl font-semibold text-slate-900">Response counts</h3>
+          <div className="text-sm text-slate-600">Max: {maxValue.toLocaleString()}</div>
+        </div>
+
+        <div className="space-y-4">
+          {metrics.map((m) => {
+            return (
+              <div key={m.metric} className="grid grid-cols-12 gap-3">
+                <div className="col-span-12 sm:col-span-3">
+                  <div className="text-sm font-medium text-slate-900">
+                    {formatMetricName(m.metric)}
+                  </div>
+                  <div className="text-xs text-slate-600">{m.metric}</div>
+                </div>
+
+                <div className="col-span-12 sm:col-span-7">
+                  <progress
+                    className="h-3 w-full overflow-hidden rounded-full"
+                    value={m.value}
+                    max={maxValue}
+                    aria-label={`${formatMetricName(m.metric)} count`}
+                  />
+                </div>
+
+                <div className="col-span-12 sm:col-span-2 text-right text-sm font-semibold text-slate-900">
+                  {m.value.toLocaleString()}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <p className="mt-6 text-sm text-slate-700">
+          Note: Qualtrics exposes multiple count types (for example,{' '}
+          <span className="font-medium">auditable</span>,{' '}
+          <span className="font-medium">generated</span>,{' '}
+          <span className="font-medium">deleted</span>). We chart each type as its own metric.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/src/data/qualtrics-metrics.json
+++ b/src/data/qualtrics-metrics.json
@@ -1,0 +1,28 @@
+{
+  "collectedAt": "2026-01-15T22:38:05Z",
+  "baseUrl": "https://yul1.qualtrics.com",
+  "survey": {
+    "id": "SV_bkMopd73A8fzfwO",
+    "name": "Technology Adoption Barriers Survey",
+    "organizationId": "smeal"
+  },
+  "responseCounts": {
+    "auditable": 8,
+    "generated": 501,
+    "deleted": 0
+  },
+  "metrics": [
+    {
+      "metric": "auditable",
+      "value": 8
+    },
+    {
+      "metric": "deleted",
+      "value": 0
+    },
+    {
+      "metric": "generated",
+      "value": 501
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new /barriers/survey-stats page that charts Qualtrics responseCounts metrics from a cached JSON file.

Also adds a scheduled workflow that refreshes src/data/qualtrics-metrics.json from the Qualtrics API and opens a PR with the update.