### PR TITLE
fix: update smoke test for RSC serialization + pipe errors

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -423,8 +423,9 @@ jobs:
           }
 
           # sensitivity-analysis.json → descriptive page renders sample labels with N values
-          # "Conservative Clean (N=<number>)" only appears when JSON data is loaded
-          check_data_regex "${SITE_URL}/results/descriptive" "Conservative Clean \(N=[0-9]+\)" "sensitivity → descriptive"
+          # Note: RSC serialization splits "Conservative Clean" and "(N=78)" across chunks,
+          # so we check for the label which only appears when JSON data is loaded.
+          check_data_marker "${SITE_URL}/results/descriptive" "Conservative Clean" "sensitivity → descriptive"
 
           # sensitivity-analysis.json → data-quality page renders sample definitions table
           check_data_marker "${SITE_URL}/results/data-quality" "Conservative Clean" "sensitivity → data-quality"


### PR DESCRIPTION
## Summary
- **Broken pipe fix**: grep files directly instead of `echo | grep -q` (SIGPIPE under pipefail)
- **RSC check fix**: Descriptive page regex `Conservative Clean \(N=[0-9]+\)` fails because React Server Components split the text across serialization chunks. Switch to simple marker check.

Follows up on #1290 (emoji fix) and #1304 (initial pipe fix).

## Test plan
- [ ] All 4 data render checks pass
- [ ] All 8 content checks pass
- [ ] No broken pipe warnings
- [ ] Commit status set successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)