### PR TITLE
fix: remove lifecycle slide 5 and cap references to 2

### DIFF
--- a/src/app/technology-adoption-series/lifecycle-positioning/constants.ts
+++ b/src/app/technology-adoption-series/lifecycle-positioning/constants.ts
@@ -7,7 +7,7 @@
 import type { SectionMap } from '@/app/technology-adoption-series/presentation/presentation-client'
 
 /** Slide numbers included in the lifecycle positioning focused deck. */
-export const LIFECYCLE_SLIDE_NUMBERS = [2, 4, 6, 25, 27, 30, 29, 32, 33, 34, 35] as const
+export const LIFECYCLE_SLIDE_NUMBERS = [2, 6, 25, 27, 30, 29, 32, 33, 34, 35] as const
 
 /** Look-up set for fast filtering. */
 export const LIFECYCLE_SLIDE_SET = new Set<number>(LIFECYCLE_SLIDE_NUMBERS)
@@ -15,7 +15,6 @@ export const LIFECYCLE_SLIDE_SET = new Set<number>(LIFECYCLE_SLIDE_NUMBERS)
 /** Per-slide descriptions shown in the "Included slides" table of contents. */
 export const LIFECYCLE_SLIDE_DESCRIPTIONS: Partial<Record<number, string>> = {
   2: 'Three types of adoption: organizational, individual mandatory, and individual optional.',
-  4: 'Common causes of failed adoption and the push vs. pull dynamic.',
   6: 'The dual-curve model and target zone: balancing innovation potential against adoption risk.',
   25: 'Transition signals and decision rules for moving before lifecycle risk becomes urgent.',
   27: 'Hard Disk Drives (HDDs): a 70+ year hardware lifecycle from IBM RAMAC to SSD displacement.',
@@ -36,7 +35,7 @@ export const LIFECYCLE_DECK_SUBTITLE =
 
 /** Section map for the lifecycle positioning presentation footer. */
 export const LIFECYCLE_SECTIONS: SectionMap = {
-  2: { label: 'FOUNDATIONS', title: 'Adoption Foundations', count: '2 slides' },
+  2: { label: 'FOUNDATIONS', title: 'Adoption Foundations', count: '1 slide' },
   6: { label: 'MODEL', title: 'Lifecycle Model', count: '1 slide' },
   25: { label: 'TIMELINES', title: 'Hardware & Supply Chain', count: '5 slides' },
   33: { label: 'AI / ML', title: 'AI & ML Lifecycle', count: '3 slides' },

--- a/src/app/technology-adoption-series/lifecycle-positioning/presentation/4k/page.tsx
+++ b/src/app/technology-adoption-series/lifecycle-positioning/presentation/4k/page.tsx
@@ -38,6 +38,7 @@ export default async function LifecyclePositioningPresentationPage4K() {
       visualFirstSlides={[2, 6, 25, 27, 29, 30, 32, 33, 34, 35]}
       hideTableFramesForSlides={[27, 30, 29, 32, 33, 34, 35]}
       mergeFirstTwoNonVisualFramesForSlides={[27, 29, 30, 32, 33]}
+      referenceFrameLimit={2}
       appendReferenceFramesToEnd
     />
   )

--- a/src/app/technology-adoption-series/lifecycle-positioning/presentation/page.tsx
+++ b/src/app/technology-adoption-series/lifecycle-positioning/presentation/page.tsx
@@ -37,6 +37,7 @@ export default async function LifecyclePositioningPresentationPage() {
       visualFirstSlides={[2, 6, 25, 27, 29, 30, 32, 33, 34, 35]}
       hideTableFramesForSlides={[27, 30, 29, 32, 33, 34, 35]}
       mergeFirstTwoNonVisualFramesForSlides={[27, 29, 30, 32, 33]}
+      referenceFrameLimit={2}
       appendReferenceFramesToEnd
     />
   )

--- a/src/app/technology-adoption-series/presentation/presentation-client.tsx
+++ b/src/app/technology-adoption-series/presentation/presentation-client.tsx
@@ -62,6 +62,7 @@ interface FrameExpansionOptions {
   combinedContentVisualSlides?: number[]
   hideTableFramesForSlides?: number[]
   mergeFirstTwoNonVisualFramesForSlides?: number[]
+  referenceFrameLimit?: number
   appendReferenceFramesToEnd?: boolean
   referenceSection?: {
     startSlide: number
@@ -237,6 +238,78 @@ function dedupeReferenceNodes(nodes: MarkdownNode[]): MarkdownNode[] {
   }
 
   return deduped
+}
+
+function frameToReferenceNodes(frame: PresentationFrame): MarkdownNode[] {
+  if (frame.nodes && frame.nodes.length > 0) return frame.nodes
+  if (frame.statement) return [{ type: 'paragraph', text: frame.statement }]
+  return []
+}
+
+function limitReferenceFrames(
+  referenceFrames: PresentationFrame[],
+  frameLimit: number,
+  titleBase: string,
+  sourceSlide: number
+): PresentationFrame[] {
+  if (frameLimit < 1 || referenceFrames.length <= frameLimit) return referenceFrames
+
+  const allNodes = referenceFrames.flatMap((frame) => frameToReferenceNodes(frame))
+  if (allNodes.length === 0) return referenceFrames.slice(0, frameLimit)
+
+  const totalSize = allNodes.reduce((sum, node) => sum + estimateNodeSize(node), 0)
+  const targetSize = Math.max(1, Math.ceil(totalSize / frameLimit))
+  const limitedFrames: PresentationFrame[] = []
+  let currentNodes: MarkdownNode[] = []
+  let currentSize = 0
+
+  for (let i = 0; i < allNodes.length; i++) {
+    const node = allNodes[i]
+    const nodeSize = estimateNodeSize(node)
+    const remainingNodes = allNodes.length - i
+    const remainingFrames = frameLimit - limitedFrames.length
+
+    if (
+      currentNodes.length > 0 &&
+      currentSize + nodeSize > targetSize &&
+      remainingNodes >= remainingFrames
+    ) {
+      limitedFrames.push({
+        type: 'content',
+        sourceSlide,
+        title: `${titleBase} (${limitedFrames.length + 1}/${frameLimit})`,
+        nodes: currentNodes,
+      })
+      currentNodes = []
+      currentSize = 0
+    }
+
+    currentNodes.push(node)
+    currentSize += nodeSize
+  }
+
+  if (currentNodes.length > 0) {
+    limitedFrames.push({
+      type: 'content',
+      sourceSlide,
+      title: `${titleBase} (${limitedFrames.length + 1}/${frameLimit})`,
+      nodes: currentNodes,
+    })
+  }
+
+  if (limitedFrames.length > frameLimit) {
+    const kept = limitedFrames.slice(0, frameLimit - 1)
+    const overflowNodes = limitedFrames.slice(frameLimit - 1).flatMap((frame) => frame.nodes ?? [])
+    kept.push({
+      type: 'content',
+      sourceSlide,
+      title: `${titleBase} (${frameLimit}/${frameLimit})`,
+      nodes: overflowNodes,
+    })
+    return kept
+  }
+
+  return limitedFrames
 }
 
 function estimateNodeSize(node: MarkdownNode): number {
@@ -524,7 +597,21 @@ function expandToFrames(
   // ── Move reference/supporting frames to the end when requested ──
   if (options?.appendReferenceFramesToEnd) {
     const inlineReferenceFrames = frames.filter((f) => isReferenceFrame(f))
-    const referenceFrames = [...extractedReferenceFrames, ...inlineReferenceFrames]
+    let referenceFrames = [...extractedReferenceFrames, ...inlineReferenceFrames]
+    const referenceFrameLimit = options.referenceFrameLimit
+
+    if (referenceFrameLimit && referenceFrameLimit > 0) {
+      const titleBase = options.referenceSection?.title ?? 'References'
+      const referenceSourceSlide =
+        options.referenceSection?.startSlide ?? referenceFrames[0]?.sourceSlide ?? 0
+      referenceFrames = limitReferenceFrames(
+        referenceFrames,
+        referenceFrameLimit,
+        titleBase,
+        referenceSourceSlide
+      )
+    }
+
     if (referenceFrames.length > 0) {
       const primaryFrames = frames.filter((f) => !isReferenceFrame(f))
       if (options.referenceSection) {
@@ -919,6 +1006,8 @@ export interface PresentationClientProps {
   hideTableFramesForSlides?: number[]
   /** For specific slide numbers, merge the first two non-visual frames into one. */
   mergeFirstTwoNonVisualFramesForSlides?: number[]
+  /** Cap appended reference/supporting material frames to a maximum count. */
+  referenceFrameLimit?: number
   /** Move reference/supporting source frames to the end of the deck. */
   appendReferenceFramesToEnd?: boolean
   /** Optional dedicated references section inserted before appended reference frames. */
@@ -940,6 +1029,7 @@ export default function PresentationClient({
   combinedContentVisualSlides,
   hideTableFramesForSlides,
   mergeFirstTwoNonVisualFramesForSlides,
+  referenceFrameLimit,
   appendReferenceFramesToEnd,
   referenceSection,
 }: PresentationClientProps) {
@@ -953,6 +1043,7 @@ export default function PresentationClient({
         combinedContentVisualSlides,
         hideTableFramesForSlides,
         mergeFirstTwoNonVisualFramesForSlides,
+        referenceFrameLimit,
         appendReferenceFramesToEnd,
         referenceSection,
       }),
@@ -965,6 +1056,7 @@ export default function PresentationClient({
       combinedContentVisualSlides,
       hideTableFramesForSlides,
       mergeFirstTwoNonVisualFramesForSlides,
+      referenceFrameLimit,
       appendReferenceFramesToEnd,
       referenceSection,
     ]


### PR DESCRIPTION
## Summary
- remove lifecycle source slide 4 (which was rendered as slide 5 in sequence)
- cap appended reference frames to a maximum of 2
- apply the 2-frame cap to both lifecycle presentation routes (standard + 4k)

## Validation
- npm run lint
- npm run build
- runtime verification in local preview confirms 33 total frames, no frame-5 mapping to slide 4, and REFERENCES (1/2), (2/2)