### PR TITLE
feat: add production incident notifications to smoke test

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -395,7 +395,12 @@ jobs:
             const infraFail = parseInt(process.env.INFRA_FAIL || '0');
             const totalFail = routeFail + assetFail + infraFail;
             const siteUrl = process.env.SITE_URL;
-            const sha = context.sha.substring(0, 7);
+
+            // Use the deployed commit SHA on workflow_run (matches commit status steps)
+            const fullSha = context.eventName === 'workflow_run'
+              ? '${{ github.event.workflow_run.head_sha }}'
+              : context.sha;
+            const shortSha = (fullSha || context.sha).substring(0, 7);
 
             // Build failure breakdown
             const lines = [];
@@ -404,11 +409,11 @@ jobs:
             if (infraFail > 0) lines.push(`- **Infrastructure:** ${infraFail} check(s) failed`);
             const breakdown = lines.length > 0 ? lines.join('\n') : '- See workflow run for details';
 
-            const title = `🚨 Production smoke test failed: ${totalFail} check(s) after deploy (${sha})`;
+            const title = `🚨 Production smoke test failed: ${totalFail} check(s) after deploy (${shortSha})`;
             const body = [
               `## 🚨 Production Site Issue Detected`,
               ``,
-              `The post-deploy smoke test **failed** after deploying commit \`${context.sha}\` to ${siteUrl}.`,
+              `The post-deploy smoke test **failed** after deploying commit \`${fullSha}\` to ${siteUrl}.`,
               ``,
               `### Failure Summary`,
               ``,
@@ -417,7 +422,7 @@ jobs:
               `### Links`,
               ``,
               `- **Workflow run:** ${runUrl}`,
-              `- **Deployed commit:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`,
+              `- **Deployed commit:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${fullSha}`,
               `- **Site:** ${siteUrl}`,
               ``,
               `### Priority`,
@@ -428,21 +433,24 @@ jobs:
               `*Auto-created by Post-Deploy Smoke Test workflow*`,
             ].join('\n');
 
-            // Ensure label exists
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: 'production-incident',
-              });
-            } catch {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: 'production-incident',
-                color: 'B60205',
-                description: 'Live production site issue detected by smoke tests',
-              });
+            // Ensure required labels exist
+            for (const label of [
+              { name: 'production-incident', color: 'B60205', description: 'Live production site issue detected by smoke tests' },
+              { name: 'bug', color: 'd73a4a', description: 'Something isn\'t working' },
+            ]) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+              }
             }
 
             const { data: issue } = await github.rest.issues.create({


### PR DESCRIPTION
## Summary

Enhances the post-deploy smoke test workflow with clear, high-visibility notification mechanisms when the production site breaks.

## Changes

### 1. Auto-created Production Incident Issue
When the smoke test fails, automatically creates a GitHub issue with:
- **Labels:** `production-incident` (bright red, auto-created if missing) + `bug`
- **Title:** Includes failure count and short commit SHA
- **Body:** Failure breakdown by category (routes/assets/infra), links to workflow run, commit, and site
- **Priority context:** Explicitly states this is a live production issue

### 2. Commit Status Annotation
Sets a commit status check on the deployed commit SHA:
- **Failure:** Red X with `Production smoke test failed -- site may be broken`
- **Success:** Green check with `All production smoke tests passed`
- Visible in commit history, PR merge commits, and branch protection

### 3. Improved Error Annotations
Enhanced `::error` annotations in the Actions log with:
- Per-category breakdown (routes, assets, infrastructure)
- Direct link to the workflow run
- Prominent emoji prefix for scannability

## Notification Flow

\\\
Deploy completes -> Smoke test runs -> If failure:
  1. Detailed ::error annotations in workflow log
  2. Red X commit status on the deployed SHA
  3. GitHub issue created (production-incident label)
  4. GitHub sends email notification for the issue (existing setting)
  5. GitHub sends email for the failed workflow run (existing setting)
\\\

## Permissions Added
- `issues: write` -- needed to create incident issues and labels
- `statuses: write` -- needed to set commit status annotations