### PR TITLE
fix: harden daily automation reliability

### DIFF
--- a/.github/workflows/daily-disposition-processing.yml
+++ b/.github/workflows/daily-disposition-processing.yml
@@ -15,6 +15,10 @@ on:
     - cron: '0 10 * * *' # Daily at 10:00 UTC (6am ET)
   workflow_dispatch:
 
+concurrency:
+  group: daily-disposition-processing
+  cancel-in-progress: false # Let the current run finish; queue the next one
+
 permissions:
   contents: write
   pull-requests: write
@@ -120,6 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: prolific-prod
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         disposition:
@@ -232,6 +237,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Fetch latest main so PREV_FILE has the most recent committed data
+          ref: main
 
       - uses: actions/download-artifact@v8
         with:

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -229,11 +229,28 @@ $RECONCILIATION_TABLE
 "
 fi
 
-# --- Build report ---
-if [ "$HAS_DASHBOARD" = true ]; then
-  DASHBOARD_NOTE=""
-else
-  DASHBOARD_NOTE="> **Note:** Dashboard data was unavailable; Prolific status counts and deltas may be incomplete.
+# --- Build warnings for upstream failures ---
+WARNINGS=""
+if [ "${TRIAGE_RESULT:-}" = "failure" ]; then
+  WARNINGS="$WARNINGS
+> ⚠️ **Export & Triage failed** — triage counts may be stale."
+fi
+if [ "${APPROVE_RESULT_STATUS:-}" = "failure" ]; then
+  WARNINGS="$WARNINGS
+> ⚠️ **Auto-Approve failed** — CLEAN submissions may not have been approved."
+fi
+if [ "${MESSAGE_RESULT:-}" = "failure" ]; then
+  WARNINGS="$WARNINGS
+> ⚠️ **Messaging failed** — some FLAG participants may not have been contacted."
+fi
+if [ "${DASHBOARD_RESULT:-}" = "failure" ] || [ "$HAS_DASHBOARD" = false ]; then
+  WARNINGS="$WARNINGS
+> ⚠️ **Dashboard data unavailable** — Prolific status counts and deltas may be incomplete."
+fi
+
+DASHBOARD_NOTE=""
+if [ -n "$WARNINGS" ]; then
+  DASHBOARD_NOTE="$WARNINGS
 "
 fi
 


### PR DESCRIPTION
## Summary

Fixes 4 reliability gaps identified in the daily disposition automation:

1. **Concurrency control** — Adds `concurrency` group to prevent overlapping runs from corrupting PRs/data
2. **fail-fast: false** — One failing message disposition no longer cancels the rest
3. **Fresh PREV_FILE** — Checkout `main` HEAD (not workflow ref) so deltas use the latest committed data
4. **Upstream failure warnings** — Report now shows ⚠️ warnings when triage/approve/message/dashboard jobs failed

## Test plan

- [ ] Run Daily Disposition Processing and verify report has no warnings (all green)
- [ ] Verify deltas compute correctly against last committed dashboard data
- [ ] Verify concurrent `workflow_dispatch` triggers queue instead of race

🤖 Generated with [Claude Code](https://claude.com/claude-code)