### PR TITLE
Header: Google site search

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -281,14 +281,14 @@ const Header: React.FC = () => {
                   />
                   <button
                     onClick={handleSearch}
-                    className="ml-2 p-2 text-gray-600"
+                    className="ml-2 p-2 text-gray-600 hover:text-blue-600 transition-colors"
                     aria-label="Submit search"
                   >
                     <LiaSearchSolid className="cursor-pointer h-5 w-5" />
                   </button>
                   <button
                     onClick={handleSearchToggle}
-                    className="ml-2 p-2 text-gray-600"
+                    className="ml-2 p-2 text-gray-600 hover:text-blue-600 transition-colors"
                     aria-label="Close search"
                   >
                     <RxCross2 className="cursor-pointer h-5 w-5" />


### PR DESCRIPTION
Closes #121.\n\nAdds a header search UI that opens a Google site: query for the current hostname (works on custom domain and GitHub Pages).\n\nScope:\n- Header search UI + handler only\n- No bundled workflow/content changes