### PR TITLE
chore: make Prolific workflow CI-safe

### DIFF
--- a/.github/workflows/prolific.yml
+++ b/.github/workflows/prolific.yml
@@ -12,6 +12,21 @@ on:
         description: 'Specific Study ID to query (optional - leave blank to list all studies)'
         required: false
         type: string
+      export_csv:
+        description: 'Export submissions CSV to a file (CI-safe: file only; not printed)'
+        required: false
+        type: boolean
+        default: false
+      upload_csv_artifact:
+        description: 'Upload exported CSV as a workflow artifact (requires export_csv=true)'
+        required: false
+        type: boolean
+        default: false
+      csv_preview_lines:
+        description: 'Optional: include first N CSV lines in GITHUB_STEP_SUMMARY (sensitive; default 0)'
+        required: false
+        type: number
+        default: 0
 
 # Prevent concurrent runs
 concurrency:
@@ -52,12 +67,23 @@ jobs:
       - name: Run data collection
         env:
           PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
-          STUDY_ID: ${{ inputs.study_id }}
+          STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
+          PROLIFIC_EXPORT_CSV: ${{ inputs.export_csv }}
+          PROLIFIC_CSV_PREVIEW_LINES: ${{ inputs.csv_preview_lines }}
+          PROLIFIC_CSV_OUTPUT_PATH: ${{ runner.temp }}/prolific-submissions.csv
         run: |
           echo "Starting Prolific data collection..."
           echo "Study ID: ${STUDY_ID:-'all studies'}"
           echo ""
           npx --no-install tsx scripts/collect-prolific-data.ts
+
+      - name: Upload CSV artifact
+        if: ${{ inputs.export_csv && inputs.upload_csv_artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: prolific-submissions-csv
+          path: ${{ runner.temp }}/prolific-submissions.csv
+          if-no-files-found: error
 
       - name: Error summary
         if: failure()


### PR DESCRIPTION
Refs #91\n\nPartial merge: Prolific CI-safety only.\n\n- Stops printing Prolific submissions CSV to CI logs by default (CI-safe).\n- Adds explicit workflow inputs to export CSV to a file and optionally upload as an artifact (opt-in).\n\nFollow-up PR will add QualtricsProlific verification workflow.