### PR TITLE
fix: Qualtrics COMPLETE_URL includes ResponseID

### DIFF
--- a/scripts/qualtrics-apply-prolific-integration.ts
+++ b/scripts/qualtrics-apply-prolific-integration.ts
@@ -429,6 +429,20 @@ function getProlificCompletionUrlFromFlow(flowObj: unknown): string | null {
   return found
 }
 
+function appendRawQueryParam(url: string, rawParam: string): string {
+  const trimmed = rawParam.trim()
+  if (!trimmed) return url
+  return url.includes('?') ? `${url}&${trimmed}` : `${url}?${trimmed}`
+}
+
+function ensureResponseIdInCompletionUrl(url: string): string {
+  // Don't double-add.
+  if (url.includes('rid=${e://Field/ResponseID}')) return url
+  if (/[?&]rid=/.test(url)) return url
+  // IMPORTANT: do not URL-encode Qualtrics piped text.
+  return appendRawQueryParam(url, 'rid=${e://Field/ResponseID}')
+}
+
 function ensureCompletionRedirectInOptions(
   optionsObj: unknown,
   redirectUrlTemplate: string
@@ -1064,9 +1078,10 @@ async function main() {
   const authenticityScript = process.env.PROLIFIC_QUALTRICS_AUTHENTICITY_SCRIPT || ''
 
   const lockDownRedirect = parseBoolEnv('QUALTRICS_PROLIFIC_LOCK_DOWN_REDIRECT')
-  const websiteCompletionUrl =
+  const websiteCompletionUrlBase =
     (process.env.TABS_WEBSITE_COMPLETE_URL || '').trim() ||
     'https://technologyadoptionbarriers.org/survey-complete'
+  const websiteCompletionUrl = ensureResponseIdInCompletionUrl(websiteCompletionUrlBase)
 
   const redirectUrlTemplate = '${e://Field/COMPLETE_URL}'
 
@@ -1099,6 +1114,8 @@ async function main() {
     console.log(`Survey GET: ${surveyGet.status} ${surveyGet.url}`)
     prolificCompletionUrl = getProlificCompletionUrlFromSurvey(surveyGet.json)
   }
+
+  prolificCompletionUrl = ensureResponseIdInCompletionUrl(prolificCompletionUrl)
 
   // If the default COMPLETE_URL is no longer the Prolific URL (by design), fall back to
   // scanning the Survey Flow for the Branch setter value.

--- a/src/lib/tabs-survey.ts
+++ b/src/lib/tabs-survey.ts
@@ -35,10 +35,9 @@ export type ProlificSurveyParams = {
 }
 
 export function buildProlificQualtricsSurveyUrl(params: ProlificSurveyParams): string {
-  return buildTabsQualtricsSurveyUrl({
-    ...params,
-    SOURCE: TABS_SURVEY_PROLIFIC_SOURCE,
-  })
+  // Prolific provides PROLIFIC_PID/STUDY_ID/SESSION_ID only.
+  // Survey Flow sets SOURCE/COMPLETE_URL based on PROLIFIC_PID presence.
+  return buildTabsQualtricsSurveyUrl({ ...params })
 }
 
 // Safe to ship publicly: uses deterministic test IDs.


### PR DESCRIPTION
﻿Closes #242

- Ensures the completion redirect URL always includes `rid=${e://Field/ResponseID}` (without URL-encoding Qualtrics piped text).
- Applies this to both website and Prolific completion destinations when Flow redirect lockdown is enabled.
- Updates the Prolific “sim” URL builder to match real Prolific inbound params (only PROLIFIC_PID/STUDY_ID/SESSION_ID).

Notes:
- This does not rely on Prolific providing COMPLETE_URL inbound.
- Survey options continue to use `EOSRedirectURL=${e://Field/COMPLETE_URL}`; Survey Flow sets COMPLETE_URL.
