### PR TITLE
fix: skip messaging for already-actioned submissions

### DIFF
--- a/scripts/message-flagged-submissions.ts
+++ b/scripts/message-flagged-submissions.ts
@@ -19,7 +19,12 @@
  *                           Supports: single PID, comma-separated batch, or empty for all
  */
 
-import { getCurrentUser, sendMessage, listUserMessages } from '../src/lib/prolific-api'
+import {
+  getCurrentUser,
+  sendMessage,
+  listUserMessages,
+  listStudySubmissions,
+} from '../src/lib/prolific-api'
 import { appendGithubStepSummary, mdEscape } from '../src/lib/github-utils'
 import { readFileSync } from 'node:fs'
 import { parseCsvLine } from '../src/lib/disposition'
@@ -349,12 +354,22 @@ async function main() {
     console.log('')
   }
 
-  /* ---------- Verify API connection ---------------------------------- */
+  /* ---------- Verify API connection + fetch submission statuses -------- */
 
   console.log('Verifying Prolific API connection...')
   const user = await getCurrentUser(apiToken)
   console.log(`Connected as: ${user.name} (${user.email})`)
+
+  console.log('Fetching submission statuses from Prolific...')
+  const submissions = await listStudySubmissions(studyId, apiToken)
+  const statusMap = new Map<string, string>()
+  for (const s of submissions.results || []) {
+    statusMap.set(s.participant_id, s.status)
+  }
+  console.log(`Loaded ${statusMap.size} submission statuses`)
   console.log('')
+
+  const SKIP_STATUSES = new Set(['APPROVED', 'REJECTED', 'RETURNED', 'TIMED-OUT'])
 
   /* ---------- Execute or dry run ------------------------------------- */
 
@@ -377,9 +392,18 @@ async function main() {
     let sent = 0
     let failed = 0
     let skippedAlreadyMessaged = 0
+    let skippedAlreadyActioned = 0
 
     for (const r of filtered) {
       try {
+        // Check if submission is already actioned (approved/rejected/returned/timed-out)
+        const submissionStatus = statusMap.get(r.pid)
+        if (submissionStatus && SKIP_STATUSES.has(submissionStatus)) {
+          skippedAlreadyActioned++
+          console.log(`  SKIPPED ${r.pid} — submission already ${submissionStatus}`)
+          continue
+        }
+
         // Check if participant already received this same message
         const existingMsgs = await listUserMessages(r.pid, apiToken)
         const studyMessages = (existingMsgs.results || []).filter(
@@ -416,7 +440,7 @@ async function main() {
 
     console.log('')
     console.log(
-      `SENT: ${sent} | SKIPPED (already messaged): ${skippedAlreadyMessaged} | FAILED: ${failed}`
+      `SENT: ${sent} | SKIPPED (already actioned): ${skippedAlreadyActioned} | SKIPPED (already messaged): ${skippedAlreadyMessaged} | FAILED: ${failed}`
     )
   }
 

--- a/scripts/send-thank-you-message.ts
+++ b/scripts/send-thank-you-message.ts
@@ -8,7 +8,7 @@
  *   DRY_RUN             – When "false", send messages live (default: true)
  */
 
-import { sendMessage, listUserMessages } from '../src/lib/prolific-api'
+import { sendMessage, listUserMessages, listStudySubmissions } from '../src/lib/prolific-api'
 
 const THANK_YOU_MESSAGE =
   'Hi, thank you for participating in our Technology Adoption Barriers Survey and for taking the time to respond to our review message. Your submission has been approved. We appreciate your thoughtful engagement and the insights you shared — they are valuable to our research. Thank you again for your contribution!'
@@ -41,12 +41,31 @@ async function main() {
   console.log(`Mode: ${dryRun ? 'DRY RUN' : 'LIVE'}`)
   console.log('')
 
+  // Fetch submission statuses to skip non-approved participants
+  console.log('Fetching submission statuses...')
+  const submissions = await listStudySubmissions(studyId, token)
+  const statusMap = new Map<string, string>()
+  for (const s of submissions.results || []) {
+    statusMap.set(s.participant_id, s.status)
+  }
+  console.log(`Loaded ${statusMap.size} statuses`)
+  console.log('')
+
   let sent = 0
   let skipped = 0
+  let skippedNotApproved = 0
   let failed = 0
 
   for (const pid of pids) {
     try {
+      // Only send thank-you to APPROVED submissions
+      const status = statusMap.get(pid)
+      if (status && status !== 'APPROVED') {
+        skippedNotApproved++
+        console.log(`  SKIP ${pid} — status is ${status} (not APPROVED)`)
+        continue
+      }
+
       // Check for existing thank-you message
       const existing = await listUserMessages(pid, token)
       const alreadySent = (existing.results || []).some(
@@ -74,7 +93,9 @@ async function main() {
   }
 
   console.log('')
-  console.log(`SENT: ${sent} | SKIPPED: ${skipped} | FAILED: ${failed}`)
+  console.log(
+    `SENT: ${sent} | SKIPPED (not approved): ${skippedNotApproved} | SKIPPED (already sent): ${skipped} | FAILED: ${failed}`
+  )
 }
 
 main().catch((e) => {


### PR DESCRIPTION
Prevents sending automated messages to participants whose submissions are already APPROVED, REJECTED, RETURNED, or TIMED-OUT. Both message-flagged-submissions.ts and send-thank-you-message.ts now check live Prolific status before sending.