### PR TITLE
Remove extra caption text from /technology-adoption-models

### DIFF
--- a/src/app/technology-adoption-models/page.tsx
+++ b/src/app/technology-adoption-models/page.tsx
@@ -151,9 +151,6 @@ const ModelsPage = () => {
                 className="w-full h-auto rounded-lg shadow-sm"
               />
             </div>
-            <figcaption className="text-center text-sm text-gray-500 mt-2 italic">
-              Fig 2. The evolutionary roadmap of technology adoption theories.
-            </figcaption>
           </figure>
 
           <ul className="list-disc pl-6 space-y-4 mb-6">


### PR DESCRIPTION
Follow-up for #35: removes the extra Series Roadmap figure caption text so the visible copy matches the canonical Article 1 text more closely.

- Updates: src/app/technology-adoption-models/page.tsx
- Verified: npm run lint, npm test, npm run build