### PR TITLE
feat: add SPEED_IRI message type for borderline auto-exclude participants

### DIFF
--- a/.github/workflows/check-participant.yml
+++ b/.github/workflows/check-participant.yml
@@ -11,6 +11,7 @@ on:
           - single
           - all-replies
           - send-thank-you
+          - unreject
         default: 'single'
       pid:
         description: 'Prolific Participant ID (required for single mode)'
@@ -36,6 +37,15 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+
+      - name: Unreject submissions
+        if: inputs.mode == 'unreject'
+        env:
+          PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+          STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
+          PID_LIST: ${{ inputs.pid }}
+          DRY_RUN: 'false'
+        run: npx --no-install tsx scripts/unreject-submissions.ts
 
       - name: Send thank-you messages
         if: inputs.mode == 'send-thank-you'

--- a/.github/workflows/prolific-message-flagged.yml
+++ b/.github/workflows/prolific-message-flagged.yml
@@ -32,6 +32,7 @@ on:
           - FLAG-RECAPTCHA
           - FLAG-PARTIAL-STRAIGHTLINING
           - AUTO-EXCLUDE:SPEED_IRI
+          - AUTO-EXCLUDE:IRI2_RETURN
       study_id:
         description: 'Prolific Study ID (defaults to PROLIFIC_STUDY_ID env var)'
         required: false

--- a/scripts/message-flagged-submissions.ts
+++ b/scripts/message-flagged-submissions.ts
@@ -35,6 +35,7 @@ const VALID_DISPOSITIONS = [
   'FLAG-RECAPTCHA',
   'FLAG-PARTIAL-STRAIGHTLINING',
   'AUTO-EXCLUDE:SPEED_IRI',
+  'AUTO-EXCLUDE:IRI2_RETURN',
 ] as const
 
 type FlagDisposition = (typeof VALID_DISPOSITIONS)[number]
@@ -131,6 +132,21 @@ function buildFlagMessage(record: Omit<FlaggedRecord, 'message'>): string {
         'We want to treat all participants fairly and appreciate your time.',
         'Please reply within 48 hours.',
       ].join(' ')
+
+    case 'AUTO-EXCLUDE:IRI2_RETURN':
+      return [
+        'Hi, thank you for participating in our Technology Adoption Barriers Survey.',
+        'After reviewing your submission, we found that 2 of 3 embedded attention check',
+        'questions were answered differently than the instructions specified.',
+        'These items are designed to confirm that respondents are reading each question carefully.',
+        'Rather than rejecting your submission (which would negatively impact your Prolific record),',
+        'we would like to offer you the option to return it voluntarily.',
+        'To return your submission, go to your Prolific Submissions page and click the',
+        'circular arrow icon next to this study to "Return and cancel reward".',
+        'If you believe you did answer the attention checks correctly and would like to discuss,',
+        'please reply to this message within 48 hours and we will review further.',
+        'We appreciate your participation and want to treat all participants fairly.',
+      ].join(' ')
   }
 }
 
@@ -153,6 +169,8 @@ function getMessageSignature(disposition: FlagDisposition): string {
       return 'showed very little variation, which our quality checks flag'
     case 'AUTO-EXCLUDE:SPEED_IRI':
       return 'What is your professional background and role'
+    case 'AUTO-EXCLUDE:IRI2_RETURN':
+      return 'offer you the option to return it voluntarily'
   }
 }
 
@@ -263,6 +281,10 @@ async function main() {
       const iriFail = parseInt(fields[iriFailIdx] ?? '0', 10)
       const speed = parseInt(fields[speedIdx] ?? '0', 10)
       matches = disposition === 'AUTO-EXCLUDE' && speed === 1 && iriFail === 1
+    } else if (dispositionFilter === 'AUTO-EXCLUDE:IRI2_RETURN') {
+      const iriFail = parseInt(fields[iriFailIdx] ?? '0', 10)
+      const speed = parseInt(fields[speedIdx] ?? '0', 10)
+      matches = disposition === 'AUTO-EXCLUDE' && iriFail === 2 && speed === 0
     } else {
       matches = disposition === dispositionFilter
     }

--- a/scripts/unreject-submissions.ts
+++ b/scripts/unreject-submissions.ts
@@ -1,0 +1,100 @@
+/**
+ * Unreject previously rejected submissions (transition REJECTED → AWAITING REVIEW).
+ *
+ * Used when a rejection should be reversed so the participant can be offered
+ * a voluntary return instead.
+ *
+ * Environment:
+ *   PROLIFIC_API_TOKEN  – Prolific API token (required)
+ *   STUDY_ID            – Prolific study ID (required)
+ *   PID_LIST            – Comma-separated PIDs to unreject (required)
+ *   DRY_RUN             – When "false", unreject live (default: true)
+ */
+
+import { getCurrentUser, listStudySubmissions, unrejectSubmission } from '../src/lib/prolific-api'
+
+async function main() {
+  const token = process.env.PROLIFIC_API_TOKEN
+  if (!token) {
+    console.error('PROLIFIC_API_TOKEN required')
+    process.exit(1)
+  }
+  const studyId = process.env.STUDY_ID
+  if (!studyId) {
+    console.error('STUDY_ID required')
+    process.exit(1)
+  }
+  const pidListRaw = process.env.PID_LIST
+  if (!pidListRaw) {
+    console.error('PID_LIST required')
+    process.exit(1)
+  }
+  const dryRun = (process.env.DRY_RUN ?? 'true').toLowerCase() !== 'false'
+
+  const pids = pidListRaw
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean)
+
+  console.log('================================================================')
+  console.log('  Unreject Submissions (REJECTED → AWAITING REVIEW)')
+  console.log(`  Study: ${studyId}`)
+  console.log(`  PIDs: ${pids.length}`)
+  console.log(`  Mode: ${dryRun ? 'DRY RUN' : 'LIVE'}`)
+  console.log('================================================================')
+  console.log('')
+
+  const user = await getCurrentUser(token)
+  console.log(`Connected as: ${user.name} (${user.email})`)
+  console.log('')
+
+  // Look up submission IDs
+  const subs = await listStudySubmissions(studyId, token)
+  const pidToSub = new Map<string, { id: string; status: string }>()
+  for (const s of subs.results || []) {
+    pidToSub.set(s.participant_id, { id: s.id, status: s.status })
+  }
+
+  let unrejected = 0
+  let skipped = 0
+  let notFound = 0
+  let failed = 0
+
+  for (const pid of pids) {
+    const sub = pidToSub.get(pid)
+    if (!sub) {
+      console.log(`  NOT FOUND: ${pid}`)
+      notFound++
+      continue
+    }
+    if (sub.status !== 'REJECTED') {
+      console.log(`  SKIP: ${pid} — status is ${sub.status} (not REJECTED)`)
+      skipped++
+      continue
+    }
+
+    if (dryRun) {
+      console.log(`  DRY RUN: would unreject ${pid} (submission ${sub.id})`)
+      unrejected++
+    } else {
+      try {
+        await unrejectSubmission(sub.id, token)
+        unrejected++
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error)
+        console.error(`  FAILED: ${pid} — ${msg}`)
+        failed++
+      }
+    }
+  }
+
+  console.log('')
+  console.log(
+    `UNREJECTED: ${unrejected} | SKIPPED: ${skipped} | NOT FOUND: ${notFound} | FAILED: ${failed}`
+  )
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/lib/prolific-api.ts
+++ b/src/lib/prolific-api.ts
@@ -615,6 +615,62 @@ export async function rejectSubmission(
 }
 
 /**
+ * Unreject a previously rejected submission.
+ * Transitions the submission from REJECTED back to AWAITING REVIEW.
+ *
+ * POST /api/v1/submissions/{submissionId}/transition/
+ * Body: { "action": "UNREJECT" }
+ *
+ * @see https://docs.prolific.com/api-reference/submissions/transition-submission
+ */
+export async function unrejectSubmission(submissionId: string, apiToken: string): Promise<void> {
+  const url = `${PROLIFIC_API_BASE_URL}/submissions/${submissionId}/transition/`
+
+  const headers = new Headers()
+  headers.set('Authorization', `Token ${apiToken}`)
+  headers.set('Content-Type', 'application/json')
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ action: 'UNREJECT' }),
+    })
+  } catch (error) {
+    throw new ProlificApiErrorClass(
+      `Network error during unreject: ${error instanceof Error ? error.message : String(error)}`,
+      0,
+      {}
+    )
+  }
+
+  if (!response.ok) {
+    let errorData: ProlificApiError = {}
+    try {
+      errorData = (await response.json()) as ProlificApiError
+    } catch {
+      // Empty or non-JSON error body
+    }
+    throw new ProlificApiErrorClass(
+      errorData.detail ||
+        errorData.error ||
+        errorData.message ||
+        `Unreject submission ${submissionId} failed with status ${response.status}`,
+      response.status,
+      errorData
+    )
+  }
+
+  try {
+    await response.text()
+  } catch {
+    // drain
+  }
+  console.log(`  Unrejected ${submissionId}`)
+}
+
+/**
  * DESTRUCTIVE: Bulk reject submissions for a study by participant IDs.
  *
  * WARNING: Rejected participants will NOT be paid for their submission.


### PR DESCRIPTION
Adds AUTO-EXCLUDE:SPEED_IRI as a new messaging option. These are participants who completed under 5 min with 1 IRI failure — borderline cases that deserve inquiry before rejection. Message asks for background, survey thoughts, and speed explanation.