### PR TITLE
fix: stop configure-pages from stripping trailingSlash config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,10 +42,10 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          static_site_generator: next
+        # Note: Do NOT use static_site_generator: next here.
+        # That option rewrites next.config.ts and strips trailingSlash,
+        # assetPrefix, and remotePatterns. Our next.config.ts already
+        # sets output: 'export', images.unoptimized, basePath, etc.
 
       - name: Restore Next.js cache
         uses: actions/cache@v4


### PR DESCRIPTION
Closes #354

## Problem

`actions/configure-pages@v5` with `static_site_generator: next` rewrites `next.config.ts` at deploy time, replacing the entire config object with only `basePath`, `output`, and `images.unoptimized`. This strips:

- **`trailingSlash: true`** — causes trailing-slash URLs to 404 on GitHub Pages
- **`assetPrefix`** — could affect asset loading
- **`remotePatterns`** — could affect image loading

### Evidence from deploy run 22201771846 logs

```
Injecting property=output and value=export in:
Injecting property=basePath and value= in:
const nextConfig = {basePath: "",output: "export"}
Injecting property=images.unoptimized and value=true in:
const nextConfig = {images: {unoptimized: true},basePath: "",output: "export"}
```

No `trailingSlash`, no `assetPrefix`, no `remotePatterns`.

## Fix

Remove `static_site_generator: next` from the `configure-pages` step. Our `next.config.ts` already correctly sets all required properties.

## Regression

PR #270 added `trailingSlash: true` to fix trailing-slash routing, but the deploy workflow was already overwriting the config, negating the fix in production builds.

## Testing

- Local build with `trailingSlash: true` confirmed: all pages generate `dir/index.html` structure
- Verified all 8 making-of-tabs pages produce correct output