### PR TITLE
Release: v0.2.0 2026-01-19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-01-19
+
 ### Added
 
 - Community health files for better GitHub integration
@@ -21,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CITATION.cff for academic citation
   - CHANGELOG.md for release tracking
   - COMMUNITY_HEALTH_FILES.md for community health documentation
+
+### Changed
+
+- Automation and integrations: added and hardened Qualtrics/Prolific automation workflows and supporting scripts
+- Site UX: refined header CTAs and introduced Google site search
+- Testing: expanded unit + E2E coverage and improved stability
 
 ## [0.1.0] - 2025-12-11
 

--- a/RELEASE_NOTES_SITE_2026-01-19.md
+++ b/RELEASE_NOTES_SITE_2026-01-19.md
@@ -1,74 +1,56 @@
-# Site Release: 2026-01-19
+# v0.2.0 2026-01-19
 
-This release captures recent automation work (Qualtrics + Prolific), CI hardening, and operational lessons learned from iterative review cycles.
+## Main Summary
 
-## Summary
+- Added robust survey automation workflows (Qualtrics + Prolific) and improved operational visibility via GitHub Actions summaries.
+- Improved site content and navigation CTAs while keeping accessibility/testing coverage strong.
+- Reduced review/maintenance friction by deduplicating automation helpers and strengthening tests and documentation.
 
-- Added automation for fetching Qualtrics survey questions (script + workflow) with safer Markdown output to GitHub Actions Step Summary.
-- Hardened API clients and workflows with clearer preflight checks and error messages.
-- Improved maintainability by deduplicating shared GitHub Step Summary helpers and adding unit tests.
+## 1. User Facing Changes
 
-## What Changed (Highlights)
+- Header: added Google site search and improved hover styling.
+- Navigation/content: added and refined “Get Involved” and research-support CTAs.
+- Content terminology: standardized “donation” terminology to “contribution” across the site.
+- Media: added a press kit section.
+- Reliability: automated display of the “surveys completed” statistic (site content stays current).
 
-### Qualtrics automation
+## 2. Internal Application Improvements
 
-- New workflow to fetch survey questions: `.github/workflows/fetch-qualtrics-questions.yml`.
-- New script: `scripts/fetch-qualtrics-questions.ts`.
-- New Qualtrics client utilities:
-  - `src/lib/qualtrics-api.ts` (`makeApiRequest`, `getSurveyQuestions`)
-  - `src/lib/stripHtml.ts` for sanitizing question text
-- Added/expanded Jest coverage:
-  - `__tests__/lib/qualtrics-api.test.ts`
-  - `__tests__/lib/stripHtml.test.ts`
+- CI/CD hardening: improved workflow consistency and failure diagnostics.
+- Testing: expanded unit and E2E coverage, stabilized selectors, and added more edge-case coverage.
+- Utilities: centralized GitHub Actions Step Summary + Markdown table escaping utilities and added unit tests.
+- Documentation: expanded deployment, integration, and troubleshooting guidance.
 
-### GitHub Actions / CI quality
+## 3. External Integrations
 
-- Standardized and hardened workflow configuration and summaries across automation workflows.
-- Added shared helpers for GitHub Actions Step Summary + Markdown table escaping:
-  - `src/lib/github-utils.ts`
-  - `__tests__/lib/github-utils.test.ts`
+### 3.1 Prolific
 
-### Site/UI improvements (recent)
+- Added CI-safe Prolific data collection workflow and supporting script improvements.
+- Added Qualtrics↔Prolific verification workflow to validate markers and definition endpoints.
 
-- Header button hover styling improvements.
+### 3.2 Qualtrics
+
+- Added workflow + script to fetch Qualtrics survey questions and publish readable output to the GitHub Step Summary.
+- Added Qualtrics survey copy/import workflows and API-based fallback paths.
+- Automated Qualtrics survey metrics updates and added coverage for Qualtrics stats edge cases.
+
+### 3.3 Google
+
+- Added Google Analytics Data API client, scheduled GA report workflow, and report generation script improvements.
+- Added Google site search in the header.
+
+### 3.4 Microsoft
+
+- None in this release.
 
 ## Lessons Learned
 
-### 1) Secrets scope: GitHub Environments vs local dev
-
-- GitHub Actions _environment secrets_ are only available inside workflow runs; local development and MCP processes cannot read them.
-- For local dev, use explicit environment variables (`QUALTRICS_API_TOKEN`, etc.) and keep workflow secrets in GitHub Environments.
-
-### 2) Prefer simple auth paths for automation
-
-- When a service supports a straightforward API token header (`X-API-TOKEN`), it’s usually the most reliable path for CI automation.
-- More complex auth layers (OAuth clients, multi-hop proxying) tend to introduce brittle startup/auth issues.
-
-### 3) Avoid bundled PRs; keep changes reviewable
-
-- Large “holding PRs” slow review and complicate issue tracking.
-- Smaller PRs reduce rework, reduce review latency, and keep issue ↔ PR closure semantics clean.
-
-### 4) GitHub Step Summary is a UX bonus, not a dependency
-
-- Step Summary writing should never fail a workflow.
-- Escape table content (`|`, `\\`, newlines) defensively to avoid broken Markdown rendering.
-
-### 5) Watcher approach: prefer polling `gh api` over interactive watch
-
-- `gh run watch` can trigger pager/alternate-buffer behavior depending on terminal settings.
-- A simple polling loop (`gh api repos/.../actions/runs/<id>`) is reliable in CI, in scripts, and in restrictive shells.
-
-## How to Use the New Automation
-
-- Fetch Qualtrics questions locally:
-  - Set `QUALTRICS_API_TOKEN`, `QUALTRICS_BASE_URL`, `QUALTRICS_SURVEY_ID`
-  - Run `npx --no-install tsx scripts/fetch-qualtrics-questions.ts`
-
-- Run via GitHub Actions:
-  - Trigger the “Fetch Qualtrics Questions” workflow and ensure the `qualtrics-prod` environment is configured.
+- GitHub Actions environment secrets are workflow-scoped; local tooling needs explicit env vars.
+- Prefer the simplest auth mechanism available for automation (e.g., `X-API-TOKEN`) to reduce brittleness.
+- Small, focused PRs + early CI validation reduce churn during iterative review cycles.
+- GitHub Step Summary is a UX bonus: treat it as best-effort and escape Markdown defensively.
+- When terminals/pagers are inconsistent, polling `gh api` is more reliable than interactive watch mode.
 
 ## Related
 
-- Issue: #151
-- PR: #125
+- Issue: #153


### PR DESCRIPTION
Closes #153

Restructures release notes into discrete sections (summary, user-facing, internal improvements, external integrations) and prepares content for the GitHub Release body.