### PR TITLE
Fix copy: em-dash spacing on Making of TABS

### DIFF
--- a/src/app/making-of-tabs/page.tsx
+++ b/src/app/making-of-tabs/page.tsx
@@ -25,7 +25,7 @@ const MakingOfTabsPage = () => {
           </p>
           <p className="mb-6">
             This page provides an overview of the &quot;stack&quot;—the collection of technologies
-            and methodologies— we employ to bring TABS to life. From the survey instrument itself to
+            and methodologies—we employ to bring TABS to life. From the survey instrument itself to
             the analytics that help us understand our audience, every component plays a critical
             role.
           </p>


### PR DESCRIPTION
Fixes #188\n\nTiny copy/typography cleanup called out as a leftover optional delta from holding PR #94.