### PR TITLE
feat: add post-deploy smoke test workflow

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -239,7 +239,8 @@ jobs:
           : > /tmp/infra-results.txt
 
           # 1. 404 error handling — nonexistent URL must return 404
-          check "404 error page" "${SITE_URL}/nonexistent-smoke-test-xyz-404" "404"
+          # NOTE: This path is reserved for smoke testing and must NEVER be created as a real page.
+          check "404 error page" "${SITE_URL}/__smoke-test-404-check__" "404"
 
           # 2. sitemap.xml — SEO infrastructure
           check "sitemap.xml" "${SITE_URL}/sitemap.xml" "200"
@@ -272,13 +273,15 @@ jobs:
           fi
 
           # 8. HTTPS redirect — HTTP must redirect to HTTPS
+          # Intentionally non-blocking (⚠️ not ❌): CI runners may have network
+          # restrictions that prevent following HTTP→HTTPS redirects, so a
+          # failure here does NOT increment INFRA_FAIL.
           HTTP_URL=$(echo "${SITE_URL}" | sed 's|^https://|http://|')
           FINAL_URL=$(curl -s -o /dev/null -w '%{url_effective}' -L --max-time 15 "${HTTP_URL}" 2>/dev/null || echo "")
           if echo "$FINAL_URL" | grep -q '^https://'; then
             echo "| HTTPS redirect | ✅ HTTP → HTTPS |" >> /tmp/infra-results.txt
           else
             echo "| HTTPS redirect | ⚠️ Could not verify (${FINAL_URL:-timeout}) |" >> /tmp/infra-results.txt
-            # Don't fail on HTTPS check — could be a network restriction in CI
           fi
 
           echo ""


### PR DESCRIPTION
## Description

Adds a comprehensive post-deploy smoke test that runs against the **live production site** after every GitHub Pages deployment. This catches regressions that CI (which tests against a local build) cannot detect — such as the trailing-slash 404 bug (#354) caused by `actions/configure-pages` rewriting `next.config.ts`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] CI/CD or tooling change

## Related Issue(s)

Closes #358

## Changes Made

- Added `.github/workflows/post-deploy-smoke.yml` — new workflow that:
  - **Triggers** automatically after every successful "Deploy to GitHub Pages" workflow
  - **Builds** the site locally to auto-discover ALL routes and assets (self-maintaining — new pages are automatically included)
  - **Tests all page routes** both with and without trailing slash (catches #354-type regressions)
  - **Tests all static assets** (images, SVGs, manifest, CNAME)
  - **Infrastructure checks**: 404 handling, sitemap.xml, robots.txt, CNAME, site.webmanifest, homepage content, Content-Type headers, HTTPS redirect
  - **Parallel execution** (20 concurrent connections) with retry logic
  - **Job summary** with markdown tables showing pass/fail counts and details
  - **Manual trigger** via `workflow_dispatch` with configurable site URL

### What this catches that CI cannot:
| Risk | Example | How this test catches it |
|------|---------|------------------------|
| Deploy pipeline rewrites config | `configure-pages` stripping `trailingSlash` (#354) | Tests trailing-slash URLs on live site |
| Missing assets after deploy | Files not included in Pages artifact | Tests every asset from build output |
| CDN/DNS issues | Custom domain misconfiguration | Tests CNAME, HTTPS redirect |
| SEO infrastructure | Broken sitemap or robots.txt | Tests sitemap.xml and robots.txt |

## Testing Performed

### Automated Testing

- [x] `npm run format` - Formatting passes
- [x] `npm run lint` - All linting checks pass (clean output)
- [x] Workflow YAML validated (proper indentation, correct action versions)
- [x] Workflow uses same patterns as existing `lighthouse.yml` (workflow_run trigger, build step)

### Accessibility

- N/A (CI/CD workflow, no UI changes)

## Documentation

- Issue #358 documents the motivation and acceptance criteria
- Workflow file is extensively commented explaining each check