### PR TITLE
refactor: always log GA diagnostics, simplify metric comments

### DIFF
--- a/scripts/generate-report.ts
+++ b/scripts/generate-report.ts
@@ -58,7 +58,22 @@ async function generateReport() {
     console.log(`Report generated successfully: ${filepath}`)
     console.log(`Rows fetched: ${response.rowCount || 0}`)
 
-    // --- Hostname breakdown (used to extract production-only visitors) ---
+    // --- Diagnostic: channel breakdown (logged for visibility) ---
+    const channelBreakdownResponse = await gaClient.runReport({
+      startDate: '28daysAgo',
+      endDate: 'today',
+      metrics: ['activeUsers'],
+      dimensions: ['sessionDefaultChannelGroup'],
+      orderBys: [{ metric: { metricName: 'activeUsers' }, desc: true }],
+    })
+    console.log('--- Channel Breakdown (all hostnames) ---')
+    for (const row of channelBreakdownResponse.rows || []) {
+      const channel = row.dimensionValues?.[0]?.value || '(unknown)'
+      const users = row.metricValues?.[0]?.value || '0'
+      console.log(`  ${channel}: ${users}`)
+    }
+
+    // --- Diagnostic: hostname breakdown (detect test/CI traffic) ---
     const hostnameBreakdownResponse = await gaClient.runReport({
       startDate: '28daysAgo',
       endDate: 'today',
@@ -66,46 +81,24 @@ async function generateReport() {
       dimensions: ['hostName'],
       orderBys: [{ metric: { metricName: 'activeUsers' }, desc: true }],
     })
-
-    // Diagnostic breakdowns: only on manual workflow_dispatch runs
-    const isManualRun = process.env.GITHUB_EVENT_NAME === 'workflow_dispatch'
-    if (isManualRun) {
-      // Channel breakdown
-      const channelBreakdownResponse = await gaClient.runReport({
-        startDate: '28daysAgo',
-        endDate: 'today',
-        metrics: ['activeUsers'],
-        dimensions: ['sessionDefaultChannelGroup'],
-        orderBys: [{ metric: { metricName: 'activeUsers' }, desc: true }],
-      })
-      console.log('--- Channel Breakdown (all hostnames) ---')
-      for (const row of channelBreakdownResponse.rows || []) {
-        const channel = row.dimensionValues?.[0]?.value || '(unknown)'
-        const users = row.metricValues?.[0]?.value || '0'
-        console.log(`  ${channel}: ${users}`)
-      }
-
-      // Hostname breakdown
-      console.log('--- Hostname Breakdown ---')
-      for (const row of hostnameBreakdownResponse.rows || []) {
-        const hostname = row.dimensionValues?.[0]?.value || '(unknown)'
-        const users = row.metricValues?.[0]?.value || '0'
-        console.log(`  ${hostname}: ${users}`)
-      }
+    console.log('--- Hostname Breakdown ---')
+    for (const row of hostnameBreakdownResponse.rows || []) {
+      const hostname = row.dimensionValues?.[0]?.value || '(unknown)'
+      const users = row.metricValues?.[0]?.value || '0'
+      console.log(`  ${hostname}: ${users}`)
     }
 
-    // --- Production hostname visitors ---
-    // Derived from the GA4 hostname breakdown for the production hostname only.
-    // This excludes localhost/CI/Playwright/AI test traffic, but does NOT apply
-    // any additional channel/source/medium filtering.
-    // We extract the production row in JS because GA4 dimensionFilter does not
-    // reliably apply with this client library version.
+    // --- Verified human visitors ---
+    // Production hostname only – excludes localhost/CI/Playwright/AI test traffic.
+    // We use the hostname breakdown (already fetched above) and extract the
+    // production row directly, since GA4 dimensionFilter does not reliably
+    // apply with this client library version.
     const PRODUCTION_HOSTNAME = 'technologyadoptionbarriers.org'
     const productionRow = (hostnameBreakdownResponse.rows || []).find(
       (row: ReportRow) => row.dimensionValues?.[0]?.value === PRODUCTION_HOSTNAME
     )
     const verifiedVisitors = productionRow?.metricValues?.[0]?.value || '0'
-    console.log(`Production hostname visitors (${PRODUCTION_HOSTNAME}): ${verifiedVisitors}`)
+    console.log(`Verified human visitors (production hostname only): ${verifiedVisitors}`)
 
     // --- Generate Public Impact Stats ---
     const publicStatsPath = path.join(process.cwd(), 'src', 'data', 'impact.json')

--- a/src/app/media/page.tsx
+++ b/src/app/media/page.tsx
@@ -38,7 +38,6 @@ export const metadata: Metadata = {
 const MediaPage = () => {
   const surveysCompleted = getSurveysCompletedCount(metricsData.responseCounts)
   const pageViews = parseInt(impactData.pageViews) || 0
-  // "Verified Visitors" = activeUsers scoped to production hostname only.
   const verifiedVisitors = parseInt(impactData.verifiedVisitors) || 0
 
   const orgLdJson = {

--- a/src/components/tabs-page/statistics.tsx
+++ b/src/components/tabs-page/statistics.tsx
@@ -8,8 +8,7 @@ import { getSurveysCompletedCount } from '@/lib/qualtricsStats'
  */
 const Statistics = () => {
   const surveysCompleted = getSurveysCompletedCount(metricsData.responseCounts)
-  // "Verified Visitors" = activeUsers scoped to production hostname only.
-  // Distinct from "Active Visitors" (activeUsers), which includes localhost/CI/Playwright traffic.
+  // Production hostname visitors (excludes localhost/CI/Playwright test traffic).
   const verifiedVisitors = parseInt(impactData.verifiedVisitors) || 0
 
   return (


### PR DESCRIPTION
Closes #338

Refactors the GA report script to always log channel + hostname diagnostic breakdowns (previously gated behind workflow_dispatch only). Simplifies comments across statistics and media pages to be more concise.

Changes:
- Always log channel and hostname breakdowns for GA reports (not just manual runs)
- Simplify comments in statistics.tsx and media/page.tsx
- Improve log message wording for verified visitors