### PR TITLE
chore: store Prolific/Qualtrics IDs as env vars

### DIFF
--- a/.github/workflows/prolific.yml
+++ b/.github/workflows/prolific.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run data collection
         env:
           PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
-          STUDY_ID: ${{ inputs.study_id }}
+          STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
         run: |
           echo "Starting Prolific data collection..."
           echo "Study ID: ${STUDY_ID:-'all studies'}"

--- a/.github/workflows/qualtrics-api-smoke.yml
+++ b/.github/workflows/qualtrics-api-smoke.yml
@@ -19,7 +19,7 @@ jobs:
   qualtrics-smoke:
     name: Qualtrics API smoke
     runs-on: ubuntu-latest
-    environment: QUALTRICS-prod
+    environment: qualtrics-prod
     env:
       QUALTRICS_API_TOKEN: ${{ secrets.QUALTRICS_API_TOKEN }}
       QUALTRICS_USERID: ${{ secrets.QUALTRICS_USERID }}


### PR DESCRIPTION
Adds GitHub Actions environment variables for Prolific/Qualtrics integration metadata (non-secret IDs/URLs) and updates workflows to default to those vars.

- Environment vars added:
  - prolific-prod: PROLIFIC_STUDY_ID, PROLIFIC_STUDY_NAME, PROLIFIC_EXTERNAL_URL_TEMPLATE
  - qualtrics-prod: QUALTRICS_SURVEY_ID, QUALTRICS_SURVEY_NAME (QUALTRICS_BASE_URL already existed)
- Workflow updates:
  - Prolific workflow defaults STUDY_ID from vars.PROLIFIC_STUDY_ID
  - Qualtrics smoke workflow uses environment qualtrics-prod (consistent casing)

Validation: triggered workflow_dispatch runs on this branch; Qualtrics smoke and Prolific collection both succeeded.