### PR TITLE
fix: resolve strict mode violation in survey-complete e2e test

### DIFF
--- a/tests/survey-complete.spec.ts
+++ b/tests/survey-complete.spec.ts
@@ -15,7 +15,9 @@ test.describe('Survey Complete Page', () => {
 
     await expect(page.getByText('Your response has been recorded.', { exact: false })).toBeVisible()
 
-    const email = page.getByRole('link', { name: 'contact@technologyadoptionbarriers.org' })
+    const email = page
+      .getByRole('main')
+      .getByRole('link', { name: 'contact@technologyadoptionbarriers.org' })
     await expect(email).toHaveAttribute('href', 'mailto:contact@technologyadoptionbarriers.org')
   })
 })


### PR DESCRIPTION
The previous PR added the official email to the footer, which caused the survey-complete e2e test to fail due to a strict mode violation (two elements matching the same locator). This PR updates the locator to specifically target the main content area.