### PR TITLE
fix: standardize Qualtrics API hostname to smeal.yul1.qualtrics.com

### DIFF
--- a/scripts/qualtrics-apply-prolific-integration.ts
+++ b/scripts/qualtrics-apply-prolific-integration.ts
@@ -1068,7 +1068,7 @@ async function main() {
   const auth = resolveQualtricsAuth()
 
   const fallback = getDefaultSurveyInfoFromRepo() || {
-    baseUrl: 'https://smeal.qualtrics.com',
+    baseUrl: 'https://smeal.yul1.qualtrics.com',
     surveyId: 'SV_bkMopd73A8fzfwO',
   }
 

--- a/scripts/qualtrics-dump-flow.ts
+++ b/scripts/qualtrics-dump-flow.ts
@@ -122,7 +122,7 @@ async function main() {
   const auth = resolveQualtricsAuth()
 
   const fallback = getDefaultSurveyInfoFromRepo() || {
-    baseUrl: 'https://smeal.qualtrics.com',
+    baseUrl: 'https://smeal.yul1.qualtrics.com',
     surveyId: 'SV_bkMopd73A8fzfwO',
   }
 

--- a/src/data/qualtrics-metrics.json
+++ b/src/data/qualtrics-metrics.json
@@ -1,6 +1,6 @@
 {
   "collectedAt": "2026-02-17T04:04:54Z",
-  "baseUrl": "https://yul1.qualtrics.com",
+  "baseUrl": "https://smeal.yul1.qualtrics.com",
   "survey": {
     "id": "SV_bkMopd73A8fzfwO",
     "name": "Technology Adoption Barriers Survey",


### PR DESCRIPTION
Refs #91, refs #241

Standardizes the Qualtrics API hostname across all scripts and data files.

**Changes:**
- `scripts/qualtrics-apply-prolific-integration.ts`: fallback `smeal.qualtrics.com` -> `smeal.yul1.qualtrics.com`
- `scripts/qualtrics-dump-flow.ts`: fallback `smeal.qualtrics.com` -> `smeal.yul1.qualtrics.com`
- `src/data/qualtrics-metrics.json`: `yul1.qualtrics.com` -> `smeal.yul1.qualtrics.com`

The public survey link (`smeal.qualtrics.com/jfe/form/...`) is correct and unchanged.