### PR TITLE
fix: handle Qualtrics numeric export values in disposition triage

### DIFF
--- a/__tests__/lib/disposition-triage.test.ts
+++ b/__tests__/lib/disposition-triage.test.ts
@@ -35,8 +35,13 @@ describe('computeDisposition', () => {
     expect(computeDisposition(makeRow())).toBe('CLEAN')
   })
 
-  it('returns INCOMPLETE when Finished !== TRUE', () => {
+  it('returns CLEAN when Finished is "1" (Qualtrics numeric format)', () => {
+    expect(computeDisposition(makeRow({ Finished: '1' }))).toBe('CLEAN')
+  })
+
+  it('returns INCOMPLETE when Finished !== TRUE and !== 1', () => {
     expect(computeDisposition(makeRow({ Finished: 'FALSE' }))).toBe('INCOMPLETE')
+    expect(computeDisposition(makeRow({ Finished: '0' }))).toBe('INCOMPLETE')
     expect(computeDisposition(makeRow({ Finished: '' }))).toBe('INCOMPLETE')
   })
 

--- a/src/lib/disposition.ts
+++ b/src/lib/disposition.ts
@@ -67,7 +67,7 @@ export function parseCsvLine(line: string): string[] {
 /* ------------------------------------------------------------------ */
 
 export function computeDisposition(row: Omit<DispositionRow, 'Disposition'>): string {
-  if (row.Finished !== 'TRUE') return 'INCOMPLETE'
+  if (row.Finished !== 'TRUE' && row.Finished !== '1') return 'INCOMPLETE'
   if (row.IRI_Fail_Count >= 2) return 'AUTO-EXCLUDE'
   if (row.Speed_Flag === 1 && row.IRI_Fail_Count >= 1) return 'AUTO-EXCLUDE'
   if (row.Speed_Flag === 1 && row.IRI_Fail_Count === 0) return 'FLAG-SPEED'

--- a/src/lib/qualtrics-api.ts
+++ b/src/lib/qualtrics-api.ts
@@ -158,7 +158,7 @@ export async function startResponseExport(
     baseUrl,
     {
       method: 'POST',
-      body: JSON.stringify({ format: 'csv' }),
+      body: JSON.stringify({ format: 'csv', useLabels: true }),
     }
   )
   return result.progressId


### PR DESCRIPTION
## Summary

First live test of the disposition pipeline revealed two data format issues:

1. **Finished column**: Qualtrics exports `1`/`0` not `TRUE`/`FALSE` — updated waterfall to accept both
2. **IRI answer columns**: Exported as numeric codes instead of text labels — added `useLabels: true` to the Qualtrics export request so answers come as "Major Barrier", "Low Readiness/Capability", etc.

## Evidence

Dry-run of the pipeline showed all 191 responses classified as INCOMPLETE because `Finished: "1"` didn't match `"TRUE"`.

## Test plan

- [x] New test for `Finished: "1"` → CLEAN
- [x] 266 tests pass
- [ ] Re-run disposition pipeline dry-run to verify correct dispositions

🤖 Generated with [Claude Code](https://claude.com/claude-code)