### PR TITLE
fix: eliminate broken pipe errors in smoke test checks

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -395,7 +395,7 @@ jobs:
             local url="$1" marker="$2" label="$3"
             fetch_data_page "$url" "$label"
             [ "$FETCH_OK" -ne 0 ] && return 0
-            if echo "$DATA_CONTENT" | grep -F -q -- "$marker"; then
+            if grep -F -q -- "$marker" /tmp/data-body; then
               echo "| $label | ✅ Data renders |" >> /tmp/data-results.txt
             else
               echo "| $label | ❌ Missing: $marker |" >> /tmp/data-results.txt
@@ -410,7 +410,7 @@ jobs:
             fetch_data_page "$url" "$label"
             [ "$FETCH_OK" -ne 0 ] && return 0
             grep_status=0
-            echo "$DATA_CONTENT" | grep -qE -- "$pattern" || grep_status=$?
+            grep -qE -- "$pattern" /tmp/data-body || grep_status=$?
             if [ "$grep_status" -eq 0 ]; then
               echo "| $label | ✅ Data renders |" >> /tmp/data-results.txt
             elif [ "$grep_status" -eq 1 ]; then
@@ -451,9 +451,8 @@ jobs:
 
           check_content() {
             local url="$1" expected="$2" label="$3"
-            local content
-            content=$(curl -s -L --max-time 15 "$url" 2>/dev/null || echo "")
-            if echo "$content" | grep -q "$expected"; then
+            curl -s -L --max-time 15 "$url" -o /tmp/content-body 2>/dev/null || true
+            if grep -q "$expected" /tmp/content-body 2>/dev/null; then
               echo "| $label | ✅ Contains: \"$expected\" |" >> /tmp/content-results.txt
             else
               echo "| $label | ❌ Missing: \"$expected\" |" >> /tmp/content-results.txt


### PR DESCRIPTION
## Summary
- **Root cause**: `echo "$LARGE_HTML" | grep -q` under `bash -e` + `pipefail` causes SIGPIPE (exit 141) when `grep -q` exits early, killing the script before results are recorded
- **Fix**: All three check functions (`check_data_marker`, `check_data_regex`, `check_content`) now grep files directly instead of piping through echo. No pipe = no SIGPIPE.
- Also includes the previous fix: commit status emoji replaced with ASCII (GitHub API rejects 4-byte Unicode)

## Test plan
- [ ] All 4 pipeline data checks should pass (descriptive, data-quality, dashboard, reliability)
- [ ] All 8 content spot-checks should pass
- [ ] Commit status should be set without 422 error
- [ ] No "Broken pipe" warnings in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)