### PR TITLE
Fix Prettier: .copilot/SETUP_COMPLETE.md

### DIFF
--- a/.copilot/SETUP_COMPLETE.md
+++ b/.copilot/SETUP_COMPLETE.md
@@ -3,7 +3,6 @@
 **Date:** January 21, 2026  
 **Issues:** #162, #173 — Establish MCP servers for coding agents
 
-
 ## Configuration Summary
 
 Successfully configured a consistent set of Model Context Protocol (MCP) servers for both:


### PR DESCRIPTION
Fixes #184\n\nCI on main is failing due to Prettier format:check flagging .copilot/SETUP_COMPLETE.md. This PR applies the minimal formatting-only change so format:check passes again.