### PR TITLE
fix: log anomaly when AUTO-EXCLUDE is APPROVED

### DIFF
--- a/scripts/generate-disposition-summary.ts
+++ b/scripts/generate-disposition-summary.ts
@@ -146,6 +146,11 @@ async function main() {
     dispositionByStatus[disposition][prolificStatus] =
       (dispositionByStatus[disposition][prolificStatus] || 0) + 1
 
+    // Flag anomalies: AUTO-EXCLUDE should never be APPROVED
+    if (disposition === 'AUTO-EXCLUDE' && prolificStatus === 'APPROVED') {
+      console.warn(`⚠️  ANOMALY: AUTO-EXCLUDE PID ${pid} is APPROVED on Prolific`)
+    }
+
     // IRI pass rates
     if (iriBarrierIdx >= 0) iriBarrierPass += parseInt(fields[iriBarrierIdx] ?? '0', 10) || 0
     if (iriReadinessIdx >= 0) iriReadinessPass += parseInt(fields[iriReadinessIdx] ?? '0', 10) || 0


### PR DESCRIPTION
## Summary

Adds a warning log when an AUTO-EXCLUDE participant has APPROVED status on Prolific, which should never happen through normal automation (AUTO-EXCLUDE participants are either rejected or offered a return).

Found 1 such anomaly in the current data — this will help identify the PID in the next workflow run.

## Test plan

- [ ] Run Daily Disposition Processing and check logs for the anomaly warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)