### PR TITLE
feat: add Prolific demographics API support

### DIFF
--- a/scripts/fetch-prolific-demographics.ts
+++ b/scripts/fetch-prolific-demographics.ts
@@ -1,0 +1,98 @@
+/**
+ * Fetch Prolific demographics for study submissions.
+ *
+ * Usage:
+ *   PROLIFIC_API_TOKEN=... STUDY_ID=... npx tsx scripts/fetch-prolific-demographics.ts
+ *   PROLIFIC_API_TOKEN=... STUDY_ID=... npx tsx scripts/fetch-prolific-demographics.ts --sample 3
+ *   PROLIFIC_API_TOKEN=... STUDY_ID=... npx tsx scripts/fetch-prolific-demographics.ts --all --output demographics.csv
+ */
+
+import {
+  listStudySubmissions,
+  getSubmissionDemographics,
+  type SubmissionDemographics,
+} from '../src/lib/prolific-api'
+import { writeFileSync } from 'node:fs'
+
+async function main() {
+  const apiToken = process.env.PROLIFIC_API_TOKEN
+  const studyId = process.env.STUDY_ID
+  if (!apiToken || !studyId) {
+    console.error('Required: PROLIFIC_API_TOKEN and STUDY_ID')
+    process.exit(1)
+  }
+
+  const args = process.argv.slice(2)
+  const sampleSize = args.includes('--sample')
+    ? parseInt(args[args.indexOf('--sample') + 1] || '3', 10)
+    : args.includes('--all')
+      ? Infinity
+      : 3
+  const outputPath = args.includes('--output') ? args[args.indexOf('--output') + 1] : null
+
+  console.log('Fetching submissions...')
+  const subs = await listStudySubmissions(studyId, apiToken)
+  console.log(`Total submissions: ${subs.results.length}`)
+
+  const toFetch = subs.results.slice(0, sampleSize)
+  console.log(`Fetching demographics for ${toFetch.length} submission(s)...\n`)
+
+  const allDemos: SubmissionDemographics[] = []
+  const allDemoKeys = new Set<string>()
+
+  for (const sub of toFetch) {
+    console.log(`--- ${sub.participant_id} (${sub.status}) ---`)
+    const demo = await getSubmissionDemographics(sub.id, apiToken)
+    if (!demo) {
+      console.log('  No demographics archived\n')
+      continue
+    }
+
+    allDemos.push(demo)
+
+    console.log(`  total_approvals: ${demo.total_approvals}`)
+    console.log('  demographics:')
+    for (const [key, value] of Object.entries(demo.demographics).sort(([a], [b]) =>
+      a.localeCompare(b)
+    )) {
+      allDemoKeys.add(key)
+      console.log(`    ${key}: ${value}`)
+    }
+    console.log()
+  }
+
+  // Summary of all demographic fields found
+  console.log('='.repeat(60))
+  console.log(`DEMOGRAPHIC FIELDS FOUND (${allDemoKeys.size} unique):`)
+  for (const key of [...allDemoKeys].sort()) {
+    console.log(`  - ${key}`)
+  }
+
+  // CSV output
+  if (outputPath && allDemos.length > 0) {
+    const demoKeys = [...allDemoKeys].sort()
+    const csvHeaders = ['participant_id', 'submission_id', 'total_approvals', ...demoKeys]
+    const csvRows = allDemos.map((d) => {
+      const row: Record<string, string> = {
+        participant_id: d.participant_id,
+        submission_id: d.submission_id,
+        total_approvals: String(d.total_approvals),
+      }
+      for (const key of demoKeys) {
+        row[key] = String(d.demographics[key] ?? '')
+      }
+      return csvHeaders.map((h) => `"${(row[h] || '').replace(/"/g, '""')}"`).join(',')
+    })
+
+    const csv = [csvHeaders.map((h) => `"${h}"`).join(','), ...csvRows].join('\n')
+    writeFileSync(outputPath, csv, 'utf-8')
+    console.log(
+      `\nCSV written: ${outputPath} (${allDemos.length} rows, ${csvHeaders.length} columns)`
+    )
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err)
+  process.exit(1)
+})

--- a/src/lib/prolific-api.ts
+++ b/src/lib/prolific-api.ts
@@ -127,6 +127,21 @@ export interface Submission {
 }
 
 /**
+ * Demographics archived at submission completion.
+ * Fields vary per participant — values are strings or DATA_EXPIRED if not answered.
+ * @see https://docs.prolific.com/api-reference/submissions/get-submission-demographics
+ */
+export interface SubmissionDemographics {
+  submission_id: string
+  participant_id: string
+  started_at: string
+  completed_at: string
+  time_taken: number
+  total_approvals: number
+  demographics: Record<string, string | number | null>
+}
+
+/**
  * Represents a participant
  */
 export interface Participant {
@@ -330,6 +345,52 @@ export async function getSubmission(
   apiToken: string
 ): Promise<Submission> {
   return makeApiRequest(`/studies/${studyId}/submissions/${submissionId}/`, apiToken)
+}
+
+/**
+ * Get demographics archived at submission completion.
+ *
+ * @param submissionId - The Prolific submission ID
+ * @param apiToken - Prolific API token
+ * @returns Promise resolving to submission demographics (or null if not found)
+ * @see https://docs.prolific.com/api-reference/submissions/get-submission-demographics
+ */
+export async function getSubmissionDemographics(
+  submissionId: string,
+  apiToken: string
+): Promise<SubmissionDemographics | null> {
+  try {
+    return await makeApiRequest<SubmissionDemographics>(
+      `/submissions/${submissionId}/demographics/`,
+      apiToken
+    )
+  } catch (error) {
+    if (error instanceof ProlificApiErrorClass && error.statusCode === 404) {
+      return null // No demographics archived for this submission
+    }
+    throw error
+  }
+}
+
+/**
+ * Fetch demographics for all submissions in a study.
+ * Makes one API call per submission — use sparingly.
+ */
+export async function getStudyDemographics(
+  studyId: string,
+  apiToken: string
+): Promise<Map<string, SubmissionDemographics>> {
+  const subs = await listStudySubmissions(studyId, apiToken)
+  const results = new Map<string, SubmissionDemographics>()
+
+  for (const sub of subs.results) {
+    const demo = await getSubmissionDemographics(sub.id, apiToken)
+    if (demo) {
+      results.set(sub.participant_id, demo)
+    }
+  }
+
+  return results
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds support for fetching Prolific pre-screening demographics via the submissions demographics endpoint.

- `getSubmissionDemographics()` — fetch demographics for a single submission
- `getStudyDemographics()` — fetch demographics for all study submissions  
- `fetch-prolific-demographics.ts` — CLI script for testing and CSV export

### API Endpoint
`GET /api/v1/submissions/{id}/demographics/`

This returns pre-screening profile data (age, sex, nationality, employment status, etc.) that Prolific collects separately from the survey responses. This data is what the "Download demographic data" button in the Prolific UI exports.

## Test plan
- [ ] Run `fetch-prolific-demographics.ts --sample 3` to verify API returns demographics
- [ ] Verify demographic field names match the Prolific UI CSV export
- [ ] Run with `--all --output demographics.csv` for full export

🤖 Generated with [Claude Code](https://claude.com/claude-code)