### PR TITLE
fix: revert broken per-PID status check to batch fetch

### DIFF
--- a/scripts/message-flagged-submissions.ts
+++ b/scripts/message-flagged-submissions.ts
@@ -24,7 +24,6 @@ import {
   sendMessage,
   listUserMessages,
   listStudySubmissions,
-  getSubmission,
 } from '../src/lib/prolific-api'
 import { appendGithubStepSummary, mdEscape } from '../src/lib/github-utils'
 import { readFileSync } from 'node:fs'
@@ -487,15 +486,6 @@ async function main() {
   const user = await getCurrentUser(apiToken)
   console.log(`Connected as: ${user.name} (${user.email})`)
 
-  console.log('Fetching submission IDs from Prolific...')
-  const submissions = await listStudySubmissions(studyId, apiToken)
-  const pidToSubId = new Map<string, string>()
-  for (const s of submissions.results || []) {
-    pidToSubId.set(s.participant_id, s.id)
-  }
-  console.log(`Loaded ${pidToSubId.size} submissions`)
-  console.log('')
-
   const SKIP_STATUSES = new Set(['APPROVED', 'REJECTED', 'RETURNED', 'TIMED-OUT'])
 
   /* ---------- Execute or dry run ------------------------------------- */
@@ -516,6 +506,16 @@ async function main() {
     console.log('================================================================')
     console.log('')
 
+    // Fetch fresh submission statuses right before sending (minimizes race window)
+    console.log('Fetching fresh submission statuses...')
+    const freshSubs = await listStudySubmissions(studyId, apiToken)
+    const statusMap = new Map<string, string>()
+    for (const s of freshSubs.results || []) {
+      statusMap.set(s.participant_id, s.status)
+    }
+    console.log(`Loaded ${statusMap.size} statuses`)
+    console.log('')
+
     let sent = 0
     let failed = 0
     let skippedAlreadyMessaged = 0
@@ -523,15 +523,12 @@ async function main() {
 
     for (const r of filtered) {
       try {
-        // Fresh per-PID status check right before sending (not cached — avoids race conditions)
-        const subId = pidToSubId.get(r.pid)
-        if (subId) {
-          const freshSub = await getSubmission(studyId, subId, apiToken)
-          if (SKIP_STATUSES.has(freshSub.status)) {
-            skippedAlreadyActioned++
-            console.log(`  SKIPPED ${r.pid} — submission is ${freshSub.status} (live check)`)
-            continue
-          }
+        // Check submission status (fresh batch fetched right before this loop)
+        const submissionStatus = statusMap.get(r.pid)
+        if (submissionStatus && SKIP_STATUSES.has(submissionStatus)) {
+          skippedAlreadyActioned++
+          console.log(`  SKIPPED ${r.pid} — submission is ${submissionStatus}`)
+          continue
         }
 
         // Check if participant already received this same message

--- a/scripts/send-thank-you-message.ts
+++ b/scripts/send-thank-you-message.ts
@@ -8,12 +8,7 @@
  *   DRY_RUN             – When "false", send messages live (default: true)
  */
 
-import {
-  sendMessage,
-  listUserMessages,
-  listStudySubmissions,
-  getSubmission,
-} from '../src/lib/prolific-api'
+import { sendMessage, listUserMessages, listStudySubmissions } from '../src/lib/prolific-api'
 
 const THANK_YOU_MESSAGE =
   'Hi, thank you for participating in our Technology Adoption Barriers Survey and for taking the time to respond to our review message. Your submission has been approved. We appreciate your thoughtful engagement and the insights you shared — they are valuable to our research. Thank you again for your contribution!'
@@ -46,14 +41,14 @@ async function main() {
   console.log(`Mode: ${dryRun ? 'DRY RUN' : 'LIVE'}`)
   console.log('')
 
-  // Build PID → submission ID map for per-PID live status checks
-  console.log('Fetching submission IDs...')
+  // Fetch fresh submission statuses right before sending
+  console.log('Fetching submission statuses...')
   const submissions = await listStudySubmissions(studyId, token)
-  const pidToSubId = new Map<string, string>()
+  const statusMap = new Map<string, string>()
   for (const s of submissions.results || []) {
-    pidToSubId.set(s.participant_id, s.id)
+    statusMap.set(s.participant_id, s.status)
   }
-  console.log(`Loaded ${pidToSubId.size} submissions`)
+  console.log(`Loaded ${statusMap.size} statuses`)
   console.log('')
 
   let sent = 0
@@ -63,15 +58,12 @@ async function main() {
 
   for (const pid of pids) {
     try {
-      // Fresh per-PID status check right before sending (not cached)
-      const subId = pidToSubId.get(pid)
-      if (subId) {
-        const freshSub = await getSubmission(studyId, subId, token)
-        if (freshSub.status !== 'APPROVED') {
-          skippedNotApproved++
-          console.log(`  SKIP ${pid} — status is ${freshSub.status} (not APPROVED, live check)`)
-          continue
-        }
+      // Only send thank-you to APPROVED submissions
+      const status = statusMap.get(pid)
+      if (status && status !== 'APPROVED') {
+        skippedNotApproved++
+        console.log(`  SKIP ${pid} — status is ${status} (not APPROVED)`)
+        continue
       }
 
       // Check for existing thank-you message


### PR DESCRIPTION
getSubmission(studyId, subId) returns 404 for all PIDs. Reverted to batch listStudySubmissions fetched right before the send loop. Status guard still works.