### PR TITLE
fix: align visual gallery ascii art

### DIFF
--- a/src/app/technology-adoption-series/visual-gallery/page.tsx
+++ b/src/app/technology-adoption-series/visual-gallery/page.tsx
@@ -115,7 +115,10 @@ export default function VisualGalleryPage() {
                     {/* ASCII View */}
                     {(viewMode === 'split' || viewMode === 'ascii') && (
                       <div className="bg-gray-900 p-6 min-h-[400px] overflow-auto flex items-center justify-center">
-                        <pre className="font-mono text-xs sm:text-sm text-emerald-400 whitespace-pre leading-snug">
+                        <pre
+                          className="text-xs sm:text-sm text-emerald-400 whitespace-pre leading-none"
+                          style={{ fontFamily: 'Consolas, "Courier New", monospace' }}
+                        >
                           {visual.ascii.trim()}
                         </pre>
                       </div>


### PR DESCRIPTION
Closes #410. 

Updated the Visual Gallery's ASCII rendering to explicitly use \Consolas, 'Courier New'\ and \leading-none\. This resolves the issue where standard modern ui-monospace fonts map box-drawing characters (like \│\ and \┌\) inconsistently, allowing the ASCII diagrams to line up perfectly.