### PR TITLE
Update daily pipeline data

### DIFF
--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -4,31 +4,31 @@
       "key": "conservative_clean",
       "label": "Conservative Clean",
       "description": "Prolific APPROVED + all quality checks (IRI, duration >= 540s, reCAPTCHA, straightlining, auth)",
-      "n": 79
+      "n": 49
     },
     {
       "key": "flexible_clean",
       "label": "Flexible Clean",
       "description": "Prolific APPROVED + basic quality (all 3 IRIs + duration >= 480s)",
-      "n": 116
+      "n": 66
     },
     {
       "key": "prolific_accepted",
       "label": "Prolific Accepted",
-      "description": "Full CRP sample (including lower-quality tier 3 cases) regardless of quality checks",
-      "n": 200
+      "description": "All deduplicated V2 rows with Prolific APPROVED status",
+      "n": 119
     },
     {
       "key": "v2_finished",
-      "label": "V2 Finished",
-      "description": "All V2 responses included in this CRP dataset (completed, regardless of quality tier)",
-      "n": 200
+      "label": "All V2 Finished",
+      "description": "Finished + duration >= 120s (extreme speeders excluded)",
+      "n": 119
     },
     {
       "key": "v2_all",
-      "label": "V2 All",
-      "description": "All V2 Prolific responses in this CRP frozen dataset (all tiers, including lower-quality)",
-      "n": 200
+      "label": "All V2",
+      "description": "All V2 responses including incomplete",
+      "n": 119
     }
   ],
   "metrics": [
@@ -36,267 +36,376 @@
       "key": "barrier_mean",
       "label": "Barrier Grand Mean",
       "values": {
-        "conservative_clean": 2.8354,
-        "flexible_clean": 2.7913,
-        "prolific_accepted": 2.753,
-        "v2_finished": 2.753,
-        "v2_all": 2.753
+        "conservative_clean": 2.8289,
+        "flexible_clean": 2.8244,
+        "prolific_accepted": 2.7773,
+        "v2_finished": 2.7773,
+        "v2_all": 2.7773
       }
     },
     {
       "key": "barrier_sd",
       "label": "Barrier SD",
       "values": {
-        "conservative_clean": 0.6534,
-        "flexible_clean": 0.6625,
-        "prolific_accepted": 0.6518,
-        "v2_finished": 0.6518,
-        "v2_all": 0.6518
+        "conservative_clean": 0.5999,
+        "flexible_clean": 0.6792,
+        "prolific_accepted": 0.6595,
+        "v2_finished": 0.6595,
+        "v2_all": 0.6595
       }
     },
     {
       "key": "readiness_mean",
-      "label": "Readiness Mean",
+      "label": "Readiness Grand Mean",
       "values": {
-        "conservative_clean": 3.1532,
-        "flexible_clean": 3.1067,
-        "prolific_accepted": 3.1139,
-        "v2_finished": 3.1139,
-        "v2_all": 3.1139
+        "conservative_clean": 3.0929,
+        "flexible_clean": 3.1025,
+        "prolific_accepted": 3.1008,
+        "v2_finished": 3.1008,
+        "v2_all": 3.1008
       }
     },
     {
       "key": "readiness_sd",
       "label": "Readiness SD",
       "values": {
-        "conservative_clean": 0.6238,
-        "flexible_clean": 0.6356,
-        "prolific_accepted": 0.6485,
-        "v2_finished": 0.6485,
-        "v2_all": 0.6485
+        "conservative_clean": 0.463,
+        "flexible_clean": 0.5779,
+        "prolific_accepted": 0.6349,
+        "v2_finished": 0.6349,
+        "v2_all": 0.6349
       }
     },
     {
       "key": "maturity_mean",
-      "label": "Maturity Mean",
+      "label": "Maturity Grand Mean",
       "values": {
-        "conservative_clean": 3.1139,
-        "flexible_clean": 3.0759,
-        "prolific_accepted": 3.1079,
-        "v2_finished": 3.1079,
-        "v2_all": 3.1079
+        "conservative_clean": 3.032,
+        "flexible_clean": 3.0276,
+        "prolific_accepted": 3.0834,
+        "v2_finished": 3.0834,
+        "v2_all": 3.0834
       }
     },
     {
       "key": "maturity_sd",
       "label": "Maturity SD",
       "values": {
-        "conservative_clean": 0.6785,
-        "flexible_clean": 0.6821,
-        "prolific_accepted": 0.6725,
-        "v2_finished": 0.6725,
-        "v2_all": 0.6725
+        "conservative_clean": 0.6719,
+        "flexible_clean": 0.7635,
+        "prolific_accepted": 0.8001,
+        "v2_finished": 0.8001,
+        "v2_all": 0.8001
       }
     },
     {
       "key": "corr_br",
-      "label": "Barriers\u2013Readiness Correlation",
+      "label": "B-R Correlation",
       "values": {
-        "conservative_clean": -0.5016,
-        "flexible_clean": -0.5172,
-        "prolific_accepted": -0.3814,
-        "v2_finished": -0.3814,
-        "v2_all": -0.3814
+        "conservative_clean": -0.4013,
+        "flexible_clean": -0.5289,
+        "prolific_accepted": -0.4198,
+        "v2_finished": -0.4198,
+        "v2_all": -0.4198
       }
     },
     {
       "key": "corr_bm",
-      "label": "Barriers\u2013Maturity Correlation",
+      "label": "B-M Correlation",
       "values": {
-        "conservative_clean": -0.2451,
-        "flexible_clean": -0.3653,
-        "prolific_accepted": -0.3156,
-        "v2_finished": -0.3156,
-        "v2_all": -0.3156
+        "conservative_clean": -0.0569,
+        "flexible_clean": -0.2887,
+        "prolific_accepted": -0.2358,
+        "v2_finished": -0.2358,
+        "v2_all": -0.2358
       }
     },
     {
       "key": "corr_rm",
-      "label": "Readiness\u2013Maturity Correlation",
+      "label": "R-M Correlation",
       "values": {
-        "conservative_clean": 0.7234,
-        "flexible_clean": 0.7281,
-        "prolific_accepted": 0.7231,
-        "v2_finished": 0.7231,
-        "v2_all": 0.7231
+        "conservative_clean": 0.508,
+        "flexible_clean": 0.7003,
+        "prolific_accepted": 0.7454,
+        "v2_finished": 0.7454,
+        "v2_all": 0.7454
       }
     },
     {
       "key": "alpha_barriers",
-      "label": "Cronbach's Alpha (Barriers)",
+      "label": "Alpha Barriers",
       "values": {
-        "conservative_clean": 0.848,
-        "flexible_clean": 0.851,
-        "prolific_accepted": 0.853,
-        "v2_finished": 0.853,
-        "v2_all": 0.853
+        "conservative_clean": 0.8415,
+        "flexible_clean": 0.8749,
+        "prolific_accepted": 0.8623,
+        "v2_finished": 0.8623,
+        "v2_all": 0.8623
       }
     },
     {
       "key": "alpha_readiness",
-      "label": "Cronbach's Alpha (Readiness)",
+      "label": "Alpha Readiness",
       "values": {
-        "conservative_clean": 0.897,
-        "flexible_clean": 0.901,
-        "prolific_accepted": 0.903,
-        "v2_finished": 0.903,
-        "v2_all": 0.903
+        "conservative_clean": 0.7888,
+        "flexible_clean": 0.8879,
+        "prolific_accepted": 0.9032,
+        "v2_finished": 0.9032,
+        "v2_all": 0.9032
       }
     },
     {
       "key": "alpha_maturity",
-      "label": "Cronbach's Alpha (Maturity)",
+      "label": "Alpha Maturity",
       "values": {
-        "conservative_clean": 0.886,
-        "flexible_clean": 0.889,
-        "prolific_accepted": 0.891,
-        "v2_finished": 0.891,
-        "v2_all": 0.891
+        "conservative_clean": 0.7974,
+        "flexible_clean": 0.8613,
+        "prolific_accepted": 0.8719,
+        "v2_finished": 0.8719,
+        "v2_all": 0.8719
       }
     }
   ],
   "demographic_sources": {
-    "survey_items": [
-      "Q1_Role",
-      "Q2_DecisionAuth",
-      "Q3_Industry",
-      "Q4_OrgSize",
-      "Q5_ProfitModel",
-      "Q6_RevenueBudget",
-      "Q7_PersonalBudget",
-      "Q8_GeoScope",
-      "Q9_GeoScale",
-      "Q74_Feedback"
-    ],
-    "prolific_fields": ["age", "sex", "ethnicity", "language", "nationality", "employment_status"],
-    "prolific_prescreener": [
-      "company_size_50_249",
-      "company_size_250_999",
-      "company_size_1000_plus",
-      "occupation_c_level",
-      "occupation_vp",
-      "occupation_director",
-      "occupation_manager"
-    ]
+    "survey_demographics": {
+      "source": "Qualtrics CSV export (Q1-Q9)",
+      "type": "Organizational/role-based characteristics",
+      "fields": {
+        "Q1_Role": "Executive Role (CIO, CTO, CEO, CFO, COO, CHRO, CMO, CSO, CRO, Other)",
+        "Q2_DecisionAuth": "Decision Authority level",
+        "Q3_Industry": "Industry classification",
+        "Q4_OrgSize": "Organization Size (<100, 100-499, 500-999, 1000-4999, 5000-9999, 10000+)",
+        "Q5_ProfitModel": "Profit Model (For-Profit, Non-Profit, Government/Public Sector)",
+        "Q6_RevenueBudget": "Organizational revenue/budget range",
+        "Q7_PersonalBudget": "Personal budget responsibility",
+        "Q8_GeoScope": "Geographic scope",
+        "Q9_GeoScale": "Geographic scale"
+      },
+      "note": "Self-reported by participants within the TABS survey instrument."
+    },
+    "platform_demographics": {
+      "source": "Prolific API (POST /studies/{id}/demographic-export/)",
+      "filters_api": "GET /api/v1/filters/ (returns full catalog of available prescreener categories)",
+      "type": "Personal/sociodemographic and professional characteristics",
+      "base_fields": {
+        "age": "Participant age (range filter)",
+        "sex": "Biological sex as recorded on legal documents",
+        "ethnicity": "Ethnic background (simplified)",
+        "language": "First/primary language",
+        "country_of_residence": "Current country of residence",
+        "nationality": "Nationality",
+        "country_of_birth": "Country of birth",
+        "student_status": "Current student status",
+        "employment_status": "Employment status"
+      },
+      "prescreener_fields": {
+        "employment_sector": "Employment sector (Private, Public, Non-profit, etc.)",
+        "industry": "Industry classification",
+        "company_size": "Company/organization size",
+        "occupation": "Occupation/job title category",
+        "education_level": "Highest level of education completed",
+        "household_income": "Household income bracket",
+        "fluent_languages": "Languages spoken fluently"
+      },
+      "study_screeners": [
+        {
+          "filter_id": "current_country_of_residence",
+          "label": "Current Country of Residence",
+          "selected_values": ["United States"],
+          "base_field": true
+        },
+        {
+          "filter_id": "employment_status",
+          "label": "Employment Status",
+          "selected_values": ["Full-Time"],
+          "base_field": true
+        },
+        {
+          "filter_id": "employment_sector",
+          "label": "Employer Type",
+          "selected_values": [
+            "Employee of a for-profit company or business or of an individual, for wages, salary, or commissions",
+            "Employee of a not-for-profit, tax-exempt, or charitable organization",
+            "Local government employee (city, county, etc.)",
+            "State government employee",
+            "Federal government employee",
+            "Self-employed in own not-incorporated business, professional practice, or farm",
+            "Self-employed in own incorporated business, professional practice, or farm",
+            "Working without pay in family business or farm"
+          ],
+          "base_field": false
+        },
+        {
+          "filter_id": "company_size",
+          "label": "Company Size",
+          "selected_values": ["50-249", "250-999", "1000+"],
+          "base_field": false
+        },
+        {
+          "filter_id": "occupation",
+          "label": "Job Position",
+          "selected_values": [
+            "C-Level (e.g. CEO, CFO), Owner, Partner, President",
+            "Vice President (EVP, SVP, AVP, VP)",
+            "Director (Group Director, Sr. Director, Director)",
+            "Manager (Group Manager, Sr. Manager, Manager, Program Manager)"
+          ],
+          "base_field": false
+        }
+      ],
+      "prescreener_note": "Up to 15 prescreener filters can be selected per export.",
+      "fields": {
+        "age": "Participant age",
+        "sex": "Biological sex",
+        "ethnicity": "Ethnic background",
+        "language": "Primary/first language",
+        "country_of_residence": "Current country of residence",
+        "nationality": "Nationality",
+        "country_of_birth": "Country of birth",
+        "student_status": "Current student status",
+        "employment_status": "Employment status",
+        "employment_sector": "Employment sector (prescreener)",
+        "industry": "Industry classification (prescreener)",
+        "company_size": "Company/organization size (prescreener)",
+        "occupation": "Occupation/job title category (prescreener)",
+        "education_level": "Education level (prescreener)",
+        "household_income": "Household income (prescreener)",
+        "fluent_languages": "Fluent languages (prescreener)"
+      },
+      "cross_validation": {
+        "description": "Prolific prescreener fields overlap with Qualtrics survey demographics.",
+        "overlapping_fields": {
+          "industry": {
+            "prolific": "industry",
+            "qualtrics": "Q3_Industry"
+          },
+          "company_size": {
+            "prolific": "company_size",
+            "qualtrics": "Q4_OrgSize"
+          },
+          "employment_sector": {
+            "prolific": "employment_sector",
+            "qualtrics": "Q5_ProfitModel"
+          },
+          "occupation": {
+            "prolific": "occupation",
+            "qualtrics": "Q1_Role"
+          }
+        },
+        "use_cases": [
+          "Flag discrepancies between Prolific profile and survey responses",
+          "Balance samples using validated Prolific profile data",
+          "Augment survey demographics with additional Prolific fields"
+        ]
+      },
+      "note": "Base fields are always included in the Prolific demographic export."
+    }
   },
   "sample_details": {
     "conservative_clean": {
       "demographics": {
         "roles": {
-          "CIO": 15,
-          "Other": 13,
-          "COO": 11,
-          "CMO": 8,
-          "CEO": 7,
-          "CHRO": 7,
+          "Other": 9,
+          "COO": 7,
           "CSO": 6,
-          "CFO": 6,
-          "CTO": 4,
-          "CRO": 2
+          "CEO": 5,
+          "CIO": 5,
+          "CMO": 5,
+          "CHRO": 4,
+          "CFO": 3,
+          "CRO": 3,
+          "CTO": 2
         },
         "org_sizes": {
-          "<100": 12,
-          "100-499": 18,
-          "500-999": 9,
-          "1000-4999": 17,
-          "5000-9999": 7,
-          "10000+": 16
+          "<100": 5,
+          "100-499": 17,
+          "500-999": 4,
+          "1000-4999": 11,
+          "5000-9999": 4,
+          "10000+": 8
         },
         "profit_models": {
-          "For-Profit": 56,
-          "Non-Profit": 15,
-          "Government/Public Sector": 8
+          "For-Profit": 33,
+          "Non-Profit": 9,
+          "Government/Public Sector": 7
         },
         "tech_vs_nontech": {
-          "technical": 15,
-          "non_technical": 51,
-          "other": 13
+          "technical": 7,
+          "non_technical": 35,
+          "other": 7
         },
         "other_roles": {
-          "total": 13,
+          "total": 9,
           "categories": {
-            "Director": 6,
-            "VP / SVP": 3,
-            "Uncategorized": 2,
-            "Manager / Program Lead": 2
+            "Director": 5,
+            "Uncategorized": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 15,
-          "nontech_n": 51,
+          "tech_n": 7,
+          "nontech_n": 35,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.5714,
-              "tech_mean_ci_lower": 2.5714,
-              "tech_mean_ci_upper": 2.5714,
-              "nontech_mean": 2.9098,
-              "nontech_mean_ci_lower": 2.9098,
-              "nontech_mean_ci_upper": 2.9098,
-              "d": -0.6714,
-              "d_ci_lower": -1.1927,
-              "d_ci_upper": -0.1502
+              "tech_mean": 2.754,
+              "tech_mean_ci_lower": 2.754,
+              "tech_mean_ci_upper": 2.754,
+              "nontech_mean": 2.8812,
+              "nontech_mean_ci_lower": 2.8812,
+              "nontech_mean_ci_upper": 2.8812,
+              "d": -0.2024,
+              "d_ci_lower": -1.1845,
+              "d_ci_upper": 0.815
             },
             "readiness": {
-              "tech_mean": 3.4667,
-              "tech_mean_ci_lower": 3.4667,
-              "tech_mean_ci_upper": 3.4667,
-              "nontech_mean": 3.0098,
-              "nontech_mean_ci_lower": 3.0098,
-              "nontech_mean_ci_upper": 3.0098,
-              "d": 0.8764,
-              "d_ci_lower": 0.3331,
-              "d_ci_upper": 1.4197
+              "tech_mean": 3.1754,
+              "tech_mean_ci_lower": 3.1754,
+              "tech_mean_ci_upper": 3.1754,
+              "nontech_mean": 3.048,
+              "nontech_mean_ci_lower": 3.048,
+              "nontech_mean_ci_upper": 3.048,
+              "d": 0.2693,
+              "d_ci_lower": -0.6122,
+              "d_ci_upper": 1.247
             },
             "maturity": {
-              "tech_mean": 3.2,
-              "tech_mean_ci_lower": 3.2,
-              "tech_mean_ci_upper": 3.2,
-              "nontech_mean": 3.0588,
-              "nontech_mean_ci_lower": 3.0588,
-              "nontech_mean_ci_upper": 3.0588,
-              "d": 0.2571,
-              "d_ci_lower": -0.2666,
-              "d_ci_upper": 0.7809
+              "tech_mean": 2.9464,
+              "tech_mean_ci_lower": 2.9464,
+              "tech_mean_ci_upper": 2.9464,
+              "nontech_mean": 3.027,
+              "nontech_mean_ci_lower": 3.027,
+              "nontech_mean_ci_upper": 3.027,
+              "d": -0.1181,
+              "d_ci_lower": -1.0654,
+              "d_ci_upper": 0.8233
             }
           }
         },
         "large_vs_small": {
-          "large_n": 23,
-          "small_medium_n": 56,
+          "large_n": 12,
+          "small_medium_n": 37,
           "constructs": {
             "barriers": {
-              "large_mean": 3.0261,
-              "large_mean_ci_lower": 3.0261,
-              "large_mean_ci_upper": 3.0261,
-              "small_medium_mean": 2.743,
-              "small_medium_mean_ci_lower": 2.743,
-              "small_medium_mean_ci_upper": 2.743,
-              "d": 0.5,
-              "d_ci_lower": 0.0158,
-              "d_ci_upper": 0.9842
+              "large_mean": 3.0515,
+              "large_mean_ci_lower": 3.0515,
+              "large_mean_ci_upper": 3.0515,
+              "small_medium_mean": 2.7568,
+              "small_medium_mean_ci_lower": 2.7568,
+              "small_medium_mean_ci_upper": 2.7568,
+              "d": 0.4977,
+              "d_ci_lower": -0.1199,
+              "d_ci_upper": 1.1491
             },
             "readiness": {
-              "large_mean": 3.0217,
-              "large_mean_ci_lower": 3.0217,
-              "large_mean_ci_upper": 3.0217,
-              "small_medium_mean": 3.2234,
-              "small_medium_mean_ci_lower": 3.2234,
-              "small_medium_mean_ci_upper": 3.2234,
-              "d": -0.3542,
-              "d_ci_lower": -0.8383,
-              "d_ci_upper": 0.1299
+              "large_mean": 3.1981,
+              "large_mean_ci_lower": 3.1981,
+              "large_mean_ci_upper": 3.1981,
+              "small_medium_mean": 3.0588,
+              "small_medium_mean_ci_lower": 3.0588,
+              "small_medium_mean_ci_upper": 3.0588,
+              "d": 0.3002,
+              "d_ci_lower": -0.4669,
+              "d_ci_upper": 1.1732
             }
           }
         }
@@ -305,155 +414,161 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 15,
-            "barrier_mean": 2.5714,
-            "readiness_mean": 3.4667,
-            "maturity_mean": 3.2
+            "n": 7,
+            "barrier_mean": 2.754,
+            "readiness_mean": 3.1754,
+            "maturity_mean": 2.9464
           },
           {
             "group": "Non-Technical",
-            "n": 51,
-            "barrier_mean": 2.9098,
-            "readiness_mean": 3.0098,
-            "maturity_mean": 3.0588
+            "n": 35,
+            "barrier_mean": 2.8812,
+            "readiness_mean": 3.048,
+            "maturity_mean": 3.027
           },
           {
             "group": "Other",
-            "n": 13,
-            "barrier_mean": 2.6923,
-            "readiness_mean": 2.7538,
-            "maturity_mean": 3.0462
+            "n": 7,
+            "barrier_mean": 2.6429,
+            "readiness_mean": 3.2353,
+            "maturity_mean": 3.1429
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 30,
-            "barrier_mean": 2.7833,
-            "readiness_mean": 3.1667,
-            "maturity_mean": 3.0333
+            "n": 22,
+            "barrier_mean": 2.7626,
+            "readiness_mean": 3.123,
+            "maturity_mean": 2.9867
           },
           {
             "group": "Medium (500-4999)",
-            "n": 26,
-            "barrier_mean": 2.65,
-            "readiness_mean": 3.0846,
-            "maturity_mean": 3.1308
+            "n": 15,
+            "barrier_mean": 2.7481,
+            "readiness_mean": 2.9647,
+            "maturity_mean": 2.9012
           },
           {
             "group": "Large (5000+)",
-            "n": 23,
-            "barrier_mean": 3.0261,
-            "readiness_mean": 3.0217,
-            "maturity_mean": 3.1739
+            "n": 12,
+            "barrier_mean": 3.0515,
+            "readiness_mean": 3.1981,
+            "maturity_mean": 3.2786
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 15,
-          "nontech_n": 51,
+          "tech_n": 7,
+          "nontech_n": 35,
           "constructs": {
             "barriers": {
-              "t": -2.0484,
-              "p": 0.0499,
-              "df": 28.32,
-              "sig": true,
-              "mean_diff": -0.3384
+              "t": -0.4107,
+              "p": 0.0,
+              "df": 7.5,
+              "mean_diff_ci_lower": -0.1272,
+              "mean_diff_ci_upper": -0.1272,
+              "sig": true
             },
             "readiness": {
-              "t": 0.1996,
-              "p": 0.8435,
-              "df": 24.24,
-              "sig": false,
-              "mean_diff": 0.4569
+              "t": 0.554,
+              "p": 0.0,
+              "df": 7.57,
+              "mean_diff_ci_lower": 0.1275,
+              "mean_diff_ci_upper": 0.1275,
+              "sig": true
             },
             "maturity": {
-              "t": 1.6095,
-              "p": 0.1214,
-              "df": 22.52,
-              "sig": false,
-              "mean_diff": 0.1412
+              "t": -0.2449,
+              "p": 0.0,
+              "df": 7.61,
+              "mean_diff_ci_lower": -0.0805,
+              "mean_diff_ci_upper": -0.0805,
+              "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 23,
-          "small_medium_n": 56,
+          "large_n": 12,
+          "small_medium_n": 37,
           "constructs": {
             "barriers": {
-              "t": 1.3284,
-              "p": 0.1919,
-              "df": 38.45,
-              "sig": false,
-              "mean_diff": 0.2831
+              "t": 1.5538,
+              "p": 0.0,
+              "df": 19.9,
+              "mean_diff_ci_lower": 0.2947,
+              "mean_diff_ci_upper": 0.2947,
+              "sig": true
             },
             "readiness": {
-              "t": -1.4328,
-              "p": 0.16,
-              "df": 38.29,
-              "sig": false,
-              "mean_diff": -0.2017
+              "t": 0.7452,
+              "p": 0.0,
+              "df": 14.48,
+              "mean_diff_ci_lower": 0.1393,
+              "mean_diff_ci_upper": 0.1393,
+              "sig": true
             },
             "maturity": {
-              "t": 0.5405,
-              "p": 0.5921,
-              "df": 36.98,
-              "sig": false,
-              "mean_diff": 0.1406
+              "t": 1.3633,
+              "p": 0.0,
+              "df": 16.52,
+              "mean_diff_ci_lower": 0.3265,
+              "mean_diff_ci_upper": 0.3265,
+              "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [15, 51, 13],
+          "group_ns": [7, 35, 7],
           "constructs": {
             "barriers": {
-              "f": 0.4926,
-              "p": 0.613,
+              "f": 0.5134,
+              "p": 0.6018,
               "df_between": 2,
-              "df_within": 76,
+              "df_within": 46,
               "sig": false
             },
             "readiness": {
-              "f": 2.2525,
-              "p": 0.1121,
+              "f": 0.597,
+              "p": 0.5547,
               "df_between": 2,
-              "df_within": 76,
+              "df_within": 46,
               "sig": false
             },
             "maturity": {
-              "f": 0.2401,
-              "p": 0.7871,
+              "f": 0.1476,
+              "p": 0.8632,
               "df_between": 2,
-              "df_within": 76,
+              "df_within": 46,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [30, 26, 23],
+          "group_ns": [22, 15, 12],
           "constructs": {
             "barriers": {
-              "f": 2.3884,
-              "p": 0.0986,
+              "f": 1.101,
+              "p": 0.3411,
               "df_between": 2,
-              "df_within": 76,
+              "df_within": 46,
               "sig": false
             },
             "readiness": {
-              "f": 0.0213,
-              "p": 0.979,
+              "f": 0.9284,
+              "p": 0.4025,
               "df_between": 2,
-              "df_within": 76,
+              "df_within": 46,
               "sig": false
             },
             "maturity": {
-              "f": 1.5696,
-              "p": 0.2148,
+              "f": 1.1492,
+              "p": 0.3258,
               "df_between": 2,
-              "df_within": 76,
+              "df_within": 46,
               "sig": false
             }
           }
@@ -463,111 +578,109 @@
     "flexible_clean": {
       "demographics": {
         "roles": {
-          "CIO": 22,
-          "Other": 18,
-          "COO": 14,
-          "CMO": 11,
-          "CEO": 11,
-          "CHRO": 10,
-          "CSO": 9,
-          "CFO": 8,
-          "CTO": 7,
-          "CRO": 6
+          "Other": 12,
+          "COO": 9,
+          "CIO": 9,
+          "CEO": 7,
+          "CSO": 7,
+          "CHRO": 5,
+          "CMO": 5,
+          "CTO": 4,
+          "CFO": 4,
+          "CRO": 4
         },
         "org_sizes": {
-          "<100": 16,
-          "100-499": 36,
-          "500-999": 14,
-          "1000-4999": 28,
-          "5000-9999": 7,
-          "10000+": 15
+          "<100": 9,
+          "100-499": 23,
+          "500-999": 6,
+          "1000-4999": 14,
+          "5000-9999": 5,
+          "10000+": 9
         },
         "profit_models": {
-          "For-Profit": 81,
-          "Non-Profit": 24,
-          "Government/Public Sector": 11
+          "For-Profit": 47,
+          "Non-Profit": 12,
+          "Government/Public Sector": 7
         },
         "tech_vs_nontech": {
-          "technical": 29,
-          "non_technical": 69,
-          "other": 18
+          "technical": 13,
+          "non_technical": 44,
+          "other": 9
         },
         "other_roles": {
-          "total": 18,
+          "total": 12,
           "categories": {
-            "Director": 9,
-            "Uncategorized": 3,
-            "VP / SVP": 3,
-            "Manager / Program Lead": 2,
-            "C-Suite Adjacent": 1
+            "Director": 6,
+            "Uncategorized": "<5",
+            "C-Suite Adjacent": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 29,
-          "nontech_n": 69,
+          "tech_n": 13,
+          "nontech_n": 44,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6475,
-              "tech_mean_ci_lower": 2.6475,
-              "tech_mean_ci_upper": 2.6475,
-              "nontech_mean": 2.853,
-              "nontech_mean_ci_lower": 2.853,
-              "nontech_mean_ci_upper": 2.853,
-              "d": -0.2996,
-              "d_ci_lower": -0.7294,
-              "d_ci_upper": 0.1507
+              "tech_mean": 2.5598,
+              "tech_mean_ci_lower": 2.5598,
+              "tech_mean_ci_upper": 2.5598,
+              "nontech_mean": 2.9018,
+              "nontech_mean_ci_lower": 2.9018,
+              "nontech_mean_ci_upper": 2.9018,
+              "d": -0.5023,
+              "d_ci_lower": -1.3006,
+              "d_ci_upper": 0.2014
             },
             "readiness": {
-              "tech_mean": 3.4173,
-              "tech_mean_ci_lower": 3.4173,
-              "tech_mean_ci_upper": 3.4173,
-              "nontech_mean": 2.9981,
-              "nontech_mean_ci_lower": 2.9981,
-              "nontech_mean_ci_upper": 2.9981,
-              "d": 0.6828,
-              "d_ci_lower": 0.289,
-              "d_ci_upper": 1.127
+              "tech_mean": 3.3931,
+              "tech_mean_ci_lower": 3.3931,
+              "tech_mean_ci_upper": 3.3931,
+              "nontech_mean": 3.0269,
+              "nontech_mean_ci_lower": 3.0269,
+              "nontech_mean_ci_upper": 3.0269,
+              "d": 0.6364,
+              "d_ci_lower": -0.0134,
+              "d_ci_upper": 1.377
             },
             "maturity": {
-              "tech_mean": 3.2716,
-              "tech_mean_ci_lower": 3.2716,
-              "tech_mean_ci_upper": 3.2716,
-              "nontech_mean": 3.0147,
-              "nontech_mean_ci_lower": 3.0147,
-              "nontech_mean_ci_upper": 3.0147,
-              "d": 0.3429,
-              "d_ci_lower": -0.0722,
-              "d_ci_upper": 0.7824
+              "tech_mean": 3.2212,
+              "tech_mean_ci_lower": 3.2212,
+              "tech_mean_ci_upper": 3.2212,
+              "nontech_mean": 2.993,
+              "nontech_mean_ci_lower": 2.993,
+              "nontech_mean_ci_upper": 2.993,
+              "d": 0.2981,
+              "d_ci_lower": -0.374,
+              "d_ci_upper": 0.9899
             }
           }
         },
         "large_vs_small": {
-          "large_n": 22,
-          "small_medium_n": 94,
+          "large_n": 14,
+          "small_medium_n": 52,
           "constructs": {
             "barriers": {
-              "large_mean": 3.215,
-              "large_mean_ci_lower": 3.215,
-              "large_mean_ci_upper": 3.215,
-              "small_medium_mean": 2.6894,
-              "small_medium_mean_ci_lower": 2.6894,
-              "small_medium_mean_ci_upper": 2.6894,
-              "d": 0.8335,
-              "d_ci_lower": 0.3923,
-              "d_ci_upper": 1.2812
+              "large_mean": 3.1632,
+              "large_mean_ci_lower": 3.1632,
+              "large_mean_ci_upper": 3.1632,
+              "small_medium_mean": 2.7332,
+              "small_medium_mean_ci_lower": 2.7332,
+              "small_medium_mean_ci_upper": 2.7332,
+              "d": 0.6507,
+              "d_ci_lower": 0.1216,
+              "d_ci_upper": 1.2729
             },
             "readiness": {
-              "large_mean": 2.8808,
-              "large_mean_ci_lower": 2.8808,
-              "large_mean_ci_upper": 2.8808,
-              "small_medium_mean": 3.1223,
-              "small_medium_mean_ci_lower": 3.1223,
-              "small_medium_mean_ci_upper": 3.1223,
-              "d": -0.3899,
-              "d_ci_lower": -0.8931,
-              "d_ci_upper": 0.1053
+              "large_mean": 3.0017,
+              "large_mean_ci_lower": 3.0017,
+              "large_mean_ci_upper": 3.0017,
+              "small_medium_mean": 3.1296,
+              "small_medium_mean_ci_lower": 3.1296,
+              "small_medium_mean_ci_upper": 3.1296,
+              "d": -0.2205,
+              "d_ci_lower": -0.9423,
+              "d_ci_upper": 0.4874
             }
           }
         }
@@ -576,155 +689,161 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 29,
-            "barrier_mean": 2.6475,
-            "readiness_mean": 3.4173,
-            "maturity_mean": 3.2716
+            "n": 13,
+            "barrier_mean": 2.5598,
+            "readiness_mean": 3.3931,
+            "maturity_mean": 3.2212
           },
           {
             "group": "Non-Technical",
-            "n": 69,
-            "barrier_mean": 2.853,
-            "readiness_mean": 2.9981,
-            "maturity_mean": 3.0147
+            "n": 44,
+            "barrier_mean": 2.9018,
+            "readiness_mean": 3.0269,
+            "maturity_mean": 2.993
           },
           {
             "group": "Other",
-            "n": 18,
-            "barrier_mean": 2.7721,
-            "readiness_mean": 2.8279,
-            "maturity_mean": 2.9028
+            "n": 9,
+            "barrier_mean": 2.8281,
+            "readiness_mean": 3.0523,
+            "maturity_mean": 2.9167
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 52,
-            "barrier_mean": 2.7356,
-            "readiness_mean": 3.103,
-            "maturity_mean": 3.0064
+            "n": 32,
+            "barrier_mean": 2.7522,
+            "readiness_mean": 3.1444,
+            "maturity_mean": 3.0065
           },
           {
             "group": "Medium (500-4999)",
-            "n": 42,
-            "barrier_mean": 2.6323,
-            "readiness_mean": 3.1462,
-            "maturity_mean": 3.1301
+            "n": 20,
+            "barrier_mean": 2.7028,
+            "readiness_mean": 3.1059,
+            "maturity_mean": 3.0321
           },
           {
             "group": "Large (5000+)",
-            "n": 22,
-            "barrier_mean": 3.215,
-            "readiness_mean": 2.8808,
-            "maturity_mean": 3.061
+            "n": 14,
+            "barrier_mean": 3.1632,
+            "readiness_mean": 3.0017,
+            "maturity_mean": 3.0691
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 29,
-          "nontech_n": 69,
+          "tech_n": 13,
+          "nontech_n": 44,
           "constructs": {
             "barriers": {
-              "t": -1.3216,
-              "p": 0.1923,
-              "df": 49.98,
-              "sig": false,
-              "mean_diff": -0.2055
+              "t": -1.3667,
+              "p": 0.0,
+              "df": 16.27,
+              "mean_diff_ci_lower": -0.342,
+              "mean_diff_ci_upper": -0.342,
+              "sig": true
             },
             "readiness": {
-              "t": 3.209,
-              "p": 0.0022,
-              "df": 57.59,
-              "sig": true,
-              "mean_diff": 0.4193
+              "t": 1.9113,
+              "p": 0.0,
+              "df": 18.26,
+              "mean_diff_ci_lower": 0.3662,
+              "mean_diff_ci_upper": 0.3662,
+              "sig": true
             },
             "maturity": {
-              "t": 1.5572,
-              "p": 0.1253,
-              "df": 53.25,
-              "sig": false,
-              "mean_diff": 0.2568
+              "t": 0.8846,
+              "p": 0.0,
+              "df": 17.98,
+              "mean_diff_ci_lower": 0.2281,
+              "mean_diff_ci_upper": 0.2281,
+              "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 22,
-          "small_medium_n": 94,
+          "large_n": 14,
+          "small_medium_n": 52,
           "constructs": {
             "barriers": {
-              "t": 3.8737,
-              "p": 0.0004,
-              "df": 35.69,
-              "sig": true,
-              "mean_diff": 0.5255
+              "t": 2.3187,
+              "p": 0.0,
+              "df": 22.76,
+              "mean_diff_ci_lower": 0.43,
+              "mean_diff_ci_upper": 0.43,
+              "sig": true
             },
             "readiness": {
-              "t": -1.5312,
-              "p": 0.1365,
-              "df": 29.29,
-              "sig": false,
-              "mean_diff": -0.2415
+              "t": -0.5979,
+              "p": 0.0,
+              "df": 16.59,
+              "mean_diff_ci_lower": -0.1279,
+              "mean_diff_ci_upper": -0.1279,
+              "sig": true
             },
             "maturity": {
-              "t": -0.0031,
-              "p": 0.9975,
-              "df": 27.38,
-              "sig": false,
-              "mean_diff": -0.0006
+              "t": 0.2027,
+              "p": 0.0,
+              "df": 17.96,
+              "mean_diff_ci_lower": 0.0528,
+              "mean_diff_ci_upper": 0.0528,
+              "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [29, 69, 18],
+          "group_ns": [13, 44, 9],
           "constructs": {
             "barriers": {
-              "f": 0.9941,
-              "p": 0.3733,
+              "f": 1.2834,
+              "p": 0.2842,
               "df_between": 2,
-              "df_within": 113,
+              "df_within": 63,
               "sig": false
             },
             "readiness": {
-              "f": 6.9532,
-              "p": 0.0014,
+              "f": 2.1255,
+              "p": 0.1279,
               "df_between": 2,
-              "df_within": 113,
-              "sig": true
+              "df_within": 63,
+              "sig": false
             },
             "maturity": {
-              "f": 1.6945,
-              "p": 0.1883,
+              "f": 0.5501,
+              "p": 0.5797,
               "df_between": 2,
-              "df_within": 113,
+              "df_within": 63,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [52, 42, 22],
+          "group_ns": [32, 20, 14],
           "constructs": {
             "barriers": {
-              "f": 6.4834,
-              "p": 0.0022,
+              "f": 2.3354,
+              "p": 0.1051,
               "df_between": 2,
-              "df_within": 113,
-              "sig": true
+              "df_within": 63,
+              "sig": false
             },
             "readiness": {
-              "f": 1.4009,
-              "p": 0.2506,
+              "f": 0.291,
+              "p": 0.7485,
               "df_between": 2,
-              "df_within": 113,
+              "df_within": 63,
               "sig": false
             },
             "maturity": {
-              "f": 0.3121,
-              "p": 0.7325,
+              "f": 0.0323,
+              "p": 0.9682,
               "df_between": 2,
-              "df_within": 113,
+              "df_within": 63,
               "sig": false
             }
           }
@@ -734,113 +853,110 @@
     "prolific_accepted": {
       "demographics": {
         "roles": {
-          "Other": 38,
-          "CIO": 33,
-          "COO": 22,
-          "CSO": 20,
-          "CEO": 18,
-          "CMO": 15,
-          "CHRO": 14,
-          "CTO": 14,
-          "CFO": 12,
-          "CRO": 12,
-          "Unknown": 2
+          "Other": 25,
+          "CSO": 16,
+          "CIO": 16,
+          "CEO": 14,
+          "COO": 13,
+          "CRO": 9,
+          "CHRO": 7,
+          "CTO": 7,
+          "CMO": 6,
+          "CFO": 6
         },
         "org_sizes": {
-          "<100": 33,
-          "100-499": 52,
-          "500-999": 29,
-          "1000-4999": 41,
-          "5000-9999": 18,
-          "10000+": 27
+          "<100": 24,
+          "100-499": 35,
+          "500-999": 12,
+          "1000-4999": 20,
+          "5000-9999": 12,
+          "10000+": 16
         },
         "profit_models": {
-          "For-Profit": 151,
-          "Non-Profit": 36,
-          "Government/Public Sector": 13
+          "For-Profit": 90,
+          "Non-Profit": 22,
+          "Government/Public Sector": 7
         },
         "tech_vs_nontech": {
-          "technical": 47,
-          "non_technical": 113,
-          "other": 38
+          "technical": 24,
+          "non_technical": 78,
+          "other": 17
         },
         "other_roles": {
-          "total": 38,
+          "total": 25,
           "categories": {
-            "Director": 20,
-            "VP / SVP": 6,
-            "Uncategorized": 5,
-            "Manager / Program Lead": 4,
-            "C-Suite Adjacent": 2,
-            "Owner / Founder / President": 1
+            "Director": 12,
+            "Uncategorized": "<5",
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 47,
-          "nontech_n": 113,
+          "tech_n": 24,
+          "nontech_n": 78,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7098,
-              "tech_mean_ci_lower": 2.7098,
-              "tech_mean_ci_upper": 2.7098,
-              "nontech_mean": 2.7785,
-              "nontech_mean_ci_lower": 2.7785,
-              "nontech_mean_ci_upper": 2.7785,
-              "d": -0.0965,
-              "d_ci_lower": -0.4532,
-              "d_ci_upper": 0.2681
+              "tech_mean": 2.6481,
+              "tech_mean_ci_lower": 2.6481,
+              "tech_mean_ci_upper": 2.6481,
+              "nontech_mean": 2.7886,
+              "nontech_mean_ci_lower": 2.7886,
+              "nontech_mean_ci_upper": 2.7886,
+              "d": -0.2071,
+              "d_ci_lower": -0.7177,
+              "d_ci_upper": 0.2779
             },
             "readiness": {
-              "tech_mean": 3.4577,
-              "tech_mean_ci_lower": 3.4577,
-              "tech_mean_ci_upper": 3.4577,
-              "nontech_mean": 3.0538,
-              "nontech_mean_ci_lower": 3.0538,
-              "nontech_mean_ci_upper": 3.0538,
-              "d": 0.6387,
-              "d_ci_lower": 0.3076,
-              "d_ci_upper": 0.9981
+              "tech_mean": 3.3919,
+              "tech_mean_ci_lower": 3.3919,
+              "tech_mean_ci_upper": 3.3919,
+              "nontech_mean": 3.0752,
+              "nontech_mean_ci_lower": 3.0752,
+              "nontech_mean_ci_upper": 3.0752,
+              "d": 0.5166,
+              "d_ci_lower": 0.0886,
+              "d_ci_upper": 0.9916
             },
             "maturity": {
-              "tech_mean": 3.3625,
-              "tech_mean_ci_lower": 3.3625,
-              "tech_mean_ci_upper": 3.3625,
-              "nontech_mean": 3.0675,
-              "nontech_mean_ci_lower": 3.0675,
-              "nontech_mean_ci_upper": 3.0675,
-              "d": 0.3838,
-              "d_ci_lower": 0.056,
-              "d_ci_upper": 0.7493
+              "tech_mean": 3.4062,
+              "tech_mean_ci_lower": 3.4062,
+              "tech_mean_ci_upper": 3.4063,
+              "nontech_mean": 3.0359,
+              "nontech_mean_ci_lower": 3.0359,
+              "nontech_mean_ci_upper": 3.0359,
+              "d": 0.4675,
+              "d_ci_lower": -0.0044,
+              "d_ci_upper": 0.9472
             }
           }
         },
         "large_vs_small": {
-          "large_n": 45,
-          "small_medium_n": 155,
+          "large_n": 28,
+          "small_medium_n": 91,
           "constructs": {
             "barriers": {
-              "large_mean": 2.963,
-              "large_mean_ci_lower": 2.963,
-              "large_mean_ci_upper": 2.963,
-              "small_medium_mean": 2.7067,
-              "small_medium_mean_ci_lower": 2.7067,
-              "small_medium_mean_ci_upper": 2.7067,
-              "d": 0.3756,
-              "d_ci_lower": 0.0383,
-              "d_ci_upper": 0.7349
+              "large_mean": 2.8872,
+              "large_mean_ci_lower": 2.8872,
+              "large_mean_ci_upper": 2.8872,
+              "small_medium_mean": 2.7435,
+              "small_medium_mean_ci_lower": 2.7435,
+              "small_medium_mean_ci_upper": 2.7435,
+              "d": 0.2179,
+              "d_ci_lower": -0.1926,
+              "d_ci_upper": 0.6394
             },
             "readiness": {
-              "large_mean": 3.2082,
-              "large_mean_ci_lower": 3.2082,
-              "large_mean_ci_upper": 3.2082,
-              "small_medium_mean": 3.1151,
-              "small_medium_mean_ci_lower": 3.1151,
-              "small_medium_mean_ci_upper": 3.1151,
-              "d": 0.1394,
-              "d_ci_lower": -0.2422,
-              "d_ci_upper": 0.513
+              "large_mean": 3.2678,
+              "large_mean_ci_lower": 3.2678,
+              "large_mean_ci_upper": 3.2678,
+              "small_medium_mean": 3.0495,
+              "small_medium_mean_ci_lower": 3.0495,
+              "small_medium_mean_ci_upper": 3.0495,
+              "d": 0.3462,
+              "d_ci_lower": -0.0968,
+              "d_ci_upper": 0.7993
             }
           }
         }
@@ -849,155 +965,713 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 47,
-            "barrier_mean": 2.7098,
-            "readiness_mean": 3.4577,
-            "maturity_mean": 3.3625
+            "n": 24,
+            "barrier_mean": 2.6481,
+            "readiness_mean": 3.3919,
+            "maturity_mean": 3.4062
           },
           {
             "group": "Non-Technical",
-            "n": 113,
-            "barrier_mean": 2.7785,
-            "readiness_mean": 3.0538,
-            "maturity_mean": 3.0675
+            "n": 78,
+            "barrier_mean": 2.7886,
+            "readiness_mean": 3.0752,
+            "maturity_mean": 3.0359
           },
           {
             "group": "Other",
-            "n": 38,
-            "barrier_mean": 2.7715,
-            "readiness_mean": 2.9359,
-            "maturity_mean": 3.0921
+            "n": 17,
+            "barrier_mean": 2.9075,
+            "readiness_mean": 2.8075,
+            "maturity_mean": 2.8456
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 85,
-            "barrier_mean": 2.7294,
-            "readiness_mean": 3.0118,
-            "maturity_mean": 2.9714
+            "n": 59,
+            "barrier_mean": 2.7616,
+            "readiness_mean": 2.9976,
+            "maturity_mean": 2.9227
           },
           {
             "group": "Medium (500-4999)",
-            "n": 70,
-            "barrier_mean": 2.679,
-            "readiness_mean": 3.2406,
-            "maturity_mean": 3.2441
+            "n": 32,
+            "barrier_mean": 2.7101,
+            "readiness_mean": 3.1451,
+            "maturity_mean": 3.1295
           },
           {
             "group": "Large (5000+)",
-            "n": 45,
-            "barrier_mean": 2.963,
-            "readiness_mean": 3.2082,
-            "maturity_mean": 3.3556
+            "n": 28,
+            "barrier_mean": 2.8872,
+            "readiness_mean": 3.2678,
+            "maturity_mean": 3.3694
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 47,
-          "nontech_n": 113,
+          "tech_n": 24,
+          "nontech_n": 78,
           "constructs": {
             "barriers": {
-              "t": -0.5275,
-              "p": 0.5994,
-              "df": 77.17,
-              "sig": false,
-              "mean_diff": -0.0687
+              "t": -0.8219,
+              "p": 0.0,
+              "df": 34.3,
+              "mean_diff_ci_lower": -0.1405,
+              "mean_diff_ci_upper": -0.1405,
+              "sig": true
             },
             "readiness": {
-              "t": 3.7752,
-              "p": 0.0003,
-              "df": 91.19,
-              "sig": true,
-              "mean_diff": 0.4039
+              "t": 2.2654,
+              "p": 0.0,
+              "df": 39.71,
+              "mean_diff_ci_lower": 0.3166,
+              "mean_diff_ci_upper": 0.3166,
+              "sig": true
             },
             "maturity": {
-              "t": 2.2124,
-              "p": 0.0296,
-              "df": 86.22,
-              "sig": true,
-              "mean_diff": 0.295
+              "t": 1.9309,
+              "p": 0.0,
+              "df": 36.23,
+              "mean_diff_ci_lower": 0.3703,
+              "mean_diff_ci_upper": 0.3703,
+              "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 45,
-          "small_medium_n": 155,
+          "large_n": 28,
+          "small_medium_n": 91,
           "constructs": {
             "barriers": {
-              "t": 2.232,
-              "p": 0.0287,
-              "df": 72.2,
-              "sig": true,
-              "mean_diff": 0.2564
+              "t": 1.0182,
+              "p": 0.0,
+              "df": 45.6,
+              "mean_diff_ci_lower": 0.1437,
+              "mean_diff_ci_upper": 0.1437,
+              "sig": true
             },
             "readiness": {
-              "t": 0.7606,
-              "p": 0.4497,
-              "df": 64.39,
-              "sig": false,
-              "mean_diff": 0.0931
+              "t": 1.4342,
+              "p": 0.0,
+              "df": 38.57,
+              "mean_diff_ci_lower": 0.2183,
+              "mean_diff_ci_upper": 0.2183,
+              "sig": true
             },
             "maturity": {
-              "t": 1.8682,
-              "p": 0.0662,
-              "df": 66.2,
-              "sig": false,
-              "mean_diff": 0.2611
+              "t": 2.1429,
+              "p": 0.0,
+              "df": 43.22,
+              "mean_diff_ci_lower": 0.374,
+              "mean_diff_ci_upper": 0.374,
+              "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [47, 113, 38],
+          "group_ns": [24, 78, 17],
           "constructs": {
             "barriers": {
-              "f": 0.1703,
-              "p": 0.8435,
+              "f": 0.8001,
+              "p": 0.4518,
               "df_between": 2,
-              "df_within": 195,
+              "df_within": 116,
               "sig": false
             },
             "readiness": {
-              "f": 8.7081,
-              "p": 0.0002,
+              "f": 4.6728,
+              "p": 0.0112,
               "df_between": 2,
-              "df_within": 195,
+              "df_within": 116,
               "sig": true
             },
             "maturity": {
-              "f": 2.5043,
-              "p": 0.0844,
+              "f": 2.9352,
+              "p": 0.0571,
               "df_between": 2,
-              "df_within": 195,
+              "df_within": 116,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [85, 70, 45],
+          "group_ns": [59, 32, 28],
           "constructs": {
             "barriers": {
-              "f": 2.5541,
-              "p": 0.0803,
+              "f": 0.5673,
+              "p": 0.5686,
               "df_between": 2,
-              "df_within": 197,
+              "df_within": 116,
               "sig": false
             },
             "readiness": {
-              "f": 2.6376,
-              "p": 0.0741,
+              "f": 1.8527,
+              "p": 0.1614,
               "df_between": 2,
-              "df_within": 197,
+              "df_within": 116,
               "sig": false
             },
             "maturity": {
-              "f": 4.3854,
-              "p": 0.0137,
+              "f": 3.1413,
+              "p": 0.0469,
               "df_between": 2,
-              "df_within": 197,
+              "df_within": 116,
+              "sig": true
+            }
+          }
+        }
+      }
+    },
+    "v2_finished": {
+      "demographics": {
+        "roles": {
+          "Other": 25,
+          "CSO": 16,
+          "CIO": 16,
+          "CEO": 14,
+          "COO": 13,
+          "CRO": 9,
+          "CHRO": 7,
+          "CTO": 7,
+          "CMO": 6,
+          "CFO": 6
+        },
+        "org_sizes": {
+          "<100": 24,
+          "100-499": 35,
+          "500-999": 12,
+          "1000-4999": 20,
+          "5000-9999": 12,
+          "10000+": 16
+        },
+        "profit_models": {
+          "For-Profit": 90,
+          "Non-Profit": 22,
+          "Government/Public Sector": 7
+        },
+        "tech_vs_nontech": {
+          "technical": 24,
+          "non_technical": 78,
+          "other": 17
+        },
+        "other_roles": {
+          "total": 25,
+          "categories": {
+            "Director": 12,
+            "Uncategorized": "<5",
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5"
+          }
+        }
+      },
+      "effect_sizes": {
+        "tech_vs_nontech": {
+          "tech_n": 24,
+          "nontech_n": 78,
+          "constructs": {
+            "barriers": {
+              "tech_mean": 2.6481,
+              "tech_mean_ci_lower": 2.6481,
+              "tech_mean_ci_upper": 2.6481,
+              "nontech_mean": 2.7886,
+              "nontech_mean_ci_lower": 2.7886,
+              "nontech_mean_ci_upper": 2.7886,
+              "d": -0.2071,
+              "d_ci_lower": -0.7177,
+              "d_ci_upper": 0.2779
+            },
+            "readiness": {
+              "tech_mean": 3.3919,
+              "tech_mean_ci_lower": 3.3919,
+              "tech_mean_ci_upper": 3.3919,
+              "nontech_mean": 3.0752,
+              "nontech_mean_ci_lower": 3.0752,
+              "nontech_mean_ci_upper": 3.0752,
+              "d": 0.5166,
+              "d_ci_lower": 0.0886,
+              "d_ci_upper": 0.9916
+            },
+            "maturity": {
+              "tech_mean": 3.4062,
+              "tech_mean_ci_lower": 3.4062,
+              "tech_mean_ci_upper": 3.4063,
+              "nontech_mean": 3.0359,
+              "nontech_mean_ci_lower": 3.0359,
+              "nontech_mean_ci_upper": 3.0359,
+              "d": 0.4675,
+              "d_ci_lower": -0.0044,
+              "d_ci_upper": 0.9472
+            }
+          }
+        },
+        "large_vs_small": {
+          "large_n": 28,
+          "small_medium_n": 91,
+          "constructs": {
+            "barriers": {
+              "large_mean": 2.8872,
+              "large_mean_ci_lower": 2.8872,
+              "large_mean_ci_upper": 2.8872,
+              "small_medium_mean": 2.7435,
+              "small_medium_mean_ci_lower": 2.7435,
+              "small_medium_mean_ci_upper": 2.7435,
+              "d": 0.2179,
+              "d_ci_lower": -0.1926,
+              "d_ci_upper": 0.6394
+            },
+            "readiness": {
+              "large_mean": 3.2678,
+              "large_mean_ci_lower": 3.2678,
+              "large_mean_ci_upper": 3.2678,
+              "small_medium_mean": 3.0495,
+              "small_medium_mean_ci_lower": 3.0495,
+              "small_medium_mean_ci_upper": 3.0495,
+              "d": 0.3462,
+              "d_ci_lower": -0.0968,
+              "d_ci_upper": 0.7993
+            }
+          }
+        }
+      },
+      "cross_tabs": {
+        "by_role": [
+          {
+            "group": "Technical",
+            "n": 24,
+            "barrier_mean": 2.6481,
+            "readiness_mean": 3.3919,
+            "maturity_mean": 3.4062
+          },
+          {
+            "group": "Non-Technical",
+            "n": 78,
+            "barrier_mean": 2.7886,
+            "readiness_mean": 3.0752,
+            "maturity_mean": 3.0359
+          },
+          {
+            "group": "Other",
+            "n": 17,
+            "barrier_mean": 2.9075,
+            "readiness_mean": 2.8075,
+            "maturity_mean": 2.8456
+          }
+        ],
+        "by_org_size": [
+          {
+            "group": "Small (<500)",
+            "n": 59,
+            "barrier_mean": 2.7616,
+            "readiness_mean": 2.9976,
+            "maturity_mean": 2.9227
+          },
+          {
+            "group": "Medium (500-4999)",
+            "n": 32,
+            "barrier_mean": 2.7101,
+            "readiness_mean": 3.1451,
+            "maturity_mean": 3.1295
+          },
+          {
+            "group": "Large (5000+)",
+            "n": 28,
+            "barrier_mean": 2.8872,
+            "readiness_mean": 3.2678,
+            "maturity_mean": 3.3694
+          }
+        ]
+      },
+      "inferential": {
+        "t_tests_tech_vs_nontech": {
+          "tech_n": 24,
+          "nontech_n": 78,
+          "constructs": {
+            "barriers": {
+              "t": -0.8219,
+              "p": 0.0,
+              "df": 34.3,
+              "mean_diff_ci_lower": -0.1405,
+              "mean_diff_ci_upper": -0.1405,
+              "sig": true
+            },
+            "readiness": {
+              "t": 2.2654,
+              "p": 0.0,
+              "df": 39.71,
+              "mean_diff_ci_lower": 0.3166,
+              "mean_diff_ci_upper": 0.3166,
+              "sig": true
+            },
+            "maturity": {
+              "t": 1.9309,
+              "p": 0.0,
+              "df": 36.23,
+              "mean_diff_ci_lower": 0.3703,
+              "mean_diff_ci_upper": 0.3703,
+              "sig": true
+            }
+          }
+        },
+        "t_tests_large_vs_small": {
+          "large_n": 28,
+          "small_medium_n": 91,
+          "constructs": {
+            "barriers": {
+              "t": 1.0182,
+              "p": 0.0,
+              "df": 45.6,
+              "mean_diff_ci_lower": 0.1437,
+              "mean_diff_ci_upper": 0.1437,
+              "sig": true
+            },
+            "readiness": {
+              "t": 1.4342,
+              "p": 0.0,
+              "df": 38.57,
+              "mean_diff_ci_lower": 0.2183,
+              "mean_diff_ci_upper": 0.2183,
+              "sig": true
+            },
+            "maturity": {
+              "t": 2.1429,
+              "p": 0.0,
+              "df": 43.22,
+              "mean_diff_ci_lower": 0.374,
+              "mean_diff_ci_upper": 0.374,
+              "sig": true
+            }
+          }
+        },
+        "anova_by_role": {
+          "groups": ["Technical", "Non-Technical", "Other"],
+          "group_ns": [24, 78, 17],
+          "constructs": {
+            "barriers": {
+              "f": 0.8001,
+              "p": 0.4518,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": false
+            },
+            "readiness": {
+              "f": 4.6728,
+              "p": 0.0112,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": true
+            },
+            "maturity": {
+              "f": 2.9352,
+              "p": 0.0571,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": false
+            }
+          }
+        },
+        "anova_by_org_size": {
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [59, 32, 28],
+          "constructs": {
+            "barriers": {
+              "f": 0.5673,
+              "p": 0.5686,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": false
+            },
+            "readiness": {
+              "f": 1.8527,
+              "p": 0.1614,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": false
+            },
+            "maturity": {
+              "f": 3.1413,
+              "p": 0.0469,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": true
+            }
+          }
+        }
+      }
+    },
+    "v2_all": {
+      "demographics": {
+        "roles": {
+          "Other": 25,
+          "CSO": 16,
+          "CIO": 16,
+          "CEO": 14,
+          "COO": 13,
+          "CRO": 9,
+          "CHRO": 7,
+          "CTO": 7,
+          "CMO": 6,
+          "CFO": 6
+        },
+        "org_sizes": {
+          "<100": 24,
+          "100-499": 35,
+          "500-999": 12,
+          "1000-4999": 20,
+          "5000-9999": 12,
+          "10000+": 16
+        },
+        "profit_models": {
+          "For-Profit": 90,
+          "Non-Profit": 22,
+          "Government/Public Sector": 7
+        },
+        "tech_vs_nontech": {
+          "technical": 24,
+          "non_technical": 78,
+          "other": 17
+        },
+        "other_roles": {
+          "total": 25,
+          "categories": {
+            "Director": 12,
+            "Uncategorized": "<5",
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5"
+          }
+        }
+      },
+      "effect_sizes": {
+        "tech_vs_nontech": {
+          "tech_n": 24,
+          "nontech_n": 78,
+          "constructs": {
+            "barriers": {
+              "tech_mean": 2.6481,
+              "tech_mean_ci_lower": 2.6481,
+              "tech_mean_ci_upper": 2.6481,
+              "nontech_mean": 2.7886,
+              "nontech_mean_ci_lower": 2.7886,
+              "nontech_mean_ci_upper": 2.7886,
+              "d": -0.2071,
+              "d_ci_lower": -0.7177,
+              "d_ci_upper": 0.2779
+            },
+            "readiness": {
+              "tech_mean": 3.3919,
+              "tech_mean_ci_lower": 3.3919,
+              "tech_mean_ci_upper": 3.3919,
+              "nontech_mean": 3.0752,
+              "nontech_mean_ci_lower": 3.0752,
+              "nontech_mean_ci_upper": 3.0752,
+              "d": 0.5166,
+              "d_ci_lower": 0.0886,
+              "d_ci_upper": 0.9916
+            },
+            "maturity": {
+              "tech_mean": 3.4062,
+              "tech_mean_ci_lower": 3.4062,
+              "tech_mean_ci_upper": 3.4063,
+              "nontech_mean": 3.0359,
+              "nontech_mean_ci_lower": 3.0359,
+              "nontech_mean_ci_upper": 3.0359,
+              "d": 0.4675,
+              "d_ci_lower": -0.0044,
+              "d_ci_upper": 0.9472
+            }
+          }
+        },
+        "large_vs_small": {
+          "large_n": 28,
+          "small_medium_n": 91,
+          "constructs": {
+            "barriers": {
+              "large_mean": 2.8872,
+              "large_mean_ci_lower": 2.8872,
+              "large_mean_ci_upper": 2.8872,
+              "small_medium_mean": 2.7435,
+              "small_medium_mean_ci_lower": 2.7435,
+              "small_medium_mean_ci_upper": 2.7435,
+              "d": 0.2179,
+              "d_ci_lower": -0.1926,
+              "d_ci_upper": 0.6394
+            },
+            "readiness": {
+              "large_mean": 3.2678,
+              "large_mean_ci_lower": 3.2678,
+              "large_mean_ci_upper": 3.2678,
+              "small_medium_mean": 3.0495,
+              "small_medium_mean_ci_lower": 3.0495,
+              "small_medium_mean_ci_upper": 3.0495,
+              "d": 0.3462,
+              "d_ci_lower": -0.0968,
+              "d_ci_upper": 0.7993
+            }
+          }
+        }
+      },
+      "cross_tabs": {
+        "by_role": [
+          {
+            "group": "Technical",
+            "n": 24,
+            "barrier_mean": 2.6481,
+            "readiness_mean": 3.3919,
+            "maturity_mean": 3.4062
+          },
+          {
+            "group": "Non-Technical",
+            "n": 78,
+            "barrier_mean": 2.7886,
+            "readiness_mean": 3.0752,
+            "maturity_mean": 3.0359
+          },
+          {
+            "group": "Other",
+            "n": 17,
+            "barrier_mean": 2.9075,
+            "readiness_mean": 2.8075,
+            "maturity_mean": 2.8456
+          }
+        ],
+        "by_org_size": [
+          {
+            "group": "Small (<500)",
+            "n": 59,
+            "barrier_mean": 2.7616,
+            "readiness_mean": 2.9976,
+            "maturity_mean": 2.9227
+          },
+          {
+            "group": "Medium (500-4999)",
+            "n": 32,
+            "barrier_mean": 2.7101,
+            "readiness_mean": 3.1451,
+            "maturity_mean": 3.1295
+          },
+          {
+            "group": "Large (5000+)",
+            "n": 28,
+            "barrier_mean": 2.8872,
+            "readiness_mean": 3.2678,
+            "maturity_mean": 3.3694
+          }
+        ]
+      },
+      "inferential": {
+        "t_tests_tech_vs_nontech": {
+          "tech_n": 24,
+          "nontech_n": 78,
+          "constructs": {
+            "barriers": {
+              "t": -0.8219,
+              "p": 0.0,
+              "df": 34.3,
+              "mean_diff_ci_lower": -0.1405,
+              "mean_diff_ci_upper": -0.1405,
+              "sig": true
+            },
+            "readiness": {
+              "t": 2.2654,
+              "p": 0.0,
+              "df": 39.71,
+              "mean_diff_ci_lower": 0.3166,
+              "mean_diff_ci_upper": 0.3166,
+              "sig": true
+            },
+            "maturity": {
+              "t": 1.9309,
+              "p": 0.0,
+              "df": 36.23,
+              "mean_diff_ci_lower": 0.3703,
+              "mean_diff_ci_upper": 0.3703,
+              "sig": true
+            }
+          }
+        },
+        "t_tests_large_vs_small": {
+          "large_n": 28,
+          "small_medium_n": 91,
+          "constructs": {
+            "barriers": {
+              "t": 1.0182,
+              "p": 0.0,
+              "df": 45.6,
+              "mean_diff_ci_lower": 0.1437,
+              "mean_diff_ci_upper": 0.1437,
+              "sig": true
+            },
+            "readiness": {
+              "t": 1.4342,
+              "p": 0.0,
+              "df": 38.57,
+              "mean_diff_ci_lower": 0.2183,
+              "mean_diff_ci_upper": 0.2183,
+              "sig": true
+            },
+            "maturity": {
+              "t": 2.1429,
+              "p": 0.0,
+              "df": 43.22,
+              "mean_diff_ci_lower": 0.374,
+              "mean_diff_ci_upper": 0.374,
+              "sig": true
+            }
+          }
+        },
+        "anova_by_role": {
+          "groups": ["Technical", "Non-Technical", "Other"],
+          "group_ns": [24, 78, 17],
+          "constructs": {
+            "barriers": {
+              "f": 0.8001,
+              "p": 0.4518,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": false
+            },
+            "readiness": {
+              "f": 4.6728,
+              "p": 0.0112,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": true
+            },
+            "maturity": {
+              "f": 2.9352,
+              "p": 0.0571,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": false
+            }
+          }
+        },
+        "anova_by_org_size": {
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [59, 32, 28],
+          "constructs": {
+            "barriers": {
+              "f": 0.5673,
+              "p": 0.5686,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": false
+            },
+            "readiness": {
+              "f": 1.8527,
+              "p": 0.1614,
+              "df_between": 2,
+              "df_within": 116,
+              "sig": false
+            },
+            "maturity": {
+              "f": 3.1413,
+              "p": 0.0469,
+              "df_between": 2,
+              "df_within": 116,
               "sig": true
             }
           }
@@ -1008,22 +1682,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 2.26,
-      "p_value": 0.894,
+      "chi2": 0.97,
+      "p_value": 0.9869,
       "df": 6,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 7.22,
-      "p_value": 0.9511,
+      "chi2": 5.64,
+      "p_value": 0.9852,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 2.7,
-      "p_value": 0.8456,
+      "chi2": 4.8,
+      "p_value": 0.5702,
       "df": 6,
       "error": null
     },
@@ -1031,24 +1705,24 @@
       "labels": ["For-Profit", "Non-Profit", "Government/Public Sector"],
       "groups": {
         "Conservative Clean": {
-          "For-Profit": 56,
-          "Non-Profit": 15,
-          "Government/Public Sector": 8
+          "For-Profit": 33,
+          "Non-Profit": 9,
+          "Government/Public Sector": 7
         },
         "Flexible Clean": {
-          "For-Profit": 81,
-          "Non-Profit": 24,
-          "Government/Public Sector": 11
+          "For-Profit": 47,
+          "Non-Profit": 12,
+          "Government/Public Sector": 7
         },
         "Prolific Accepted": {
-          "For-Profit": 151,
-          "Non-Profit": 36,
-          "Government/Public Sector": 13
+          "For-Profit": 90,
+          "Non-Profit": 22,
+          "Government/Public Sector": 7
         },
         "All V2 Finished": {
-          "For-Profit": 151,
-          "Non-Profit": 36,
-          "Government/Public Sector": 13
+          "For-Profit": 90,
+          "Non-Profit": 22,
+          "Government/Public Sector": 7
         }
       }
     }
@@ -1086,8 +1760,9 @@
     },
     {
       "label": "Uncategorized",
-      "description": "Responses that did not match any keyword pattern, or blank entries",
+      "description": "Responses that did not match any keyword pattern",
       "examples": ""
     }
-  ]
+  ],
+  "last_updated": "2026-04-10T21:12:34.926122Z"
 }

--- a/src/data/crp-validation.json
+++ b/src/data/crp-validation.json
@@ -1,7 +1,7 @@
 {
   "Barriers": {
     "cronbach_alpha": 0.8728,
-    "cronbach_alpha_ci": [0.843, 0.899],
+    "cronbach_alpha_ci": [0.845, 0.8976],
     "n_listwise": 192,
     "mcdonalds_omega": 0.8729,
     "composite_reliability": 0.8729,
@@ -10,65 +10,65 @@
     "kmo_bartlett": {
       "kmo_overall": 0.8508,
       "bartlett_chi2": 1135.51,
-      "bartlett_p": 0.0
+      "bartlett_p": 1.2408888250155992e-149
     },
     "parallel_analysis": {
       "n_factors": 2,
-      "eigenvalues_real": [5.874, 1.903, 1.146, 1.015]
+      "eigenvalues_real": [5.8741, 1.9033, 1.146, 1.0148]
     },
     "efa": {
       "construct": "Barriers",
       "n_factors": 2,
-      "variance_explained": [0.285, 0.114],
+      "variance_explained": [0.2849, 0.1144],
       "total_variance": 0.3994,
       "factor_correlations": [
-        [1.0, 0.505],
-        [0.505, 1.0]
+        [1.0, 0.5049],
+        [0.5049, 1.0]
       ],
       "loadings": {
-        "B1": [0.747, -0.253],
-        "B2": [0.824, -0.217],
-        "B3": [0.738, -0.126],
-        "B4": [0.684, -0.075],
-        "B5": [0.63, -0.027],
-        "B6": [0.371, 0.117],
-        "B7": [0.503, 0.197],
-        "B8": [0.476, 0.059],
-        "B9": [0.487, 0.194],
-        "B10": [0.643, 0.126],
-        "B11": [0.605, 0.121],
-        "B12": [0.537, 0.185],
-        "B13": [-0.091, 0.838],
-        "B14": [-0.014, 0.799],
-        "B15": [0.105, 0.629],
-        "B16": [0.114, 0.517],
-        "B17": [0.228, 0.356],
-        "B18": [0.243, 0.327]
+        "B1": [0.7466, -0.2531],
+        "B2": [0.8244, -0.2172],
+        "B3": [0.7383, -0.1262],
+        "B4": [0.6844, -0.0745],
+        "B5": [0.5679, 0.0174],
+        "B6": [0.4306, 0.1003],
+        "B7": [0.5198, 0.0423],
+        "B8": [0.4856, 0.1202],
+        "B9": [0.5432, -0.0355],
+        "B10": [0.7312, -0.0264],
+        "B11": [0.437, 0.155],
+        "B12": [0.5394, 0.0901],
+        "B13": [-0.227, 0.8502],
+        "B14": [-0.2075, 0.952],
+        "B15": [0.3967, 0.187],
+        "B16": [0.1465, 0.3538],
+        "B17": [0.4753, 0.0712],
+        "B18": [0.232, 0.2677]
       }
     },
     "cfa": {
       "construct": "Barriers",
-      "chi2": 376.183,
-      "df": 135,
-      "chi2_p": 0.0,
-      "cfi": 0.766,
-      "tli": 0.7348,
-      "rmsea": 0.0967,
+      "chi2": null,
+      "df": null,
+      "chi2_p": null,
+      "cfi": null,
+      "tli": null,
+      "rmsea": null,
       "srmr": null
     },
     "inter_item": {
-      "mean_r": 0.275,
-      "min_r": -0.06,
-      "max_r": 0.64,
-      "sd_r": 0.13
+      "mean_r": 0.2769,
+      "min_r": -0.0453,
+      "max_r": 0.669,
+      "sd_r": 0.1175
     },
-    "itc_min": 0.17,
+    "itc_min": 0.28,
     "itc_all_above_030": false
   },
   "Readiness": {
     "cronbach_alpha": 0.9171,
-    "cronbach_alpha_ci": [0.901, 0.931],
-    "n_listwise": 192,
+    "cronbach_alpha_ci": [0.8984, 0.9337],
+    "n_listwise": 181,
     "mcdonalds_omega": 0.9183,
     "composite_reliability": 0.9183,
     "ave": 0.4001,
@@ -76,11 +76,11 @@
     "kmo_bartlett": {
       "kmo_overall": 0.9266,
       "bartlett_chi2": 1278.99,
-      "bartlett_p": 0.0
+      "bartlett_p": 5.598940441600992e-185
     },
     "parallel_analysis": {
       "n_factors": 1,
-      "eigenvalues_real": [7.392, 1.071, 0.966, 0.888]
+      "eigenvalues_real": [7.3921, 1.0705, 0.9659, 0.888]
     },
     "efa": {
       "construct": "Readiness",
@@ -88,31 +88,49 @@
       "variance_explained": [0.4001],
       "total_variance": 0.4001,
       "factor_correlations": null,
-      "loadings": {}
+      "loadings": {
+        "R1": [0.6989],
+        "R2": [0.6682],
+        "R3": [0.6528],
+        "R4": [0.5702],
+        "R5": [0.638],
+        "R6": [0.6945],
+        "R7": [0.6611],
+        "R8": [0.6377],
+        "R9": [0.5935],
+        "R10": [0.6044],
+        "R11": [0.6619],
+        "R12": [0.6031],
+        "R13": [0.6128],
+        "R14": [0.6073],
+        "R15": [0.6601],
+        "R16": [0.6917],
+        "R17": [0.4516]
+      }
     },
     "cfa": {
       "construct": "Readiness",
-      "chi2": 203.253,
-      "df": 119,
-      "chi2_p": 0.0,
-      "cfi": 0.9297,
-      "tli": 0.9196,
-      "rmsea": 0.0627,
+      "chi2": null,
+      "df": null,
+      "chi2_p": null,
+      "cfi": null,
+      "tli": null,
+      "rmsea": null,
       "srmr": null
     },
     "inter_item": {
-      "mean_r": 0.395,
-      "min_r": 0.12,
-      "max_r": 0.7,
-      "sd_r": 0.11
+      "mean_r": 0.3969,
+      "min_r": 0.1887,
+      "max_r": 0.6075,
+      "sd_r": 0.0724
     },
-    "itc_min": null,
+    "itc_min": 0.44,
     "itc_all_above_030": true
   },
   "Maturity": {
     "cronbach_alpha": 0.8847,
-    "cronbach_alpha_ci": [0.86, 0.906],
-    "n_listwise": 192,
+    "cronbach_alpha_ci": [0.8582, 0.9078],
+    "n_listwise": 191,
     "mcdonalds_omega": 0.8857,
     "composite_reliability": 0.8857,
     "ave": 0.4934,
@@ -120,11 +138,11 @@
     "kmo_bartlett": {
       "kmo_overall": 0.9121,
       "bartlett_chi2": 650.13,
-      "bartlett_p": 0.0
+      "bartlett_p": 5.061310067052528e-119
     },
     "parallel_analysis": {
       "n_factors": 1,
-      "eigenvalues_real": [4.444, 0.716, 0.643, 0.567]
+      "eigenvalues_real": [4.4439, 0.7161, 0.6427, 0.5667]
     },
     "efa": {
       "construct": "Maturity",
@@ -132,49 +150,58 @@
       "variance_explained": [0.4934],
       "total_variance": 0.4934,
       "factor_correlations": null,
-      "loadings": {}
+      "loadings": {
+        "M1": [0.7486],
+        "M2": [0.7536],
+        "M3": [0.6383],
+        "M4": [0.6644],
+        "M5": [0.6644],
+        "M6": [0.7921],
+        "M7": [0.6882],
+        "M8": [0.6537]
+      }
     },
     "cfa": {
       "construct": "Maturity",
-      "chi2": 32.147,
-      "df": 20,
-      "chi2_p": 0.0425,
-      "cfi": 0.981,
-      "tli": 0.9733,
-      "rmsea": 0.0565,
+      "chi2": null,
+      "df": null,
+      "chi2_p": null,
+      "cfi": null,
+      "tli": null,
+      "rmsea": null,
       "srmr": null
     },
     "inter_item": {
-      "mean_r": 0.487,
-      "min_r": 0.3,
-      "max_r": 0.67,
-      "sd_r": 0.08
+      "mean_r": 0.4902,
+      "min_r": 0.3503,
+      "max_r": 0.6055,
+      "sd_r": 0.0622
     },
-    "itc_min": null,
+    "itc_min": 0.6,
     "itc_all_above_030": true
   },
   "htmt": [
     {
       "pair": "Barriers vs Readiness",
       "htmt": 0.4981,
-      "ci_lower": 0.3963,
-      "ci_upper": 0.6527,
+      "ci_lower": 0.4022,
+      "ci_upper": 0.6546,
       "below_085": true,
       "below_090": true
     },
     {
       "pair": "Barriers vs Maturity",
       "htmt": 0.4407,
-      "ci_lower": 0.3684,
-      "ci_upper": 0.5458,
+      "ci_lower": 0.3673,
+      "ci_upper": 0.5542,
       "below_085": true,
       "below_090": true
     },
     {
       "pair": "Readiness vs Maturity",
       "htmt": 0.8044,
-      "ci_lower": 0.7098,
-      "ci_upper": 0.8804,
+      "ci_lower": 0.714,
+      "ci_upper": 0.881,
       "below_085": true,
       "below_090": true
     }
@@ -203,61 +230,49 @@
     }
   ],
   "construct_correlations": {
-    "Barriers": { "Barriers": 1.0, "Readiness": -0.3814, "Maturity": -0.3156 },
-    "Readiness": { "Barriers": -0.3814, "Readiness": 1.0, "Maturity": 0.7194 },
-    "Maturity": { "Barriers": -0.3156, "Readiness": 0.7194, "Maturity": 1.0 }
+    "Barriers": {
+      "Barriers": 1.0,
+      "Readiness": -0.3814,
+      "Maturity": -0.3156
+    },
+    "Readiness": {
+      "Barriers": -0.3814,
+      "Readiness": 1.0,
+      "Maturity": 0.7194
+    },
+    "Maturity": {
+      "Barriers": -0.3156,
+      "Readiness": 0.7194,
+      "Maturity": 1.0
+    }
   },
   "barriers_4f_cfa": {
-    "chi2": 307.835,
-    "df": 129,
-    "chi2_p": 0.0,
-    "cfi": 0.8265,
-    "tli": 0.7942,
-    "rmsea": 0.0852,
-    "aic": 80.79,
-    "bic": 217.61
+    "chi2": null,
+    "df": null,
+    "chi2_p": null,
+    "cfi": null,
+    "tli": null,
+    "rmsea": null,
+    "aic": null,
+    "bic": null
   },
   "factor_analysis": {
     "efa_factors": [
       {
-        "name": "F1: Internal Organizational Barriers",
-        "items": 12,
-        "alpha": 0.872,
-        "eigenvalue": 5.874,
+        "name": "F1",
+        "items": 14,
+        "eigenvalue": 5.8741,
         "variance_pct": 28.5
       },
       {
-        "name": "F2: External Risk & Trust Barriers",
-        "items": 6,
-        "alpha": 0.666,
-        "eigenvalue": 1.903,
+        "name": "F2",
+        "items": 4,
+        "eigenvalue": 1.9033,
         "variance_pct": 11.4
       }
     ],
-    "three_groups": [
-      {
-        "name": "F1a: Strategic & Capability",
-        "items": 9,
-        "alpha": 0.833,
-        "cr": 0.834,
-        "ave": 0.366
-      },
-      {
-        "name": "F1b: Operational & Resource",
-        "items": 5,
-        "alpha": 0.746,
-        "cr": 0.748,
-        "ave": 0.374
-      },
-      {
-        "name": "F2: External Risk & Trust",
-        "items": 4,
-        "alpha": 0.666,
-        "cr": 0.695,
-        "ave": 0.405
-      }
-    ],
-    "factor_correlation": 0.505,
+    "three_groups": [],
+    "factor_correlation": 0.5049,
     "barrier_names": [
       "Resistance to Change",
       "Lack of Leadership Support",
@@ -279,24 +294,114 @@
       "Vendor/Partner Difficulty"
     ],
     "loadings_matrix": [
-      { "id": "B1", "f1": 0.747, "f2": -0.253, "assigned": "F1" },
-      { "id": "B2", "f1": 0.824, "f2": -0.217, "assigned": "F1" },
-      { "id": "B3", "f1": 0.738, "f2": -0.126, "assigned": "F1" },
-      { "id": "B4", "f1": 0.684, "f2": -0.075, "assigned": "F1" },
-      { "id": "B5", "f1": 0.63, "f2": -0.027, "assigned": "F1" },
-      { "id": "B6", "f1": 0.371, "f2": 0.117, "assigned": "F1" },
-      { "id": "B7", "f1": 0.503, "f2": 0.197, "assigned": "F1" },
-      { "id": "B8", "f1": 0.476, "f2": 0.059, "assigned": "F1" },
-      { "id": "B9", "f1": 0.487, "f2": 0.194, "assigned": "F1" },
-      { "id": "B10", "f1": 0.643, "f2": 0.126, "assigned": "F1" },
-      { "id": "B11", "f1": 0.605, "f2": 0.121, "assigned": "F1" },
-      { "id": "B12", "f1": 0.537, "f2": 0.185, "assigned": "F1" },
-      { "id": "B13", "f1": -0.091, "f2": 0.838, "assigned": "F2" },
-      { "id": "B14", "f1": -0.014, "f2": 0.799, "assigned": "F2" },
-      { "id": "B15", "f1": 0.105, "f2": 0.629, "assigned": "F2" },
-      { "id": "B16", "f1": 0.114, "f2": 0.517, "assigned": "F2" },
-      { "id": "B17", "f1": 0.228, "f2": 0.356, "assigned": "F2" },
-      { "id": "B18", "f1": 0.243, "f2": 0.327, "assigned": "F2" }
+      {
+        "id": "B1",
+        "f1": 0.7466,
+        "f2": -0.2531,
+        "assigned": "F1"
+      },
+      {
+        "id": "B2",
+        "f1": 0.8244,
+        "f2": -0.2172,
+        "assigned": "F1"
+      },
+      {
+        "id": "B3",
+        "f1": 0.7383,
+        "f2": -0.1262,
+        "assigned": "F1"
+      },
+      {
+        "id": "B4",
+        "f1": 0.6844,
+        "f2": -0.0745,
+        "assigned": "F1"
+      },
+      {
+        "id": "B5",
+        "f1": 0.5679,
+        "f2": 0.0174,
+        "assigned": "F1"
+      },
+      {
+        "id": "B6",
+        "f1": 0.4306,
+        "f2": 0.1003,
+        "assigned": "F1"
+      },
+      {
+        "id": "B7",
+        "f1": 0.5198,
+        "f2": 0.0423,
+        "assigned": "F1"
+      },
+      {
+        "id": "B8",
+        "f1": 0.4856,
+        "f2": 0.1202,
+        "assigned": "F1"
+      },
+      {
+        "id": "B9",
+        "f1": 0.5432,
+        "f2": -0.0355,
+        "assigned": "F1"
+      },
+      {
+        "id": "B10",
+        "f1": 0.7312,
+        "f2": -0.0264,
+        "assigned": "F1"
+      },
+      {
+        "id": "B11",
+        "f1": 0.437,
+        "f2": 0.155,
+        "assigned": "F1"
+      },
+      {
+        "id": "B12",
+        "f1": 0.5394,
+        "f2": 0.0901,
+        "assigned": "F1"
+      },
+      {
+        "id": "B13",
+        "f1": -0.227,
+        "f2": 0.8502,
+        "assigned": "F2"
+      },
+      {
+        "id": "B14",
+        "f1": -0.2075,
+        "f2": 0.952,
+        "assigned": "F2"
+      },
+      {
+        "id": "B15",
+        "f1": 0.3967,
+        "f2": 0.187,
+        "assigned": "F1"
+      },
+      {
+        "id": "B16",
+        "f1": 0.1465,
+        "f2": 0.3538,
+        "assigned": "F2"
+      },
+      {
+        "id": "B17",
+        "f1": 0.4753,
+        "f2": 0.0712,
+        "assigned": "F1"
+      },
+      {
+        "id": "B18",
+        "f1": 0.232,
+        "f2": 0.2677,
+        "assigned": "F2"
+      }
     ]
   },
   "verdicts": {
@@ -310,7 +415,7 @@
       "kmo_above_060": true,
       "bartlett_significant": true,
       "cfa_cfi_above_090": false,
-      "pass_count": 6,
+      "pass_count": 2,
       "total_criteria": 9
     },
     "Readiness": {
@@ -322,8 +427,8 @@
       "split_half_above_070": true,
       "kmo_above_060": true,
       "bartlett_significant": true,
-      "cfa_cfi_above_090": true,
-      "pass_count": 8,
+      "cfa_cfi_above_090": false,
+      "pass_count": 3,
       "total_criteria": 9
     },
     "Maturity": {
@@ -335,8 +440,8 @@
       "split_half_above_070": true,
       "kmo_above_060": true,
       "bartlett_significant": true,
-      "cfa_cfi_above_090": true,
-      "pass_count": 8,
+      "cfa_cfi_above_090": false,
+      "pass_count": 3,
       "total_criteria": 9
     }
   },
@@ -346,7 +451,6 @@
     "constructs": ["Barriers", "Readiness", "Maturity"],
     "n_barriers": 18,
     "n_readiness": 17,
-    "n_maturity": 8,
-    "seed_source": "hard-coded values from initial validation run — will be regenerated by daily pipeline"
+    "n_maturity": 8
   }
 }

--- a/src/data/data-audit.json
+++ b/src/data/data-audit.json
@@ -1,102 +1,102 @@
 {
   "disposition_counts": {
-    "INCOMPLETE": 66,
-    "CLEAN": 83,
+    "INCOMPLETE": 67,
+    "CLEAN": 84,
     "FLAG-SMEAL": 48,
     "FLAG-SPEED": 7,
     "FLAG-PARTIAL-STRAIGHTLINING": 33,
-    "FLAG-SINGLE-IRI": 78,
+    "FLAG-SINGLE-IRI": 79,
     "AUTO-EXCLUDE": 116,
     "FLAG-RECAPTCHA": 3
   },
   "iri_pass_rates": {
-    "barrier": 0.49078341013824883,
-    "readiness": 0.5921658986175116,
-    "maturity": 0.6889400921658986
+    "barrier": 0.4897025171624714,
+    "readiness": 0.5926773455377574,
+    "maturity": 0.6887871853546911
   },
   "duration_stats": {
-    "mean": 660.2834101382489,
-    "median": 536,
+    "mean": 659.4256292906178,
+    "median": 532,
     "q25": 318,
-    "q75": 794,
+    "q75": 792,
     "min": 2,
     "max": 5935
   },
   "straightlining_stats": {
     "full_block_flagged": 14,
-    "partial_flagged": 131
+    "partial_flagged": 132
   },
   "sample_sizes": {
-    "total": 434,
-    "complete": 368,
-    "clean": 83
+    "total": 437,
+    "complete": 370,
+    "clean": 84
   },
   "waterfall_steps": [
     {
       "step": 0,
       "name": "INCOMPLETE",
-      "count": 66,
-      "cumulative_excluded": 66
+      "count": 67,
+      "cumulative_excluded": 67
     },
     {
       "step": 1,
       "name": "FLAG-AUTH-FAIL",
       "count": 0,
-      "cumulative_excluded": 66
+      "cumulative_excluded": 67
     },
     {
       "step": 2,
       "name": "FLAG-AUTH-MIXED",
       "count": 0,
-      "cumulative_excluded": 66
+      "cumulative_excluded": 67
     },
     {
       "step": 3,
       "name": "AUTO-EXCLUDE",
       "count": 116,
-      "cumulative_excluded": 182
+      "cumulative_excluded": 183
     },
     {
       "step": 4,
       "name": "FLAG-SPEED",
       "count": 7,
-      "cumulative_excluded": 189
+      "cumulative_excluded": 190
     },
     {
       "step": 5,
       "name": "FLAG-SINGLE-IRI",
-      "count": 78,
-      "cumulative_excluded": 267
+      "count": 79,
+      "cumulative_excluded": 269
     },
     {
       "step": 6,
       "name": "FLAG-SMEAL",
       "count": 48,
-      "cumulative_excluded": 315
+      "cumulative_excluded": 317
     },
     {
       "step": 7,
       "name": "FLAG-RECAPTCHA",
       "count": 3,
-      "cumulative_excluded": 318
+      "cumulative_excluded": 320
     },
     {
       "step": 8,
       "name": "FLAG-STRAIGHTLINING",
       "count": 0,
-      "cumulative_excluded": 318
+      "cumulative_excluded": 320
     },
     {
       "step": 9,
       "name": "FLAG-PARTIAL-STRAIGHTLINING",
       "count": 33,
-      "cumulative_excluded": 351
+      "cumulative_excluded": 353
     },
     {
       "step": 10,
       "name": "CLEAN",
-      "count": 83,
-      "cumulative_excluded": 83
+      "count": 84,
+      "cumulative_excluded": 84
     }
   ]
 }

--- a/src/data/disposition-summary.json
+++ b/src/data/disposition-summary.json
@@ -1,12 +1,12 @@
 {
-  "updatedAt": "2026-04-10T10:47:26.393249+00:00",
-  "last_updated": "2026-04-10T10:47:26.393263+00:00",
+  "updatedAt": "2026-04-10T21:16:41.023126+00:00",
+  "last_updated": "2026-04-10T21:16:41.023138+00:00",
   "study": {
     "id": "69c17630acada6abeead2da5",
     "name": "Technology Adoption Barriers Survey (2026)",
     "status": "ACTIVE",
     "totalAvailablePlaces": 500,
-    "placesTaken": 265,
+    "placesTaken": 268,
     "averageRewardPerHour": 3986.55,
     "averageTimeTaken": 10,
     "reward": 700,
@@ -14,31 +14,31 @@
   },
   "completionProgress": {
     "target": 500,
-    "completed": 265,
-    "approved": 233,
-    "awaitingReview": 32,
-    "percentComplete": 53.0
+    "completed": 268,
+    "approved": 234,
+    "awaitingReview": 34,
+    "percentComplete": 53.6
   },
-  "totalResponses": 450,
-  "uniqueParticipants": 434,
+  "totalResponses": 455,
+  "uniqueParticipants": 437,
   "duplicatesRemoved": 0,
   "dispositions": {
-    "INCOMPLETE": 66,
-    "CLEAN": 83,
+    "INCOMPLETE": 67,
+    "CLEAN": 84,
     "FLAG-SMEAL": 48,
     "FLAG-SPEED": 7,
     "FLAG-PARTIAL-STRAIGHTLINING": 33,
-    "FLAG-SINGLE-IRI": 78,
+    "FLAG-SINGLE-IRI": 79,
     "AUTO-EXCLUDE": 116,
     "FLAG-RECAPTCHA": 3
   },
   "dispositionByStatus": {
     "INCOMPLETE": {
       "RETURNED": 61,
-      "TIMED-OUT": 5
+      "TIMED-OUT": 6
     },
     "CLEAN": {
-      "APPROVED": 82,
+      "APPROVED": 83,
       "RETURNED": 1
     },
     "FLAG-SMEAL": {
@@ -57,7 +57,7 @@
     "FLAG-SINGLE-IRI": {
       "RETURNED": 7,
       "APPROVED": 67,
-      "AWAITING REVIEW": 4
+      "AWAITING REVIEW": 5
     },
     "AUTO-EXCLUDE": {
       "REJECTED": 29,
@@ -77,19 +77,19 @@
     "SPEED_IRI": 14
   },
   "actions": {
-    "approved": 233,
+    "approved": 234,
     "rejected": 29,
-    "returned": 150,
+    "returned": 152,
     "timedOut": 6,
-    "awaitingReview": 32,
+    "awaitingReview": 34,
     "active": 0,
     "messaged": 0
   },
   "iriPassRates": {
     "barrier": 57.6,
-    "readiness": 69.6,
-    "maturity": 81.3,
-    "denominator": 368
+    "readiness": 69.7,
+    "maturity": 81.4,
+    "denominator": 370
   },
   "studyId": "69c17630acada6abeead2da5",
   "studyName": "Technology Adoption Barriers Survey (2026)"

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -4,31 +4,31 @@
       "key": "conservative_clean",
       "label": "Conservative Clean",
       "description": "Prolific APPROVED + all quality checks (IRI, duration >= 540s, reCAPTCHA, straightlining, auth)",
-      "n": 80
+      "n": 82
     },
     {
       "key": "flexible_clean",
       "label": "Flexible Clean",
       "description": "Prolific APPROVED + basic quality (all 3 IRIs + duration >= 480s)",
-      "n": 127
+      "n": 129
     },
     {
       "key": "prolific_accepted",
       "label": "Prolific Accepted",
       "description": "All deduplicated V2 rows with Prolific APPROVED status",
-      "n": 231
+      "n": 233
     },
     {
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 368
+      "n": 370
     },
     {
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 434
+      "n": 437
     }
   ],
   "metrics": [
@@ -36,132 +36,132 @@
       "key": "barrier_mean",
       "label": "Barrier Grand Mean",
       "values": {
-        "conservative_clean": 2.8239,
-        "flexible_clean": 2.8146,
-        "prolific_accepted": 2.779,
-        "v2_finished": 2.7401,
-        "v2_all": 2.7458
+        "conservative_clean": 2.8315,
+        "flexible_clean": 2.8196,
+        "prolific_accepted": 2.7821,
+        "v2_finished": 2.7436,
+        "v2_all": 2.7492
       }
     },
     {
       "key": "barrier_sd",
       "label": "Barrier SD",
       "values": {
-        "conservative_clean": 0.6332,
-        "flexible_clean": 0.7178,
-        "prolific_accepted": 0.7153,
-        "v2_finished": 0.7714,
-        "v2_all": 0.7752
+        "conservative_clean": 0.6291,
+        "flexible_clean": 0.7143,
+        "prolific_accepted": 0.7136,
+        "v2_finished": 0.771,
+        "v2_all": 0.7747
       }
     },
     {
       "key": "readiness_mean",
       "label": "Readiness Grand Mean",
       "values": {
-        "conservative_clean": 3.0528,
-        "flexible_clean": 3.0968,
-        "prolific_accepted": 3.14,
-        "v2_finished": 3.2494,
-        "v2_all": 3.2494
+        "conservative_clean": 3.0543,
+        "flexible_clean": 3.0971,
+        "prolific_accepted": 3.1398,
+        "v2_finished": 3.249,
+        "v2_all": 3.249
       }
     },
     {
       "key": "readiness_sd",
       "label": "Readiness SD",
       "values": {
-        "conservative_clean": 0.5806,
-        "flexible_clean": 0.6572,
-        "prolific_accepted": 0.6749,
-        "v2_finished": 0.715,
-        "v2_all": 0.7141
+        "conservative_clean": 0.5742,
+        "flexible_clean": 0.6525,
+        "prolific_accepted": 0.6722,
+        "v2_finished": 0.7142,
+        "v2_all": 0.7132
       }
     },
     {
       "key": "maturity_mean",
       "label": "Maturity Grand Mean",
       "values": {
-        "conservative_clean": 3.0377,
-        "flexible_clean": 3.0661,
-        "prolific_accepted": 3.1571,
-        "v2_finished": 3.2667,
-        "v2_all": 3.2667
+        "conservative_clean": 3.0276,
+        "flexible_clean": 3.0592,
+        "prolific_accepted": 3.1525,
+        "v2_finished": 3.2706,
+        "v2_all": 3.2706
       }
     },
     {
       "key": "maturity_sd",
       "label": "Maturity SD",
       "values": {
-        "conservative_clean": 0.7061,
-        "flexible_clean": 0.796,
-        "prolific_accepted": 0.8055,
-        "v2_finished": 0.8058,
-        "v2_all": 0.8058
+        "conservative_clean": 0.7027,
+        "flexible_clean": 0.793,
+        "prolific_accepted": 0.8043,
+        "v2_finished": 0.8056,
+        "v2_all": 0.8056
       }
     },
     {
       "key": "corr_br",
       "label": "B-R Correlation",
       "values": {
-        "conservative_clean": -0.4856,
-        "flexible_clean": -0.4595,
-        "prolific_accepted": -0.3423,
-        "v2_finished": -0.3165,
-        "v2_all": -0.3162
+        "conservative_clean": -0.477,
+        "flexible_clean": -0.4558,
+        "prolific_accepted": -0.3408,
+        "v2_finished": -0.3146,
+        "v2_all": -0.3144
       }
     },
     {
       "key": "corr_bm",
       "label": "B-M Correlation",
       "values": {
-        "conservative_clean": -0.2315,
-        "flexible_clean": -0.3197,
-        "prolific_accepted": -0.2787,
-        "v2_finished": -0.31,
-        "v2_all": -0.31
+        "conservative_clean": -0.2419,
+        "flexible_clean": -0.3244,
+        "prolific_accepted": -0.2819,
+        "v2_finished": -0.3039,
+        "v2_all": -0.3039
       }
     },
     {
       "key": "corr_rm",
       "label": "R-M Correlation",
       "values": {
-        "conservative_clean": 0.5899,
-        "flexible_clean": 0.6982,
-        "prolific_accepted": 0.7125,
-        "v2_finished": 0.7341,
-        "v2_all": 0.7341
+        "conservative_clean": 0.5789,
+        "flexible_clean": 0.6926,
+        "prolific_accepted": 0.7094,
+        "v2_finished": 0.7319,
+        "v2_all": 0.7319
       }
     },
     {
       "key": "alpha_barriers",
       "label": "Alpha Barriers",
       "values": {
-        "conservative_clean": 0.858,
-        "flexible_clean": 0.8772,
-        "prolific_accepted": 0.877,
-        "v2_finished": 0.9011,
-        "v2_all": 0.9025
+        "conservative_clean": 0.8555,
+        "flexible_clean": 0.8758,
+        "prolific_accepted": 0.8763,
+        "v2_finished": 0.9005,
+        "v2_all": 0.9019
       }
     },
     {
       "key": "alpha_readiness",
       "label": "Alpha Readiness",
       "values": {
-        "conservative_clean": 0.8756,
-        "flexible_clean": 0.9181,
-        "prolific_accepted": 0.9207,
-        "v2_finished": 0.9305,
-        "v2_all": 0.9305
+        "conservative_clean": 0.8696,
+        "flexible_clean": 0.9152,
+        "prolific_accepted": 0.9193,
+        "v2_finished": 0.9301,
+        "v2_all": 0.9301
       }
     },
     {
       "key": "alpha_maturity",
       "label": "Alpha Maturity",
       "values": {
-        "conservative_clean": 0.833,
-        "flexible_clean": 0.8833,
-        "prolific_accepted": 0.8897,
-        "v2_finished": 0.89,
-        "v2_all": 0.89
+        "conservative_clean": 0.8282,
+        "flexible_clean": 0.8808,
+        "prolific_accepted": 0.8886,
+        "v2_finished": 0.8901,
+        "v2_all": 0.8901
       }
     }
   ],
@@ -180,7 +180,7 @@
         "Q8_GeoScope": "Geographic scope",
         "Q9_GeoScale": "Geographic scale"
       },
-      "note": "Self-reported by participants within the TABS survey instrument. Used for all per-group demographic breakdowns, effect sizes, and cross-tabulations."
+      "note": "Self-reported by participants within the TABS survey instrument."
     },
     "platform_demographics": {
       "source": "Prolific API (POST /studies/{id}/demographic-export/)",
@@ -252,7 +252,7 @@
           "base_field": false
         }
       ],
-      "prescreener_note": "Up to 15 prescreener filters can be selected per export (configurable twice before locking). The 5 study screeners above are exported for cross-validation. Additional augmentation filters (education_level, household_income, fluent_languages) are also included, totaling 7 of the 15-filter maximum.",
+      "prescreener_note": "Up to 15 prescreener filters can be selected per export.",
       "fields": {
         "age": "Participant age",
         "sex": "Biological sex",
@@ -272,7 +272,7 @@
         "fluent_languages": "Fluent languages (prescreener)"
       },
       "cross_validation": {
-        "description": "Prolific prescreener fields overlap with Qualtrics survey demographics, enabling independent cross-validation of self-reported data and sample balancing.",
+        "description": "Prolific prescreener fields overlap with Qualtrics survey demographics.",
         "overlapping_fields": {
           "industry": {
             "prolific": "industry",
@@ -294,20 +294,20 @@
         "use_cases": [
           "Flag discrepancies between Prolific profile and survey responses",
           "Balance samples using validated Prolific profile data",
-          "Augment survey demographics with additional Prolific fields (education, income, languages)"
+          "Augment survey demographics with additional Prolific fields"
         ]
       },
-      "note": "Base fields are always included in the Prolific demographic export. Prescreener fields are available when configured as study filters (up to 15 per export). The export is a snapshot of participants' prescreening responses at the time they took the study. Both base and prescreener data can be cross-referenced with Qualtrics survey data using Prolific Participant ID as join key."
+      "note": "Base fields are always included in the Prolific demographic export."
     }
   },
   "sample_details": {
     "conservative_clean": {
       "demographics": {
         "roles": {
-          "Other": 13,
+          "Other": 14,
           "CIO": 11,
           "COO": 10,
-          "CEO": 9,
+          "CEO": 10,
           "CMO": 9,
           "CSO": 8,
           "CHRO": 7,
@@ -316,98 +316,97 @@
           "CRO": 3
         },
         "org_sizes": {
-          "<100": 9,
+          "<100": 10,
           "100-499": 29,
-          "500-999": 7,
+          "500-999": 8,
           "1000-4999": 18,
           "5000-9999": 6,
           "10000+": 11
         },
         "profit_models": {
-          "For-Profit": 57,
+          "For-Profit": 58,
           "Non-Profit": 15,
-          "Government/Public Sector": 8
+          "Government/Public Sector": 9
         },
         "tech_vs_nontech": {
           "technical": 15,
-          "non_technical": 52,
-          "other": 13
+          "non_technical": 55,
+          "other": 12
         },
         "other_roles": {
-          "total": 13,
+          "total": 14,
           "categories": {
-            "Director": 7,
-            "Uncategorized": 3,
-            "VP / SVP": 2,
-            "Manager / Program Lead": 1
+            "Director": 8,
+            "Uncategorized": "<5",
+            "Manager / Program Lead": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 15,
-          "nontech_n": 52,
+          "nontech_n": 55,
           "constructs": {
             "barriers": {
               "tech_mean": 2.7222,
               "tech_mean_ci_lower": 2.7222,
               "tech_mean_ci_upper": 2.7222,
-              "nontech_mean": 2.8807,
-              "nontech_mean_ci_lower": 2.8807,
-              "nontech_mean_ci_upper": 2.8807,
-              "d": -0.2342,
-              "d_ci_lower": -0.8445,
-              "d_ci_upper": 0.3672
+              "nontech_mean": 2.8923,
+              "nontech_mean_ci_lower": 2.8923,
+              "nontech_mean_ci_upper": 2.8923,
+              "d": -0.2556,
+              "d_ci_lower": -0.8392,
+              "d_ci_upper": 0.3417
             },
             "readiness": {
               "tech_mean": 3.325,
               "tech_mean_ci_lower": 3.325,
               "tech_mean_ci_upper": 3.325,
-              "nontech_mean": 3.0075,
-              "nontech_mean_ci_lower": 3.0075,
-              "nontech_mean_ci_upper": 3.0075,
-              "d": 0.5428,
-              "d_ci_lower": 0.0205,
-              "d_ci_upper": 1.1859
+              "nontech_mean": 3.0071,
+              "nontech_mean_ci_lower": 3.0071,
+              "nontech_mean_ci_upper": 3.0071,
+              "d": 0.5543,
+              "d_ci_lower": 0.0161,
+              "d_ci_upper": 1.1792
             },
             "maturity": {
               "tech_mean": 3.1083,
               "tech_mean_ci_lower": 3.1083,
               "tech_mean_ci_upper": 3.1083,
-              "nontech_mean": 3.0003,
-              "nontech_mean_ci_lower": 3.0003,
-              "nontech_mean_ci_upper": 3.0003,
-              "d": 0.1516,
-              "d_ci_lower": -0.4542,
-              "d_ci_upper": 0.8094
+              "nontech_mean": 2.9844,
+              "nontech_mean_ci_lower": 2.9844,
+              "nontech_mean_ci_upper": 2.9844,
+              "d": 0.1755,
+              "d_ci_lower": -0.4474,
+              "d_ci_upper": 0.7883
             }
           }
         },
         "large_vs_small": {
           "large_n": 17,
-          "small_medium_n": 63,
+          "small_medium_n": 65,
           "constructs": {
             "barriers": {
               "large_mean": 3.0919,
               "large_mean_ci_lower": 3.0919,
               "large_mean_ci_upper": 3.0919,
-              "small_medium_mean": 2.7515,
-              "small_medium_mean_ci_lower": 2.7515,
-              "small_medium_mean_ci_upper": 2.7515,
-              "d": 0.5477,
-              "d_ci_lower": 0.0732,
-              "d_ci_upper": 1.0521
+              "small_medium_mean": 2.7634,
+              "small_medium_mean_ci_lower": 2.7634,
+              "small_medium_mean_ci_upper": 2.7634,
+              "d": 0.5311,
+              "d_ci_lower": 0.0462,
+              "d_ci_upper": 1.0707
             },
             "readiness": {
               "large_mean": 3.0222,
               "large_mean_ci_lower": 3.0222,
               "large_mean_ci_upper": 3.0222,
-              "small_medium_mean": 3.0611,
-              "small_medium_mean_ci_lower": 3.0611,
-              "small_medium_mean_ci_upper": 3.0611,
-              "d": -0.0667,
-              "d_ci_lower": -0.6299,
-              "d_ci_upper": 0.5212
+              "small_medium_mean": 3.0627,
+              "small_medium_mean_ci_lower": 3.0627,
+              "small_medium_mean_ci_upper": 3.0627,
+              "d": -0.0702,
+              "d_ci_lower": -0.6538,
+              "d_ci_upper": 0.4677
             }
           }
         }
@@ -415,7 +414,7 @@
       "cross_tabs": {
         "by_role": [
           {
-            "group": "Technical (CIO/CTO)",
+            "group": "Technical",
             "n": 15,
             "barrier_mean": 2.7222,
             "readiness_mean": 3.325,
@@ -423,33 +422,33 @@
           },
           {
             "group": "Non-Technical",
-            "n": 52,
-            "barrier_mean": 2.8807,
-            "readiness_mean": 3.0075,
-            "maturity_mean": 3.0003
+            "n": 55,
+            "barrier_mean": 2.8923,
+            "readiness_mean": 3.0071,
+            "maturity_mean": 2.9844
           },
           {
             "group": "Other",
-            "n": 13,
-            "barrier_mean": 2.7137,
-            "readiness_mean": 2.9201,
-            "maturity_mean": 3.1058
+            "n": 12,
+            "barrier_mean": 2.6898,
+            "readiness_mean": 2.9324,
+            "maturity_mean": 3.125
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 38,
-            "barrier_mean": 2.8015,
-            "readiness_mean": 3.0642,
-            "maturity_mean": 2.9759
+            "n": 39,
+            "barrier_mean": 2.818,
+            "readiness_mean": 3.0701,
+            "maturity_mean": 2.9573
           },
           {
             "group": "Medium (500-4999)",
-            "n": 25,
-            "barrier_mean": 2.6756,
-            "readiness_mean": 3.0565,
-            "maturity_mean": 2.9536
+            "n": 26,
+            "barrier_mean": 2.6816,
+            "readiness_mean": 3.0517,
+            "maturity_mean": 2.9554
           },
           {
             "group": "Large (5000+)",
@@ -463,114 +462,114 @@
       "inferential": {
         "t_tests_tech_vs_nontech": {
           "tech_n": 15,
-          "nontech_n": 52,
+          "nontech_n": 55,
           "constructs": {
             "barriers": {
-              "t": -0.7577,
+              "t": -0.8204,
               "p": 0.0,
-              "df": 21.15,
-              "mean_diff_ci_lower": -0.1585,
-              "mean_diff_ci_upper": -0.1585,
+              "df": 20.46,
+              "mean_diff_ci_lower": -0.1701,
+              "mean_diff_ci_upper": -0.1701,
               "sig": true
             },
             "readiness": {
-              "t": 1.9082,
+              "t": 1.9345,
               "p": 0.0,
-              "df": 23.76,
-              "mean_diff_ci_lower": 0.3175,
-              "mean_diff_ci_upper": 0.3175,
+              "df": 22.76,
+              "mean_diff_ci_lower": 0.3179,
+              "mean_diff_ci_upper": 0.3179,
               "sig": true
             },
             "maturity": {
-              "t": 0.4737,
+              "t": 0.5469,
               "p": 0.0,
-              "df": 20.26,
-              "mean_diff_ci_lower": 0.108,
-              "mean_diff_ci_upper": 0.108,
+              "df": 19.8,
+              "mean_diff_ci_lower": 0.124,
+              "mean_diff_ci_upper": 0.124,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 17,
-          "small_medium_n": 63,
+          "small_medium_n": 65,
           "constructs": {
             "barriers": {
-              "t": 2.1629,
+              "t": 2.099,
               "p": 0.0,
-              "df": 28.3,
-              "mean_diff_ci_lower": 0.3404,
-              "mean_diff_ci_upper": 0.3404,
+              "df": 27.77,
+              "mean_diff_ci_lower": 0.3285,
+              "mean_diff_ci_upper": 0.3285,
               "sig": true
             },
             "readiness": {
-              "t": -0.234,
+              "t": -0.2451,
               "p": 0.0,
-              "df": 24.02,
-              "mean_diff_ci_lower": -0.039,
-              "mean_diff_ci_upper": -0.039,
+              "df": 23.54,
+              "mean_diff_ci_lower": -0.0406,
+              "mean_diff_ci_upper": -0.0406,
               "sig": true
             },
             "maturity": {
-              "t": 1.5717,
+              "t": 1.6271,
               "p": 0.0,
-              "df": 22.37,
-              "mean_diff_ci_lower": 0.3326,
-              "mean_diff_ci_upper": 0.3326,
+              "df": 22.09,
+              "mean_diff_ci_lower": 0.3431,
+              "mean_diff_ci_upper": 0.3431,
               "sig": true
             }
           }
         },
         "anova_by_role": {
-          "groups": ["Technical (CIO/CTO)", "Non-Technical", "Other"],
-          "group_ns": [15, 52, 13],
+          "groups": ["Technical", "Non-Technical", "Other"],
+          "group_ns": [15, 55, 12],
           "constructs": {
             "barriers": {
-              "f": 0.5936,
-              "p": 0.5548,
+              "f": 0.7833,
+              "p": 0.4604,
               "df_between": 2,
-              "df_within": 77,
+              "df_within": 79,
               "sig": false
             },
             "readiness": {
-              "f": 2.2118,
-              "p": 0.1164,
+              "f": 2.1853,
+              "p": 0.1192,
               "df_between": 2,
-              "df_within": 77,
+              "df_within": 79,
               "sig": false
             },
             "maturity": {
-              "f": 0.2042,
-              "p": 0.8157,
+              "f": 0.3129,
+              "p": 0.7322,
               "df_between": 2,
-              "df_within": 77,
+              "df_within": 79,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [38, 25, 17],
+          "group_ns": [39, 26, 17],
           "constructs": {
             "barriers": {
-              "f": 2.3066,
-              "p": 0.1064,
+              "f": 2.2729,
+              "p": 0.1097,
               "df_between": 2,
-              "df_within": 77,
+              "df_within": 79,
               "sig": false
             },
             "readiness": {
-              "f": 0.0307,
-              "p": 0.9698,
+              "f": 0.0406,
+              "p": 0.9602,
               "df_between": 2,
-              "df_within": 77,
+              "df_within": 79,
               "sig": false
             },
             "maturity": {
-              "f": 1.5116,
-              "p": 0.227,
+              "f": 1.631,
+              "p": 0.2023,
               "df_between": 2,
-              "df_within": 77,
+              "df_within": 79,
               "sig": false
             }
           }
@@ -581,10 +580,10 @@
       "demographics": {
         "roles": {
           "CIO": 22,
-          "Other": 19,
+          "Other": 20,
           "COO": 16,
+          "CEO": 13,
           "CMO": 12,
-          "CEO": 12,
           "CFO": 11,
           "CHRO": 10,
           "CSO": 10,
@@ -592,99 +591,98 @@
           "CTO": 7
         },
         "org_sizes": {
-          "<100": 17,
+          "<100": 18,
           "100-499": 40,
-          "500-999": 16,
+          "500-999": 17,
           "1000-4999": 30,
           "5000-9999": 8,
           "10000+": 16
         },
         "profit_models": {
-          "For-Profit": 87,
+          "For-Profit": 88,
           "Non-Profit": 27,
-          "Government/Public Sector": 13
+          "Government/Public Sector": 14
         },
         "tech_vs_nontech": {
           "technical": 29,
-          "non_technical": 79,
-          "other": 19
+          "non_technical": 84,
+          "other": 16
         },
         "other_roles": {
-          "total": 19,
+          "total": 20,
           "categories": {
-            "Director": 9,
-            "Manager / Program Lead": 3,
-            "Uncategorized": 3,
-            "VP / SVP": 3,
-            "C-Suite Adjacent": 1
+            "Director": 10,
+            "Uncategorized": "<5",
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 29,
-          "nontech_n": 79,
+          "nontech_n": 84,
           "constructs": {
             "barriers": {
               "tech_mean": 2.6475,
               "tech_mean_ci_lower": 2.6475,
               "tech_mean_ci_upper": 2.6475,
-              "nontech_mean": 2.8762,
-              "nontech_mean_ci_lower": 2.8762,
-              "nontech_mean_ci_upper": 2.8762,
-              "d": -0.3064,
-              "d_ci_lower": -0.74,
-              "d_ci_upper": 0.1164
+              "nontech_mean": 2.8803,
+              "nontech_mean_ci_lower": 2.8803,
+              "nontech_mean_ci_upper": 2.8803,
+              "d": -0.3173,
+              "d_ci_lower": -0.7473,
+              "d_ci_upper": 0.1078
             },
             "readiness": {
               "tech_mean": 3.4173,
               "tech_mean_ci_lower": 3.4173,
               "tech_mean_ci_upper": 3.4173,
-              "nontech_mean": 3.038,
-              "nontech_mean_ci_lower": 3.038,
-              "nontech_mean_ci_upper": 3.038,
-              "d": 0.5748,
-              "d_ci_lower": 0.1787,
-              "d_ci_upper": 1.0064
+              "nontech_mean": 3.0294,
+              "nontech_mean_ci_lower": 3.0294,
+              "nontech_mean_ci_upper": 3.0294,
+              "d": 0.5982,
+              "d_ci_lower": 0.2165,
+              "d_ci_upper": 1.014
             },
             "maturity": {
               "tech_mean": 3.2716,
               "tech_mean_ci_lower": 3.2716,
               "tech_mean_ci_upper": 3.2716,
-              "nontech_mean": 3.0334,
-              "nontech_mean_ci_lower": 3.0334,
-              "nontech_mean_ci_upper": 3.0334,
-              "d": 0.2954,
-              "d_ci_lower": -0.1095,
-              "d_ci_upper": 0.7287
+              "nontech_mean": 3.0091,
+              "nontech_mean_ci_lower": 3.0091,
+              "nontech_mean_ci_upper": 3.0091,
+              "d": 0.3292,
+              "d_ci_lower": -0.0769,
+              "d_ci_upper": 0.7522
             }
           }
         },
         "large_vs_small": {
           "large_n": 24,
-          "small_medium_n": 103,
+          "small_medium_n": 105,
           "constructs": {
             "barriers": {
               "large_mean": 3.0883,
               "large_mean_ci_lower": 3.0883,
               "large_mean_ci_upper": 3.0883,
-              "small_medium_mean": 2.7508,
-              "small_medium_mean_ci_lower": 2.7508,
-              "small_medium_mean_ci_upper": 2.7508,
-              "d": 0.4764,
-              "d_ci_lower": 0.0368,
-              "d_ci_upper": 0.9305
+              "small_medium_mean": 2.7582,
+              "small_medium_mean_ci_lower": 2.7582,
+              "small_medium_mean_ci_upper": 2.7582,
+              "d": 0.4679,
+              "d_ci_lower": 0.0137,
+              "d_ci_upper": 0.9164
             },
             "readiness": {
               "large_mean": 2.9544,
               "large_mean_ci_lower": 2.9544,
               "large_mean_ci_upper": 2.9544,
-              "small_medium_mean": 3.13,
-              "small_medium_mean_ci_lower": 3.13,
-              "small_medium_mean_ci_upper": 3.13,
-              "d": -0.2676,
-              "d_ci_lower": -0.7338,
-              "d_ci_upper": 0.1912
+              "small_medium_mean": 3.1297,
+              "small_medium_mean_ci_lower": 3.1297,
+              "small_medium_mean_ci_upper": 3.1297,
+              "d": -0.2691,
+              "d_ci_lower": -0.7557,
+              "d_ci_upper": 0.2123
             }
           }
         }
@@ -692,7 +690,7 @@
       "cross_tabs": {
         "by_role": [
           {
-            "group": "Technical (CIO/CTO)",
+            "group": "Technical",
             "n": 29,
             "barrier_mean": 2.6475,
             "readiness_mean": 3.4173,
@@ -700,33 +698,33 @@
           },
           {
             "group": "Non-Technical",
-            "n": 79,
-            "barrier_mean": 2.8762,
-            "readiness_mean": 3.038,
-            "maturity_mean": 3.0334
+            "n": 84,
+            "barrier_mean": 2.8803,
+            "readiness_mean": 3.0294,
+            "maturity_mean": 3.0091
           },
           {
             "group": "Other",
-            "n": 19,
-            "barrier_mean": 2.8133,
-            "readiness_mean": 2.8524,
-            "maturity_mean": 2.8882
+            "n": 16,
+            "barrier_mean": 2.813,
+            "readiness_mean": 2.8721,
+            "maturity_mean": 2.9375
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 57,
-            "barrier_mean": 2.7461,
-            "readiness_mean": 3.1159,
-            "maturity_mean": 2.9773
+            "n": 58,
+            "barrier_mean": 2.7581,
+            "readiness_mean": 3.119,
+            "maturity_mean": 2.9648
           },
           {
             "group": "Medium (500-4999)",
-            "n": 46,
-            "barrier_mean": 2.7566,
-            "readiness_mean": 3.1475,
-            "maturity_mean": 3.1432
+            "n": 47,
+            "barrier_mean": 2.7583,
+            "readiness_mean": 3.143,
+            "maturity_mean": 3.1402
           },
           {
             "group": "Large (5000+)",
@@ -740,114 +738,114 @@
       "inferential": {
         "t_tests_tech_vs_nontech": {
           "tech_n": 29,
-          "nontech_n": 79,
+          "nontech_n": 84,
           "constructs": {
             "barriers": {
-              "t": -1.4504,
+              "t": -1.4988,
               "p": 0.0,
-              "df": 52.65,
-              "mean_diff_ci_lower": -0.2287,
-              "mean_diff_ci_upper": -0.2287,
+              "df": 50.25,
+              "mean_diff_ci_lower": -0.2328,
+              "mean_diff_ci_upper": -0.2328,
               "sig": true
             },
             "readiness": {
-              "t": 2.8829,
+              "t": 3.0025,
               "p": 0.0,
-              "df": 59.56,
-              "mean_diff_ci_lower": 0.3794,
-              "mean_diff_ci_upper": 0.3794,
+              "df": 56.63,
+              "mean_diff_ci_lower": 0.3879,
+              "mean_diff_ci_upper": 0.3879,
               "sig": true
             },
             "maturity": {
-              "t": 1.431,
+              "t": 1.5995,
               "p": 0.0,
-              "df": 55.25,
-              "mean_diff_ci_lower": 0.2381,
-              "mean_diff_ci_upper": 0.2381,
+              "df": 53.03,
+              "mean_diff_ci_lower": 0.2624,
+              "mean_diff_ci_upper": 0.2624,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 24,
-          "small_medium_n": 103,
+          "small_medium_n": 105,
           "constructs": {
             "barriers": {
-              "t": 2.1546,
+              "t": 2.1136,
               "p": 0.0,
-              "df": 35.55,
-              "mean_diff_ci_lower": 0.3374,
-              "mean_diff_ci_upper": 0.3374,
+              "df": 35.18,
+              "mean_diff_ci_lower": 0.33,
+              "mean_diff_ci_upper": 0.33,
               "sig": true
             },
             "readiness": {
-              "t": -1.1279,
+              "t": -1.1293,
               "p": 0.0,
-              "df": 32.9,
-              "mean_diff_ci_lower": -0.1756,
-              "mean_diff_ci_upper": -0.1756,
+              "df": 32.53,
+              "mean_diff_ci_lower": -0.1753,
+              "mean_diff_ci_upper": -0.1753,
               "sig": true
             },
             "maturity": {
-              "t": 0.389,
+              "t": 0.4307,
               "p": 0.0,
-              "df": 31.38,
-              "mean_diff_ci_lower": 0.0774,
-              "mean_diff_ci_upper": 0.0774,
+              "df": 31.14,
+              "mean_diff_ci_lower": 0.0856,
+              "mean_diff_ci_upper": 0.0856,
               "sig": true
             }
           }
         },
         "anova_by_role": {
-          "groups": ["Technical (CIO/CTO)", "Non-Technical", "Other"],
-          "group_ns": [29, 79, 19],
+          "groups": ["Technical", "Non-Technical", "Other"],
+          "group_ns": [29, 84, 16],
           "constructs": {
             "barriers": {
-              "f": 1.0781,
-              "p": 0.3434,
+              "f": 1.1479,
+              "p": 0.3206,
               "df_between": 2,
-              "df_within": 124,
+              "df_within": 126,
               "sig": false
             },
             "readiness": {
-              "f": 5.436,
-              "p": 0.0055,
+              "f": 5.219,
+              "p": 0.0066,
               "df_between": 2,
-              "df_within": 124,
+              "df_within": 126,
               "sig": true
             },
             "maturity": {
-              "f": 1.5197,
-              "p": 0.2228,
+              "f": 1.4044,
+              "p": 0.2493,
               "df_between": 2,
-              "df_within": 124,
+              "df_within": 126,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [57, 46, 24],
+          "group_ns": [58, 47, 24],
           "constructs": {
             "barriers": {
-              "f": 2.1943,
-              "p": 0.1157,
+              "f": 2.1216,
+              "p": 0.1241,
               "df_between": 2,
-              "df_within": 124,
+              "df_within": 126,
               "sig": false
             },
             "readiness": {
-              "f": 0.7209,
-              "p": 0.4884,
+              "f": 0.7192,
+              "p": 0.4891,
               "df_between": 2,
-              "df_within": 124,
+              "df_within": 126,
               "sig": false
             },
             "maturity": {
-              "f": 0.6413,
-              "p": 0.5283,
+              "f": 0.7457,
+              "p": 0.4765,
               "df_between": 2,
-              "df_within": 124,
+              "df_within": 126,
               "sig": false
             }
           }
@@ -857,12 +855,12 @@
     "prolific_accepted": {
       "demographics": {
         "roles": {
-          "Other": 45,
+          "Other": 46,
           "CIO": 36,
           "COO": 24,
           "CSO": 22,
+          "CEO": 20,
           "CMO": 19,
-          "CEO": 19,
           "CHRO": 17,
           "CFO": 17,
           "CTO": 15,
@@ -870,100 +868,98 @@
           "Unknown": 2
         },
         "org_sizes": {
-          "<100": 40,
+          "<100": 41,
           "100-499": 57,
-          "500-999": 33,
+          "500-999": 34,
           "1000-4999": 48,
           "5000-9999": 20,
           "10000+": 33
         },
         "profit_models": {
-          "For-Profit": 172,
+          "For-Profit": 173,
           "Non-Profit": 41,
-          "Government/Public Sector": 18
+          "Government/Public Sector": 19
         },
         "tech_vs_nontech": {
-          "technical": 51,
-          "non_technical": 133,
-          "other": 45
+          "technical": 52,
+          "non_technical": 146,
+          "other": 35
         },
         "other_roles": {
-          "total": 45,
+          "total": 46,
           "categories": {
-            "Director": 23,
+            "Director": 22,
             "Uncategorized": 7,
-            "VP / SVP": 6,
-            "Manager / Program Lead": 5,
-            "C-Suite Adjacent": 3,
-            "Owner / Founder / President": 1
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 51,
-          "nontech_n": 133,
+          "tech_n": 52,
+          "nontech_n": 146,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7097,
-              "tech_mean_ci_lower": 2.7097,
-              "tech_mean_ci_upper": 2.7097,
-              "nontech_mean": 2.7974,
-              "nontech_mean_ci_lower": 2.7974,
-              "nontech_mean_ci_upper": 2.7974,
-              "d": -0.1183,
-              "d_ci_lower": -0.4447,
-              "d_ci_upper": 0.2256
+              "tech_mean": 2.7185,
+              "tech_mean_ci_lower": 2.7185,
+              "tech_mean_ci_upper": 2.7185,
+              "nontech_mean": 2.8094,
+              "nontech_mean_ci_lower": 2.8094,
+              "nontech_mean_ci_upper": 2.8094,
+              "d": -0.125,
+              "d_ci_lower": -0.4406,
+              "d_ci_upper": 0.2117
             },
             "readiness": {
-              "tech_mean": 3.4402,
-              "tech_mean_ci_lower": 3.4402,
-              "tech_mean_ci_upper": 3.4402,
-              "nontech_mean": 3.0718,
-              "nontech_mean_ci_lower": 3.0718,
-              "nontech_mean_ci_upper": 3.0718,
-              "d": 0.5601,
-              "d_ci_lower": 0.2428,
-              "d_ci_upper": 0.8723
+              "tech_mean": 3.4295,
+              "tech_mean_ci_lower": 3.4295,
+              "tech_mean_ci_upper": 3.4295,
+              "nontech_mean": 3.09,
+              "nontech_mean_ci_lower": 3.09,
+              "nontech_mean_ci_upper": 3.09,
+              "d": 0.5145,
+              "d_ci_lower": 0.2232,
+              "d_ci_upper": 0.8408
             },
             "maturity": {
-              "tech_mean": 3.3463,
-              "tech_mean_ci_lower": 3.3463,
-              "tech_mean_ci_upper": 3.3463,
-              "nontech_mean": 3.0949,
-              "nontech_mean_ci_lower": 3.0949,
-              "nontech_mean_ci_upper": 3.0949,
-              "d": 0.3138,
-              "d_ci_lower": -0.0174,
-              "d_ci_upper": 0.6331
+              "tech_mean": 3.3372,
+              "tech_mean_ci_lower": 3.3372,
+              "tech_mean_ci_upper": 3.3372,
+              "nontech_mean": 3.1121,
+              "nontech_mean_ci_lower": 3.1121,
+              "nontech_mean_ci_upper": 3.1121,
+              "d": 0.2812,
+              "d_ci_lower": -0.0244,
+              "d_ci_upper": 0.6129
             }
           }
         },
         "large_vs_small": {
           "large_n": 53,
-          "small_medium_n": 178,
+          "small_medium_n": 180,
           "constructs": {
             "barriers": {
               "large_mean": 2.9026,
               "large_mean_ci_lower": 2.9026,
               "large_mean_ci_upper": 2.9026,
-              "small_medium_mean": 2.7422,
-              "small_medium_mean_ci_lower": 2.7422,
-              "small_medium_mean_ci_upper": 2.7422,
-              "d": 0.2247,
-              "d_ci_lower": -0.0942,
-              "d_ci_upper": 0.5468
+              "small_medium_mean": 2.7466,
+              "small_medium_mean_ci_lower": 2.7466,
+              "small_medium_mean_ci_upper": 2.7466,
+              "d": 0.219,
+              "d_ci_lower": -0.0801,
+              "d_ci_upper": 0.5456
             },
             "readiness": {
               "large_mean": 3.1666,
               "large_mean_ci_lower": 3.1666,
               "large_mean_ci_upper": 3.1666,
-              "small_medium_mean": 3.1321,
-              "small_medium_mean_ci_lower": 3.1321,
-              "small_medium_mean_ci_upper": 3.1321,
-              "d": 0.0511,
-              "d_ci_lower": -0.2555,
-              "d_ci_upper": 0.3929
+              "small_medium_mean": 3.1318,
+              "small_medium_mean_ci_lower": 3.1318,
+              "small_medium_mean_ci_upper": 3.1318,
+              "d": 0.0516,
+              "d_ci_lower": -0.2792,
+              "d_ci_upper": 0.3937
             }
           }
         }
@@ -971,41 +967,41 @@
       "cross_tabs": {
         "by_role": [
           {
-            "group": "Technical (CIO/CTO)",
-            "n": 51,
-            "barrier_mean": 2.7097,
-            "readiness_mean": 3.4402,
-            "maturity_mean": 3.3463
+            "group": "Technical",
+            "n": 52,
+            "barrier_mean": 2.7185,
+            "readiness_mean": 3.4295,
+            "maturity_mean": 3.3372
           },
           {
             "group": "Non-Technical",
-            "n": 133,
-            "barrier_mean": 2.7974,
-            "readiness_mean": 3.0718,
-            "maturity_mean": 3.0949
+            "n": 146,
+            "barrier_mean": 2.8094,
+            "readiness_mean": 3.09,
+            "maturity_mean": 3.1121
           },
           {
             "group": "Other",
-            "n": 45,
-            "barrier_mean": 2.7885,
-            "readiness_mean": 2.9615,
-            "maturity_mean": 3.0778
+            "n": 35,
+            "barrier_mean": 2.7629,
+            "readiness_mean": 2.9167,
+            "maturity_mean": 3.0464
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 97,
-            "barrier_mean": 2.736,
-            "readiness_mean": 3.0517,
-            "maturity_mean": 2.9955
+            "n": 98,
+            "barrier_mean": 2.7432,
+            "readiness_mean": 3.0542,
+            "maturity_mean": 2.9879
           },
           {
             "group": "Medium (500-4999)",
-            "n": 81,
-            "barrier_mean": 2.7497,
-            "readiness_mean": 3.2283,
-            "maturity_mean": 3.2357
+            "n": 82,
+            "barrier_mean": 2.7507,
+            "readiness_mean": 3.2247,
+            "maturity_mean": 3.2328
           },
           {
             "group": "Large (5000+)",
@@ -1018,115 +1014,115 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 51,
-          "nontech_n": 133,
+          "tech_n": 52,
+          "nontech_n": 146,
           "constructs": {
             "barriers": {
-              "t": -0.7105,
+              "t": -0.7587,
               "p": 0.0,
-              "df": 88.78,
-              "mean_diff_ci_lower": -0.0877,
-              "mean_diff_ci_upper": -0.0877,
+              "df": 86.63,
+              "mean_diff_ci_lower": -0.0909,
+              "mean_diff_ci_upper": -0.0909,
               "sig": true
             },
             "readiness": {
-              "t": 3.4927,
+              "t": 3.2873,
               "p": 0.0,
-              "df": 95.77,
-              "mean_diff_ci_lower": 0.3684,
-              "mean_diff_ci_upper": 0.3684,
+              "df": 95.31,
+              "mean_diff_ci_lower": 0.3395,
+              "mean_diff_ci_upper": 0.3395,
               "sig": true
             },
             "maturity": {
-              "t": 1.9032,
+              "t": 1.7457,
               "p": 0.0,
-              "df": 90.46,
-              "mean_diff_ci_lower": 0.2514,
-              "mean_diff_ci_upper": 0.2514,
+              "df": 90.22,
+              "mean_diff_ci_lower": 0.2251,
+              "mean_diff_ci_upper": 0.2251,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 53,
-          "small_medium_n": 178,
+          "small_medium_n": 180,
           "constructs": {
             "barriers": {
-              "t": 1.452,
+              "t": 1.415,
               "p": 0.0,
-              "df": 86.81,
-              "mean_diff_ci_lower": 0.1604,
-              "mean_diff_ci_upper": 0.1604,
+              "df": 86.23,
+              "mean_diff_ci_lower": 0.156,
+              "mean_diff_ci_upper": 0.156,
               "sig": true
             },
             "readiness": {
-              "t": 0.3018,
+              "t": 0.3042,
               "p": 0.0,
-              "df": 76.65,
-              "mean_diff_ci_lower": 0.0345,
-              "mean_diff_ci_upper": 0.0345,
+              "df": 76.11,
+              "mean_diff_ci_lower": 0.0347,
+              "mean_diff_ci_upper": 0.0347,
               "sig": true
             },
             "maturity": {
-              "t": 1.7294,
+              "t": 1.7726,
               "p": 0.0,
-              "df": 79.61,
-              "mean_diff_ci_lower": 0.2278,
-              "mean_diff_ci_upper": 0.2278,
+              "df": 79.17,
+              "mean_diff_ci_lower": 0.2331,
+              "mean_diff_ci_upper": 0.2331,
               "sig": true
             }
           }
         },
         "anova_by_role": {
-          "groups": ["Technical (CIO/CTO)", "Non-Technical", "Other"],
-          "group_ns": [51, 133, 45],
+          "groups": ["Technical", "Non-Technical", "Other"],
+          "group_ns": [52, 146, 35],
           "constructs": {
             "barriers": {
-              "f": 0.2853,
-              "p": 0.7521,
+              "f": 0.3241,
+              "p": 0.7235,
               "df_between": 2,
-              "df_within": 226,
+              "df_within": 230,
               "sig": false
             },
             "readiness": {
-              "f": 7.7698,
-              "p": 0.0005,
+              "f": 7.5623,
+              "p": 0.0007,
               "df_between": 2,
-              "df_within": 226,
+              "df_within": 230,
               "sig": true
             },
             "maturity": {
-              "f": 2.0426,
-              "p": 0.1321,
+              "f": 1.8737,
+              "p": 0.1559,
               "df_between": 2,
-              "df_within": 226,
+              "df_within": 230,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [97, 81, 53],
+          "group_ns": [98, 82, 53],
           "constructs": {
             "barriers": {
-              "f": 1.0347,
-              "p": 0.357,
+              "f": 0.9802,
+              "p": 0.3768,
               "df_between": 2,
-              "df_within": 228,
+              "df_within": 230,
               "sig": false
             },
             "readiness": {
-              "f": 1.5713,
-              "p": 0.21,
+              "f": 1.4966,
+              "p": 0.2261,
               "df_between": 2,
-              "df_within": 228,
+              "df_within": 230,
               "sig": false
             },
             "maturity": {
-              "f": 3.6787,
-              "p": 0.0268,
+              "f": 3.8837,
+              "p": 0.0219,
               "df_between": 2,
-              "df_within": 228,
+              "df_within": 230,
               "sig": true
             }
           }
@@ -1137,11 +1133,11 @@
       "demographics": {
         "roles": {
           "Other": 66,
-          "CIO": 57,
+          "CIO": 58,
           "CEO": 38,
           "COO": 34,
           "CTO": 34,
-          "CFO": 32,
+          "CFO": 33,
           "CSO": 31,
           "CMO": 25,
           "CHRO": 24,
@@ -1149,100 +1145,98 @@
           "Unknown": 5
         },
         "org_sizes": {
-          "<100": 56,
-          "100-499": 98,
+          "<100": 57,
+          "100-499": 99,
           "500-999": 57,
           "1000-4999": 73,
           "5000-9999": 31,
           "10000+": 53
         },
         "profit_models": {
-          "For-Profit": 277,
+          "For-Profit": 278,
           "Non-Profit": 62,
-          "Government/Public Sector": 29
+          "Government/Public Sector": 30
         },
         "tech_vs_nontech": {
-          "technical": 91,
-          "non_technical": 206,
-          "other": 66
+          "technical": 93,
+          "non_technical": 227,
+          "other": 50
         },
         "other_roles": {
           "total": 66,
           "categories": {
-            "Director": 29,
-            "VP / SVP": 12,
+            "Director": 27,
             "Uncategorized": 10,
-            "Manager / Program Lead": 8,
-            "C-Suite Adjacent": 5,
-            "Owner / Founder / President": 2
+            "Manager / Program Lead": 6,
+            "C-Suite Adjacent": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 91,
-          "nontech_n": 206,
+          "tech_n": 93,
+          "nontech_n": 227,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6633,
-              "tech_mean_ci_lower": 2.6633,
-              "tech_mean_ci_upper": 2.6633,
-              "nontech_mean": 2.7598,
-              "nontech_mean_ci_lower": 2.7598,
-              "nontech_mean_ci_upper": 2.7598,
-              "d": -0.1202,
-              "d_ci_lower": -0.3702,
-              "d_ci_upper": 0.1257
+              "tech_mean": 2.6789,
+              "tech_mean_ci_lower": 2.6789,
+              "tech_mean_ci_upper": 2.6789,
+              "nontech_mean": 2.7673,
+              "nontech_mean_ci_lower": 2.7673,
+              "nontech_mean_ci_upper": 2.7673,
+              "d": -0.1121,
+              "d_ci_lower": -0.3612,
+              "d_ci_upper": 0.1326
             },
             "readiness": {
-              "tech_mean": 3.4678,
-              "tech_mean_ci_lower": 3.4678,
-              "tech_mean_ci_upper": 3.4678,
-              "nontech_mean": 3.2151,
-              "nontech_mean_ci_lower": 3.2151,
-              "nontech_mean_ci_upper": 3.2151,
-              "d": 0.3548,
-              "d_ci_lower": 0.1092,
-              "d_ci_upper": 0.6112
+              "tech_mean": 3.4641,
+              "tech_mean_ci_lower": 3.4641,
+              "tech_mean_ci_upper": 3.4641,
+              "nontech_mean": 3.2136,
+              "nontech_mean_ci_lower": 3.2136,
+              "nontech_mean_ci_upper": 3.2136,
+              "d": 0.354,
+              "d_ci_lower": 0.1037,
+              "d_ci_upper": 0.5984
             },
             "maturity": {
-              "tech_mean": 3.4084,
-              "tech_mean_ci_lower": 3.4084,
-              "tech_mean_ci_upper": 3.4084,
-              "nontech_mean": 3.2395,
-              "nontech_mean_ci_lower": 3.2395,
-              "nontech_mean_ci_upper": 3.2395,
-              "d": 0.2104,
-              "d_ci_lower": -0.04,
-              "d_ci_upper": 0.4462
+              "tech_mean": 3.4117,
+              "tech_mean_ci_lower": 3.4117,
+              "tech_mean_ci_upper": 3.4117,
+              "nontech_mean": 3.248,
+              "nontech_mean_ci_lower": 3.248,
+              "nontech_mean_ci_upper": 3.248,
+              "d": 0.2038,
+              "d_ci_lower": -0.0288,
+              "d_ci_upper": 0.4469
             }
           }
         },
         "large_vs_small": {
           "large_n": 84,
-          "small_medium_n": 284,
+          "small_medium_n": 286,
           "constructs": {
             "barriers": {
               "large_mean": 2.8781,
               "large_mean_ci_lower": 2.8781,
               "large_mean_ci_upper": 2.8781,
-              "small_medium_mean": 2.6993,
-              "small_medium_mean_ci_lower": 2.6993,
-              "small_medium_mean_ci_upper": 2.6993,
-              "d": 0.2325,
-              "d_ci_lower": -0.004,
-              "d_ci_upper": 0.4799
+              "small_medium_mean": 2.7041,
+              "small_medium_mean_ci_lower": 2.7041,
+              "small_medium_mean_ci_upper": 2.7041,
+              "d": 0.2263,
+              "d_ci_lower": -0.0116,
+              "d_ci_upper": 0.485
             },
             "readiness": {
               "large_mean": 3.2641,
               "large_mean_ci_lower": 3.2641,
               "large_mean_ci_upper": 3.2641,
-              "small_medium_mean": 3.245,
-              "small_medium_mean_ci_lower": 3.245,
-              "small_medium_mean_ci_upper": 3.245,
-              "d": 0.0268,
-              "d_ci_lower": -0.2281,
-              "d_ci_upper": 0.2714
+              "small_medium_mean": 3.2445,
+              "small_medium_mean_ci_lower": 3.2445,
+              "small_medium_mean_ci_upper": 3.2445,
+              "d": 0.0275,
+              "d_ci_lower": -0.2296,
+              "d_ci_upper": 0.2708
             }
           }
         }
@@ -1250,34 +1244,34 @@
       "cross_tabs": {
         "by_role": [
           {
-            "group": "Technical (CIO/CTO)",
-            "n": 91,
-            "barrier_mean": 2.6633,
-            "readiness_mean": 3.4678,
-            "maturity_mean": 3.4084
+            "group": "Technical",
+            "n": 93,
+            "barrier_mean": 2.6789,
+            "readiness_mean": 3.4641,
+            "maturity_mean": 3.4117
           },
           {
             "group": "Non-Technical",
-            "n": 206,
-            "barrier_mean": 2.7598,
-            "readiness_mean": 3.2151,
-            "maturity_mean": 3.2395
+            "n": 227,
+            "barrier_mean": 2.7673,
+            "readiness_mean": 3.2136,
+            "maturity_mean": 3.248
           },
           {
             "group": "Other",
-            "n": 66,
-            "barrier_mean": 2.7776,
-            "readiness_mean": 3.0189,
-            "maturity_mean": 3.1172
+            "n": 50,
+            "barrier_mean": 2.7566,
+            "readiness_mean": 3.0047,
+            "maturity_mean": 3.1079
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 154,
-            "barrier_mean": 2.6628,
-            "readiness_mean": 3.1718,
-            "maturity_mean": 3.1382
+            "n": 156,
+            "barrier_mean": 2.6721,
+            "readiness_mean": 3.1719,
+            "maturity_mean": 3.1492
           },
           {
             "group": "Medium (500-4999)",
@@ -1297,115 +1291,115 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 91,
-          "nontech_n": 206,
+          "tech_n": 93,
+          "nontech_n": 227,
           "constructs": {
             "barriers": {
-              "t": -0.9504,
+              "t": -0.8971,
               "p": 0.0,
-              "df": 170.55,
-              "mean_diff_ci_lower": -0.0965,
-              "mean_diff_ci_upper": -0.0965,
+              "df": 165.94,
+              "mean_diff_ci_lower": -0.0884,
+              "mean_diff_ci_upper": -0.0884,
               "sig": true
             },
             "readiness": {
-              "t": 2.8365,
+              "t": 2.8944,
               "p": 0.0,
-              "df": 174.93,
-              "mean_diff_ci_lower": 0.2527,
-              "mean_diff_ci_upper": 0.2527,
+              "df": 173.63,
+              "mean_diff_ci_lower": 0.2505,
+              "mean_diff_ci_upper": 0.2505,
               "sig": true
             },
             "maturity": {
-              "t": 1.6997,
+              "t": 1.6873,
               "p": 0.0,
-              "df": 179.21,
-              "mean_diff_ci_lower": 0.1689,
-              "mean_diff_ci_upper": 0.1689,
+              "df": 178.48,
+              "mean_diff_ci_lower": 0.1637,
+              "mean_diff_ci_upper": 0.1637,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 84,
-          "small_medium_n": 284,
+          "small_medium_n": 286,
           "constructs": {
             "barriers": {
-              "t": 1.8799,
+              "t": 1.8309,
               "p": 0.0,
-              "df": 136.69,
-              "mean_diff_ci_lower": 0.1788,
-              "mean_diff_ci_upper": 0.1788,
+              "df": 136.28,
+              "mean_diff_ci_lower": 0.174,
+              "mean_diff_ci_upper": 0.174,
               "sig": true
             },
             "readiness": {
-              "t": 0.2095,
+              "t": 0.215,
               "p": 0.0,
-              "df": 130.74,
-              "mean_diff_ci_lower": 0.0192,
-              "mean_diff_ci_upper": 0.0192,
+              "df": 130.25,
+              "mean_diff_ci_lower": 0.0196,
+              "mean_diff_ci_upper": 0.0196,
               "sig": true
             },
             "maturity": {
-              "t": 1.2613,
+              "t": 1.2103,
               "p": 0.0,
-              "df": 129.94,
-              "mean_diff_ci_lower": 0.1303,
-              "mean_diff_ci_upper": 0.1303,
+              "df": 129.62,
+              "mean_diff_ci_lower": 0.1249,
+              "mean_diff_ci_upper": 0.1249,
               "sig": true
             }
           }
         },
         "anova_by_role": {
-          "groups": ["Technical (CIO/CTO)", "Non-Technical", "Other"],
-          "group_ns": [91, 206, 66],
+          "groups": ["Technical", "Non-Technical", "Other"],
+          "group_ns": [93, 227, 50],
           "constructs": {
             "barriers": {
-              "f": 0.5937,
-              "p": 0.5528,
+              "f": 0.4404,
+              "p": 0.6441,
               "df_between": 2,
-              "df_within": 360,
+              "df_within": 367,
               "sig": false
             },
             "readiness": {
-              "f": 8.1681,
-              "p": 0.0003,
+              "f": 7.6289,
+              "p": 0.0006,
               "df_between": 2,
-              "df_within": 359,
+              "df_within": 366,
               "sig": true
             },
             "maturity": {
-              "f": 2.6559,
-              "p": 0.0716,
+              "f": 2.5357,
+              "p": 0.0806,
               "df_between": 2,
-              "df_within": 359,
+              "df_within": 366,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [154, 130, 84],
+          "group_ns": [156, 130, 84],
           "constructs": {
             "barriers": {
-              "f": 2.1308,
-              "p": 0.1202,
+              "f": 1.959,
+              "p": 0.1425,
               "df_between": 2,
-              "df_within": 365,
+              "df_within": 367,
               "sig": false
             },
             "readiness": {
-              "f": 1.8,
-              "p": 0.1668,
+              "f": 1.8148,
+              "p": 0.1643,
               "df_between": 2,
-              "df_within": 364,
+              "df_within": 366,
               "sig": false
             },
             "maturity": {
-              "f": 3.4238,
-              "p": 0.0336,
+              "f": 3.1102,
+              "p": 0.0458,
               "df_between": 2,
-              "df_within": 364,
+              "df_within": 366,
               "sig": true
             }
           }
@@ -1417,111 +1411,109 @@
         "roles": {
           "Other": 68,
           "Unknown": 63,
-          "CIO": 57,
+          "CIO": 59,
           "CEO": 38,
           "COO": 35,
+          "CFO": 34,
           "CTO": 34,
           "CSO": 33,
-          "CFO": 33,
           "CMO": 25,
           "CHRO": 25,
           "CRO": 23
         },
         "org_sizes": {
-          "<100": 57,
-          "100-499": 100,
+          "<100": 58,
+          "100-499": 102,
           "500-999": 59,
           "1000-4999": 74,
           "5000-9999": 32,
           "10000+": 54
         },
         "profit_models": {
-          "For-Profit": 284,
+          "For-Profit": 286,
           "Non-Profit": 63,
-          "Government/Public Sector": 29
+          "Government/Public Sector": 30
         },
         "tech_vs_nontech": {
-          "technical": 91,
-          "non_technical": 212,
-          "other": 68
+          "technical": 94,
+          "non_technical": 233,
+          "other": 110
         },
         "other_roles": {
           "total": 68,
           "categories": {
-            "Director": 29,
-            "VP / SVP": 12,
+            "Director": 27,
             "Uncategorized": 12,
-            "Manager / Program Lead": 8,
-            "C-Suite Adjacent": 5,
-            "Owner / Founder / President": 2
+            "Manager / Program Lead": 6,
+            "C-Suite Adjacent": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 91,
-          "nontech_n": 212,
+          "tech_n": 94,
+          "nontech_n": 233,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6633,
-              "tech_mean_ci_lower": 2.6633,
-              "tech_mean_ci_upper": 2.6633,
-              "nontech_mean": 2.7648,
-              "nontech_mean_ci_lower": 2.7648,
-              "nontech_mean_ci_upper": 2.7648,
-              "d": -0.1259,
-              "d_ci_lower": -0.3797,
-              "d_ci_upper": 0.124
+              "tech_mean": 2.6789,
+              "tech_mean_ci_lower": 2.6789,
+              "tech_mean_ci_upper": 2.6789,
+              "nontech_mean": 2.7718,
+              "nontech_mean_ci_lower": 2.7718,
+              "nontech_mean_ci_upper": 2.7718,
+              "d": -0.1173,
+              "d_ci_lower": -0.3662,
+              "d_ci_upper": 0.1238
             },
             "readiness": {
-              "tech_mean": 3.4678,
-              "tech_mean_ci_lower": 3.4678,
-              "tech_mean_ci_upper": 3.4678,
-              "nontech_mean": 3.2153,
-              "nontech_mean_ci_lower": 3.2153,
-              "nontech_mean_ci_upper": 3.2153,
-              "d": 0.355,
-              "d_ci_lower": 0.1054,
-              "d_ci_upper": 0.6075
+              "tech_mean": 3.4641,
+              "tech_mean_ci_lower": 3.4641,
+              "tech_mean_ci_upper": 3.4641,
+              "nontech_mean": 3.2138,
+              "nontech_mean_ci_lower": 3.2138,
+              "nontech_mean_ci_upper": 3.2138,
+              "d": 0.3542,
+              "d_ci_lower": 0.1189,
+              "d_ci_upper": 0.6058
             },
             "maturity": {
-              "tech_mean": 3.4084,
-              "tech_mean_ci_lower": 3.4084,
-              "tech_mean_ci_upper": 3.4084,
-              "nontech_mean": 3.2395,
-              "nontech_mean_ci_lower": 3.2395,
-              "nontech_mean_ci_upper": 3.2395,
-              "d": 0.2104,
-              "d_ci_lower": -0.04,
-              "d_ci_upper": 0.4462
+              "tech_mean": 3.4117,
+              "tech_mean_ci_lower": 3.4117,
+              "tech_mean_ci_upper": 3.4117,
+              "nontech_mean": 3.248,
+              "nontech_mean_ci_lower": 3.248,
+              "nontech_mean_ci_upper": 3.248,
+              "d": 0.2038,
+              "d_ci_lower": -0.0288,
+              "d_ci_upper": 0.4469
             }
           }
         },
         "large_vs_small": {
           "large_n": 86,
-          "small_medium_n": 348,
+          "small_medium_n": 351,
           "constructs": {
             "barriers": {
               "large_mean": 2.888,
               "large_mean_ci_lower": 2.888,
               "large_mean_ci_upper": 2.888,
-              "small_medium_mean": 2.7036,
-              "small_medium_mean_ci_lower": 2.7036,
-              "small_medium_mean_ci_upper": 2.7036,
-              "d": 0.2388,
-              "d_ci_lower": -0.0063,
-              "d_ci_upper": 0.4837
+              "small_medium_mean": 2.7084,
+              "small_medium_mean_ci_lower": 2.7084,
+              "small_medium_mean_ci_upper": 2.7084,
+              "d": 0.2327,
+              "d_ci_lower": -0.0215,
+              "d_ci_upper": 0.4726
             },
             "readiness": {
               "large_mean": 3.2641,
               "large_mean_ci_lower": 3.2641,
               "large_mean_ci_upper": 3.2641,
-              "small_medium_mean": 3.245,
-              "small_medium_mean_ci_lower": 3.245,
-              "small_medium_mean_ci_upper": 3.245,
-              "d": 0.0267,
-              "d_ci_lower": -0.2132,
-              "d_ci_upper": 0.2713
+              "small_medium_mean": 3.2446,
+              "small_medium_mean_ci_lower": 3.2446,
+              "small_medium_mean_ci_upper": 3.2446,
+              "d": 0.0274,
+              "d_ci_lower": -0.2188,
+              "d_ci_upper": 0.271
             }
           }
         }
@@ -1529,34 +1521,34 @@
       "cross_tabs": {
         "by_role": [
           {
-            "group": "Technical (CIO/CTO)",
-            "n": 91,
-            "barrier_mean": 2.6633,
-            "readiness_mean": 3.4678,
-            "maturity_mean": 3.4084
+            "group": "Technical",
+            "n": 94,
+            "barrier_mean": 2.6789,
+            "readiness_mean": 3.4641,
+            "maturity_mean": 3.4117
           },
           {
             "group": "Non-Technical",
-            "n": 212,
-            "barrier_mean": 2.7648,
-            "readiness_mean": 3.2153,
-            "maturity_mean": 3.2395
+            "n": 233,
+            "barrier_mean": 2.7718,
+            "readiness_mean": 3.2138,
+            "maturity_mean": 3.248
           },
           {
             "group": "Other",
-            "n": 68,
-            "barrier_mean": 2.7917,
-            "readiness_mean": 3.0189,
-            "maturity_mean": 3.1172
+            "n": 110,
+            "barrier_mean": 2.7755,
+            "readiness_mean": 3.0047,
+            "maturity_mean": 3.1079
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 157,
-            "barrier_mean": 2.6771,
-            "readiness_mean": 3.1724,
-            "maturity_mean": 3.1382
+            "n": 160,
+            "barrier_mean": 2.6861,
+            "readiness_mean": 3.1725,
+            "maturity_mean": 3.1492
           },
           {
             "group": "Medium (500-4999)",
@@ -1576,115 +1568,115 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 91,
-          "nontech_n": 212,
+          "tech_n": 94,
+          "nontech_n": 233,
           "constructs": {
             "barriers": {
-              "t": -1.0005,
+              "t": -0.9428,
               "p": 0.0,
-              "df": 170.55,
-              "mean_diff_ci_lower": -0.1015,
-              "mean_diff_ci_upper": -0.1015,
+              "df": 165.98,
+              "mean_diff_ci_lower": -0.0929,
+              "mean_diff_ci_upper": -0.0929,
               "sig": true
             },
             "readiness": {
-              "t": 2.838,
+              "t": 2.8955,
               "p": 0.0,
-              "df": 174.23,
-              "mean_diff_ci_lower": 0.2525,
-              "mean_diff_ci_upper": 0.2525,
+              "df": 172.99,
+              "mean_diff_ci_lower": 0.2503,
+              "mean_diff_ci_upper": 0.2503,
               "sig": true
             },
             "maturity": {
-              "t": 1.6997,
+              "t": 1.6873,
               "p": 0.0,
-              "df": 179.21,
-              "mean_diff_ci_lower": 0.1689,
-              "mean_diff_ci_upper": 0.1689,
+              "df": 178.48,
+              "mean_diff_ci_lower": 0.1637,
+              "mean_diff_ci_upper": 0.1637,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 86,
-          "small_medium_n": 348,
+          "small_medium_n": 351,
           "constructs": {
             "barriers": {
-              "t": 1.9459,
+              "t": 1.8976,
               "p": 0.0,
-              "df": 138.91,
-              "mean_diff_ci_lower": 0.1844,
-              "mean_diff_ci_upper": 0.1844,
+              "df": 138.48,
+              "mean_diff_ci_lower": 0.1797,
+              "mean_diff_ci_upper": 0.1797,
               "sig": true
             },
             "readiness": {
-              "t": 0.2089,
+              "t": 0.2143,
               "p": 0.0,
-              "df": 130.39,
-              "mean_diff_ci_lower": 0.0191,
-              "mean_diff_ci_upper": 0.0191,
+              "df": 129.92,
+              "mean_diff_ci_lower": 0.0196,
+              "mean_diff_ci_upper": 0.0196,
               "sig": true
             },
             "maturity": {
-              "t": 1.2613,
+              "t": 1.2103,
               "p": 0.0,
-              "df": 129.94,
-              "mean_diff_ci_lower": 0.1303,
-              "mean_diff_ci_upper": 0.1303,
+              "df": 129.62,
+              "mean_diff_ci_lower": 0.1249,
+              "mean_diff_ci_upper": 0.1249,
               "sig": true
             }
           }
         },
         "anova_by_role": {
-          "groups": ["Technical (CIO/CTO)", "Non-Technical", "Other"],
-          "group_ns": [91, 212, 68],
+          "groups": ["Technical", "Non-Technical", "Other"],
+          "group_ns": [94, 233, 110],
           "constructs": {
             "barriers": {
-              "f": 0.6935,
-              "p": 0.5005,
+              "f": 0.5086,
+              "p": 0.6017,
               "df_between": 2,
-              "df_within": 364,
+              "df_within": 371,
               "sig": false
             },
             "readiness": {
-              "f": 8.1886,
-              "p": 0.0003,
+              "f": 7.6471,
+              "p": 0.0006,
               "df_between": 2,
-              "df_within": 360,
+              "df_within": 367,
               "sig": true
             },
             "maturity": {
-              "f": 2.6559,
-              "p": 0.0716,
+              "f": 2.5357,
+              "p": 0.0806,
               "df_between": 2,
-              "df_within": 359,
+              "df_within": 366,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [157, 133, 86],
+          "group_ns": [160, 133, 86],
           "constructs": {
             "barriers": {
-              "f": 2.0675,
-              "p": 0.128,
+              "f": 1.9196,
+              "p": 0.1481,
               "df_between": 2,
-              "df_within": 369,
+              "df_within": 371,
               "sig": false
             },
             "readiness": {
-              "f": 1.7963,
-              "p": 0.1674,
+              "f": 1.8112,
+              "p": 0.1649,
               "df_between": 2,
-              "df_within": 365,
+              "df_within": 367,
               "sig": false
             },
             "maturity": {
-              "f": 3.4238,
-              "p": 0.0336,
+              "f": 3.1102,
+              "p": 0.0458,
               "df_between": 2,
-              "df_within": 364,
+              "df_within": 366,
               "sig": true
             }
           }
@@ -1695,22 +1687,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 3.51,
-      "p_value": 0.7425,
+      "chi2": 2.52,
+      "p_value": 0.8667,
       "df": 6,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 9.46,
-      "p_value": 0.852,
+      "chi2": 7.98,
+      "p_value": 0.9245,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 2.69,
-      "p_value": 0.8462,
+      "chi2": 3.04,
+      "p_value": 0.8038,
       "df": 6,
       "error": null
     },
@@ -1718,24 +1710,24 @@
       "labels": ["For-Profit", "Non-Profit", "Government/Public Sector"],
       "groups": {
         "Conservative Clean": {
-          "For-Profit": 57,
+          "For-Profit": 58,
           "Non-Profit": 15,
-          "Government/Public Sector": 8
+          "Government/Public Sector": 9
         },
         "Flexible Clean": {
-          "For-Profit": 87,
+          "For-Profit": 88,
           "Non-Profit": 27,
-          "Government/Public Sector": 13
+          "Government/Public Sector": 14
         },
         "Prolific Accepted": {
-          "For-Profit": 172,
+          "For-Profit": 173,
           "Non-Profit": 41,
-          "Government/Public Sector": 18
+          "Government/Public Sector": 19
         },
         "All V2 Finished": {
-          "For-Profit": 277,
+          "For-Profit": 278,
           "Non-Profit": 62,
-          "Government/Public Sector": 29
+          "Government/Public Sector": 30
         }
       }
     }
@@ -1773,8 +1765,9 @@
     },
     {
       "label": "Uncategorized",
-      "description": "Responses that did not match any keyword pattern, or blank entries",
+      "description": "Responses that did not match any keyword pattern",
       "examples": ""
     }
-  ]
+  ],
+  "last_updated": "2026-04-10T21:10:12.447916Z"
 }


### PR DESCRIPTION
Automated update from the unified daily pipeline.

**Data flow**: Qualtrics export → Prolific enrichment →
disposition waterfall → analysis suite → CRP dataset (N=200) →
approve CLEAN → dashboard summary.

All statistics computed across 5 sample definitions.
CRP dataset: N=200 tiered selection + NIST de-identification.