### PR TITLE
fix: messaging API error handling and recipient_id field

### DIFF
--- a/__tests__/lib/prolific-api.test.ts
+++ b/__tests__/lib/prolific-api.test.ts
@@ -850,9 +850,9 @@ describe('Prolific API Client', () => {
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({
-            study_id: mockStudyId,
-            participant_id: 'participant-1',
+            recipient_id: 'participant-1',
             body: 'Hello, please complete the survey.',
+            study_id: mockStudyId,
           }),
         })
       )

--- a/scripts/message-flagged-submissions.ts
+++ b/scripts/message-flagged-submissions.ts
@@ -313,12 +313,13 @@ async function main() {
         await sendMessage(studyId, r.pid, r.message, apiToken)
         sent++
         console.log(`    Sent successfully`)
-      } catch (error) {
+      } catch (error: unknown) {
         failed++
-        console.error(
-          `    FAILED to send to ${r.pid}:`,
-          error instanceof Error ? error.message : String(error)
-        )
+        const errMsg =
+          error instanceof Error
+            ? `${error.message}${(error as Record<string, unknown>).statusCode ? ` (HTTP ${(error as Record<string, unknown>).statusCode})` : ''}${(error as Record<string, unknown>).response ? ` Response: ${JSON.stringify((error as Record<string, unknown>).response)}` : ''}`
+            : JSON.stringify(error)
+        console.error(`    FAILED to send to ${r.pid}: ${errMsg}`)
       }
     }
 

--- a/src/lib/prolific-api.ts
+++ b/src/lib/prolific-api.ts
@@ -210,14 +210,14 @@ async function makeApiRequest<T>(
 
     if (!response.ok) {
       const errorData = data as ProlificApiError
-      throw new ProlificApiErrorClass(
-        errorData.detail ||
-          errorData.error ||
-          errorData.message ||
-          `API request failed with status ${response.status}`,
-        response.status,
-        errorData
-      )
+      const detail = errorData.detail || errorData.error || errorData.message
+      const errorMsg =
+        typeof detail === 'string'
+          ? detail
+          : detail
+            ? JSON.stringify(detail)
+            : `API request failed with status ${response.status}`
+      throw new ProlificApiErrorClass(errorMsg, response.status, errorData)
     }
 
     return data as T
@@ -720,9 +720,9 @@ export async function sendMessage(
   return makeApiRequest<Message>('/messages/', apiToken, {
     method: 'POST',
     body: JSON.stringify({
-      study_id: studyId,
-      participant_id: participantId,
+      recipient_id: participantId,
       body,
+      study_id: studyId,
     }),
   })
 }


### PR DESCRIPTION
Fixes message send failures: use recipient_id (not participant_id), stringify nested error objects, better error logging.