### PR TITLE
feat: Automate Daily SEO Dashboard Sync

### DIFF
--- a/.github/workflows/seo-dashboard-sync.yml
+++ b/.github/workflows/seo-dashboard-sync.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Update SEO Dashboard Timestamp
         run: npx tsx scripts/update-seo-dashboard-sync.ts
 
+      - name: Format updated data file
+        run: npx prettier --write src/data/seo-metrics.json
+
       - name: Create pull request with updated sync time
         id: cpr
         uses: peter-evans/create-pull-request@v8
@@ -40,7 +43,7 @@ jobs:
           body: |
             Automated execution of `scripts/update-seo-dashboard-sync.ts`.
 
-            This PR bumps the SEO Transparency Dashboard `generatedAt` static export timestamp to reflect the latest CI build synchronization phase.
+            This PR bumps the `dashboardSyncedAt` field in `src/data/seo-metrics.json` to reflect the latest CI build synchronization date. The underlying metrics data (`generatedAt`, `dateRange`, and all metrics) are not modified by this script.
           branch: chore/seo-dashboard-daily-sync
           delete-branch: true
 

--- a/scripts/update-seo-dashboard-sync.ts
+++ b/scripts/update-seo-dashboard-sync.ts
@@ -9,10 +9,12 @@ function updateSeoDashboardTimestamp() {
     const data = JSON.parse(rawData)
 
     const now = new Date()
-    data.generatedAt = now.toISOString()
+    data.dashboardSyncedAt = now.toISOString()
 
     fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8')
-    console.log(`Successfully updated SEO Dashboard generatedAt timestamp to: ${data.generatedAt}`)
+    console.log(
+      `Successfully bumped SEO Dashboard dashboardSyncedAt to: ${data.dashboardSyncedAt} (generatedAt/dateRange/metrics not modified by this script)`
+    )
   } catch (error) {
     console.error('Failed to update seo-metrics.json timestamp:', error)
     process.exit(1)

--- a/src/app/making-of-tabs/seo/page.tsx
+++ b/src/app/making-of-tabs/seo/page.tsx
@@ -13,10 +13,10 @@ export const metadata: Metadata = {
 }
 
 const SEOTransparencyPage = () => {
-  // Format the build-time date in UTC so the display is consistent regardless
-  // of the build machine's locale. In this statically exported app, this
-  // timestamp is computed at build time and remains fixed until the next build.
-  const dateObj = new Date(seoMetrics.generatedAt)
+  // The dashboardSyncedAt field is written by the daily CI sync workflow before
+  // the Next.js build runs, so it reflects the last time the pipeline executed.
+  // generatedAt tracks when the underlying metrics data was collected.
+  const syncDateObj = new Date(seoMetrics.dashboardSyncedAt)
   const utcDateFormatter = new Intl.DateTimeFormat('en-US', {
     timeZone: 'UTC',
     year: 'numeric',
@@ -26,7 +26,7 @@ const SEOTransparencyPage = () => {
     minute: '2-digit',
     timeZoneName: 'short',
   })
-  const formattedSnapshotDate = utcDateFormatter.format(dateObj)
+  const formattedSnapshotDate = utcDateFormatter.format(syncDateObj)
 
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">

--- a/src/data/seo-metrics.json
+++ b/src/data/seo-metrics.json
@@ -1,5 +1,6 @@
 {
-  "generatedAt": "2026-03-26T12:52:28.828Z",
+  "generatedAt": "2026-03-23T12:52:28.828Z",
+  "dashboardSyncedAt": "2026-03-26T12:52:28.828Z",
   "dateRange": {
     "startDate": "2026-02-23",
     "endDate": "2026-03-23"


### PR DESCRIPTION
Automates a daily GitHub Actions workflow that bumps the `dashboardSyncedAt` timestamp in `src/data/seo-metrics.json` and opens an auto-merge PR so the SEO transparency dashboard always reflects the latest CI sync date.

The `generatedAt` field remains aligned with the actual metrics data collection date (`dateRange.endDate`), while the new `dashboardSyncedAt` field tracks the last CI pipeline execution. This separation makes it clear that the daily sync updates only the build marker — not the underlying metrics data.

Also consolidates the former `/making-of-tabs/seo/baseline-audit`, `/strategy`, and `/dashboard` sub-pages into the unified `/making-of-tabs/seo` page, with stub redirect pages kept at the old routes so existing links remain functional.

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.