### PR TITLE
feat: add CRP dataset builder with tiered quality selection

### DIFF
--- a/scripts/analysis/create_crp_dataset.py
+++ b/scripts/analysis/create_crp_dataset.py
@@ -57,7 +57,7 @@ Usage:
 
 Exit codes:
     0  Success
-    1  PII detected in output (verification failed)
+    1  PII flagged / review required (input free-text or output verification)
     2  Input / configuration error
 
 Author: Clarke Moyer, Penn State Smeal DBA
@@ -839,7 +839,8 @@ def deidentify_selected(
 ) -> int:
     """Run the full 5-step NIST de-identification on selected rows.
 
-    Returns True on success, False if PII verification fails.
+    Returns:
+        0 on success, 1 if PII verification/review fails.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     rows = rows_to_dicts(selected_rows, headers)
@@ -982,6 +983,7 @@ def main() -> int:
         "PROLIFIC_PID", "Prolific_Status", "ResponseId", "StartDate",
         "Finished", "Duration (in seconds)",
         BARRIER_IRI, READINESS_IRI, MATURITY_IRI,
+        "Auth_LLM", "Auth_Bots", "Q_RecaptchaScore", "Q_StraightliningCount",
     ]
     missing_columns = [col for col in required_columns if col not in idx]
     if missing_columns:


### PR DESCRIPTION
## Summary

- Adds `scripts/analysis/create_crp_dataset.py` (1,026 lines) — builds the final N=200 CRP public dataset from Prolific Accepted responses using three-tier quality-based selection, then applies NIST 5-step de-identification for ScholarSphere deposit
- **Tier 1**: All Conservative Clean (APPROVED + every quality gate passed)
- **Tier 2**: All Flexible Clean surplus (APPROVED + all 3 IRIs + duration >= 480s)
- **Tier 3**: Quality-ranked fill from remaining Accepted using 6-indicator composite score (0–100 pts): IRI count (35), duration (20), reCAPTCHA (15), Prolific auth (15), full straightlining (8), partial straightlining (7)
- Generates detailed selection manifest with FLAG-SPEED breakdown showing which "Speed Only" responses were selected vs excluded
- Produces 6 output files: public CSV, selection manifest, ResponseId mapping, Prolific linkage, PII report, de-identification audit log

## Design Decisions

- Auth checks (Auth_LLM, Auth_Bots) weighted equally with reCAPTCHA and straightlining at 15 pts each — all three are independent platform-level authenticity signals
- FLAG-SPEED responses (all 3 IRIs correct, dur < 300s) are eligible for Tier 3 selection and explicitly reported in the manifest
- AUTO-EXCLUDE responses (IRI fail >= 2) rank lowest and are very unlikely to make the N=200 cut
- De-identification reuses the same NIST protocol as `deidentify_tabs_data.py` but operates only on the selected N=200 subset

## Test plan

- [ ] Verify Python syntax: `python3 -c "import ast; ast.parse(open('scripts/analysis/create_crp_dataset.py').read())"`
- [ ] Run with `--dry-run` flag against enriched Qualtrics CSV to validate selection logic without writing de-identified output
- [ ] Verify selection manifest shows correct tier counts and FLAG-SPEED detail
- [ ] Confirm N=200 with expected tier breakdown (~78 + ~45 + ~77)
- [ ] Verify public CSV has no PII columns (PROLIFIC_PID, IPAddress, etc.)
- [ ] Verify all 6 output files are generated

https://claude.ai/code/session_01VPDhLAKE66gUSpvFhBcRC1