### PR TITLE
fix: remove unused swiper dependency to resolve CVE-2026-27212

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,6 @@ Vercel automatically enables PR preview deployments and comments.
 - **Modern Styling:** Tailwind CSS with utility-first approach
 - **Animation:** Framer Motion for smooth transitions
 - **Icons:** Lucide React and React Icons libraries
-- **Carousels:** Swiper for image carousels and sliders
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "technologyadoptionbarriers-org",
-  "version": "0.1.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "technologyadoptionbarriers-org",
-      "version": "0.1.0",
+      "version": "0.3.1",
       "dependencies": {
         "@google-analytics/data": "^5.2.1",
         "framer-motion": "^12.34.0",
@@ -17,8 +17,7 @@
         "postcss": "^8.5.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "react-icons": "^5.5.0",
-        "swiper": "^12.1.1"
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@axe-core/react": "^4.11.1",
@@ -13970,25 +13969,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/swiper": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.1.tgz",
-      "integrity": "sha512-NB8Uvpu6m725Xf68l2hZBHD184v/ZAi6WIvAorDuR3gRuwCWbGSam233/8seeeIrMJ9isHGk/CTKFdpgeT5u2Q==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "postcss": "^8.5.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-icons": "^5.5.0",
-    "swiper": "^12.1.1"
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@axe-core/react": "^4.11.1",


### PR DESCRIPTION
Closes #363

## Summary

Removes the unused `swiper` dependency entirely to resolve **critical** prototype pollution vulnerability [CVE-2026-27212](https://github.com/advisories/GHSA-hmx5-qpq5-p643) (Dependabot alert #11).

Swiper was a leftover from the testimonials carousel removed in v0.3.0. No source files import it — removing it eliminates the CVE and reduces the dependency tree.

## Changes

- `package.json`: removed `swiper` from dependencies
- `package-lock.json`: lockfile updated (swiper removed)
- `README.md`: removed stale "Carousels: Swiper" mention from tech stack

## Verification

- `npm run format` ✅
- `npm run lint` ✅ (clean)
- `npm test` ✅ (18 suites, 157 tests passing)
- `npm run build` ✅ (162 pages generated)

## Minimatch (alert #10)

The high-severity minimatch ReDoS (CVE-2026-26996) affects v3.1.2 pulled transitively by build/test tooling (jest, eslint). Since minimatch is **not used at runtime** in this static-export site, that alert has been dismissed as tolerable dev-only risk.