### PR TITLE
fix: detect and auto-merge Copilot sub-PRs in review cycle

### DIFF
--- a/scripts/copilot-review-cycle.ts
+++ b/scripts/copilot-review-cycle.ts
@@ -154,7 +154,7 @@ function assignCopilotToFix(repo: string, prNumber: string, comments: ReviewComm
   const body = [
     `Fix the following Copilot code review comments on PR #${prNumber}:\n`,
     commentList,
-    `\nPush fixes directly to the PR branch.`,
+    `\nPush fixes to the PR branch directly or via a sub-PR (branch: copilot/sub-pr-<number>).`,
   ].join('\n')
 
   // Create a temporary issue and assign Copilot to it


### PR DESCRIPTION
## Summary
The Copilot coding agent creates sub-PRs (e.g., `copilot/sub-pr-496`) targeting the feature branch instead of pushing directly. The previous `waitForNewPush()` would always timeout waiting for a direct push that never came.

This PR replaces it with `waitForFixes()` which polls for **both**:
1. A direct push to the PR branch (human or bot fix)
2. A Copilot sub-PR targeting the branch — auto-merges it when found

### New functions
- `findCopilotSubPr()` — searches for open PRs from `copilot/*` branches targeting the feature branch
- `mergeCopilotSubPr()` — marks draft sub-PRs as ready and merges with `--delete-branch`
- `waitForFixes()` — unified polling loop replacing `waitForNewPush()`

Relates to #500

## Test plan
- [x] `npm run format` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 208 passed
- [x] `npm run build` — succeeds
- [ ] End-to-end: trigger review cycle on a PR after merge, verify sub-PR detection and auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)