### PR TITLE
fix: log Prolific bulk-approve response for debugging

### DIFF
--- a/__tests__/lib/prolific-api.test.ts
+++ b/__tests__/lib/prolific-api.test.ts
@@ -612,7 +612,7 @@ describe('Prolific API Client', () => {
     it('should send bulk approve request with study ID and participant IDs', async () => {
       ;(global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
-        json: async () => ({}),
+        text: async () => '{}',
       })
 
       const participantIds = ['pid-1', 'pid-2', 'pid-3']
@@ -639,6 +639,7 @@ describe('Prolific API Client', () => {
       ;(global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
         status: 204,
+        text: async () => '',
       })
 
       await expect(

--- a/src/lib/prolific-api.ts
+++ b/src/lib/prolific-api.ts
@@ -468,11 +468,11 @@ export async function bulkApproveSubmissions(
       errorData
     )
   }
-  // Drain response body to release the underlying connection.
-  // Endpoint may return 200 with JSON or 204 with empty body.
-  try {
-    await response.text()
-  } catch {
-    // Ignore drain errors
+  // Log response body for debugging, then return.
+  const responseBody = await response.text()
+  if (responseBody) {
+    console.log(`Prolific bulk-approve response (${response.status}): ${responseBody}`)
+  } else {
+    console.log(`Prolific bulk-approve response: ${response.status} (empty body)`)
   }
 }


### PR DESCRIPTION
API returned 200 but approval didn't take effect. Adding response body logging to diagnose.