### PR TITLE
fix: correct grep regex, add idempotent label creation, separate --label flags in build-daily-report.sh

### DIFF
--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -311,7 +311,8 @@ STATUSEOF
 # Critical if:
 # 1. Any job failed (TRIAGE, APPROVE, MESSAGE, DASHBOARD)
 # 2. Dashboard data is unavailable (HAS_DASHBOARD=false)
-# 3. Recommendations contain "Critical", "Anomaly", or "Action"
+# 3. Recommendations contain a critical-priority emoji (🔴 Critical, 🟡 Action, 🟠 Anomaly)
+#    Note: ⏳ Waiting and 🔵 Low are non-critical and do not block auto-close.
 # 4. New rejections (DELTA_REJECTED > 0)
 # 5. New returns (DELTA_RETURNED > 0)
 # 6. Total awaiting review > 0
@@ -323,23 +324,36 @@ CRITICAL_FINDINGS=false
 [ "${MESSAGE_RESULT:-}" = "failure" ] && CRITICAL_FINDINGS=true
 [ "${DASHBOARD_RESULT:-}" = "failure" ] && CRITICAL_FINDINGS=true
 [ "$HAS_DASHBOARD" = false ] && CRITICAL_FINDINGS=true
-echo "$RECOMMENDATIONS" | grep -qE "Critical|Anomaly|Action" && CRITICAL_FINDINGS=true
+echo "$RECOMMENDATIONS" | grep -qP "🔴|🟡|🟠" && CRITICAL_FINDINGS=true
 [ "$DELTA_REJECTED" -gt 0 ] && CRITICAL_FINDINGS=true
 [ "$DELTA_RETURNED" -gt 0 ] && CRITICAL_FINDINGS=true
 [ "$TODAY_AWAITING" -gt 0 ] && CRITICAL_FINDINGS=true
 [ "$TOTAL_FAILED" -gt 0 ] && CRITICAL_FINDINGS=true
 
+# --- Ensure required labels exist (idempotent) ---
+gh label create "auto-close-eligible" \
+  --color "0075ca" \
+  --description "Report with no critical findings, eligible for auto-close" \
+  --force
+gh label create "auto-closed" \
+  --color "e4e669" \
+  --description "Automatically closed after >23h with no critical findings" \
+  --force
+
 # --- Create issue ---
 TITLE="Daily Disposition Report -- $DATE"
-LABELS="documentation"
 if [ "$CRITICAL_FINDINGS" = false ]; then
-  LABELS="$LABELS,auto-close-eligible"
+  ISSUE_URL=$(gh issue create \
+    --title "$TITLE" \
+    --body-file /tmp/report-body.md \
+    --label "documentation" \
+    --label "auto-close-eligible")
+else
+  ISSUE_URL=$(gh issue create \
+    --title "$TITLE" \
+    --body-file /tmp/report-body.md \
+    --label "documentation")
 fi
-
-ISSUE_URL=$(gh issue create \
-  --title "$TITLE" \
-  --body-file /tmp/report-body.md \
-  --label "$LABELS")
 
 echo "Daily report issue created: $TITLE ($ISSUE_URL)"
 
@@ -351,7 +365,7 @@ OLD_ISSUES=$(gh issue list --label "auto-close-eligible" --state "open" --json n
 
 for ISSUE_NUM in $OLD_ISSUES; do
   echo "Auto-closing issue #$ISSUE_NUM"
-  gh issue comment "$ISSUE_NUM" --body "Auto-closing this report as it has been open for >24h with no critical findings."
+  gh issue comment "$ISSUE_NUM" --body "Auto-closing this report as it has been open for >23h with no critical findings."
   gh issue edit "$ISSUE_NUM" --add-label "auto-closed" --remove-label "auto-close-eligible"
   gh issue close "$ISSUE_NUM"
 done


### PR DESCRIPTION
Follow-up fixes for the auto-close daily disposition reports feature (#1158), addressing review comments that remained after the original PR was merged.

## Changes

1. **Fix false-positive critical detection**: `grep -qE "Critical|Anomaly|Action"` was always matching the `| Priority | Item | Recommended Action |` table header, causing every report to be treated as critical regardless of actual findings. Changed to `grep -qP "🔴|🟡|🟠"` to match only on the actual emoji priority markers used in recommendation rows.

2. **Idempotent label creation**: Added `gh label create --force` calls for `auto-close-eligible` and `auto-closed` before they are first used. This prevents the workflow from failing with a "label not found" error when the script is run in a fresh repo environment.

3. **Separate `--label` flags**: Replaced comma-separated `--label "documentation,auto-close-eligible"` with separate `--label "documentation" --label "auto-close-eligible"` flags to avoid `gh` interpreting the comma-separated string as a single label name.

4. **Consistent threshold message**: Updated the auto-close comment from ">24h" to ">23h" to match the actual 23-hour threshold used in the script.

Addresses review comments from #1158.