### PR TITLE
style: format find-url-reply.ts with prettier

### DIFF
--- a/scripts/find-url-reply.ts
+++ b/scripts/find-url-reply.ts
@@ -7,31 +7,40 @@ async function main() {
   const studyId = process.env.STUDY_ID!
 
   const subs = await listStudySubmissions(studyId, token)
-  
+
   for (const sub of subs.results || []) {
     try {
       const resp = await fetch(
         'https://api.prolific.com/api/v1/messages/?user_id=' + sub.participant_id,
-        { headers: { 'Authorization': 'Token ' + token } }
+        { headers: { Authorization: 'Token ' + token } }
       )
       if (!resp.ok) continue
-      const data = await resp.json() as any
+      const data = (await resp.json()) as any
       const msgs = data.results || []
-      
+
       // Check if any researcher message contains the URL
-      const hasUrl = msgs.some((m: any) => 
-        m.sender_id === RESEARCHER_ID && 
-        m.body && 
-        m.body.includes('technologyadoptionbarriers.org')
+      const hasUrl = msgs.some(
+        (m: any) =>
+          m.sender_id === RESEARCHER_ID &&
+          m.body &&
+          m.body.includes('technologyadoptionbarriers.org')
       )
       if (!hasUrl) continue
-      
+
       // Check if participant replied AFTER the URL message
       const participantMsgs = msgs.filter((m: any) => m.sender_id !== RESEARCHER_ID)
       if (participantMsgs.length === 0) continue
-      
+
       // Show participants who replied after getting URL
-      console.log('=== ' + sub.participant_id + ' | ' + sub.status + ' | ' + ((sub.time_taken || 0) / 60).toFixed(1) + ' min ===')
+      console.log(
+        '=== ' +
+          sub.participant_id +
+          ' | ' +
+          sub.status +
+          ' | ' +
+          ((sub.time_taken || 0) / 60).toFixed(1) +
+          ' min ==='
+      )
       for (const m of participantMsgs) {
         console.log('  [PARTICIPANT] ' + (m.body || '').substring(0, 250))
       }
@@ -39,4 +48,7 @@ async function main() {
     } catch {}
   }
 }
-main().catch(e => { console.error(e); process.exit(1) })
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Formats `scripts/find-url-reply.ts` with Prettier to fix CI formatting check failures
- This file was committed to main without formatting, causing all open Dependabot PRs to fail the `format:check` CI step

## Test plan
- [x] `npm run format:check` passes
- [x] `npm test` passes (336/336)

https://claude.ai/code/session_01HMkyBty6EHFZMW21ttfqZ5