### PR TITLE
feat: update GTM ID to use environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Build Next.js site
         run: npm run build
+        env:
+          NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID: ${{ vars.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID }}
         # Note: Do NOT set NEXT_PUBLIC_BASE_PATH here
         # The basePath is only needed for actual GitHub Pages deployment (in deploy.yml)
         # E2E tests need to run against a build without basePath since the test server

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
           # Set basePath for GitHub Pages deployment
           # This ensures images and assets work correctly at the subpath
           NEXT_PUBLIC_BASE_PATH: ''
+          NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID: ${{ vars.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID }}
 
       - name: Upload artifact for Pages
         uses: actions/upload-pages-artifact@v4

--- a/src/components/google-tag-manager/README.md
+++ b/src/components/google-tag-manager/README.md
@@ -20,13 +20,21 @@ Google Tag Manager (GTM) is a tag management system that allows you to manage an
 - ✅ Uses Next.js `Script` component with `lazyOnload` strategy
 - ✅ Includes noscript fallback for accessibility
 - ✅ Integrates with existing cookie consent system
-- ✅ GTM ID hardcoded directly in component (no environment variable needed)
+- ✅ GTM ID configured via environment variable `NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID`
 
 ## Configuration
 
 ### Setting Your GTM ID
 
-The GTM container ID is hardcoded directly in the component file. To update it:
+The GTM container ID is managed via the `NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID` environment variable.
+
+### Local Development / Fallback
+
+The component includes a default fallback ID (`GTM-P5GBFCTL`) for development convenience if the environment variable is not set.
+
+### Production
+
+Ensure the `NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID` repository variable is set in GitHub Settings > Secrets and variables > Actions > Variables.
 
 1. Open `src/components/google-tag-manager/index.tsx`
 2. Update the `GTM_ID` constant with your actual GTM container ID:

--- a/src/components/google-tag-manager/index.tsx
+++ b/src/components/google-tag-manager/index.tsx
@@ -3,7 +3,7 @@
 import Script from 'next/script'
 
 // Google Tag Manager ID
-const GTM_ID = 'GTM-TQ5H8HPR'
+const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID || 'GTM-P5GBFCTL'
 
 export default function GoogleTagManager() {
   return (


### PR DESCRIPTION
Updates GTM implementation to use NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID repo variable. Resolves #72.