### PR TITLE
fix: resolve smoke test false failures (grep + emoji)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -409,8 +409,8 @@ jobs:
             local grep_status
             fetch_data_page "$url" "$label"
             [ "$FETCH_OK" -ne 0 ] && return 0
-            echo "$DATA_CONTENT" | grep -qE -- "$pattern"
-            grep_status=$?
+            grep_status=0
+            echo "$DATA_CONTENT" | grep -qE -- "$pattern" || grep_status=$?
             if [ "$grep_status" -eq 0 ]; then
               echo "| $label | ✅ Data renders |" >> /tmp/data-results.txt
             elif [ "$grep_status" -eq 1 ]; then
@@ -709,8 +709,8 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const verdictOutcome = '${{ steps.verdict.outcome }}';
             const description = verdictOutcome === 'failure'
-              ? '🚨 Production smoke test failed — site may be broken'
-              : '🚨 Smoke test workflow failed before checks ran';
+              ? 'FAIL: Production smoke test failed -- site may be broken'
+              : 'FAIL: Smoke test workflow failed before checks ran';
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- **check_data_regex grep exit**: `bash -e` + `pipefail` causes the script to exit immediately when `grep -qE` returns 1 (no match), before `grep_status=$?` can capture the code. Fix: `grep_status=0; ... || grep_status=$?`
- **Commit status 4-byte Unicode**: GitHub's `createCommitStatus` API rejects descriptions containing 4-byte Unicode characters (emoji). The 🚨 emoji caused HTTP 422 "Description doesn't accept 4-byte Unicode". Replace with ASCII text.

## Test plan
- [ ] Smoke test should pass end-to-end after deploy
- [ ] Commit status should be set successfully (no 422 error)
- [ ] `check_data_regex` should correctly report pass/fail without script abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)