### PR TITLE
fix: live per-PID status check before each message send

### DIFF
--- a/scripts/message-flagged-submissions.ts
+++ b/scripts/message-flagged-submissions.ts
@@ -24,6 +24,7 @@ import {
   sendMessage,
   listUserMessages,
   listStudySubmissions,
+  getSubmission,
 } from '../src/lib/prolific-api'
 import { appendGithubStepSummary, mdEscape } from '../src/lib/github-utils'
 import { readFileSync } from 'node:fs'
@@ -426,19 +427,19 @@ async function main() {
     console.log('')
   }
 
-  /* ---------- Verify API connection + fetch submission statuses -------- */
+  /* ---------- Verify API connection + build submission ID map ---------- */
 
   console.log('Verifying Prolific API connection...')
   const user = await getCurrentUser(apiToken)
   console.log(`Connected as: ${user.name} (${user.email})`)
 
-  console.log('Fetching submission statuses from Prolific...')
+  console.log('Fetching submission IDs from Prolific...')
   const submissions = await listStudySubmissions(studyId, apiToken)
-  const statusMap = new Map<string, string>()
+  const pidToSubId = new Map<string, string>()
   for (const s of submissions.results || []) {
-    statusMap.set(s.participant_id, s.status)
+    pidToSubId.set(s.participant_id, s.id)
   }
-  console.log(`Loaded ${statusMap.size} submission statuses`)
+  console.log(`Loaded ${pidToSubId.size} submissions`)
   console.log('')
 
   const SKIP_STATUSES = new Set(['APPROVED', 'REJECTED', 'RETURNED', 'TIMED-OUT'])
@@ -468,12 +469,15 @@ async function main() {
 
     for (const r of filtered) {
       try {
-        // Check if submission is already actioned (approved/rejected/returned/timed-out)
-        const submissionStatus = statusMap.get(r.pid)
-        if (submissionStatus && SKIP_STATUSES.has(submissionStatus)) {
-          skippedAlreadyActioned++
-          console.log(`  SKIPPED ${r.pid} — submission already ${submissionStatus}`)
-          continue
+        // Fresh per-PID status check right before sending (not cached — avoids race conditions)
+        const subId = pidToSubId.get(r.pid)
+        if (subId) {
+          const freshSub = await getSubmission(studyId, subId, apiToken)
+          if (SKIP_STATUSES.has(freshSub.status)) {
+            skippedAlreadyActioned++
+            console.log(`  SKIPPED ${r.pid} — submission is ${freshSub.status} (live check)`)
+            continue
+          }
         }
 
         // Check if participant already received this same message

--- a/scripts/send-thank-you-message.ts
+++ b/scripts/send-thank-you-message.ts
@@ -8,7 +8,12 @@
  *   DRY_RUN             – When "false", send messages live (default: true)
  */
 
-import { sendMessage, listUserMessages, listStudySubmissions } from '../src/lib/prolific-api'
+import {
+  sendMessage,
+  listUserMessages,
+  listStudySubmissions,
+  getSubmission,
+} from '../src/lib/prolific-api'
 
 const THANK_YOU_MESSAGE =
   'Hi, thank you for participating in our Technology Adoption Barriers Survey and for taking the time to respond to our review message. Your submission has been approved. We appreciate your thoughtful engagement and the insights you shared — they are valuable to our research. Thank you again for your contribution!'
@@ -41,14 +46,14 @@ async function main() {
   console.log(`Mode: ${dryRun ? 'DRY RUN' : 'LIVE'}`)
   console.log('')
 
-  // Fetch submission statuses to skip non-approved participants
-  console.log('Fetching submission statuses...')
+  // Build PID → submission ID map for per-PID live status checks
+  console.log('Fetching submission IDs...')
   const submissions = await listStudySubmissions(studyId, token)
-  const statusMap = new Map<string, string>()
+  const pidToSubId = new Map<string, string>()
   for (const s of submissions.results || []) {
-    statusMap.set(s.participant_id, s.status)
+    pidToSubId.set(s.participant_id, s.id)
   }
-  console.log(`Loaded ${statusMap.size} statuses`)
+  console.log(`Loaded ${pidToSubId.size} submissions`)
   console.log('')
 
   let sent = 0
@@ -58,12 +63,15 @@ async function main() {
 
   for (const pid of pids) {
     try {
-      // Only send thank-you to APPROVED submissions
-      const status = statusMap.get(pid)
-      if (status && status !== 'APPROVED') {
-        skippedNotApproved++
-        console.log(`  SKIP ${pid} — status is ${status} (not APPROVED)`)
-        continue
+      // Fresh per-PID status check right before sending (not cached)
+      const subId = pidToSubId.get(pid)
+      if (subId) {
+        const freshSub = await getSubmission(studyId, subId, token)
+        if (freshSub.status !== 'APPROVED') {
+          skippedNotApproved++
+          console.log(`  SKIP ${pid} — status is ${freshSub.status} (not APPROVED, live check)`)
+          continue
+        }
       }
 
       // Check for existing thank-you message


### PR DESCRIPTION
Replaces cached status map with fresh getSubmission() call per participant right before sending. Prevents race conditions where participants are approved/returned during a messaging run. Ensures RETURNED participants are never re-messaged.