### PR TITLE
fix: deduplicate PIDs in disposition triage (latest attempt wins)

### DIFF
--- a/__tests__/lib/disposition-triage.test.ts
+++ b/__tests__/lib/disposition-triage.test.ts
@@ -195,4 +195,55 @@ describe('triageCsv', () => {
   it('throws if CSV has fewer than 4 lines', () => {
     expect(() => triageCsv('just,headers\n')).toThrow('3 header rows')
   })
+
+  it('deduplicates by PID, keeping the latest (last) attempt', () => {
+    const csv = [
+      HEADERS,
+      ROW2,
+      ROW3,
+      // First attempt: AUTO-EXCLUDE (2 IRI fails)
+      'pid-dup,TRUE,600,Wrong Answer,Wrong Answer,Level 2: Developing/Repeatable,0.9,0',
+      // Second attempt (retake): CLEAN (all pass)
+      'pid-dup,TRUE,700,Major Barrier,Low Readiness/Capability,Level 2: Developing/Repeatable,0.9,0',
+    ].join('\n')
+
+    const rows = triageCsv(csv)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].PROLIFIC_PID).toBe('pid-dup')
+    expect(rows[0].Disposition).toBe('CLEAN')
+    expect(rows[0].Duration_Seconds).toBe(700)
+  })
+
+  it('deduplicates keeping latest even when latest is worse', () => {
+    const csv = [
+      HEADERS,
+      ROW2,
+      ROW3,
+      // First attempt: CLEAN
+      'pid-dup2,TRUE,700,Major Barrier,Low Readiness/Capability,Level 2: Developing/Repeatable,0.9,0',
+      // Second attempt: AUTO-EXCLUDE
+      'pid-dup2,TRUE,600,Wrong Answer,Wrong Answer,Level 2: Developing/Repeatable,0.9,0',
+    ].join('\n')
+
+    const rows = triageCsv(csv)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].Disposition).toBe('AUTO-EXCLUDE')
+  })
+
+  it('handles mix of unique and duplicate PIDs', () => {
+    const csv = [
+      HEADERS,
+      ROW2,
+      ROW3,
+      'pid-unique,TRUE,600,Major Barrier,Low Readiness/Capability,Level 2: Developing/Repeatable,0.9,0',
+      'pid-dup,TRUE,200,Wrong Answer,Wrong Answer,Wrong Answer,0.9,0',
+      'pid-dup,TRUE,700,Major Barrier,Low Readiness/Capability,Level 2: Developing/Repeatable,0.9,0',
+    ].join('\n')
+
+    const rows = triageCsv(csv)
+    expect(rows).toHaveLength(2)
+    const pids = rows.map((r) => r.PROLIFIC_PID)
+    expect(pids).toContain('pid-unique')
+    expect(pids).toContain('pid-dup')
+  })
 })

--- a/src/lib/disposition.ts
+++ b/src/lib/disposition.ts
@@ -109,7 +109,11 @@ export function triageCsv(inputCsv: string): DispositionRow[] {
   const recaptchaIdx = colIndex(headers, 'Q_RecaptchaScore')
   const straightliningIdx = colIndex(headers, 'Q_StraightliningCount')
 
-  const results: DispositionRow[] = []
+  // Use a Map keyed by PID to deduplicate. Qualtrics exports rows in
+  // chronological order, so later entries (retakes) overwrite earlier ones.
+  // Decision: use latest attempt only — documented in issue #521.
+  const byPid = new Map<string, DispositionRow>()
+  let duplicateCount = 0
 
   for (let i = 3; i < lines.length; i++) {
     const fields = parseCsvLine(lines[i])
@@ -149,8 +153,13 @@ export function triageCsv(inputCsv: string): DispositionRow[] {
       Straightlining_Flag: straightliningFlag,
     }
 
-    results.push({ ...partial, Disposition: computeDisposition(partial) })
+    if (byPid.has(pid)) duplicateCount++
+    byPid.set(pid, { ...partial, Disposition: computeDisposition(partial) })
   }
 
-  return results
+  if (duplicateCount > 0) {
+    console.log(`Dedup: ${duplicateCount} duplicate PID(s) found — using latest attempt for each.`)
+  }
+
+  return Array.from(byPid.values())
 }


### PR DESCRIPTION
First live pipeline run found 13 participants with duplicate submissions. Deduplicates by PROLIFIC_PID keeping latest attempt. Decision documented on issue #521.