### PR TITLE
fix: enable GitHub Sponsors button in repo header

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,7 +1,7 @@
 # These are supported funding model platforms
 
 # GitHub Sponsors
-github: []
+github: clarkemoyer
 
 # Custom funding links (displayed in addition to GitHub Sponsors)
 custom:


### PR DESCRIPTION
Closes #99

Sets the `github` field in `FUNDING.yml` from `[]` to `clarkemoyer`, enabling the **Sponsor** button in the GitHub repository header.

The Sponsor button links to https://github.com/sponsors/clarkemoyer, which is backed by Stripe and offers $5/month and $50/month tiers plus custom amounts.

All three site contribution buttons already link to this page:
- "Contribute Now" (homepage support cards)
- "SUPPORT TABS" (footer)
- "Become a Sponsor" (get-involved page)

This change adds the repository-level entry point via GitHub's native Sponsor button.