### PR TITLE
feat: add Prolific messaging API integration (send, list, read)

### DIFF
--- a/__tests__/lib/prolific-api.test.ts
+++ b/__tests__/lib/prolific-api.test.ts
@@ -14,10 +14,15 @@ import {
   bulkRejectSubmissions,
   rejectSubmission,
   getSubmissionIdsByParticipant,
+  sendMessage,
+  listStudyMessages,
+  getMessageThread,
   REJECTION_CATEGORIES,
   ProlificApiErrorClass,
   type Study,
   type Submission,
+  type Message,
+  type MessageThread,
   type PaginatedResponse,
 } from '../../src/lib/prolific-api'
 
@@ -809,6 +814,239 @@ describe('Prolific API Client', () => {
       expect(result.get('pid-a')).toBe('sub-1')
       expect(result.get('pid-c')).toBe('sub-3')
       expect(result.has('pid-b')).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Messaging API
+  // -------------------------------------------------------------------------
+
+  describe('sendMessage', () => {
+    it('should POST a message to the messages endpoint', async () => {
+      const mockMessage: Message = {
+        id: 'msg-1',
+        study_id: mockStudyId,
+        participant_id: 'participant-1',
+        body: 'Hello, please complete the survey.',
+        sender_id: 'researcher-1',
+        created_at: '2024-06-01T12:00:00Z',
+      }
+
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMessage,
+      })
+
+      const result = await sendMessage(
+        mockStudyId,
+        'participant-1',
+        'Hello, please complete the survey.',
+        mockApiToken
+      )
+
+      expect(result).toEqual(mockMessage)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.prolific.com/api/v1/messages/',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            study_id: mockStudyId,
+            participant_id: 'participant-1',
+            body: 'Hello, please complete the survey.',
+          }),
+        })
+      )
+
+      const call = (global.fetch as jest.Mock).mock.calls[0]
+      const headers = call[1].headers as Headers
+      expect(headers.get('Authorization')).toBe(`Token ${mockApiToken}`)
+      expect(headers.get('Content-Type')).toBe('application/json')
+    })
+
+    it('should throw ProlificApiErrorClass on API error', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ detail: 'Invalid participant ID' }),
+      })
+
+      await expect(sendMessage(mockStudyId, 'bad-pid', 'Hello', mockApiToken)).rejects.toThrow(
+        ProlificApiErrorClass
+      )
+    })
+
+    it('should throw ProlificApiErrorClass on network error', async () => {
+      ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'))
+
+      await expect(
+        sendMessage(mockStudyId, 'participant-1', 'Hello', mockApiToken)
+      ).rejects.toThrow(ProlificApiErrorClass)
+    })
+  })
+
+  describe('listStudyMessages', () => {
+    it('should fetch messages for a study', async () => {
+      const mockMessages: PaginatedResponse<Message> = {
+        results: [
+          {
+            id: 'msg-1',
+            study_id: mockStudyId,
+            participant_id: 'participant-1',
+            body: 'First message',
+            sender_id: 'researcher-1',
+            created_at: '2024-06-01T12:00:00Z',
+          },
+          {
+            id: 'msg-2',
+            study_id: mockStudyId,
+            participant_id: 'participant-2',
+            body: 'Second message',
+            sender_id: 'researcher-1',
+            created_at: '2024-06-01T13:00:00Z',
+          },
+        ],
+        meta: {
+          count: 2,
+          next: null,
+          previous: null,
+        },
+      }
+
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMessages,
+      })
+
+      const result = await listStudyMessages(mockStudyId, mockApiToken)
+
+      expect(result).toEqual(mockMessages)
+      expect(result.results).toHaveLength(2)
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://api.prolific.com/api/v1/studies/${mockStudyId}/messages/`,
+        expect.objectContaining({
+          headers: expect.any(Headers),
+        })
+      )
+    })
+
+    it('should handle empty message list', async () => {
+      const mockMessages: PaginatedResponse<Message> = {
+        results: [],
+        meta: {
+          count: 0,
+          next: null,
+          previous: null,
+        },
+      }
+
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMessages,
+      })
+
+      const result = await listStudyMessages(mockStudyId, mockApiToken)
+
+      expect(result.results).toHaveLength(0)
+    })
+
+    it('should throw ProlificApiErrorClass on API error', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: 'Study not found' }),
+      })
+
+      await expect(listStudyMessages('bad-study', mockApiToken)).rejects.toThrow(
+        ProlificApiErrorClass
+      )
+    })
+  })
+
+  describe('getMessageThread', () => {
+    it('should fetch a message thread with replies', async () => {
+      const mockThread: MessageThread = {
+        id: 'msg-1',
+        study_id: mockStudyId,
+        participant_id: 'participant-1',
+        body: 'Hello, please complete the survey.',
+        sender_id: 'researcher-1',
+        created_at: '2024-06-01T12:00:00Z',
+        replies: [
+          {
+            id: 'msg-1-reply-1',
+            study_id: mockStudyId,
+            participant_id: 'participant-1',
+            body: 'I have a question about question 3.',
+            sender_id: 'participant-1',
+            created_at: '2024-06-01T12:30:00Z',
+          },
+          {
+            id: 'msg-1-reply-2',
+            study_id: mockStudyId,
+            participant_id: 'participant-1',
+            body: 'Please refer to the instructions.',
+            sender_id: 'researcher-1',
+            created_at: '2024-06-01T13:00:00Z',
+          },
+        ],
+      }
+
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockThread,
+      })
+
+      const result = await getMessageThread('msg-1', mockApiToken)
+
+      expect(result).toEqual(mockThread)
+      expect(result.replies).toHaveLength(2)
+      expect(result.replies[0].body).toBe('I have a question about question 3.')
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.prolific.com/api/v1/messages/msg-1/',
+        expect.objectContaining({
+          headers: expect.any(Headers),
+        })
+      )
+    })
+
+    it('should handle a thread with no replies', async () => {
+      const mockThread: MessageThread = {
+        id: 'msg-2',
+        study_id: mockStudyId,
+        participant_id: 'participant-2',
+        body: 'Your submission is under review.',
+        sender_id: 'researcher-1',
+        created_at: '2024-06-02T10:00:00Z',
+        replies: [],
+      }
+
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockThread,
+      })
+
+      const result = await getMessageThread('msg-2', mockApiToken)
+
+      expect(result.replies).toHaveLength(0)
+      expect(result.body).toBe('Your submission is under review.')
+    })
+
+    it('should throw ProlificApiErrorClass on API error', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: 'Message not found' }),
+      })
+
+      await expect(getMessageThread('bad-msg-id', mockApiToken)).rejects.toThrow(
+        ProlificApiErrorClass
+      )
+    })
+
+    it('should throw ProlificApiErrorClass on network error', async () => {
+      ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Connection refused'))
+
+      await expect(getMessageThread('msg-1', mockApiToken)).rejects.toThrow(ProlificApiErrorClass)
     })
   })
 })

--- a/src/lib/prolific-api.ts
+++ b/src/lib/prolific-api.ts
@@ -12,6 +12,35 @@
 
 const PROLIFIC_API_BASE_URL = 'https://api.prolific.com/api/v1'
 
+// ---------------------------------------------------------------------------
+// Messaging types
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a message sent to or from a participant via Prolific.
+ */
+export interface Message {
+  id: string
+  study_id: string
+  participant_id: string
+  body: string
+  sender_id?: string
+  created_at: string
+}
+
+/**
+ * Represents a message thread (a message with its replies).
+ */
+export interface MessageThread {
+  id: string
+  study_id: string
+  participant_id: string
+  body: string
+  sender_id?: string
+  created_at: string
+  replies: Message[]
+}
+
 /**
  * Study status types
  */
@@ -647,4 +676,79 @@ export async function bulkRejectSubmissions(
   } else {
     console.log(`Prolific bulk-reject response: ${response.status} (empty body)`)
   }
+}
+
+// ---------------------------------------------------------------------------
+// Messaging functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a message to a participant for a given study.
+ *
+ * Uses the Prolific messaging endpoint:
+ * POST /api/v1/messages/
+ *
+ * @param studyId - The unique identifier of the study
+ * @param participantId - The unique identifier of the participant
+ * @param body - The message body text
+ * @param apiToken - Prolific API token
+ * @returns Promise resolving to the created Message
+ * @throws {ProlificApiErrorClass} When the API request fails
+ *
+ * @see https://docs.prolific.com/api-reference/messages/send-message
+ */
+export async function sendMessage(
+  studyId: string,
+  participantId: string,
+  body: string,
+  apiToken: string
+): Promise<Message> {
+  return makeApiRequest<Message>('/messages/', apiToken, {
+    method: 'POST',
+    body: JSON.stringify({
+      study_id: studyId,
+      participant_id: participantId,
+      body,
+    }),
+  })
+}
+
+/**
+ * List all messages for a specific study.
+ *
+ * Uses the Prolific messaging endpoint:
+ * GET /api/v1/studies/{studyId}/messages/
+ *
+ * @param studyId - The unique identifier of the study
+ * @param apiToken - Prolific API token
+ * @returns Promise resolving to a paginated list of Messages
+ * @throws {ProlificApiErrorClass} When the API request fails
+ *
+ * @see https://docs.prolific.com/api-reference/messages/list-messages
+ */
+export async function listStudyMessages(
+  studyId: string,
+  apiToken: string
+): Promise<PaginatedResponse<Message>> {
+  return makeApiRequest<PaginatedResponse<Message>>(`/studies/${studyId}/messages/`, apiToken)
+}
+
+/**
+ * Get a specific message thread (message and its replies).
+ *
+ * Uses the Prolific messaging endpoint:
+ * GET /api/v1/messages/{messageId}/
+ *
+ * @param messageId - The unique identifier of the message
+ * @param apiToken - Prolific API token
+ * @returns Promise resolving to the MessageThread
+ * @throws {ProlificApiErrorClass} When the API request fails
+ *
+ * @see https://docs.prolific.com/api-reference/messages/get-message
+ */
+export async function getMessageThread(
+  messageId: string,
+  apiToken: string
+): Promise<MessageThread> {
+  return makeApiRequest<MessageThread>(`/messages/${messageId}/`, apiToken)
 }


### PR DESCRIPTION
Adds sendMessage(), listStudyMessages(), getMessageThread() to prolific-api.ts with Message/MessageThread types. 10 new unit tests. Implements #542.