### PR TITLE
feat: add reading progress bar and TOC sidebar to article pages

### DIFF
--- a/src/app/article-1-1-the-bedrock-foundational-theories-that-shaped-tech-acceptance/page.tsx
+++ b/src/app/article-1-1-the-bedrock-foundational-theories-that-shaped-tech-acceptance/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 1.1: The Bedrock – Foundational Theories That Shaped Tech Acceptance',
@@ -273,6 +274,7 @@ const FoundationalTheoriesPage = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-1-2-the-game-changer-a-deep-dive-into-the-technology-acceptance-model-tam/page.tsx
+++ b/src/app/article-1-2-the-game-changer-a-deep-dive-into-the-technology-acceptance-model-tam/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 1.2: The Game Changer – A Deep Dive into the Technology Acceptance Model (TAM)',
@@ -449,6 +450,7 @@ const Article12Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-1-3-expanding-the-classic-the-evolution-to-tam-2-tam-3-and-c-tam-tpb/page.tsx
+++ b/src/app/article-1-3-expanding-the-classic-the-evolution-to-tam-2-tam-3-and-c-tam-tpb/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 1.3: Expanding the Classic – The Evolution to TAM 2, TAM 3, and C-TAM-TPB',
@@ -504,6 +505,7 @@ const Article13Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-1-4-the-grand-unification-the-unified-theory-of-acceptance-and-use-of-technology-utaut/page.tsx
+++ b/src/app/article-1-4-the-grand-unification-the-unified-theory-of-acceptance-and-use-of-technology-utaut/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title:
@@ -762,6 +763,7 @@ const Article14Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-1-5-beyond-the-office-utaut2-consumer-context-and-modern-syntheses/page.tsx
+++ b/src/app/article-1-5-beyond-the-office-utaut2-consumer-context-and-modern-syntheses/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 1.5: Beyond the Office – UTAUT2, Consumer Context, and Modern Syntheses',
@@ -663,6 +664,7 @@ const Article15Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-1-6-context-is-king-specialized-individual-adoption-models/page.tsx
+++ b/src/app/article-1-6-context-is-king-specialized-individual-adoption-models/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 1.6: Context is King – Specialized Individual Adoption Models',
@@ -509,6 +510,7 @@ const Article16Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-1-7-are-you-ready-the-role-of-technology-readiness-tri-and-tram/page.tsx
+++ b/src/app/article-1-7-are-you-ready-the-role-of-technology-readiness-tri-and-tram/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 1.7: Are You Ready? – The Role of Technology Readiness (TRI & TRAM)',
@@ -545,6 +546,7 @@ const Article17Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-1-branch-introduction-the-users-journey/page.tsx
+++ b/src/app/article-1-branch-introduction-the-users-journey/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: "Article 1: Branch Introduction – The User's Journey",
@@ -274,6 +275,7 @@ const UsersJourneyPage = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-2-1-the-strategic-lens-foundational-theories-for-organizational-adoption/page.tsx
+++ b/src/app/article-2-1-the-strategic-lens-foundational-theories-for-organizational-adoption/page.tsx
@@ -9,6 +9,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 2.1: The Strategic Lens â€“ Foundational Theories for Organizational Adoption',
@@ -324,6 +325,7 @@ const Article21Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-2-2-from-chaos-to-control-a-guide-to-maturity-models/page.tsx
+++ b/src/app/article-2-2-from-chaos-to-control-a-guide-to-maturity-models/page.tsx
@@ -9,6 +9,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 2.2: From Chaos to Control â€“ A Guide to Maturity Models',
@@ -415,6 +416,7 @@ const Article22Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-2-3-managing-the-lifecycle-the-gartner-hype-cycle/page.tsx
+++ b/src/app/article-2-3-managing-the-lifecycle-the-gartner-hype-cycle/page.tsx
@@ -9,6 +9,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 2.3: Managing the Lifecycle â€“ The Gartner Hype Cycle',
@@ -325,6 +326,7 @@ const Article23Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-2-4-the-blueprint-for-enterprise-a-survey-of-architecture-frameworks/page.tsx
+++ b/src/app/article-2-4-the-blueprint-for-enterprise-a-survey-of-architecture-frameworks/page.tsx
@@ -9,6 +9,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 2.4: The Blueprint for Enterprise â€“ A Survey of Architecture Frameworks',
@@ -337,6 +338,7 @@ const Article24Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-2-5-the-modern-mandate-frameworks-for-cybersecurity-and-risk/page.tsx
+++ b/src/app/article-2-5-the-modern-mandate-frameworks-for-cybersecurity-and-risk/page.tsx
@@ -9,6 +9,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 2.5: The Modern Mandate â€“ Frameworks for Cybersecurity and Risk',
@@ -321,6 +322,7 @@ const Article25Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-2-6-the-cloud-revolution-prescriptive-adoption-frameworks/page.tsx
+++ b/src/app/article-2-6-the-cloud-revolution-prescriptive-adoption-frameworks/page.tsx
@@ -9,6 +9,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 2.6: The Cloud Revolution â€“ Prescriptive Adoption Frameworks',
@@ -369,6 +370,7 @@ const Article26Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-2-7-the-ai-frontier-frameworks-for-adopting-ai-ml-and-genai/page.tsx
+++ b/src/app/article-2-7-the-ai-frontier-frameworks-for-adopting-ai-ml-and-genai/page.tsx
@@ -9,6 +9,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 2.7: The AI Frontier â€“ Frameworks for Adopting AI, ML, and GenAI',
@@ -424,6 +425,7 @@ const Article27Page = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-2-branch-introduction-the-organizations-playbook/page.tsx
+++ b/src/app/article-2-branch-introduction-the-organizations-playbook/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Article 2: Branch Introduction â€“ The Organizationâ€™s Playbook',
@@ -241,6 +242,7 @@ const OrganizationsPlaybookPage = () => {
           </ol>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/article-bibliography-comprehensive-series-bibliography/page.tsx
+++ b/src/app/article-bibliography-comprehensive-series-bibliography/page.tsx
@@ -8,6 +8,7 @@ import {
   BODY_OL_CLASSES,
 } from '@/lib/articleStyles'
 import SeriesNavigation from '@/components/series-navigation'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Comprehensive Series Bibliography: Foundations of Technology Adoption',
@@ -644,6 +645,7 @@ const BibliographyPage = () => {
 
         <SeriesNavigation className="mt-6" />
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/components/article-toc/index.tsx
+++ b/src/components/article-toc/index.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/* ------------------------------------------------------------------ */
+/*  Utility                                                           */
+/* ------------------------------------------------------------------ */
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                             */
+/* ------------------------------------------------------------------ */
+
+interface TOCItem {
+  id: string
+  text: string
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Self-contained reading-progress bar + table-of-contents sidebar for
+ * article pages. Drop it anywhere inside the page – it finds the nearest
+ * `<article>` element, scans for `<h2>` headings, assigns IDs if needed,
+ * and renders:
+ *   • a thin progress bar fixed below the site header
+ *   • a sticky sidebar on xl+ screens
+ *   • a floating toggle button + popup on smaller screens
+ *
+ * Zero props required.
+ */
+export default function ArticleTOC() {
+  const [items, setItems] = useState<TOCItem[]>([])
+  const [activeId, setActiveId] = useState<string>('')
+  const [progress, setProgress] = useState(0)
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+
+  /* ---------- scan headings on mount ---------- */
+  useEffect(() => {
+    const article = document.querySelector('article')
+    if (!article) return
+
+    const headings = Array.from(article.querySelectorAll('h2'))
+    const tocItems: TOCItem[] = headings.map((h) => {
+      if (!h.id) {
+        h.id = slugify(h.textContent ?? '')
+      }
+      return { id: h.id, text: h.textContent ?? '' }
+    })
+
+    /* schedule state update to avoid synchronous setState in effect */
+    requestAnimationFrame(() => setItems(tocItems))
+
+    /* intersection observer for active heading */
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id)
+          }
+        }
+      },
+      { rootMargin: '-100px 0px -60% 0px', threshold: 0 }
+    )
+
+    headings.forEach((h) => observerRef.current?.observe(h))
+    return () => observerRef.current?.disconnect()
+  }, [])
+
+  /* ---------- scroll progress ---------- */
+  const handleScroll = useCallback(() => {
+    const article = document.querySelector('article')
+    if (!article) return
+    const rect = article.getBoundingClientRect()
+    const scrollable = article.scrollHeight - window.innerHeight
+    if (scrollable <= 0) {
+      setProgress(100)
+      return
+    }
+    setProgress(Math.min(100, Math.max(0, (-rect.top / scrollable) * 100)))
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    /* defer initial call to avoid synchronous setState in effect */
+    requestAnimationFrame(handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [handleScroll])
+
+  /* nothing to show if the article has no h2s */
+  if (items.length === 0) return null
+
+  /* ---------- render ---------- */
+  return (
+    <>
+      {/* ---- reading-progress bar ---- */}
+      <div
+        aria-hidden="true"
+        className="fixed top-[80px] left-0 right-0 z-40 h-[3px] bg-gray-200/60"
+      >
+        <div
+          className="h-full bg-tabs-teal-deep transition-[width] duration-150 ease-linear"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      {/* ---- desktop sidebar (xl+) ---- */}
+      <nav
+        aria-label="Table of contents"
+        className="hidden xl:block fixed top-[120px] z-30"
+        style={{
+          right: 'max(1rem, calc((100vw - 1200px) / 2 - 240px))',
+          width: '210px',
+        }}
+      >
+        <p className="text-[11px] font-bold text-gray-400 uppercase tracking-widest mb-3">
+          On this page
+        </p>
+        <ul className="space-y-1.5 border-l-2 border-gray-200 pl-3 max-h-[calc(100vh-180px)] overflow-y-auto">
+          {items.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className={`block text-[12px] leading-snug py-0.5 transition-colors ${
+                  activeId === item.id
+                    ? 'text-tabs-teal-deep font-semibold -ml-[14px] pl-[12px] border-l-2 border-tabs-teal-deep'
+                    : 'text-gray-500 hover:text-gray-800'
+                }`}
+              >
+                {item.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* ---- mobile floating button + popup (< xl) ---- */}
+      <div className="xl:hidden fixed bottom-6 right-6 z-50">
+        {mobileOpen && (
+          <nav
+            aria-label="Table of contents"
+            className="absolute bottom-14 right-0 w-72 max-h-[50vh] overflow-y-auto bg-white rounded-xl shadow-2xl border border-gray-200 p-4"
+          >
+            <p className="text-[11px] font-bold text-gray-400 uppercase tracking-widest mb-3">
+              On this page
+            </p>
+            <ul className="space-y-1">
+              {items.map((item) => (
+                <li key={item.id}>
+                  <a
+                    href={`#${item.id}`}
+                    onClick={() => setMobileOpen(false)}
+                    className={`block text-sm py-1 ${
+                      activeId === item.id
+                        ? 'text-tabs-teal-deep font-semibold'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }`}
+                  >
+                    {item.text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+
+        <button
+          onClick={() => setMobileOpen((o) => !o)}
+          aria-expanded={mobileOpen}
+          aria-label="Table of contents"
+          className="flex h-12 w-12 items-center justify-center rounded-full bg-tabs-teal-deep text-white shadow-lg hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tabs-teal-deep focus-visible:ring-offset-2"
+        >
+          {/* list-bullet icon */}
+          <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 6h16M4 12h16M4 18h7"
+            />
+          </svg>
+        </button>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
Closes #323

## Changes

### New component: `src/components/article-toc/index.tsx`
A self-contained client component that adds two features to article pages:

- **Reading progress bar** — A thin `tabs-teal-deep` bar fixed below the site header (80px), showing scroll progress through the article
- **Table of contents sidebar** — On xl+ screens, a sticky sidebar positioned to the right of the article content with:
  - Auto-generated TOC from `<h2>` headings in the `<article>` element
  - Active section highlighting via `IntersectionObserver`
  - Scroll-to-heading on click
- **Mobile TOC** — On smaller screens, a floating button (bottom-right) that opens a popup with the same TOC

### Implementation details
- Zero props required — the component scans the DOM for `<article>` and `<h2>` elements on mount
- Automatically generates heading IDs via `slugify()` if headings lack them
- Uses `requestAnimationFrame` for state updates to avoid React lint warnings
- Respects the existing `ARTICLE_CLASSES` layout — no changes to article styling

### Article pages updated (17 files)
Added `<ArticleTOC />` import and component to all article pages:
- Branch 1: articles 1-1 through 1-7 + branch introduction
- Branch 2: articles 2-1 through 2-7 + branch introduction
- Series bibliography

## Verification
- `npm run format` ✅
- `npm run lint` ✅ (0 errors, 0 warnings)
- `npm test` ✅ (18 suites, 157 passed, 9 skipped)
- `npm run build` ✅ (151 pages)