### PR TITLE
feat: DESTRUCTIVE — reject submissions with all 3 IRI failures

### DIFF
--- a/.github/workflows/prolific-reject-failed-iri.yml
+++ b/.github/workflows/prolific-reject-failed-iri.yml
@@ -1,0 +1,134 @@
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║  DESTRUCTIVE WORKFLOW: Reject Prolific Submissions                  ║
+# ║                                                                      ║
+# ║  This workflow REJECTS participants who failed ALL THREE IRI          ║
+# ║  attention checks (IRI_Fail_Count == 3). Rejected participants       ║
+# ║  will NOT be paid for their submission.                               ║
+# ║                                                                      ║
+# ║  SAFETY REQUIREMENTS:                                                ║
+# ║    1. Manual trigger only (workflow_dispatch)                         ║
+# ║    2. Defaults to dry-run (safe preview)                              ║
+# ║    3. Live rejection requires typing "REJECT" in confirmation field   ║
+# ║    4. Full audit trail in GitHub Actions step summary                 ║
+# ║    5. Every affected PID is logged individually                       ║
+# ║    6. Requires prolific-prod environment (with approval if configured)║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+name: 'DESTRUCTIVE: Reject Failed IRI Submissions'
+
+on:
+  workflow_dispatch:
+    inputs:
+      study_id:
+        description: 'Prolific Study ID (defaults to PROLIFIC_STUDY_ID env var)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run — preview rejections without executing'
+        required: true
+        type: boolean
+        default: true
+      confirm_reject:
+        description: 'Type REJECT to confirm live rejection (required when dry_run is false)'
+        required: false
+        type: string
+        default: ''
+
+# Prevent concurrent rejection runs
+concurrency:
+  group: 'prolific-reject-submissions'
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Step 1: Export + Triage to get fresh disposition data
+  triage:
+    name: Export & Triage
+    runs-on: ubuntu-latest
+    environment: qualtrics-prod
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Export Qualtrics responses
+        run: npx --no-install tsx scripts/export-qualtrics-responses.ts
+        env:
+          QUALTRICS_API_TOKEN: ${{ secrets.QUALTRICS_API_TOKEN }}
+          QUALTRICS_BASE_URL: ${{ vars.QUALTRICS_BASE_URL }}
+          QUALTRICS_SURVEY_ID: ${{ vars.QUALTRICS_SURVEY_ID }}
+          OUTPUT_PATH: ${{ runner.temp }}/qualtrics-export.csv
+
+      - name: Run disposition triage
+        run: npx --no-install tsx scripts/disposition-triage.ts
+        env:
+          INPUT_PATH: ${{ runner.temp }}/qualtrics-export.csv
+          OUTPUT_PATH: ${{ runner.temp }}/disposition.csv
+
+      - name: Upload disposition CSV
+        uses: actions/upload-artifact@v7
+        with:
+          name: disposition-csv
+          path: ${{ runner.temp }}/disposition.csv
+          retention-days: 1
+
+  # Step 2: Reject participants who failed all 3 IRI checks
+  reject:
+    name: 'DESTRUCTIVE: Reject Failed IRI'
+    needs: triage
+    runs-on: ubuntu-latest
+    environment: prolific-prod
+    steps:
+      - name: 'Safety check: validate confirmation'
+        if: inputs.dry_run == false
+        env:
+          CONFIRM: ${{ inputs.confirm_reject }}
+        run: |
+          echo "================================================================"
+          echo "  DESTRUCTIVE OPERATION: Prolific Submission Rejection"
+          echo "  This will REJECT participants and they will NOT be paid."
+          echo "================================================================"
+          echo ""
+          if [ "$CONFIRM" != "REJECT" ]; then
+            echo "SAFETY STOP: You must type REJECT in the confirmation field."
+            echo "Received: '$CONFIRM'"
+            exit 1
+          fi
+          echo "Confirmation accepted: '$CONFIRM'"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download disposition CSV
+        uses: actions/download-artifact@v8
+        with:
+          name: disposition-csv
+          path: ${{ runner.temp }}
+
+      - name: 'Execute rejection'
+        run: npx --no-install tsx scripts/reject-failed-iri-submissions.ts
+        env:
+          PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+          STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
+          CSV_FILE_PATH: ${{ runner.temp }}/disposition.csv
+          DRY_RUN: ${{ inputs.dry_run }}
+          CONFIRM_REJECT: ${{ inputs.confirm_reject }}

--- a/__tests__/lib/prolific-api.test.ts
+++ b/__tests__/lib/prolific-api.test.ts
@@ -11,6 +11,7 @@ import {
   listStudySubmissions,
   exportSubmissionsCSV,
   bulkApproveSubmissions,
+  bulkRejectSubmissions,
   ProlificApiErrorClass,
   type Study,
   type Submission,
@@ -677,6 +678,49 @@ describe('Prolific API Client', () => {
       ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('DNS resolution failed'))
 
       await expect(bulkApproveSubmissions(mockStudyId, ['pid-1'], mockApiToken)).rejects.toThrow(
+        ProlificApiErrorClass
+      )
+    })
+  })
+
+  describe('bulkRejectSubmissions', () => {
+    it('should send bulk reject request with study ID and participant IDs', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => '"The request to bulk reject has been made successfully."',
+      })
+
+      const participantIds = ['pid-1', 'pid-2']
+      await bulkRejectSubmissions(mockStudyId, participantIds, mockApiToken)
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.prolific.com/api/v1/submissions/bulk-reject/',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            study_id: mockStudyId,
+            participant_ids: participantIds,
+          }),
+        })
+      )
+    })
+
+    it('should throw on API error', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ detail: 'Invalid participant IDs' }),
+      })
+
+      await expect(bulkRejectSubmissions(mockStudyId, ['bad-pid'], mockApiToken)).rejects.toThrow(
+        ProlificApiErrorClass
+      )
+    })
+
+    it('should wrap network errors', async () => {
+      ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network failure'))
+
+      await expect(bulkRejectSubmissions(mockStudyId, ['pid-1'], mockApiToken)).rejects.toThrow(
         ProlificApiErrorClass
       )
     })

--- a/scripts/reject-failed-iri-submissions.ts
+++ b/scripts/reject-failed-iri-submissions.ts
@@ -1,0 +1,232 @@
+/**
+ * ╔══════════════════════════════════════════════════════════════════╗
+ * ║  DESTRUCTIVE OPERATION: Reject Prolific Submissions             ║
+ * ║                                                                  ║
+ * ║  This script REJECTS participants who failed ALL THREE IRI       ║
+ * ║  attention checks. Rejected participants will NOT be paid.       ║
+ * ║  This action cannot be easily undone.                            ║
+ * ╚══════════════════════════════════════════════════════════════════╝
+ *
+ * Reads a disposition CSV (from the triage pipeline), filters for
+ * participants with IRI_Fail_Count == 3, and calls the Prolific API
+ * to reject their submissions.
+ *
+ * Safety guards:
+ *   1. Requires CONFIRM_REJECT=REJECT to proceed (exact string match)
+ *   2. Defaults to dry-run mode
+ *   3. Always logs every PID that would be / is rejected
+ *   4. Produces a GitHub Step Summary with full audit trail
+ *   5. Only targets IRI_Fail_Count == 3 (all three failed)
+ *
+ * Environment variables:
+ *   PROLIFIC_API_TOKEN  – Prolific API token (required)
+ *   STUDY_ID            – Prolific study ID (required)
+ *   CSV_FILE_PATH       – Path to disposition CSV (required)
+ *   CONFIRM_REJECT      – Must be exactly "REJECT" to execute live (required for live)
+ *   DRY_RUN             – When "false" AND CONFIRM_REJECT=="REJECT", reject live (default: true)
+ */
+
+import { getCurrentUser, bulkRejectSubmissions } from '../src/lib/prolific-api'
+import { appendGithubStepSummary, mdEscape } from '../src/lib/github-utils'
+import { readFileSync } from 'node:fs'
+import { parseCsvLine } from '../src/lib/disposition'
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+function envFlag(name: string, defaultValue: boolean = false): boolean {
+  const value = process.env[name]
+  if (value === undefined) return defaultValue
+  const normalized = value.trim().toLowerCase()
+  if (normalized === '') return defaultValue
+  return ['1', 'true', 'yes', 'y', 'on'].includes(normalized)
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                              */
+/* ------------------------------------------------------------------ */
+
+async function main() {
+  console.log('================================================================')
+  console.log('  DESTRUCTIVE OPERATION: Prolific Submission Rejection')
+  console.log('  Participants who failed ALL 3 IRI attention checks')
+  console.log('  Rejected participants will NOT be paid.')
+  console.log('================================================================')
+  console.log('')
+
+  const apiToken = process.env.PROLIFIC_API_TOKEN
+  if (!apiToken) {
+    console.error('Error: PROLIFIC_API_TOKEN is required')
+    process.exit(1)
+  }
+
+  const studyId = process.env.STUDY_ID
+  if (!studyId) {
+    console.error('Error: STUDY_ID is required')
+    process.exit(1)
+  }
+
+  const csvFilePath = process.env.CSV_FILE_PATH
+  if (!csvFilePath) {
+    console.error('Error: CSV_FILE_PATH is required')
+    process.exit(1)
+  }
+
+  const dryRun = envFlag('DRY_RUN', true)
+  const confirmReject = (process.env.CONFIRM_REJECT ?? '').trim()
+
+  // Safety check: require explicit confirmation for live rejection
+  if (!dryRun && confirmReject !== 'REJECT') {
+    console.error('================================================================')
+    console.error('  SAFETY STOP: CONFIRM_REJECT must be exactly "REJECT"')
+    console.error('  to execute a live rejection. This is a destructive action.')
+    console.error(`  Received: "${confirmReject}"`)
+    console.error('================================================================')
+    process.exit(1)
+  }
+
+  /* ---------- Load and filter CSV ------------------------------------- */
+  console.log(`Reading disposition CSV from ${csvFilePath}`)
+  const rawCsv = readFileSync(csvFilePath, 'utf-8')
+
+  const lines = rawCsv
+    .trimEnd()
+    .split(/\r?\n/)
+    .filter((l) => l.trim() !== '')
+  if (lines.length < 2) {
+    console.error('Error: CSV must have a header row and at least one data row')
+    process.exit(1)
+  }
+
+  const headers = parseCsvLine(lines[0])
+  const pidIdx = headers.indexOf('PROLIFIC_PID')
+  const iriFailIdx = headers.indexOf('IRI_Fail_Count')
+  const dispositionIdx = headers.indexOf('Disposition')
+
+  if (pidIdx === -1 || iriFailIdx === -1) {
+    console.error('Error: CSV must have PROLIFIC_PID and IRI_Fail_Count columns')
+    process.exit(1)
+  }
+
+  // Only reject participants who failed ALL THREE IRI checks
+  const rejectPids: string[] = []
+  for (let i = 1; i < lines.length; i++) {
+    const fields = parseCsvLine(lines[i])
+    const pid = (fields[pidIdx] ?? '').trim()
+    const iriFailCount = parseInt(fields[iriFailIdx] ?? '0', 10) || 0
+    const disposition = (fields[dispositionIdx] ?? '').trim()
+
+    if (pid && iriFailCount === 3) {
+      rejectPids.push(pid)
+    }
+  }
+
+  const totalRows = lines.length - 1
+  console.log(`Parsed ${totalRows} data rows`)
+  console.log(`Participants with IRI_Fail_Count == 3: ${rejectPids.length}`)
+  console.log('')
+
+  if (rejectPids.length === 0) {
+    console.log('No participants to reject.')
+    appendGithubStepSummary(
+      [
+        '## Prolific Submission Rejection',
+        '',
+        '> **DESTRUCTIVE OPERATION** — rejects participants who failed all 3 IRI attention checks',
+        '',
+        `- **Study ID:** ${mdEscape(studyId)}`,
+        `- **CSV rows parsed:** ${totalRows}`,
+        `- **IRI_Fail_Count == 3:** 0`,
+        '',
+        'No participants to reject.',
+        '',
+      ].join('\n')
+    )
+    return
+  }
+
+  /* ---------- Log every PID ------------------------------------------- */
+  console.log('Participants to reject (IRI_Fail_Count == 3):')
+  for (const pid of rejectPids) {
+    console.log(`  - ${pid}`)
+  }
+  console.log('')
+
+  /* ---------- Verify API connection ----------------------------------- */
+  console.log('Verifying Prolific API connection...')
+  const user = await getCurrentUser(apiToken)
+  console.log(`Connected as: ${user.name} (${user.email})`)
+  console.log('')
+
+  /* ---------- Execute or dry run -------------------------------------- */
+  if (dryRun) {
+    console.log('================================================================')
+    console.log('  DRY RUN — no submissions will be rejected')
+    console.log(`  Would reject: ${rejectPids.length} participants`)
+    console.log('  Set DRY_RUN=false and CONFIRM_REJECT=REJECT to execute')
+    console.log('================================================================')
+  } else {
+    console.log('================================================================')
+    console.log(`  LIVE REJECTION: Rejecting ${rejectPids.length} submissions`)
+    console.log(`  Study: ${studyId}`)
+    console.log(`  Operator: ${user.name} (${user.email})`)
+    console.log('================================================================')
+    console.log('')
+
+    await bulkRejectSubmissions(studyId, rejectPids, apiToken)
+    console.log(`REJECTED ${rejectPids.length} submissions`)
+  }
+
+  /* ---------- Step summary -------------------------------------------- */
+  appendGithubStepSummary(
+    [
+      '## Prolific Submission Rejection',
+      '',
+      '> **DESTRUCTIVE OPERATION** — rejects participants who failed all 3 IRI attention checks.',
+      '> Rejected participants will NOT be paid.',
+      '',
+      `- **Run time (UTC):** ${new Date().toISOString()}`,
+      `- **Operator:** ${mdEscape(user.name)} (id: ${mdEscape(user.id)})`,
+      `- **Study ID:** ${mdEscape(studyId)}`,
+      `- **Mode:** ${dryRun ? 'DRY RUN' : 'LIVE REJECTION'}`,
+      '',
+      '### Results',
+      '',
+      '| Metric | Value |',
+      '|---|---:|',
+      `| CSV rows parsed | ${totalRows} |`,
+      `| IRI\\_Fail\\_Count == 3 | ${rejectPids.length} |`,
+      `| Rejected | ${dryRun ? '0 (dry run)' : String(rejectPids.length)} |`,
+      '',
+      '### Rejected PIDs',
+      '',
+      ...rejectPids.map((pid) => `- \`${pid}\``),
+      '',
+      dryRun
+        ? '> **Dry run** — set `DRY_RUN=false` and `CONFIRM_REJECT=REJECT` to execute.'
+        : '> **All listed participants have been rejected and will not be paid.**',
+      '',
+    ].join('\n')
+  )
+
+  console.log('')
+  console.log('Done')
+}
+
+main().catch((error: unknown) => {
+  console.error('REJECTION SCRIPT FAILED:', error)
+
+  appendGithubStepSummary(
+    [
+      '---',
+      '',
+      '## REJECTION FAILED',
+      '',
+      'The rejection script encountered an error. **No submissions were rejected** if the error',
+      'occurred before the API call. Check logs for details.',
+      '',
+    ].join('\n')
+  )
+  process.exit(1)
+})

--- a/src/lib/prolific-api.ts
+++ b/src/lib/prolific-api.ts
@@ -476,3 +476,72 @@ export async function bulkApproveSubmissions(
     console.log(`Prolific bulk-approve response: ${response.status} (empty body)`)
   }
 }
+
+/**
+ * DESTRUCTIVE: Bulk reject submissions for a study by participant IDs.
+ *
+ * WARNING: Rejected participants will NOT be paid for their submission.
+ * This action cannot be easily undone. Use with extreme caution.
+ *
+ * Uses the Prolific bulk-reject endpoint:
+ * POST /api/v1/submissions/bulk-reject/
+ *
+ * @param studyId - The unique identifier of the study
+ * @param participantIds - Array of participant IDs to reject
+ * @param apiToken - Prolific API token
+ * @returns Promise that resolves when the bulk rejection request completes
+ * @throws {ProlificApiErrorClass} When the API request fails
+ */
+export async function bulkRejectSubmissions(
+  studyId: string,
+  participantIds: string[],
+  apiToken: string
+): Promise<void> {
+  const url = `${PROLIFIC_API_BASE_URL}/submissions/bulk-reject/`
+
+  const headers = new Headers()
+  headers.set('Authorization', `Token ${apiToken}`)
+  headers.set('Content-Type', 'application/json')
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        study_id: studyId,
+        participant_ids: participantIds,
+      }),
+    })
+  } catch (error) {
+    throw new ProlificApiErrorClass(
+      `Network error during bulk reject: ${error instanceof Error ? error.message : String(error)}`,
+      0,
+      {}
+    )
+  }
+
+  if (!response.ok) {
+    let errorData: ProlificApiError = {}
+    try {
+      errorData = (await response.json()) as ProlificApiError
+    } catch {
+      // Empty or non-JSON error body
+    }
+    throw new ProlificApiErrorClass(
+      errorData.detail ||
+        errorData.error ||
+        errorData.message ||
+        `Bulk reject failed with status ${response.status}`,
+      response.status,
+      errorData
+    )
+  }
+
+  const responseBody = await response.text()
+  if (responseBody) {
+    console.log(`Prolific bulk-reject response (${response.status}): ${responseBody}`)
+  } else {
+    console.log(`Prolific bulk-reject response: ${response.status} (empty body)`)
+  }
+}


### PR DESCRIPTION
## Summary

> **DESTRUCTIVE OPERATION** — rejected participants will NOT be paid. This action cannot be easily undone.

Adds a workflow to reject Prolific submissions where participants failed **all 3 IRI attention checks** (IRI_Fail_Count == 3). Based on current data, this affects **29 participants**.

## Safety Guards (7 layers)

1. **Manual trigger only** — no schedule, no automatic execution
2. **Dry-run default** — must explicitly uncheck to go live
3. **Confirmation string** — must type `REJECT` in the input field
4. **Double validation** — workflow step validates AND script validates independently
5. **Full audit trail** — every PID logged individually in console + step summary
6. **Environment approval** — requires `prolific-prod` environment (can add reviewer requirement)
7. **Narrow scope** — only targets IRI_Fail_Count == 3 (hardcoded, not configurable)

## New Files

- [reject-failed-iri-submissions.ts](scripts/reject-failed-iri-submissions.ts) — script with ASCII-art warning banner, dual confirmation, per-PID logging
- [prolific-reject-failed-iri.yml](.github/workflows/prolific-reject-failed-iri.yml) — workflow with `DESTRUCTIVE:` prefix in name
- `bulkRejectSubmissions()` in prolific-api.ts

## Test plan

- [x] 284 tests pass (3 new reject API tests)
- [ ] CI passes
- [ ] Dry-run test to preview the 29 rejections
- [ ] Manual review of PIDs before live execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)