### PR TITLE
Add navigation + embeds for TABS presentation

### DIFF
--- a/src/app/making-of-tabs/page.tsx
+++ b/src/app/making-of-tabs/page.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import type { Metadata } from 'next'
 import { ARTICLE_CLASSES, H1_CLASSES, H2_CLASSES, H3_CLASSES } from '@/lib/articleStyles'
 import Link from 'next/link'
+import { assetPath } from '@/lib/assetPath'
 
 export const metadata: Metadata = {
   title: 'The Making of TABS',
@@ -27,6 +28,43 @@ const MakingOfTabsPage = () => {
             and methodologies— we employ to bring TABS to life. From the survey instrument itself to
             the analytics that help us understand our audience, every component plays a critical
             role.
+          </p>
+        </section>
+
+        <section className="mb-12 text-gray-800">
+          <h2 className={H2_CLASSES}>TABS Presentation</h2>
+          <p className="mb-4">
+            We maintain an interactive presentation that explains the project mission, key
+            challenges, and roadmap. You can view it here, or open it full-screen.
+          </p>
+
+          <div className="mb-4 flex flex-wrap gap-3">
+            <Link
+              className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+              href="/making-of-tabs/tabs-presentation"
+            >
+              View presentation page
+            </Link>
+            <a
+              className="inline-flex items-center rounded-md bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-900 shadow-sm transition-colors hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+              href={assetPath('/tabs-presentation')}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Open full-screen
+            </a>
+          </div>
+
+          <div className="aspect-video w-full overflow-hidden rounded-xl border border-gray-200 shadow-sm">
+            <iframe
+              title="TABS Presentation"
+              src={assetPath('/tabs-presentation')}
+              className="h-full w-full"
+              loading="lazy"
+            />
+          </div>
+          <p className="mt-3 text-sm text-gray-600">
+            Tip: click inside the presentation before using keyboard navigation.
           </p>
         </section>
 

--- a/src/app/making-of-tabs/tabs-presentation/page.tsx
+++ b/src/app/making-of-tabs/tabs-presentation/page.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ARTICLE_CLASSES, H1_CLASSES, H2_CLASSES } from '@/lib/articleStyles'
+import { assetPath } from '@/lib/assetPath'
+
+export const metadata: Metadata = {
+  title: 'TABS Presentation | The Making of TABS',
+  description:
+    'Interactive TABS presentation slides, embedded for easy viewing and sharing from the Making of TABS section.',
+}
+
+const TabsPresentationEmbedPage = () => {
+  return (
+    <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
+      <article className={ARTICLE_CLASSES}>
+        <h1 className={H1_CLASSES}>TABS Presentation</h1>
+
+        <p className="mb-6 text-gray-800">
+          This is the interactive TABS presentation (8 slides). Use arrow keys or the on-screen
+          controls to navigate.
+        </p>
+
+        <div className="mb-4 flex flex-wrap gap-3">
+          <a
+            className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+            href={assetPath('/tabs-presentation')}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Open full-screen
+          </a>
+          <Link
+            className="inline-flex items-center rounded-md bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-900 shadow-sm transition-colors hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+            href="/making-of-tabs"
+          >
+            Back to The Making of TABS
+          </Link>
+          <Link
+            className="inline-flex items-center rounded-md bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-900 shadow-sm transition-colors hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+            href="/"
+          >
+            Back to Home
+          </Link>
+        </div>
+
+        <section className="mt-8">
+          <h2 className={H2_CLASSES}>Embedded Presentation</h2>
+          <div className="mt-4 aspect-video w-full overflow-hidden rounded-xl border border-gray-200 shadow-sm">
+            <iframe
+              title="TABS Presentation"
+              src={assetPath('/tabs-presentation')}
+              className="h-full w-full"
+              loading="lazy"
+            />
+          </div>
+          <p className="mt-3 text-sm text-gray-600">
+            Tip: click inside the presentation before using keyboard navigation.
+          </p>
+        </section>
+      </article>
+    </main>
+  )
+}
+
+export default TabsPresentationEmbedPage

--- a/src/app/tabs-presentation/page.tsx
+++ b/src/app/tabs-presentation/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { FaBug, FaCodeBranch, FaEnvelope, FaPhone, FaScroll, FaFolderOpen } from 'react-icons/fa'
 import { FaFileInvoiceDollar } from 'react-icons/fa6'
+import { assetPath } from '@/lib/assetPath'
 import './presentation.css'
 
 const TABSPresentationPage = () => {
@@ -38,6 +39,14 @@ const TABSPresentationPage = () => {
 
   return (
     <div className="presentation-wrapper">
+      <nav className="return-nav" aria-label="Return navigation">
+        <a className="return-link" href={assetPath('/')}>
+          ← Home
+        </a>
+        <a className="return-link" href={assetPath('/media')}>
+          Media
+        </a>
+      </nav>
       {/* Slide 1: Title Slide */}
       <div className={`slide-container ${currentSlide === 1 ? 'active' : ''}`} id="slide1">
         <div style={{ textAlign: 'center' }}>

--- a/src/app/tabs-presentation/presentation.css
+++ b/src/app/tabs-presentation/presentation.css
@@ -77,6 +77,42 @@ footer {
   align-items: center;
 }
 
+/* RETURN NAVIGATION (HOME / MEDIA) */
+.return-nav {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 200;
+  display: flex;
+  gap: 8px;
+}
+
+.return-link {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  color: #e2e8f0;
+  padding: 8px 12px;
+  border-radius: 9999px;
+  text-decoration: none;
+  font-family: var(--font-fira-code), 'Fira Code', monospace;
+  font-size: 13px;
+  line-height: 1;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.return-link:hover {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: rgba(56, 189, 248, 0.65);
+}
+
+.return-link:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
 .nav-btn {
   background: rgba(56, 189, 248, 0.1);
   border: 1px solid #38bdf8;

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -36,6 +36,7 @@ const Header: React.FC = () => {
       { label: 'Home', path: '/' },
       { label: 'Tech Adoption Barriers', path: '/barriers' },
       { label: 'The Making of TABS', path: '/making-of-tabs' },
+      { label: 'TABS Presentation', path: '/making-of-tabs/tabs-presentation' },
       {
         label: 'Technology Adoption Models',
         path: '/technology-adoption-models',

--- a/src/components/tabs-page/Hero.tsx
+++ b/src/components/tabs-page/Hero.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { assetPath } from '@/lib/assetPath'
 
 /**
  * TABS Hero Section
@@ -38,14 +39,22 @@ const Hero = () => {
               </li>
             </ul>
 
-            <a
-              href="https://smeal.qualtrics.com/jfe/form/SV_bkMopd73A8fzfwO"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-block px-[35px] py-[15px] bg-[#26C699] text-white text-[18px] font-bold rounded-[4px] hover:bg-[#1fa680] transition-colors"
-            >
-              TAKE THE TABS
-            </a>
+            <div className="flex flex-wrap gap-3">
+              <a
+                href="https://smeal.qualtrics.com/jfe/form/SV_bkMopd73A8fzfwO"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block px-[35px] py-[15px] bg-[#26C699] text-white text-[18px] font-bold rounded-[4px] hover:bg-[#1fa680] transition-colors"
+              >
+                TAKE THE TABS
+              </a>
+              <a
+                href={assetPath('/making-of-tabs/tabs-presentation')}
+                className="inline-block px-[35px] py-[15px] bg-white text-[#145044] text-[18px] font-bold rounded-[4px] border border-[#145044]/30 hover:bg-gray-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#145044] focus-visible:ring-offset-2"
+              >
+                VIEW PRESENTATION
+              </a>
+            </div>
           </div>
 
           {/* Right Column: Video */}


### PR DESCRIPTION
Closes #178\n\n- Add return navigation on /tabs-presentation (Home + Media)\n- Add /making-of-tabs/tabs-presentation subpage that embeds the presentation\n- Embed the presentation on /making-of-tabs and add links\n- Add entry points from homepage hero CTA and global header navigation