### PR TITLE
feat: enable auto-merge using existing copilot environment PAT

### DIFF
--- a/.github/workflows/ga-report.yml
+++ b/.github/workflows/ga-report.yml
@@ -34,10 +34,47 @@ jobs:
           GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
           GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
 
+      - name: Upload impact data
+        uses: actions/upload-artifact@v7
+        with:
+          name: ga-impact-data
+          path: src/data/impact.json
+          retention-days: 1
+
+      - name: Upload report files
+        uses: actions/upload-artifact@v7
+        with:
+          name: google-analytics-report
+          path: reports/*.json
+          retention-days: 30
+
+      - name: Send Email Report
+        if: success()
+        run: npx tsx scripts/send-report-email.ts
+        env:
+          GOOGLE_PROJECT_OWNER_EMAIL: ${{ secrets.GOOGLE_PROJECT_OWNER_EMAIL }}
+          GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          REPORT_RECIPIENT_EMAIL: ${{ secrets.REPORT_RECIPIENT_EMAIL }}
+
+  create-pr:
+    needs: generate-report
+    runs-on: ubuntu-latest
+    environment: copilot
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download impact data
+        uses: actions/download-artifact@v7
+        with:
+          name: ga-impact-data
+          path: src/data
+
       - name: Create pull request with updated impact stats
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}
           commit-message: 'chore: update public impact stats'
           title: 'Update Google Analytics impact stats'
           body: |
@@ -51,19 +88,4 @@ jobs:
         if: steps.cpr.outputs.created == 'true'
         run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Send Email Report
-        if: success()
-        run: npx tsx scripts/send-report-email.ts
-        env:
-          GOOGLE_PROJECT_OWNER_EMAIL: ${{ secrets.GOOGLE_PROJECT_OWNER_EMAIL }}
-          GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
-          REPORT_RECIPIENT_EMAIL: ${{ secrets.REPORT_RECIPIENT_EMAIL }}
-
-      - name: Upload Report Artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: google-analytics-report
-          path: reports/*.json
-          retention-days: 30
+          GH_TOKEN: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/qualtrics-metrics-update.yml
+++ b/.github/workflows/qualtrics-metrics-update.yml
@@ -144,9 +144,9 @@ jobs:
           if [[ -f "src/data/qualtrics-metrics.json" ]]; then
             old_count=$(jq '.responseCounts | to_entries | map(.value) | add // 0' src/data/qualtrics-metrics.json)
             new_count=$(jq '.responseCounts | to_entries | map(.value) | add // 0' temp-qualtrics-metrics.json)
-            
+
             echo "Total Responses: Old=$old_count, New=$new_count"
-            
+
             if [[ "$new_count" -lt "$old_count" ]]; then
               echo "::error::Regression detected: New response count ($new_count) is lower than existing count ($old_count)."
               exit 1
@@ -157,10 +157,32 @@ jobs:
           mv temp-qualtrics-metrics.json src/data/qualtrics-metrics.json
           echo "Validation passed. File updated."
 
+      - name: Upload metrics data
+        uses: actions/upload-artifact@v7
+        with:
+          name: qualtrics-metrics-data
+          path: src/data/qualtrics-metrics.json
+          retention-days: 1
+
+  create-pr:
+    needs: update-metrics
+    runs-on: ubuntu-latest
+    environment: copilot
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download metrics data
+        uses: actions/download-artifact@v7
+        with:
+          name: qualtrics-metrics-data
+          path: src/data
+
       - name: Create pull request with updated metrics
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}
           commit-message: 'Update Qualtrics survey metrics'
           title: 'Update Qualtrics survey metrics'
           body: |
@@ -179,4 +201,4 @@ jobs:
         if: steps.cpr.outputs.created == 'true'
         run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- Split GA and Qualtrics workflows into two jobs each
- **Job 1**: Fetch data (uses `google-prod` / `qualtrics-prod` environment)
- **Job 2**: Create PR + auto-merge (uses `copilot` environment with existing `COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN`)

## Why

PRs created by `github-actions[bot]` via `GITHUB_TOKEN` **do not trigger `pull_request` events** (GitHub security limitation). This means:
1. CI never runs on automated PRs
2. `gh pr merge --auto` stays permanently BLOCKED
3. Every automated data PR requires manual close/reopen + merge

## How it works

By using the existing PAT from the `copilot` environment:
- The PR is created under the PAT owner's identity, which **does** trigger `pull_request` events
- CI runs automatically on the PR
- `gh pr merge --auto --merge` queues the merge once all checks pass
- Fully hands-off: data fetch → PR creation → CI → auto-merge

## No new secrets needed

Reuses `COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN` already configured in the `copilot` environment. Data is passed between jobs via upload/download artifact.

## Test plan

- [ ] Merge this PR
- [ ] Trigger GA workflow manually (`workflow_dispatch`) — verify PR is created, CI runs, and auto-merge completes
- [ ] Trigger Qualtrics workflow manually — verify the same
- [ ] Wait for next scheduled run to confirm end-to-end automation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)