### PR TITLE
fix: emoji alignment in visual gallery ascii art

### DIFF
--- a/src/data/visual-gallery.ts
+++ b/src/data/visual-gallery.ts
@@ -364,7 +364,7 @@ Languages     | Python / Go / JS  | Perl / PHP (Legacy)
     part: 'Part 5: Deep Dives',
     ascii: `
     ┌───────────────────────────────┐
-    │  🚫  ANTI-PATTERN GRAVEYARD   │
+    │  🚫 ANTI-PATTERN GRAVEYARD    │
     ├───────────────────────────────┤
     │ 1. "Big Bang" Deployment      │
     │ 2. Resume Driven Development  │


### PR DESCRIPTION
Closes #410.

Adjusted the spacing around double-width emojis (\❌\, \✅\, \⚠️\, \🚫\) in the Visual Gallery's ASCII tables. Because these emojis effectively render as 2 monospace characters wide in most environments, removing a padding space forces the box-drawing columns back into alignment.