### PR TITLE
Harden external links (noopener + noreferrer)

### DIFF
--- a/src/app/article-1-1-the-bedrock-foundational-theories-that-shaped-tech-acceptance/page.tsx
+++ b/src/app/article-1-1-the-bedrock-foundational-theories-that-shaped-tech-acceptance/page.tsx
@@ -226,7 +226,7 @@ const FoundationalTheoriesPage = () => {
               <a
                 href="https://doi.org/10.1016/0749-5978(91)90020-T"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1016/0749-5978(91)90020-T
@@ -243,7 +243,7 @@ const FoundationalTheoriesPage = () => {
               <a
                 href="https://doi.org/10.1111/j.1559-1816.1992.tb00945.x"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1111/j.1559-1816.1992.tb00945.x
@@ -255,7 +255,7 @@ const FoundationalTheoriesPage = () => {
               <a
                 href="https://doi.org/10.2307/249443"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/249443

--- a/src/app/article-1-branch-introduction-the-users-journey/page.tsx
+++ b/src/app/article-1-branch-introduction-the-users-journey/page.tsx
@@ -147,7 +147,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.1016/0749-5978(91)90020-T"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1016/0749-5978(91)90020-T
@@ -165,7 +165,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.1111/j.1559-1816.1992.tb00945.x"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1111/j.1559-1816.1992.tb00945.x
@@ -177,7 +177,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.2307/249443"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/249443
@@ -189,7 +189,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.2307/249008"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/249008
@@ -201,7 +201,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.1287/mnsc.46.2.186.11926"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1287/mnsc.46.2.186.11926
@@ -213,7 +213,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.1111/j.1540-5915.2008.00192.x"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1111/j.1540-5915.2008.00192.x
@@ -225,7 +225,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.2307/30036540"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/30036540
@@ -238,7 +238,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.2307/41410412"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/41410412
@@ -250,7 +250,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.2307/249244"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/249244
@@ -263,7 +263,7 @@ const UsersJourneyPage = () => {
               <a
                 href="https://doi.org/10.1177/109467050024001"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1177/109467050024001

--- a/src/app/article-2-branch-introduction-the-organizations-playbook/page.tsx
+++ b/src/app/article-2-branch-introduction-the-organizations-playbook/page.tsx
@@ -152,7 +152,7 @@ const OrganizationsPlaybookPage = () => {
               <a
                 href="https://doi.org/10.1177/014920639101700108"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1177/014920639101700108
@@ -172,7 +172,7 @@ const OrganizationsPlaybookPage = () => {
               <a
                 href="https://www.cambridge.org/core/books/how-to-make-the-right-decision-in-a-crisis/A3B8C1D6F0E0F9B9A7A7B7B8E5F0E6F0"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://www.cambridge.org/core/books/how-to-make-the-right-decision-in-a-crisis/A3B8C1D6F0E0F9B9A7A7B7B8E5F0E6F0
@@ -186,7 +186,7 @@ const OrganizationsPlaybookPage = () => {
               <a
                 href="https://doi.org/10.6028/NIST.SP.800-37r2"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.6028/NIST.SP.800-37r2
@@ -198,7 +198,7 @@ const OrganizationsPlaybookPage = () => {
               <a
                 href="https://dodcio.defense.gov/CMMC/"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://dodcio.defense.gov/CMMC/
@@ -210,7 +210,7 @@ const OrganizationsPlaybookPage = () => {
               <a
                 href="https://aws.amazon.com/professional-services/CAF/"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://aws.amazon.com/professional-services/CAF/
@@ -222,7 +222,7 @@ const OrganizationsPlaybookPage = () => {
               <a
                 href="https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/strategy/ai-strategy-and-planning"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/strategy/ai-strategy-and-planning

--- a/src/app/technology-adoption-models/page.tsx
+++ b/src/app/technology-adoption-models/page.tsx
@@ -197,7 +197,7 @@ const ModelsPage = () => {
               <a
                 href="https://doi.org/10.1177/014920639101700108"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1177/014920639101700108
@@ -217,7 +217,7 @@ const ModelsPage = () => {
               <a
                 href="https://doi.org/10.1016/0749-5978(91)90020-T"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.1016/0749-5978(91)90020-T
@@ -229,7 +229,7 @@ const ModelsPage = () => {
               <a
                 href="https://doi.org/10.2307/249008"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/249008
@@ -241,7 +241,7 @@ const ModelsPage = () => {
               <a
                 href="https://doi.org/10.2307/30036540"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/30036540
@@ -254,7 +254,7 @@ const ModelsPage = () => {
               <a
                 href="https://doi.org/10.2307/41410412"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://doi.org/10.2307/41410412
@@ -265,7 +265,7 @@ const ModelsPage = () => {
               <a
                 href="https://pubs.opengroup.org/architecture/togaf9-doc/arch/"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://pubs.opengroup.org/architecture/togaf9-doc/arch/
@@ -277,7 +277,7 @@ const ModelsPage = () => {
               <a
                 href="https://aws.amazon.com/professional-services/CAF/"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
                 https://aws.amazon.com/professional-services/CAF/


### PR DESCRIPTION
Fixes #71.

- Update external reference links that use target="_blank" to include rel="noopener noreferrer".
- Prevents window.opener access while keeping referrer suppression.

Touched pages:
- /technology-adoption-models
- /article-1-branch-introduction-the-users-journey
- /article-2-branch-introduction-the-organizations-playbook
- /article-1-1-the-bedrock-foundational-theories-that-shaped-tech-acceptance

Verification:
- npm run lint
- npm test
- npm run build
