### PR TITLE
fix: send empty filters array in demographic export

### DIFF
--- a/src/lib/prolific-api.ts
+++ b/src/lib/prolific-api.ts
@@ -429,7 +429,7 @@ export async function exportStudyDemographics(
       Authorization: `Token ${apiToken}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({}),
+    body: JSON.stringify({ filters: [] }),
   })
 
   if (!response.ok) {


### PR DESCRIPTION
Fixes 400 error from Prolific API.