### PR TITLE
docs: clarify merge queue status + add CI merge_group trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: ['main']
 
+  # Runs on merge queue temporary branches (required if merge queue is enabled)
+  merge_group:
+
   # Runs on pushes to main (before deploy)
   push:
     branches: ['main']


### PR DESCRIPTION
## What
- Updates `MERGE_QUEUE_VERIFICATION.md` to clearly call out the current reality (rulesets vs classic branch protection; merge queue not enabled today) and provides step-by-step guidance for enabling merge queue, including personal vs org repo notes.
- Adds the `merge_group` trigger to CI so checks can run on merge-queue temporary branches if/when merge queue is enabled.

## Why
- The repo previously had a historical merge queue verification report; this makes it accurate for 2026 and prevents confusion.
- Merge queue requires workflows to run on `merge_group`; adding it now makes future enablement smoother.

## Verification
- `npm run format:check`
- `npm run lint`

## Notes
- A Copilot review has started on this PR; Ill address any comments it leaves.