### PR TITLE
fix: dynamically track header height for TOC offset

### DIFF
--- a/src/components/article-toc/index.tsx
+++ b/src/components/article-toc/index.tsx
@@ -42,7 +42,19 @@ export default function ArticleTOC() {
   const [activeId, setActiveId] = useState<string>('')
   const [progress, setProgress] = useState(0)
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [headerH, setHeaderH] = useState(80)
   const observerRef = useRef<IntersectionObserver | null>(null)
+
+  /* ---------- track header height (shrinks on scroll) ---------- */
+  useEffect(() => {
+    const header = document.getElementById('header')
+    if (!header) return
+    const ro = new ResizeObserver(([entry]) => {
+      setHeaderH(entry.contentRect.height)
+    })
+    ro.observe(header)
+    return () => ro.disconnect()
+  }, [])
 
   /* ---------- scan headings on mount ---------- */
   useEffect(() => {
@@ -105,7 +117,8 @@ export default function ArticleTOC() {
       {/* ---- reading-progress bar ---- */}
       <div
         aria-hidden="true"
-        className="fixed top-[80px] left-0 right-0 z-40 h-[3px] bg-gray-200/60"
+        className="fixed left-0 right-0 z-40 h-[3px] bg-gray-200/60 transition-[top] duration-300"
+        style={{ top: `${headerH}px` }}
       >
         <div
           className="h-full bg-tabs-teal-deep transition-[width] duration-150 ease-linear"
@@ -116,8 +129,9 @@ export default function ArticleTOC() {
       {/* ---- desktop sidebar (xl+) ---- */}
       <nav
         aria-label="Table of contents"
-        className="hidden xl:block fixed top-[120px] z-30"
+        className="hidden xl:block fixed z-30 transition-[top] duration-300"
         style={{
+          top: `${headerH + 40}px`,
           right: 'max(1rem, calc((100vw - 1200px) / 2 - 240px))',
           width: '210px',
         }}
@@ -125,7 +139,10 @@ export default function ArticleTOC() {
         <p className="text-[11px] font-bold text-gray-400 uppercase tracking-widest mb-3">
           On this page
         </p>
-        <ul className="space-y-1.5 border-l-2 border-gray-200 pl-3 max-h-[calc(100vh-180px)] overflow-y-auto">
+        <ul
+          className="space-y-1.5 border-l-2 border-gray-200 pl-3 overflow-y-auto"
+          style={{ maxHeight: `calc(100vh - ${headerH + 100}px)` }}
+        >
           {items.map((item) => (
             <li key={item.id}>
               <a


### PR DESCRIPTION
Closes #330
Part of #329

## Problem

The ArticleTOC progress bar and sidebar used hardcoded top offsets (`top-[80px]` / `top-[120px]`), but the sticky header shrinks from 80 px → 55 px on scroll. After scrolling, the TOC sidebar overlapped the article text.

## Solution

Use a `ResizeObserver` on the `#header` element to dynamically track the header height. Updated:
- Progress bar: `top` set to `headerH` px
- Sidebar: `top` set to `headerH + 40` px
- Sidebar `maxHeight`: `calc(100vh - headerH - 100px)`
- Added `transition-[top] duration-300` for smooth animation matching the header transition

## Testing

- `npm run lint` ✅ (0 errors, 0 warnings)
- [ ] Visual test: scroll down on an article page to verify TOC stays properly positioned