### PR TITLE
Add Prolific footer survey link

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -3,7 +3,10 @@
 import React from 'react'
 import Link from 'next/link'
 import { Mail, Phone, MapPin, ArrowRight } from 'lucide-react'
-import { TABS_WEBSITE_QUALTRICS_SURVEY_URL } from '@/lib/tabs-survey'
+import {
+  TABS_PROLIFIC_SIM_QUALTRICS_SURVEY_URL,
+  TABS_WEBSITE_QUALTRICS_SURVEY_URL,
+} from '@/lib/tabs-survey'
 
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
@@ -124,6 +127,14 @@ const Footer: React.FC = () => {
                 className="text-gray-400 hover:text-white text-sm py-1"
               >
                 Take the TABS
+              </a>
+              <a
+                href={TABS_PROLIFIC_SIM_QUALTRICS_SURVEY_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-1 inline-flex w-fit items-center rounded-full border border-[#26C699] px-3 py-1 text-xs font-semibold text-[#26C699] transition-colors hover:bg-[#26C699] hover:text-black"
+              >
+                Prolific participant? Start survey
               </a>
               <Link href="/get-involved" className="text-gray-400 hover:text-white text-sm py-1">
                 Get Involved

--- a/src/lib/tabs-survey.ts
+++ b/src/lib/tabs-survey.ts
@@ -10,6 +10,8 @@ export const TABS_QUALTRICS_ANONYMOUS_SURVEY_URL =
 
 export const TABS_SURVEY_WEBSITE_SOURCE = 'TABS_Website'
 
+export const TABS_SURVEY_PROLIFIC_SOURCE = 'prolific'
+
 export const TABS_SURVEY_COMPLETE_PAGE_URL =
   'https://technologyadoptionbarriers.org/survey-complete'
 
@@ -24,4 +26,25 @@ export function buildTabsQualtricsSurveyUrl(params: Record<string, string>): str
 export const TABS_WEBSITE_QUALTRICS_SURVEY_URL = buildTabsQualtricsSurveyUrl({
   SOURCE: TABS_SURVEY_WEBSITE_SOURCE,
   COMPLETE_URL: TABS_SURVEY_COMPLETE_PAGE_URL,
+})
+
+export type ProlificSurveyParams = {
+  PROLIFIC_PID: string
+  STUDY_ID: string
+  SESSION_ID: string
+}
+
+export function buildProlificQualtricsSurveyUrl(params: ProlificSurveyParams): string {
+  return buildTabsQualtricsSurveyUrl({
+    ...params,
+    SOURCE: TABS_SURVEY_PROLIFIC_SOURCE,
+  })
+}
+
+// Safe to ship publicly: uses deterministic test IDs.
+// The Qualtrics Survey Flow enforces the Prolific completion redirect URL.
+export const TABS_PROLIFIC_SIM_QUALTRICS_SURVEY_URL = buildProlificQualtricsSurveyUrl({
+  PROLIFIC_PID: 'tabs_prolific_web',
+  STUDY_ID: 'tabs_prolific_web',
+  SESSION_ID: 'tabs_prolific_web',
 })


### PR DESCRIPTION
Closes #232\n\n- Adds a Prolific-style Qualtrics survey URL helper and a deterministic Prolific-sim URL (no secrets).\n- Adds a small footer button for Prolific participants that opens the Prolific-style URL.\n\nTested:\n- npm run format\n- npm run lint (warnings only; pre-existing)\n- npm test