### PR TITLE
fix: simplify lifecycle presentation flow and table-heavy frames

### DIFF
--- a/content/technology-adoption-series/01-core-presentation-deck.md
+++ b/content/technology-adoption-series/01-core-presentation-deck.md
@@ -273,15 +273,7 @@ TECHNOLOGY LIFECYCLE STAGES
      └─────────────────────────────────────────────────────────────┘
 ```
 
-**How to Read the Dual-Curve (Focused Briefing Lens)**
-
-- Innovation potential generally declines as technologies mature and standardize.
-- Adoption risk is typically highest at both extremes: very new and very old technologies.
-- The practical target zone for most delivery teams is **Leading Edge → Mainstream**.
-
-Use this slide as your strategic orientation, then use the timeline and moment-in-time slides later in this deck to see how that model behaves in hardware, supply chain, and AI/ML.
-
-**Key Takeaway:** The strategic decision is not just _what_ technology to adopt, but _when_ in its lifecycle to adopt it. Position too early and you absorb avoidable risk; position too late and you absorb avoidable technical debt.
+**Key Takeaway:** Strategic advantage comes from timing, not novelty. Adopt too early and you absorb avoidable risk; adopt too late and you absorb avoidable technical debt.
 
 **Sources:**
 

--- a/src/app/technology-adoption-series/lifecycle-positioning/presentation/4k/page.tsx
+++ b/src/app/technology-adoption-series/lifecycle-positioning/presentation/4k/page.tsx
@@ -35,7 +35,8 @@ export default async function LifecyclePositioningPresentationPage4K() {
       deckSubtitle={LIFECYCLE_DECK_SUBTITLE}
       sections={LIFECYCLE_SECTIONS}
       combinedContentVisualSlides={[4]}
-      visualFirstSlides={[6]}
+      visualFirstSlides={[6, 30, 32, 34, 35]}
+      hideTableFramesForSlides={[27, 30, 29, 32, 33, 34, 35]}
       appendReferenceFramesToEnd
     />
   )

--- a/src/app/technology-adoption-series/lifecycle-positioning/presentation/page.tsx
+++ b/src/app/technology-adoption-series/lifecycle-positioning/presentation/page.tsx
@@ -34,7 +34,8 @@ export default async function LifecyclePositioningPresentationPage() {
       deckSubtitle={LIFECYCLE_DECK_SUBTITLE}
       sections={LIFECYCLE_SECTIONS}
       combinedContentVisualSlides={[4]}
-      visualFirstSlides={[6]}
+      visualFirstSlides={[6, 30, 32, 34, 35]}
+      hideTableFramesForSlides={[27, 30, 29, 32, 33, 34, 35]}
       appendReferenceFramesToEnd
     />
   )

--- a/src/app/technology-adoption-series/presentation/presentation-client.tsx
+++ b/src/app/technology-adoption-series/presentation/presentation-client.tsx
@@ -60,6 +60,7 @@ interface FrameExpansionOptions {
   sections?: SectionMap
   visualFirstSlides?: number[]
   combinedContentVisualSlides?: number[]
+  hideTableFramesForSlides?: number[]
   appendReferenceFramesToEnd?: boolean
   referenceSection?: {
     startSlide: number
@@ -289,6 +290,7 @@ function expandToFrames(
   const sectionMap = options?.sections ?? SECTIONS
   const visualFirstSlides = new Set(options?.visualFirstSlides ?? [])
   const combinedContentVisualSlides = new Set(options?.combinedContentVisualSlides ?? [])
+  const hideTableFramesForSlides = new Set(options?.hideTableFramesForSlides ?? [])
 
   // ── Deck title frame ──
   frames.push({
@@ -378,7 +380,9 @@ function expandToFrames(
       // Tables get their own frame
       if (node.type === 'table') {
         flushChunk()
-        slideChunks.push([node])
+        if (!hideTableFramesForSlides.has(slide.number)) {
+          slideChunks.push([node])
+        }
         continue
       }
 
@@ -883,6 +887,8 @@ export interface PresentationClientProps {
   visualFirstSlides?: number[]
   /** For specific slide numbers, render a single split-layout frame with text + visual. */
   combinedContentVisualSlides?: number[]
+  /** For specific slide numbers, suppress table-only markdown frames. */
+  hideTableFramesForSlides?: number[]
   /** Move reference/supporting source frames to the end of the deck. */
   appendReferenceFramesToEnd?: boolean
   /** Optional dedicated references section inserted before appended reference frames. */
@@ -902,6 +908,7 @@ export default function PresentationClient({
   sections,
   visualFirstSlides,
   combinedContentVisualSlides,
+  hideTableFramesForSlides,
   appendReferenceFramesToEnd,
   referenceSection,
 }: PresentationClientProps) {
@@ -913,6 +920,7 @@ export default function PresentationClient({
         sections,
         visualFirstSlides,
         combinedContentVisualSlides,
+        hideTableFramesForSlides,
         appendReferenceFramesToEnd,
         referenceSection,
       }),
@@ -923,6 +931,7 @@ export default function PresentationClient({
       sections,
       visualFirstSlides,
       combinedContentVisualSlides,
+      hideTableFramesForSlides,
       appendReferenceFramesToEnd,
       referenceSection,
     ]


### PR DESCRIPTION
﻿## Summary
- remove the extra dual-curve explainer frame from lifecycle presentation flow (frame 10)
- rewrite the key takeaway statement in slide 6 without quotes and with tighter visual phrasing
- suppress table-only frames for lifecycle timeline/snapshot slides (27, 29, 30, 32, 33, 34, 35)
- reorder snapshot slides so the large visual appears before expansion/key-insight frames

## Validation
- npm run lint
- npm run build
