### PR TITLE
fix: finalize lifecycle visual-first ordering and statement styling

### DIFF
--- a/src/app/technology-adoption-series/lifecycle-positioning/presentation/4k/page.tsx
+++ b/src/app/technology-adoption-series/lifecycle-positioning/presentation/4k/page.tsx
@@ -35,7 +35,7 @@ export default async function LifecyclePositioningPresentationPage4K() {
       deckSubtitle={LIFECYCLE_DECK_SUBTITLE}
       sections={LIFECYCLE_SECTIONS}
       combinedContentVisualSlides={[4]}
-      visualFirstSlides={[6, 30, 32, 34, 35]}
+      visualFirstSlides={[2, 6, 25, 27, 29, 30, 32, 33, 34, 35]}
       hideTableFramesForSlides={[27, 30, 29, 32, 33, 34, 35]}
       appendReferenceFramesToEnd
     />

--- a/src/app/technology-adoption-series/lifecycle-positioning/presentation/page.tsx
+++ b/src/app/technology-adoption-series/lifecycle-positioning/presentation/page.tsx
@@ -34,7 +34,7 @@ export default async function LifecyclePositioningPresentationPage() {
       deckSubtitle={LIFECYCLE_DECK_SUBTITLE}
       sections={LIFECYCLE_SECTIONS}
       combinedContentVisualSlides={[4]}
-      visualFirstSlides={[6, 30, 32, 34, 35]}
+      visualFirstSlides={[2, 6, 25, 27, 29, 30, 32, 33, 34, 35]}
       hideTableFramesForSlides={[27, 30, 29, 32, 33, 34, 35]}
       appendReferenceFramesToEnd
     />

--- a/src/app/technology-adoption-series/presentation/presentation-client.tsx
+++ b/src/app/technology-adoption-series/presentation/presentation-client.tsx
@@ -781,8 +781,6 @@ function VisualFrame({ frame }: { frame: PresentationFrame }) {
 
 function StatementFrame({ frame }: { frame: PresentationFrame }) {
   const isWarning = frame.statement?.startsWith('⚠️')
-  // Only add decorative quotes when the statement isn't already quoted
-  const alreadyQuoted = /^["\u201C]/.test(frame.statement ?? '')
   return (
     <div className="flex h-full flex-col items-center justify-center text-center">
       <div className="mb-6 text-sm font-semibold tracking-wider uppercase text-cyan-400/50">
@@ -797,13 +795,9 @@ function StatementFrame({ frame }: { frame: PresentationFrame }) {
             {frame.statement?.replace(/^⚠️\s*/, '')}
           </div>
         </div>
-      ) : alreadyQuoted ? (
-        <blockquote className="max-w-4xl text-3xl font-semibold leading-snug text-white lg:text-5xl">
-          {frame.statement}
-        </blockquote>
       ) : (
         <blockquote className="max-w-4xl text-3xl font-semibold leading-snug text-white lg:text-5xl">
-          &ldquo;{frame.statement}&rdquo;
+          {frame.statement}
         </blockquote>
       )}
     </div>


### PR DESCRIPTION
﻿## Summary
- remove decorative quote wrapping for statement frames so non-quote statements render as plain text
- enforce visual-first ordering for remaining lifecycle slides that still showed explanations before full-screen visuals
- update lifecycle HD and 4K routes to prioritize visuals for slides 2, 25, 27, 29, and 33 (while retaining existing visual-first slides)

## Validation
- npm run lint
- npm run build
