### PR TITLE
feat: add partial straightlining detection (within-person SD per block)

### DIFF
--- a/__tests__/lib/disposition-triage.test.ts
+++ b/__tests__/lib/disposition-triage.test.ts
@@ -1,4 +1,10 @@
-import { computeDisposition, triageCsv, DispositionRow } from '../../src/lib/disposition'
+import {
+  computeDisposition,
+  triageCsv,
+  withinPersonSD,
+  detectPartialStraightlining,
+  DispositionRow,
+} from '../../src/lib/disposition'
 
 /* ------------------------------------------------------------------ */
 /*  Helper to build partial rows for waterfall tests                  */
@@ -22,6 +28,8 @@ function makeRow(
     reCAPTCHA_Flag: 0,
     Straightlining_Count: 0,
     Straightlining_Flag: 0,
+    Partial_Straightlining_Flag: 0,
+    Partial_Straightlining_Blocks: '',
     ...overrides,
   }
 }
@@ -139,6 +147,93 @@ describe('computeDisposition', () => {
         })
       )
     ).toBe('FLAG-SINGLE-IRI')
+  })
+
+  it('returns FLAG-PARTIAL-STRAIGHTLINING when partial flag is set', () => {
+    expect(
+      computeDisposition(
+        makeRow({ Partial_Straightlining_Flag: 1, Partial_Straightlining_Blocks: 'Barriers' })
+      )
+    ).toBe('FLAG-PARTIAL-STRAIGHTLINING')
+  })
+
+  it('waterfall precedence: FLAG-STRAIGHTLINING beats FLAG-PARTIAL-STRAIGHTLINING', () => {
+    expect(
+      computeDisposition(
+        makeRow({
+          Straightlining_Flag: 1,
+          Straightlining_Count: 1,
+          Partial_Straightlining_Flag: 1,
+          Partial_Straightlining_Blocks: 'Barriers',
+        })
+      )
+    ).toBe('FLAG-STRAIGHTLINING')
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Within-person SD tests                                            */
+/* ------------------------------------------------------------------ */
+
+describe('withinPersonSD', () => {
+  it('returns 0 for identical responses', () => {
+    expect(withinPersonSD(['A', 'A', 'A', 'A', 'A'])).toBe(0)
+  })
+
+  it('returns > 0 for varied responses', () => {
+    expect(withinPersonSD(['A', 'B', 'C', 'A', 'B'])).toBeGreaterThan(0)
+  })
+
+  it('returns NaN for fewer than 2 non-empty', () => {
+    expect(withinPersonSD(['A'])).toBeNaN()
+    expect(withinPersonSD(['', '', 'A'])).toBeNaN()
+  })
+
+  it('ignores empty responses', () => {
+    expect(withinPersonSD(['A', '', 'A', '', 'A'])).toBe(0)
+  })
+
+  it('returns SD below 0.5 for near-straightlining', () => {
+    // 18 identical + 1 different = very low variance
+    const responses = Array(18).fill('Moderate Barrier')
+    responses.push('Major Barrier')
+    expect(withinPersonSD(responses)).toBeLessThan(0.5)
+  })
+
+  it('returns SD above 0.5 for varied responses', () => {
+    const responses = ['A', 'B', 'C', 'D', 'A', 'B', 'C', 'D', 'A']
+    expect(withinPersonSD(responses)).toBeGreaterThan(0.5)
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Partial straightlining detection tests                            */
+/* ------------------------------------------------------------------ */
+
+describe('detectPartialStraightlining', () => {
+  const blocks = [{ name: 'TestBlock', prefix: 'TB_', count: 5 }]
+  const headers = ['TB_1', 'TB_2', 'TB_3', 'TB_4', 'TB_5']
+
+  it('flags a block where all items are identical', () => {
+    const fields = ['Same', 'Same', 'Same', 'Same', 'Same']
+    expect(detectPartialStraightlining(fields, headers, blocks)).toEqual(['TestBlock'])
+  })
+
+  it('does not flag a block with varied responses', () => {
+    const fields = ['A', 'B', 'C', 'D', 'E']
+    expect(detectPartialStraightlining(fields, headers, blocks)).toEqual([])
+  })
+
+  it('flags near-straightlining (4 of 5 identical)', () => {
+    const fields = ['Same', 'Same', 'Same', 'Same', 'Different']
+    const result = detectPartialStraightlining(fields, headers, blocks)
+    // SD of [0,0,0,0,1] = 0.4 < 0.5 threshold
+    expect(result).toEqual(['TestBlock'])
+  })
+
+  it('skips blocks with too few non-empty responses', () => {
+    const fields = ['A', '', '', '', '']
+    expect(detectPartialStraightlining(fields, headers, blocks)).toEqual([])
   })
 })
 

--- a/scripts/disposition-triage.ts
+++ b/scripts/disposition-triage.ts
@@ -34,6 +34,8 @@ function toCsv(rows: DispositionRow[]): string {
     'reCAPTCHA_Flag',
     'Straightlining_Count',
     'Straightlining_Flag',
+    'Partial_Straightlining_Flag',
+    'Partial_Straightlining_Blocks',
     'Disposition',
   ]
 
@@ -62,6 +64,7 @@ function generateSummary(rows: DispositionRow[]): string {
     'FLAG-SMEAL',
     'FLAG-RECAPTCHA',
     'FLAG-STRAIGHTLINING',
+    'FLAG-PARTIAL-STRAIGHTLINING',
     'INCOMPLETE',
   ]
 

--- a/src/lib/disposition.ts
+++ b/src/lib/disposition.ts
@@ -3,7 +3,26 @@
  *
  * Reusable types and waterfall logic for computing survey response dispositions.
  * Used by scripts/disposition-triage.ts and tests.
+ *
+ * Straightlining detection uses two layers:
+ *   - Qualtrics Q_StraightliningCount: full-block detection (auto-exclude)
+ *   - Within-person SD < 0.5: partial straightlining per block (manual review)
+ *     Reference: Meade & Craig (2012), Psychological Methods 17(3), 437-455
  */
+
+/* ------------------------------------------------------------------ */
+/*  Block definitions                                                 */
+/* ------------------------------------------------------------------ */
+
+/** Survey question blocks for partial straightlining analysis */
+export const SURVEY_BLOCKS = [
+  { name: 'Barriers', prefix: 'Q10-28_Barriers_', count: 19 },
+  { name: 'Readiness', prefix: 'Q47-64_Readiness_', count: 18 },
+  { name: 'Maturity', prefix: 'Q65-73_Maturity_', count: 9 },
+] as const
+
+/** Threshold for within-person SD to flag partial straightlining (Meade & Craig 2012) */
+export const PARTIAL_STRAIGHTLINING_SD_THRESHOLD = 0.5
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                             */
@@ -24,6 +43,8 @@ export interface DispositionRow {
   reCAPTCHA_Flag: 0 | 1
   Straightlining_Count: number
   Straightlining_Flag: 0 | 1
+  Partial_Straightlining_Flag: 0 | 1
+  Partial_Straightlining_Blocks: string
   Disposition: string
 }
 
@@ -63,18 +84,93 @@ export function parseCsvLine(line: string): string[] {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Straightlining analysis                                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Compute within-person standard deviation for a set of categorical responses.
+ * Maps text labels to numeric indices for SD calculation.
+ * Returns NaN if fewer than 2 non-empty responses.
+ */
+export function withinPersonSD(responses: string[]): number {
+  const nonEmpty = responses.filter((r) => r !== '')
+  if (nonEmpty.length < 2) return NaN
+
+  // Map unique values to numeric indices
+  const uniqueValues = [...new Set(nonEmpty)]
+  const numeric = nonEmpty.map((r) => uniqueValues.indexOf(r))
+
+  const mean = numeric.reduce((a, b) => a + b, 0) / numeric.length
+  const variance = numeric.reduce((sum, val) => sum + (val - mean) ** 2, 0) / numeric.length
+  return Math.sqrt(variance)
+}
+
+/**
+ * Check blocks for partial straightlining (within-person SD < threshold).
+ * Returns list of block names that are flagged.
+ */
+export function detectPartialStraightlining(
+  fields: string[],
+  headers: string[],
+  blocks: readonly { name: string; prefix: string; count: number }[],
+  threshold: number = PARTIAL_STRAIGHTLINING_SD_THRESHOLD
+): string[] {
+  const flaggedBlocks: string[] = []
+
+  for (const block of blocks) {
+    const responses: string[] = []
+    for (let item = 1; item <= block.count; item++) {
+      const colName = `${block.prefix}${item}`
+      const idx = headers.indexOf(colName)
+      if (idx >= 0) {
+        responses.push((fields[idx] ?? '').trim())
+      }
+    }
+
+    // Only evaluate if we have enough responses (at least half the block)
+    const nonEmpty = responses.filter((r) => r !== '')
+    if (nonEmpty.length < Math.ceil(block.count / 2)) continue
+
+    const sd = withinPersonSD(responses)
+    if (!isNaN(sd) && sd < threshold) {
+      flaggedBlocks.push(block.name)
+    }
+  }
+
+  return flaggedBlocks
+}
+
+/* ------------------------------------------------------------------ */
 /*  Disposition waterfall                                             */
 /* ------------------------------------------------------------------ */
 
 export function computeDisposition(row: Omit<DispositionRow, 'Disposition'>): string {
+  // Step 0: Incomplete
   if (row.Finished !== 'TRUE' && row.Finished !== '1') return 'INCOMPLETE'
+
+  // Step 1: Auto-exclude (hard fail)
   if (row.IRI_Fail_Count >= 2) return 'AUTO-EXCLUDE'
   if (row.Speed_Flag === 1 && row.IRI_Fail_Count >= 1) return 'AUTO-EXCLUDE'
+
+  // Step 2: Flag speed (fast but IRIs all pass)
   if (row.Speed_Flag === 1 && row.IRI_Fail_Count === 0) return 'FLAG-SPEED'
+
+  // Step 3: Single IRI fail at normal speed
   if (row.IRI_Fail_Count === 1 && row.Speed_Flag === 0) return 'FLAG-SINGLE-IRI'
+
+  // Step 4: Below Smeal benchmark
   if (row.Smeal_Benchmark_Flag === 1) return 'FLAG-SMEAL'
+
+  // Step 5: reCAPTCHA flag
   if (row.reCAPTCHA_Flag === 1) return 'FLAG-RECAPTCHA'
+
+  // Step 6: Full-block straightlining (Qualtrics Q_StraightliningCount)
   if (row.Straightlining_Flag === 1) return 'FLAG-STRAIGHTLINING'
+
+  // Step 7: Partial straightlining (within-person SD < 0.5 in any block)
+  if (row.Partial_Straightlining_Flag === 1) return 'FLAG-PARTIAL-STRAIGHTLINING'
+
+  // Step 8: Clean
   return 'CLEAN'
 }
 
@@ -136,6 +232,10 @@ export function triageCsv(inputCsv: string): DispositionRow[] {
     const straightliningCount = parseInt(fields[straightliningIdx] ?? '0', 10) || 0
     const straightliningFlag: 0 | 1 = straightliningCount > 0 ? 1 : 0
 
+    // Partial straightlining: within-person SD per block
+    const flaggedBlocks = detectPartialStraightlining(fields, headers, SURVEY_BLOCKS)
+    const partialStraightliningFlag: 0 | 1 = flaggedBlocks.length > 0 ? 1 : 0
+
     const partial: Omit<DispositionRow, 'Disposition'> = {
       PROLIFIC_PID: pid,
       Finished: finished,
@@ -151,6 +251,8 @@ export function triageCsv(inputCsv: string): DispositionRow[] {
       reCAPTCHA_Flag: recaptchaFlag,
       Straightlining_Count: straightliningCount,
       Straightlining_Flag: straightliningFlag,
+      Partial_Straightlining_Flag: partialStraightliningFlag,
+      Partial_Straightlining_Blocks: flaggedBlocks.join(';'),
     }
 
     if (byPid.has(pid)) duplicateCount++


### PR DESCRIPTION
## Summary

Adds block-level straightlining detection following Meade & Craig (2012, Psychological Methods).

**Two-layer approach:**
- **Step 6 — FLAG-STRAIGHTLINING**: Qualtrics `Q_StraightliningCount > 0` (full block, same answer for every item)
- **Step 7 — FLAG-PARTIAL-STRAIGHTLINING**: Within-person SD < 0.5 in any block (near-identical responses, manual review)

**Blocks analyzed:**
| Block | Items | Columns |
|---|---:|---|
| Barriers | 19 | Q10-28_Barriers_1 through _19 |
| Readiness | 18 | Q47-64_Readiness_1 through _18 |
| Maturity | 9 | Q65-73_Maturity_1 through _9 |

**New CSV columns:** `Partial_Straightlining_Flag`, `Partial_Straightlining_Blocks`

## Test plan

- [x] 281 tests pass (12 new: withinPersonSD, detectPartialStraightlining, waterfall)
- [ ] CI passes
- [ ] Re-run disposition pipeline to see how many CLEAN responses shift to FLAG-PARTIAL-STRAIGHTLINING

🤖 Generated with [Claude Code](https://claude.com/claude-code)