### PR TITLE
fix: sendMessage handles non-JSON Prolific API responses

### DIFF
--- a/__tests__/lib/prolific-api.test.ts
+++ b/__tests__/lib/prolific-api.test.ts
@@ -834,17 +834,15 @@ describe('Prolific API Client', () => {
 
       ;(global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
-        json: async () => mockMessage,
+        text: async () => JSON.stringify(mockMessage),
       })
 
-      const result = await sendMessage(
+      await sendMessage(
         mockStudyId,
         'participant-1',
         'Hello, please complete the survey.',
         mockApiToken
       )
-
-      expect(result).toEqual(mockMessage)
       expect(global.fetch).toHaveBeenCalledWith(
         'https://api.prolific.com/api/v1/messages/',
         expect.objectContaining({
@@ -867,7 +865,7 @@ describe('Prolific API Client', () => {
       ;(global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         status: 400,
-        json: async () => ({ detail: 'Invalid participant ID' }),
+        text: async () => '{"detail": "Invalid participant ID"}',
       })
 
       await expect(sendMessage(mockStudyId, 'bad-pid', 'Hello', mockApiToken)).rejects.toThrow(

--- a/src/lib/prolific-api.ts
+++ b/src/lib/prolific-api.ts
@@ -714,17 +714,55 @@ export async function bulkRejectSubmissions(
 export async function sendMessage(
   studyId: string,
   participantId: string,
-  body: string,
+  messageBody: string,
   apiToken: string
-): Promise<Message> {
-  return makeApiRequest<Message>('/messages/', apiToken, {
-    method: 'POST',
-    body: JSON.stringify({
-      recipient_id: participantId,
-      body,
-      study_id: studyId,
-    }),
-  })
+): Promise<void> {
+  const url = `${PROLIFIC_API_BASE_URL}/messages/`
+
+  const headers = new Headers()
+  headers.set('Authorization', `Token ${apiToken}`)
+  headers.set('Content-Type', 'application/json')
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        recipient_id: participantId,
+        body: messageBody,
+        study_id: studyId,
+      }),
+    })
+  } catch (error) {
+    throw new ProlificApiErrorClass(
+      `Network error sending message: ${error instanceof Error ? error.message : String(error)}`,
+      0,
+      {}
+    )
+  }
+
+  if (!response.ok) {
+    let errorDetail = ''
+    try {
+      const errorBody = await response.text()
+      errorDetail = errorBody.slice(0, 500)
+    } catch {
+      // ignore
+    }
+    throw new ProlificApiErrorClass(
+      `Send message failed (${response.status}): ${errorDetail}`,
+      response.status,
+      {}
+    )
+  }
+
+  // Drain response body
+  try {
+    await response.text()
+  } catch {
+    // ignore
+  }
 }
 
 /**


### PR DESCRIPTION
Messaging endpoint may return empty body on success. Direct fetch instead of makeApiRequest.