### PR TITLE
fix: merge lifecycle frame pairs and improve visual density

### DIFF
--- a/src/app/technology-adoption-series/lifecycle-positioning/presentation/4k/page.tsx
+++ b/src/app/technology-adoption-series/lifecycle-positioning/presentation/4k/page.tsx
@@ -37,6 +37,7 @@ export default async function LifecyclePositioningPresentationPage4K() {
       combinedContentVisualSlides={[4]}
       visualFirstSlides={[2, 6, 25, 27, 29, 30, 32, 33, 34, 35]}
       hideTableFramesForSlides={[27, 30, 29, 32, 33, 34, 35]}
+      mergeFirstTwoNonVisualFramesForSlides={[27, 29, 30, 32, 33]}
       appendReferenceFramesToEnd
     />
   )

--- a/src/app/technology-adoption-series/lifecycle-positioning/presentation/page.tsx
+++ b/src/app/technology-adoption-series/lifecycle-positioning/presentation/page.tsx
@@ -36,6 +36,7 @@ export default async function LifecyclePositioningPresentationPage() {
       combinedContentVisualSlides={[4]}
       visualFirstSlides={[2, 6, 25, 27, 29, 30, 32, 33, 34, 35]}
       hideTableFramesForSlides={[27, 30, 29, 32, 33, 34, 35]}
+      mergeFirstTwoNonVisualFramesForSlides={[27, 29, 30, 32, 33]}
       appendReferenceFramesToEnd
     />
   )

--- a/src/app/technology-adoption-series/presentation/presentation-client.tsx
+++ b/src/app/technology-adoption-series/presentation/presentation-client.tsx
@@ -61,6 +61,7 @@ interface FrameExpansionOptions {
   visualFirstSlides?: number[]
   combinedContentVisualSlides?: number[]
   hideTableFramesForSlides?: number[]
+  mergeFirstTwoNonVisualFramesForSlides?: number[]
   appendReferenceFramesToEnd?: boolean
   referenceSection?: {
     startSlide: number
@@ -291,6 +292,9 @@ function expandToFrames(
   const visualFirstSlides = new Set(options?.visualFirstSlides ?? [])
   const combinedContentVisualSlides = new Set(options?.combinedContentVisualSlides ?? [])
   const hideTableFramesForSlides = new Set(options?.hideTableFramesForSlides ?? [])
+  const mergeFirstTwoNonVisualFramesForSlides = new Set(
+    options?.mergeFirstTwoNonVisualFramesForSlides ?? []
+  )
 
   // ── Deck title frame ──
   frames.push({
@@ -482,6 +486,36 @@ function expandToFrames(
         if (a.type !== 'visual' && b.type === 'visual') return 1
         return 0
       })
+    }
+
+    if (mergeFirstTwoNonVisualFramesForSlides.has(slide.number)) {
+      const nonVisualIndexes = slideFrames
+        .map((frame, index) => ({ frame, index }))
+        .filter(({ frame }) => frame.type !== 'visual')
+
+      if (nonVisualIndexes.length >= 2) {
+        const firstIdx = nonVisualIndexes[0].index
+        const secondIdx = nonVisualIndexes[1].index
+        const first = slideFrames[firstIdx]
+        const second = slideFrames[secondIdx]
+
+        if (first.type === 'content' && second.type === 'content') {
+          first.nodes = [...(first.nodes ?? []), ...(second.nodes ?? [])]
+          slideFrames.splice(secondIdx, 1)
+        } else if (first.type === 'content' && second.type === 'statement' && second.statement) {
+          first.nodes = [
+            ...(first.nodes ?? []),
+            { type: 'paragraph', text: `Key insight: ${second.statement}` },
+          ]
+          slideFrames.splice(secondIdx, 1)
+        } else if (first.type === 'statement' && second.type === 'content' && first.statement) {
+          second.nodes = [
+            { type: 'paragraph', text: `Key insight: ${first.statement}` },
+            ...(second.nodes ?? []),
+          ]
+          slideFrames.splice(firstIdx, 1)
+        }
+      }
     }
 
     frames.push(...slideFrames)
@@ -883,6 +917,8 @@ export interface PresentationClientProps {
   combinedContentVisualSlides?: number[]
   /** For specific slide numbers, suppress table-only markdown frames. */
   hideTableFramesForSlides?: number[]
+  /** For specific slide numbers, merge the first two non-visual frames into one. */
+  mergeFirstTwoNonVisualFramesForSlides?: number[]
   /** Move reference/supporting source frames to the end of the deck. */
   appendReferenceFramesToEnd?: boolean
   /** Optional dedicated references section inserted before appended reference frames. */
@@ -903,6 +939,7 @@ export default function PresentationClient({
   visualFirstSlides,
   combinedContentVisualSlides,
   hideTableFramesForSlides,
+  mergeFirstTwoNonVisualFramesForSlides,
   appendReferenceFramesToEnd,
   referenceSection,
 }: PresentationClientProps) {
@@ -915,6 +952,7 @@ export default function PresentationClient({
         visualFirstSlides,
         combinedContentVisualSlides,
         hideTableFramesForSlides,
+        mergeFirstTwoNonVisualFramesForSlides,
         appendReferenceFramesToEnd,
         referenceSection,
       }),
@@ -926,6 +964,7 @@ export default function PresentationClient({
       visualFirstSlides,
       combinedContentVisualSlides,
       hideTableFramesForSlides,
+      mergeFirstTwoNonVisualFramesForSlides,
       appendReferenceFramesToEnd,
       referenceSection,
     ]

--- a/src/app/technology-adoption-series/presentation/presentation-visuals.tsx
+++ b/src/app/technology-adoption-series/presentation/presentation-visuals.tsx
@@ -214,32 +214,76 @@ function Visual03_VoluntaryVsInvoluntaryTable() {
 
 function Visual04_ShelfwareVsAdoptedComparison() {
   return (
-    <div className="flex h-full items-center justify-center">
-      <div className="grid w-full max-w-3xl grid-cols-2 gap-6">
-        <Card className="border-red-500/30">
-          <div className="flex items-center gap-3">
-            <IconX />
-            <CardLabel>Shelf-ware</CardLabel>
+    <div className="flex h-full items-stretch justify-center">
+      <div className="grid h-full w-full max-w-6xl grid-cols-2 gap-8">
+        <Card className="flex h-full flex-col justify-between border-cyan-500/25 p-6">
+          <div>
+            <div className="text-sm font-semibold tracking-wider uppercase text-cyan-300/80">
+              Adoption Outcome
+            </div>
+            <div className="mt-3 text-3xl font-bold leading-tight text-white">
+              Deployment does not equal adoption
+            </div>
+            <div className="mt-4 text-lg leading-relaxed text-slate-300">
+              The same rollout can fail or succeed depending on whether users see clear value, can
+              work naturally, and choose to keep using the tool.
+            </div>
           </div>
-          <CardBody>Deployed, but not used.</CardBody>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge tone="bad">No user input</Badge>
-            <Badge tone="bad">Too complex</Badge>
-            <Badge tone="bad">Workarounds</Badge>
+
+          <div className="mt-8 space-y-5">
+            <div>
+              <div className="mb-2 flex items-center justify-between text-sm text-slate-300">
+                <span className="font-semibold text-red-300">Shelf-ware Risk</span>
+                <span>85%</span>
+              </div>
+              <FrictionBar value={85} />
+            </div>
+            <div>
+              <div className="mb-2 flex items-center justify-between text-sm text-slate-300">
+                <span className="font-semibold text-emerald-300">Adoption Fit</span>
+                <span>80%</span>
+              </div>
+              <FrictionBar value={80} />
+            </div>
+            <div className="rounded-lg border border-slate-600/60 bg-slate-900/60 px-4 py-3 text-base text-slate-200">
+              Optimize for{' '}
+              <span className="font-semibold text-white">real user task completion</span>, not just
+              technical deployment milestones.
+            </div>
           </div>
         </Card>
-        <Card className="border-emerald-500/30">
-          <div className="flex items-center gap-3">
-            <IconCheck />
-            <CardLabel>Adopted</CardLabel>
-          </div>
-          <CardBody>Used to complete real tasks.</CardBody>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge tone="good">User-centered</Badge>
-            <Badge tone="good">Clear value</Badge>
-            <Badge tone="good">Fits workflows</Badge>
-          </div>
-        </Card>
+
+        <div className="grid h-full grid-rows-2 gap-6">
+          <Card className="flex h-full flex-col justify-between border-red-500/30 p-6">
+            <div>
+              <div className="flex items-center gap-3">
+                <IconX />
+                <CardLabel>Shelf-ware</CardLabel>
+              </div>
+              <CardBody>Deployed, but not used for mission work.</CardBody>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Badge tone="bad">No user input</Badge>
+              <Badge tone="bad">Too complex</Badge>
+              <Badge tone="bad">Workarounds</Badge>
+            </div>
+          </Card>
+
+          <Card className="flex h-full flex-col justify-between border-emerald-500/30 p-6">
+            <div>
+              <div className="flex items-center gap-3">
+                <IconCheck />
+                <CardLabel>Adopted</CardLabel>
+              </div>
+              <CardBody>Used consistently to complete real tasks.</CardBody>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Badge tone="good">User-centered</Badge>
+              <Badge tone="good">Clear value</Badge>
+              <Badge tone="good">Fits workflows</Badge>
+            </div>
+          </Card>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
﻿## Summary
- merge requested lifecycle frame pairs by collapsing first two non-visual frames for slides 27, 29, 30, 32, and 33
- keep visual-first order for lifecycle explanatory flow
- improve slide 4 visual density/readability by filling both halves and stacking shelf-ware/adopted cards vertically in one pane

## Validation
- npm run lint
- npm run build
