### PR TITLE
fix: use regex patterns in smoke test data markers

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -364,9 +364,13 @@ jobs:
           # Shared fetch: sets DATA_CONTENT and returns non-zero on HTTP error
           fetch_data_page() {
             local url="$1" label="$2"
-            local status
+            local status curl_exit
             DATA_CONTENT=""
-            status=$(curl -s -o /tmp/data-body -w '%{http_code}' -L --max-time 15 "$url" 2>/dev/null || echo "000")
+            status=$(curl -s -o /tmp/data-body -w '%{http_code}' -L --max-time 15 "$url" 2>/dev/null)
+            curl_exit=$?
+            if [ "$curl_exit" -ne 0 ]; then
+              status="000"
+            fi
             DATA_CONTENT=$(cat /tmp/data-body 2>/dev/null || echo "")
             if [ "$status" != "200" ]; then
               echo "| $label | ❌ HTTP $status (expected 200) |" >> /tmp/data-results.txt


### PR DESCRIPTION
## Summary\n\n- **Fix stale smoke test marker**: The reliability page check hardcoded `0.8612` which no longer exists in the data (`alpha_barriers` for `conservative_clean` is now `0.8576`)\n- **Make markers resilient to data updates**: Added a `check_data_regex()` helper that uses `grep -E` for pattern matching, replacing hardcoded values with regex patterns that survive daily pipeline runs:\n  - Reliability: `0\\.[0-9]{4}` matches any 4-decimal alpha value\n  - Descriptive: `Conservative Clean \\(N=[0-9]+` matches the sample label with any N value\n\n## Test plan\n\n- [ ] Run post-deploy smoke test via workflow_dispatch against production\n- [ ] Verify the regex patterns match rendered content on reliability and descriptive pages\n- [ ] Confirm no false positives (patterns are specific enough to only match data-derived content)\n\nhttps://claude.ai/code/session_01Y3snmesJFKAyvL7VkaKZYZ