### PR TITLE
fix: ensure GA report impact.json passes Prettier formatting

### DIFF
--- a/.github/workflows/ga-report.yml
+++ b/.github/workflows/ga-report.yml
@@ -64,11 +64,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Download impact data
         uses: actions/download-artifact@v8
         with:
           name: ga-impact-data
           path: src/data
+
+      - name: Format impact data
+        run: npx prettier --write src/data/impact.json
 
       - name: Create pull request with updated impact stats
         id: cpr
@@ -85,7 +97,7 @@ jobs:
           delete-branch: true
 
       - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}

--- a/scripts/generate-report.ts
+++ b/scripts/generate-report.ts
@@ -114,7 +114,7 @@ async function generateReport() {
     if (!fs.existsSync(dataDir)) {
       fs.mkdirSync(dataDir, { recursive: true })
     }
-    fs.writeFileSync(publicStatsPath, JSON.stringify(publicStats, null, 2))
+    fs.writeFileSync(publicStatsPath, JSON.stringify(publicStats, null, 2) + '\n')
     console.log(`Public impact stats saved to: ${publicStatsPath}`)
 
     // --- Generate GitHub Step Summary ---


### PR DESCRIPTION
## Summary
- Add trailing newline to `impact.json` output in `generate-report.ts` so it's Prettier-compliant at source
- Add `prettier --write` step in the `create-pr` job as a safety net before committing
- Enable automerge on both `created` and `updated` PR operations so the workflow stays hands-off on subsequent runs

Fixes the CI failure on PR #435 where the automated GA report PR was blocked by Prettier formatting checks.

## Test plan
- [ ] Verify `generate-report.ts` writes `impact.json` with trailing newline
- [ ] Verify `ga-report.yml` `create-pr` job runs Prettier before creating/updating the PR
- [ ] Trigger `Scheduled GA Report` workflow manually and confirm the resulting PR passes CI and auto-merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)