### PR TITLE
fix: sanitize artifact name for AUTO-EXCLUDE dispositions

### DIFF
--- a/.github/workflows/daily-disposition-processing.yml
+++ b/.github/workflows/daily-disposition-processing.yml
@@ -157,10 +157,15 @@ jobs:
 
       # Note: message-output.txt contains PIDs for operational debugging.
       # Artifact has 1-day retention; same data appears in workflow logs.
+      - name: Sanitize artifact name
+        if: always()
+        run: echo "ARTIFACT_NAME=message-metrics-${DISPOSITION_FILTER//:/-}" >> "$GITHUB_ENV"
+        env:
+          DISPOSITION_FILTER: ${{ matrix.disposition }}
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: message-metrics-${{ matrix.disposition }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ runner.temp }}/message-output.txt
           retention-days: 1
 


### PR DESCRIPTION
## Summary

- `upload-artifact@v7` rejects colons (`:`) in artifact names
- AUTO-EXCLUDE dispositions like `AUTO-EXCLUDE:IRI3_SPEED_RETURN` contain colons
- Adds a shell step to replace `:` with `-` before uploading

Found during first live test of the daily automation workflow (#614).

## Test plan

- [ ] Re-run Daily Disposition Processing workflow and verify all 9 matrix jobs pass
- [ ] Verify daily report issue is created with all disposition rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)