### PR TITLE
feat: enable auto-merge for automated data PRs

### DIFF
--- a/.github/workflows/ga-report.yml
+++ b/.github/workflows/ga-report.yml
@@ -38,6 +38,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           commit-message: 'chore: update public impact stats'
           title: 'Update Google Analytics impact stats'
           body: |
@@ -51,7 +52,7 @@ jobs:
         if: steps.cpr.outputs.created == 'true'
         run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
 
       - name: Send Email Report
         if: success()

--- a/.github/workflows/qualtrics-metrics-update.yml
+++ b/.github/workflows/qualtrics-metrics-update.yml
@@ -161,6 +161,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           commit-message: 'Update Qualtrics survey metrics'
           title: 'Update Qualtrics survey metrics'
           body: |
@@ -179,4 +180,4 @@ jobs:
         if: steps.cpr.outputs.created == 'true'
         run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

- Uses `ACTIONS_BOT_TOKEN` (PAT) instead of `GITHUB_TOKEN` in both GA and Qualtrics automated workflows
- Applies to `peter-evans/create-pull-request` (PR creation) and `gh pr merge --auto` (auto-merge)

## Why

PRs created by `github-actions[bot]` via `GITHUB_TOKEN` **do not trigger `pull_request` events** (GitHub security limitation). This means:
1. CI never runs on automated PRs
2. `gh pr merge --auto` has no checks to wait for, so it stays permanently BLOCKED
3. Every automated data PR requires manual close/reopen to trigger CI, then manual merge

## How it works

By using a Personal Access Token (PAT) instead of `GITHUB_TOKEN`:
- The PR is created under the PAT owner's identity, which **does** trigger `pull_request` events
- CI runs automatically on the PR
- `gh pr merge --auto --merge` successfully queues the merge once all checks pass
- The entire flow becomes fully hands-off

## Setup required

After merging this PR, add a repository secret:

1. Go to **GitHub Settings > Developer settings > Personal access tokens > Fine-grained tokens**
2. Create a token with **`contents: write`** and **`pull-requests: write`** permissions scoped to this repo
3. Add it as a repository secret named **`ACTIONS_BOT_TOKEN`** at Settings > Secrets and variables > Actions

## Test plan

- [ ] Create `ACTIONS_BOT_TOKEN` secret in repository settings
- [ ] Trigger GA workflow manually (`workflow_dispatch`) and verify PR is created, CI runs, and auto-merge completes
- [ ] Trigger Qualtrics workflow manually and verify the same
- [ ] Wait for next scheduled run to confirm end-to-end automation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)