### PR TITLE
fix: exclude _next/static/ from smoke test asset discovery

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -84,11 +84,15 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Find every non-HTML file (including _next/ JS/CSS chunks)
-          # excluding hidden files like .nojekyll
+          # Find every non-HTML file, excluding:
+          #   - .nojekyll (hidden deployment marker)
+          #   - _next/static/** (build-specific hashed paths that differ
+          #     between the deploy build and this discovery build; pages
+          #     already validate these assets implicitly when they return 200)
           find out -type f \
             -not -name '*.html' \
             -not -name '.nojekyll' \
+            -not -path 'out/_next/static/*' \
             | sort | while read -r f; do
             echo "/${f#out/}"
           done > /tmp/assets.txt


### PR DESCRIPTION
Closes the false positive from PR #359's first run.

The post-deploy smoke test builds the site locally to discover routes and assets, but `_next/static/` paths contain build-specific hashes (build ID, chunk content hashes) that differ between builds. The deployed site was built by `deploy.yml` — a different build producing different hashes — so these assets 404 when tested.

**Fix**: Exclude `_next/static/*` from asset discovery. Page route checks (317/317 passed) already validate that `_next/` assets load correctly, since pages reference them in their HTML.

**Failed assets from first run:**
- `/_next/static/GIlFX2sBsMaC_huXElHBs/_clientMiddlewareManifest.json`
- `/_next/static/GIlFX2sBsMaC_huXElHBs/_buildManifest.js`
- `/_next/static/GIlFX2sBsMaC_huXElHBs/_ssgManifest.js`
- `/_next/static/chunks/827dc8ff74d12ec1.js`