### PR TITLE
Update daily pipeline data

### DIFF
--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -4,31 +4,31 @@
       "key": "conservative_clean",
       "label": "Conservative Clean",
       "description": "Prolific APPROVED + all quality checks (IRI, duration >= 540s, reCAPTCHA, straightlining, auth)",
-      "n": 49
+      "n": 79
     },
     {
       "key": "flexible_clean",
       "label": "Flexible Clean",
       "description": "Prolific APPROVED + basic quality (all 3 IRIs + duration >= 480s)",
-      "n": 66
+      "n": 116
     },
     {
       "key": "prolific_accepted",
       "label": "Prolific Accepted",
       "description": "All deduplicated V2 rows with Prolific APPROVED status",
-      "n": 119
+      "n": 200
     },
     {
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 119
+      "n": 200
     },
     {
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 119
+      "n": 200
     }
   ],
   "metrics": [
@@ -36,132 +36,132 @@
       "key": "barrier_mean",
       "label": "Barrier Grand Mean",
       "values": {
-        "conservative_clean": 2.8289,
-        "flexible_clean": 2.8244,
-        "prolific_accepted": 2.7773,
-        "v2_finished": 2.7773,
-        "v2_all": 2.7773
+        "conservative_clean": 2.8139,
+        "flexible_clean": 2.7891,
+        "prolific_accepted": 2.7644,
+        "v2_finished": 2.7644,
+        "v2_all": 2.7644
       }
     },
     {
       "key": "barrier_sd",
       "label": "Barrier SD",
       "values": {
-        "conservative_clean": 0.5999,
-        "flexible_clean": 0.6792,
-        "prolific_accepted": 0.6595,
-        "v2_finished": 0.6595,
-        "v2_all": 0.6595
+        "conservative_clean": 0.6309,
+        "flexible_clean": 0.661,
+        "prolific_accepted": 0.6893,
+        "v2_finished": 0.6893,
+        "v2_all": 0.6893
       }
     },
     {
       "key": "readiness_mean",
       "label": "Readiness Grand Mean",
       "values": {
-        "conservative_clean": 3.0929,
-        "flexible_clean": 3.1025,
-        "prolific_accepted": 3.1008,
-        "v2_finished": 3.1008,
-        "v2_all": 3.1008
+        "conservative_clean": 3.0483,
+        "flexible_clean": 3.0765,
+        "prolific_accepted": 3.1361,
+        "v2_finished": 3.1361,
+        "v2_all": 3.1361
       }
     },
     {
       "key": "readiness_sd",
       "label": "Readiness SD",
       "values": {
-        "conservative_clean": 0.463,
-        "flexible_clean": 0.5779,
-        "prolific_accepted": 0.6349,
-        "v2_finished": 0.6349,
-        "v2_all": 0.6349
+        "conservative_clean": 0.5829,
+        "flexible_clean": 0.6239,
+        "prolific_accepted": 0.6674,
+        "v2_finished": 0.6674,
+        "v2_all": 0.6674
       }
     },
     {
       "key": "maturity_mean",
       "label": "Maturity Grand Mean",
       "values": {
-        "conservative_clean": 3.032,
-        "flexible_clean": 3.0276,
-        "prolific_accepted": 3.0834,
-        "v2_finished": 3.0834,
-        "v2_all": 3.0834
+        "conservative_clean": 3.0318,
+        "flexible_clean": 3.0616,
+        "prolific_accepted": 3.1533,
+        "v2_finished": 3.1533,
+        "v2_all": 3.1533
       }
     },
     {
       "key": "maturity_sd",
       "label": "Maturity SD",
       "values": {
-        "conservative_clean": 0.6719,
-        "flexible_clean": 0.7635,
-        "prolific_accepted": 0.8001,
-        "v2_finished": 0.8001,
-        "v2_all": 0.8001
+        "conservative_clean": 0.7087,
+        "flexible_clean": 0.7501,
+        "prolific_accepted": 0.7855,
+        "v2_finished": 0.7855,
+        "v2_all": 0.7855
       }
     },
     {
       "key": "corr_br",
       "label": "B-R Correlation",
       "values": {
-        "conservative_clean": -0.4013,
-        "flexible_clean": -0.5289,
-        "prolific_accepted": -0.4198,
-        "v2_finished": -0.4198,
-        "v2_all": -0.4198
+        "conservative_clean": -0.5016,
+        "flexible_clean": -0.5172,
+        "prolific_accepted": -0.3814,
+        "v2_finished": -0.3814,
+        "v2_all": -0.3814
       }
     },
     {
       "key": "corr_bm",
       "label": "B-M Correlation",
       "values": {
-        "conservative_clean": -0.0569,
-        "flexible_clean": -0.2887,
-        "prolific_accepted": -0.2358,
-        "v2_finished": -0.2358,
-        "v2_all": -0.2358
+        "conservative_clean": -0.2451,
+        "flexible_clean": -0.3653,
+        "prolific_accepted": -0.3156,
+        "v2_finished": -0.3156,
+        "v2_all": -0.3156
       }
     },
     {
       "key": "corr_rm",
       "label": "R-M Correlation",
       "values": {
-        "conservative_clean": 0.508,
-        "flexible_clean": 0.7003,
-        "prolific_accepted": 0.7454,
-        "v2_finished": 0.7454,
-        "v2_all": 0.7454
+        "conservative_clean": 0.5877,
+        "flexible_clean": 0.6821,
+        "prolific_accepted": 0.7194,
+        "v2_finished": 0.7194,
+        "v2_all": 0.7194
       }
     },
     {
       "key": "alpha_barriers",
       "label": "Alpha Barriers",
       "values": {
-        "conservative_clean": 0.8415,
-        "flexible_clean": 0.8749,
-        "prolific_accepted": 0.8623,
-        "v2_finished": 0.8623,
-        "v2_all": 0.8623
+        "conservative_clean": 0.8572,
+        "flexible_clean": 0.8691,
+        "prolific_accepted": 0.8728,
+        "v2_finished": 0.8728,
+        "v2_all": 0.8728
       }
     },
     {
       "key": "alpha_readiness",
       "label": "Alpha Readiness",
       "values": {
-        "conservative_clean": 0.7888,
-        "flexible_clean": 0.8879,
-        "prolific_accepted": 0.9032,
-        "v2_finished": 0.9032,
-        "v2_all": 0.9032
+        "conservative_clean": 0.8762,
+        "flexible_clean": 0.9052,
+        "prolific_accepted": 0.9171,
+        "v2_finished": 0.9171,
+        "v2_all": 0.9171
       }
     },
     {
       "key": "alpha_maturity",
       "label": "Alpha Maturity",
       "values": {
-        "conservative_clean": 0.7974,
-        "flexible_clean": 0.8613,
-        "prolific_accepted": 0.8719,
-        "v2_finished": 0.8719,
-        "v2_all": 0.8719
+        "conservative_clean": 0.8368,
+        "flexible_clean": 0.8761,
+        "prolific_accepted": 0.8847,
+        "v2_finished": 0.8847,
+        "v2_all": 0.8847
       }
     }
   ],
@@ -304,108 +304,109 @@
     "conservative_clean": {
       "demographics": {
         "roles": {
-          "Other": 9,
-          "COO": 7,
-          "CSO": 6,
-          "CEO": 5,
-          "CIO": 5,
-          "CMO": 5,
-          "CHRO": 4,
-          "CFO": 3,
-          "CRO": 3,
-          "CTO": 2
+          "Other": 13,
+          "CIO": 11,
+          "COO": 10,
+          "CMO": 9,
+          "CEO": 8,
+          "CSO": 8,
+          "CHRO": 7,
+          "CFO": 6,
+          "CTO": 4,
+          "CRO": 3
         },
         "org_sizes": {
-          "<100": 5,
-          "100-499": 17,
-          "500-999": 4,
-          "1000-4999": 11,
-          "5000-9999": 4,
-          "10000+": 8
+          "<100": 9,
+          "100-499": 28,
+          "500-999": 7,
+          "1000-4999": 18,
+          "5000-9999": 6,
+          "10000+": 11
         },
         "profit_models": {
-          "For-Profit": 33,
-          "Non-Profit": 9,
-          "Government/Public Sector": 7
+          "For-Profit": 56,
+          "Non-Profit": 15,
+          "Government/Public Sector": 8
         },
         "tech_vs_nontech": {
-          "technical": 7,
-          "non_technical": 35,
-          "other": 7
+          "technical": 15,
+          "non_technical": 53,
+          "other": 11
         },
         "other_roles": {
-          "total": 9,
+          "total": 13,
           "categories": {
-            "Director": 5,
-            "Uncategorized": "<5"
+            "Director": 7,
+            "Uncategorized": "<5",
+            "Manager / Program Lead": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 7,
-          "nontech_n": 35,
+          "tech_n": 15,
+          "nontech_n": 53,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.754,
-              "tech_mean_ci_lower": 2.754,
-              "tech_mean_ci_upper": 2.754,
-              "nontech_mean": 2.8812,
-              "nontech_mean_ci_lower": 2.8812,
-              "nontech_mean_ci_upper": 2.8812,
-              "d": -0.2024,
-              "d_ci_lower": -1.1845,
-              "d_ci_upper": 0.815
+              "tech_mean": 2.7222,
+              "tech_mean_ci_lower": 2.7222,
+              "tech_mean_ci_upper": 2.7222,
+              "nontech_mean": 2.8683,
+              "nontech_mean_ci_lower": 2.8683,
+              "nontech_mean_ci_upper": 2.8683,
+              "d": -0.2194,
+              "d_ci_lower": -0.8422,
+              "d_ci_upper": 0.3866
             },
             "readiness": {
-              "tech_mean": 3.1754,
-              "tech_mean_ci_lower": 3.1754,
-              "tech_mean_ci_upper": 3.1754,
-              "nontech_mean": 3.048,
-              "nontech_mean_ci_lower": 3.048,
-              "nontech_mean_ci_upper": 3.048,
-              "d": 0.2693,
-              "d_ci_lower": -0.6122,
-              "d_ci_upper": 1.247
+              "tech_mean": 3.325,
+              "tech_mean_ci_lower": 3.325,
+              "tech_mean_ci_upper": 3.325,
+              "nontech_mean": 2.9941,
+              "nontech_mean_ci_lower": 2.9941,
+              "nontech_mean_ci_upper": 2.9941,
+              "d": 0.5718,
+              "d_ci_lower": 0.0347,
+              "d_ci_upper": 1.2552
             },
             "maturity": {
-              "tech_mean": 2.9464,
-              "tech_mean_ci_lower": 2.9464,
-              "tech_mean_ci_upper": 2.9464,
-              "nontech_mean": 3.027,
-              "nontech_mean_ci_lower": 3.027,
-              "nontech_mean_ci_upper": 3.027,
-              "d": -0.1181,
-              "d_ci_lower": -1.0654,
-              "d_ci_upper": 0.8233
+              "tech_mean": 3.1083,
+              "tech_mean_ci_lower": 3.1083,
+              "tech_mean_ci_upper": 3.1083,
+              "nontech_mean": 2.9885,
+              "nontech_mean_ci_lower": 2.9885,
+              "nontech_mean_ci_upper": 2.9885,
+              "d": 0.1691,
+              "d_ci_lower": -0.4335,
+              "d_ci_upper": 0.8358
             }
           }
         },
         "large_vs_small": {
-          "large_n": 12,
-          "small_medium_n": 37,
+          "large_n": 17,
+          "small_medium_n": 62,
           "constructs": {
             "barriers": {
-              "large_mean": 3.0515,
-              "large_mean_ci_lower": 3.0515,
-              "large_mean_ci_upper": 3.0515,
-              "small_medium_mean": 2.7568,
-              "small_medium_mean_ci_lower": 2.7568,
-              "small_medium_mean_ci_upper": 2.7568,
-              "d": 0.4977,
-              "d_ci_lower": -0.1199,
-              "d_ci_upper": 1.1491
+              "large_mean": 3.0919,
+              "large_mean_ci_lower": 3.0919,
+              "large_mean_ci_upper": 3.0919,
+              "small_medium_mean": 2.7377,
+              "small_medium_mean_ci_lower": 2.7377,
+              "small_medium_mean_ci_upper": 2.7377,
+              "d": 0.5736,
+              "d_ci_lower": 0.0948,
+              "d_ci_upper": 1.0824
             },
             "readiness": {
-              "large_mean": 3.1981,
-              "large_mean_ci_lower": 3.1981,
-              "large_mean_ci_upper": 3.1981,
-              "small_medium_mean": 3.0588,
-              "small_medium_mean_ci_lower": 3.0588,
-              "small_medium_mean_ci_upper": 3.0588,
-              "d": 0.3002,
-              "d_ci_lower": -0.4669,
-              "d_ci_upper": 1.1732
+              "large_mean": 3.0222,
+              "large_mean_ci_lower": 3.0222,
+              "large_mean_ci_upper": 3.0222,
+              "small_medium_mean": 3.0555,
+              "small_medium_mean_ci_lower": 3.0555,
+              "small_medium_mean_ci_upper": 3.0555,
+              "d": -0.0568,
+              "d_ci_lower": -0.5973,
+              "d_ci_upper": 0.5216
             }
           }
         }
@@ -414,161 +415,161 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 7,
-            "barrier_mean": 2.754,
-            "readiness_mean": 3.1754,
-            "maturity_mean": 2.9464
+            "n": 15,
+            "barrier_mean": 2.7222,
+            "readiness_mean": 3.325,
+            "maturity_mean": 3.1083
           },
           {
             "group": "Non-Technical",
-            "n": 35,
-            "barrier_mean": 2.8812,
-            "readiness_mean": 3.048,
-            "maturity_mean": 3.027
+            "n": 53,
+            "barrier_mean": 2.8683,
+            "readiness_mean": 2.9941,
+            "maturity_mean": 2.9885
           },
           {
             "group": "Other",
-            "n": 7,
-            "barrier_mean": 2.6429,
-            "readiness_mean": 3.2353,
-            "maturity_mean": 3.1429
+            "n": 11,
+            "barrier_mean": 2.6768,
+            "readiness_mean": 2.9323,
+            "maturity_mean": 3.1364
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 22,
-            "barrier_mean": 2.7626,
-            "readiness_mean": 3.123,
-            "maturity_mean": 2.9867
+            "n": 37,
+            "barrier_mean": 2.7796,
+            "readiness_mean": 3.0548,
+            "maturity_mean": 2.9617
           },
           {
             "group": "Medium (500-4999)",
-            "n": 15,
-            "barrier_mean": 2.7481,
-            "readiness_mean": 2.9647,
-            "maturity_mean": 2.9012
+            "n": 25,
+            "barrier_mean": 2.6756,
+            "readiness_mean": 3.0565,
+            "maturity_mean": 2.9536
           },
           {
             "group": "Large (5000+)",
-            "n": 12,
-            "barrier_mean": 3.0515,
-            "readiness_mean": 3.1981,
-            "maturity_mean": 3.2786
+            "n": 17,
+            "barrier_mean": 3.0919,
+            "readiness_mean": 3.0222,
+            "maturity_mean": 3.2996
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 7,
-          "nontech_n": 35,
+          "tech_n": 15,
+          "nontech_n": 53,
           "constructs": {
             "barriers": {
-              "t": -0.4107,
+              "t": -0.7024,
               "p": 0.0,
-              "df": 7.5,
-              "mean_diff_ci_lower": -0.1272,
-              "mean_diff_ci_upper": -0.1272,
+              "df": 20.7,
+              "mean_diff_ci_lower": -0.1461,
+              "mean_diff_ci_upper": -0.1461,
               "sig": true
             },
             "readiness": {
-              "t": 0.554,
+              "t": 2.0,
               "p": 0.0,
-              "df": 7.57,
-              "mean_diff_ci_lower": 0.1275,
-              "mean_diff_ci_upper": 0.1275,
+              "df": 23.31,
+              "mean_diff_ci_lower": 0.3309,
+              "mean_diff_ci_upper": 0.3309,
               "sig": true
             },
             "maturity": {
-              "t": -0.2449,
+              "t": 0.5269,
               "p": 0.0,
-              "df": 7.61,
-              "mean_diff_ci_lower": -0.0805,
-              "mean_diff_ci_upper": -0.0805,
+              "df": 20.05,
+              "mean_diff_ci_lower": 0.1198,
+              "mean_diff_ci_upper": 0.1198,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 12,
-          "small_medium_n": 37,
+          "large_n": 17,
+          "small_medium_n": 62,
           "constructs": {
             "barriers": {
-              "t": 1.5538,
+              "t": 2.2504,
               "p": 0.0,
-              "df": 19.9,
-              "mean_diff_ci_lower": 0.2947,
-              "mean_diff_ci_upper": 0.2947,
+              "df": 28.32,
+              "mean_diff_ci_lower": 0.3542,
+              "mean_diff_ci_upper": 0.3542,
               "sig": true
             },
             "readiness": {
-              "t": 0.7452,
+              "t": -0.1996,
               "p": 0.0,
-              "df": 14.48,
-              "mean_diff_ci_lower": 0.1393,
-              "mean_diff_ci_upper": 0.1393,
+              "df": 24.24,
+              "mean_diff_ci_lower": -0.0333,
+              "mean_diff_ci_upper": -0.0333,
               "sig": true
             },
             "maturity": {
-              "t": 1.3633,
+              "t": 1.6095,
               "p": 0.0,
-              "df": 16.52,
-              "mean_diff_ci_lower": 0.3265,
-              "mean_diff_ci_upper": 0.3265,
+              "df": 22.52,
+              "mean_diff_ci_lower": 0.3412,
+              "mean_diff_ci_upper": 0.3412,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [7, 35, 7],
+          "group_ns": [15, 53, 11],
           "constructs": {
             "barriers": {
-              "f": 0.5134,
-              "p": 0.6018,
+              "f": 0.6091,
+              "p": 0.5465,
               "df_between": 2,
-              "df_within": 46,
+              "df_within": 76,
               "sig": false
             },
             "readiness": {
-              "f": 0.597,
-              "p": 0.5547,
+              "f": 2.2031,
+              "p": 0.1175,
               "df_between": 2,
-              "df_within": 46,
+              "df_within": 76,
               "sig": false
             },
             "maturity": {
-              "f": 0.1476,
-              "p": 0.8632,
+              "f": 0.3007,
+              "p": 0.7412,
               "df_between": 2,
-              "df_within": 46,
+              "df_within": 76,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [22, 15, 12],
+          "group_ns": [37, 25, 17],
           "constructs": {
             "barriers": {
-              "f": 1.101,
-              "p": 0.3411,
+              "f": 2.3884,
+              "p": 0.0986,
               "df_between": 2,
-              "df_within": 46,
+              "df_within": 76,
               "sig": false
             },
             "readiness": {
-              "f": 0.9284,
-              "p": 0.4025,
+              "f": 0.0213,
+              "p": 0.979,
               "df_between": 2,
-              "df_within": 46,
+              "df_within": 76,
               "sig": false
             },
             "maturity": {
-              "f": 1.1492,
-              "p": 0.3258,
+              "f": 1.5696,
+              "p": 0.2148,
               "df_between": 2,
-              "df_within": 46,
+              "df_within": 76,
               "sig": false
             }
           }
@@ -578,109 +579,110 @@
     "flexible_clean": {
       "demographics": {
         "roles": {
-          "Other": 12,
-          "COO": 9,
-          "CIO": 9,
-          "CEO": 7,
-          "CSO": 7,
-          "CHRO": 5,
-          "CMO": 5,
-          "CTO": 4,
-          "CFO": 4,
-          "CRO": 4
+          "CIO": 22,
+          "Other": 18,
+          "COO": 14,
+          "CMO": 11,
+          "CEO": 11,
+          "CHRO": 10,
+          "CSO": 9,
+          "CFO": 8,
+          "CTO": 7,
+          "CRO": 6
         },
         "org_sizes": {
-          "<100": 9,
-          "100-499": 23,
-          "500-999": 6,
-          "1000-4999": 14,
-          "5000-9999": 5,
-          "10000+": 9
+          "<100": 16,
+          "100-499": 36,
+          "500-999": 14,
+          "1000-4999": 28,
+          "5000-9999": 7,
+          "10000+": 15
         },
         "profit_models": {
-          "For-Profit": 47,
-          "Non-Profit": 12,
-          "Government/Public Sector": 7
+          "For-Profit": 81,
+          "Non-Profit": 24,
+          "Government/Public Sector": 11
         },
         "tech_vs_nontech": {
-          "technical": 13,
-          "non_technical": 44,
-          "other": 9
+          "technical": 29,
+          "non_technical": 73,
+          "other": 14
         },
         "other_roles": {
-          "total": 12,
+          "total": 18,
           "categories": {
-            "Director": 6,
+            "Director": 9,
             "Uncategorized": "<5",
+            "Manager / Program Lead": "<5",
             "C-Suite Adjacent": "<5"
           }
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 13,
-          "nontech_n": 44,
+          "tech_n": 29,
+          "nontech_n": 73,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.5598,
-              "tech_mean_ci_lower": 2.5598,
-              "tech_mean_ci_upper": 2.5598,
-              "nontech_mean": 2.9018,
-              "nontech_mean_ci_lower": 2.9018,
-              "nontech_mean_ci_upper": 2.9018,
-              "d": -0.5023,
-              "d_ci_lower": -1.3006,
-              "d_ci_upper": 0.2014
+              "tech_mean": 2.6475,
+              "tech_mean_ci_lower": 2.6475,
+              "tech_mean_ci_upper": 2.6475,
+              "nontech_mean": 2.8512,
+              "nontech_mean_ci_lower": 2.8512,
+              "nontech_mean_ci_upper": 2.8512,
+              "d": -0.3018,
+              "d_ci_lower": -0.75,
+              "d_ci_upper": 0.1235
             },
             "readiness": {
-              "tech_mean": 3.3931,
-              "tech_mean_ci_lower": 3.3931,
-              "tech_mean_ci_upper": 3.3931,
-              "nontech_mean": 3.0269,
-              "nontech_mean_ci_lower": 3.0269,
-              "nontech_mean_ci_upper": 3.0269,
-              "d": 0.6364,
-              "d_ci_lower": -0.0134,
-              "d_ci_upper": 1.377
+              "tech_mean": 3.4173,
+              "tech_mean_ci_lower": 3.4173,
+              "tech_mean_ci_upper": 3.4173,
+              "nontech_mean": 2.9869,
+              "nontech_mean_ci_lower": 2.9869,
+              "nontech_mean_ci_upper": 2.9869,
+              "d": 0.7117,
+              "d_ci_lower": 0.3005,
+              "d_ci_upper": 1.1617
             },
             "maturity": {
-              "tech_mean": 3.2212,
-              "tech_mean_ci_lower": 3.2212,
-              "tech_mean_ci_upper": 3.2212,
-              "nontech_mean": 2.993,
-              "nontech_mean_ci_lower": 2.993,
-              "nontech_mean_ci_upper": 2.993,
-              "d": 0.2981,
-              "d_ci_lower": -0.374,
-              "d_ci_upper": 0.9899
+              "tech_mean": 3.2716,
+              "tech_mean_ci_lower": 3.2716,
+              "tech_mean_ci_upper": 3.2716,
+              "nontech_mean": 2.9985,
+              "nontech_mean_ci_lower": 2.9985,
+              "nontech_mean_ci_upper": 2.9985,
+              "d": 0.3685,
+              "d_ci_lower": -0.0678,
+              "d_ci_upper": 0.8034
             }
           }
         },
         "large_vs_small": {
-          "large_n": 14,
-          "small_medium_n": 52,
+          "large_n": 22,
+          "small_medium_n": 94,
           "constructs": {
             "barriers": {
-              "large_mean": 3.1632,
-              "large_mean_ci_lower": 3.1632,
-              "large_mean_ci_upper": 3.1632,
-              "small_medium_mean": 2.7332,
-              "small_medium_mean_ci_lower": 2.7332,
-              "small_medium_mean_ci_upper": 2.7332,
-              "d": 0.6507,
-              "d_ci_lower": 0.1216,
-              "d_ci_upper": 1.2729
+              "large_mean": 3.215,
+              "large_mean_ci_lower": 3.215,
+              "large_mean_ci_upper": 3.215,
+              "small_medium_mean": 2.6894,
+              "small_medium_mean_ci_lower": 2.6894,
+              "small_medium_mean_ci_upper": 2.6894,
+              "d": 0.8335,
+              "d_ci_lower": 0.4138,
+              "d_ci_upper": 1.2952
             },
             "readiness": {
-              "large_mean": 3.0017,
-              "large_mean_ci_lower": 3.0017,
-              "large_mean_ci_upper": 3.0017,
-              "small_medium_mean": 3.1296,
-              "small_medium_mean_ci_lower": 3.1296,
-              "small_medium_mean_ci_upper": 3.1296,
-              "d": -0.2205,
-              "d_ci_lower": -0.9423,
-              "d_ci_upper": 0.4874
+              "large_mean": 2.8808,
+              "large_mean_ci_lower": 2.8808,
+              "large_mean_ci_upper": 2.8808,
+              "small_medium_mean": 3.1223,
+              "small_medium_mean_ci_lower": 3.1223,
+              "small_medium_mean_ci_upper": 3.1223,
+              "d": -0.3899,
+              "d_ci_lower": -0.8729,
+              "d_ci_upper": 0.1109
             }
           }
         }
@@ -689,161 +691,161 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 13,
-            "barrier_mean": 2.5598,
-            "readiness_mean": 3.3931,
-            "maturity_mean": 3.2212
+            "n": 29,
+            "barrier_mean": 2.6475,
+            "readiness_mean": 3.4173,
+            "maturity_mean": 3.2716
           },
           {
             "group": "Non-Technical",
-            "n": 44,
-            "barrier_mean": 2.9018,
-            "readiness_mean": 3.0269,
-            "maturity_mean": 2.993
+            "n": 73,
+            "barrier_mean": 2.8512,
+            "readiness_mean": 2.9869,
+            "maturity_mean": 2.9985
           },
           {
             "group": "Other",
-            "n": 9,
-            "barrier_mean": 2.8281,
-            "readiness_mean": 3.0523,
-            "maturity_mean": 2.9167
+            "n": 14,
+            "barrier_mean": 2.7585,
+            "readiness_mean": 2.8375,
+            "maturity_mean": 2.9554
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 32,
-            "barrier_mean": 2.7522,
-            "readiness_mean": 3.1444,
-            "maturity_mean": 3.0065
+            "n": 52,
+            "barrier_mean": 2.7356,
+            "readiness_mean": 3.103,
+            "maturity_mean": 3.0064
           },
           {
             "group": "Medium (500-4999)",
-            "n": 20,
-            "barrier_mean": 2.7028,
-            "readiness_mean": 3.1059,
-            "maturity_mean": 3.0321
+            "n": 42,
+            "barrier_mean": 2.6323,
+            "readiness_mean": 3.1462,
+            "maturity_mean": 3.1301
           },
           {
             "group": "Large (5000+)",
-            "n": 14,
-            "barrier_mean": 3.1632,
-            "readiness_mean": 3.0017,
-            "maturity_mean": 3.0691
+            "n": 22,
+            "barrier_mean": 3.215,
+            "readiness_mean": 2.8808,
+            "maturity_mean": 3.061
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 13,
-          "nontech_n": 44,
+          "tech_n": 29,
+          "nontech_n": 73,
           "constructs": {
             "barriers": {
-              "t": -1.3667,
+              "t": -1.3274,
               "p": 0.0,
-              "df": 16.27,
-              "mean_diff_ci_lower": -0.342,
-              "mean_diff_ci_upper": -0.342,
+              "df": 47.98,
+              "mean_diff_ci_lower": -0.2037,
+              "mean_diff_ci_upper": -0.2037,
               "sig": true
             },
             "readiness": {
-              "t": 1.9113,
+              "t": 3.3484,
               "p": 0.0,
-              "df": 18.26,
-              "mean_diff_ci_lower": 0.3662,
-              "mean_diff_ci_upper": 0.3662,
+              "df": 55.18,
+              "mean_diff_ci_lower": 0.4304,
+              "mean_diff_ci_upper": 0.4304,
               "sig": true
             },
             "maturity": {
-              "t": 0.8846,
+              "t": 1.6767,
               "p": 0.0,
-              "df": 17.98,
-              "mean_diff_ci_lower": 0.2281,
-              "mean_diff_ci_upper": 0.2281,
+              "df": 51.36,
+              "mean_diff_ci_lower": 0.2731,
+              "mean_diff_ci_upper": 0.2731,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 14,
-          "small_medium_n": 52,
+          "large_n": 22,
+          "small_medium_n": 94,
           "constructs": {
             "barriers": {
-              "t": 2.3187,
+              "t": 3.8737,
               "p": 0.0,
-              "df": 22.76,
-              "mean_diff_ci_lower": 0.43,
-              "mean_diff_ci_upper": 0.43,
+              "df": 35.69,
+              "mean_diff_ci_lower": 0.5255,
+              "mean_diff_ci_upper": 0.5255,
               "sig": true
             },
             "readiness": {
-              "t": -0.5979,
+              "t": -1.5312,
               "p": 0.0,
-              "df": 16.59,
-              "mean_diff_ci_lower": -0.1279,
-              "mean_diff_ci_upper": -0.1279,
+              "df": 29.29,
+              "mean_diff_ci_lower": -0.2415,
+              "mean_diff_ci_upper": -0.2415,
               "sig": true
             },
             "maturity": {
-              "t": 0.2027,
+              "t": -0.0031,
               "p": 0.0,
-              "df": 17.96,
-              "mean_diff_ci_lower": 0.0528,
-              "mean_diff_ci_upper": 0.0528,
+              "df": 27.38,
+              "mean_diff_ci_lower": -0.0006,
+              "mean_diff_ci_upper": -0.0006,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [13, 44, 9],
+          "group_ns": [29, 73, 14],
           "constructs": {
             "barriers": {
-              "f": 1.2834,
-              "p": 0.2842,
+              "f": 1.0026,
+              "p": 0.3702,
               "df_between": 2,
-              "df_within": 63,
+              "df_within": 113,
               "sig": false
             },
             "readiness": {
-              "f": 2.1255,
-              "p": 0.1279,
+              "f": 6.7131,
+              "p": 0.0018,
               "df_between": 2,
-              "df_within": 63,
-              "sig": false
+              "df_within": 113,
+              "sig": true
             },
             "maturity": {
-              "f": 0.5501,
-              "p": 0.5797,
+              "f": 1.5494,
+              "p": 0.2168,
               "df_between": 2,
-              "df_within": 63,
+              "df_within": 113,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [32, 20, 14],
+          "group_ns": [52, 42, 22],
           "constructs": {
             "barriers": {
-              "f": 2.3354,
-              "p": 0.1051,
+              "f": 6.4834,
+              "p": 0.0022,
               "df_between": 2,
-              "df_within": 63,
-              "sig": false
+              "df_within": 113,
+              "sig": true
             },
             "readiness": {
-              "f": 0.291,
-              "p": 0.7485,
+              "f": 1.4009,
+              "p": 0.2506,
               "df_between": 2,
-              "df_within": 63,
+              "df_within": 113,
               "sig": false
             },
             "maturity": {
-              "f": 0.0323,
-              "p": 0.9682,
+              "f": 0.3121,
+              "p": 0.7325,
               "df_between": 2,
-              "df_within": 63,
+              "df_within": 113,
               "sig": false
             }
           }
@@ -853,40 +855,41 @@
     "prolific_accepted": {
       "demographics": {
         "roles": {
-          "Other": 25,
-          "CSO": 16,
-          "CIO": 16,
-          "CEO": 14,
-          "COO": 13,
-          "CRO": 9,
-          "CHRO": 7,
-          "CTO": 7,
-          "CMO": 6,
-          "CFO": 6
+          "Other": 38,
+          "CIO": 33,
+          "COO": 22,
+          "CSO": 20,
+          "CEO": 18,
+          "CMO": 15,
+          "CHRO": 14,
+          "CTO": 14,
+          "CFO": 12,
+          "CRO": 12,
+          "Unknown": 2
         },
         "org_sizes": {
-          "<100": 24,
-          "100-499": 35,
-          "500-999": 12,
-          "1000-4999": 20,
-          "5000-9999": 12,
-          "10000+": 16
+          "<100": 33,
+          "100-499": 52,
+          "500-999": 29,
+          "1000-4999": 41,
+          "5000-9999": 18,
+          "10000+": 27
         },
         "profit_models": {
-          "For-Profit": 90,
-          "Non-Profit": 22,
-          "Government/Public Sector": 7
+          "For-Profit": 151,
+          "Non-Profit": 36,
+          "Government/Public Sector": 13
         },
         "tech_vs_nontech": {
-          "technical": 24,
-          "non_technical": 78,
-          "other": 17
+          "technical": 48,
+          "non_technical": 124,
+          "other": 28
         },
         "other_roles": {
-          "total": 25,
+          "total": 38,
           "categories": {
-            "Director": 12,
-            "Uncategorized": "<5",
+            "Director": 18,
+            "Uncategorized": 5,
             "Manager / Program Lead": "<5",
             "C-Suite Adjacent": "<5"
           }
@@ -894,69 +897,69 @@
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 24,
-          "nontech_n": 78,
+          "tech_n": 48,
+          "nontech_n": 124,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6481,
-              "tech_mean_ci_lower": 2.6481,
-              "tech_mean_ci_upper": 2.6481,
-              "nontech_mean": 2.7886,
-              "nontech_mean_ci_lower": 2.7886,
-              "nontech_mean_ci_upper": 2.7886,
-              "d": -0.2071,
-              "d_ci_lower": -0.7177,
-              "d_ci_upper": 0.2779
+              "tech_mean": 2.7193,
+              "tech_mean_ci_lower": 2.7193,
+              "tech_mean_ci_upper": 2.7193,
+              "nontech_mean": 2.7825,
+              "nontech_mean_ci_lower": 2.7825,
+              "nontech_mean_ci_upper": 2.7825,
+              "d": -0.0906,
+              "d_ci_lower": -0.4455,
+              "d_ci_upper": 0.2712
             },
             "readiness": {
-              "tech_mean": 3.3919,
-              "tech_mean_ci_lower": 3.3919,
-              "tech_mean_ci_upper": 3.3919,
-              "nontech_mean": 3.0752,
-              "nontech_mean_ci_lower": 3.0752,
-              "nontech_mean_ci_upper": 3.0752,
-              "d": 0.5166,
-              "d_ci_lower": 0.0886,
-              "d_ci_upper": 0.9916
+              "tech_mean": 3.4457,
+              "tech_mean_ci_lower": 3.4457,
+              "tech_mean_ci_upper": 3.4457,
+              "nontech_mean": 3.0723,
+              "nontech_mean_ci_lower": 3.0723,
+              "nontech_mean_ci_upper": 3.0723,
+              "d": 0.5832,
+              "d_ci_lower": 0.284,
+              "d_ci_upper": 0.9214
             },
             "maturity": {
-              "tech_mean": 3.4062,
-              "tech_mean_ci_lower": 3.4062,
-              "tech_mean_ci_upper": 3.4063,
-              "nontech_mean": 3.0359,
-              "nontech_mean_ci_lower": 3.0359,
-              "nontech_mean_ci_upper": 3.0359,
-              "d": 0.4675,
-              "d_ci_lower": -0.0044,
-              "d_ci_upper": 0.9472
+              "tech_mean": 3.3523,
+              "tech_mean_ci_lower": 3.3523,
+              "tech_mean_ci_upper": 3.3523,
+              "nontech_mean": 3.0937,
+              "nontech_mean_ci_lower": 3.0937,
+              "nontech_mean_ci_upper": 3.0937,
+              "d": 0.3348,
+              "d_ci_lower": 0.0173,
+              "d_ci_upper": 0.6927
             }
           }
         },
         "large_vs_small": {
-          "large_n": 28,
-          "small_medium_n": 91,
+          "large_n": 45,
+          "small_medium_n": 155,
           "constructs": {
             "barriers": {
-              "large_mean": 2.8872,
-              "large_mean_ci_lower": 2.8872,
-              "large_mean_ci_upper": 2.8872,
-              "small_medium_mean": 2.7435,
-              "small_medium_mean_ci_lower": 2.7435,
-              "small_medium_mean_ci_upper": 2.7435,
-              "d": 0.2179,
-              "d_ci_lower": -0.1926,
-              "d_ci_upper": 0.6394
+              "large_mean": 2.963,
+              "large_mean_ci_lower": 2.963,
+              "large_mean_ci_upper": 2.963,
+              "small_medium_mean": 2.7067,
+              "small_medium_mean_ci_lower": 2.7067,
+              "small_medium_mean_ci_upper": 2.7067,
+              "d": 0.3756,
+              "d_ci_lower": 0.025,
+              "d_ci_upper": 0.737
             },
             "readiness": {
-              "large_mean": 3.2678,
-              "large_mean_ci_lower": 3.2678,
-              "large_mean_ci_upper": 3.2678,
-              "small_medium_mean": 3.0495,
-              "small_medium_mean_ci_lower": 3.0495,
-              "small_medium_mean_ci_upper": 3.0495,
-              "d": 0.3462,
-              "d_ci_lower": -0.0968,
-              "d_ci_upper": 0.7993
+              "large_mean": 3.2082,
+              "large_mean_ci_lower": 3.2082,
+              "large_mean_ci_upper": 3.2082,
+              "small_medium_mean": 3.1151,
+              "small_medium_mean_ci_lower": 3.1151,
+              "small_medium_mean_ci_upper": 3.1151,
+              "d": 0.1394,
+              "d_ci_lower": -0.2345,
+              "d_ci_upper": 0.5116
             }
           }
         }
@@ -965,161 +968,161 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 24,
-            "barrier_mean": 2.6481,
-            "readiness_mean": 3.3919,
-            "maturity_mean": 3.4062
+            "n": 48,
+            "barrier_mean": 2.7193,
+            "readiness_mean": 3.4457,
+            "maturity_mean": 3.3523
           },
           {
             "group": "Non-Technical",
-            "n": 78,
-            "barrier_mean": 2.7886,
-            "readiness_mean": 3.0752,
-            "maturity_mean": 3.0359
+            "n": 124,
+            "barrier_mean": 2.7825,
+            "readiness_mean": 3.0723,
+            "maturity_mean": 3.0937
           },
           {
             "group": "Other",
-            "n": 17,
-            "barrier_mean": 2.9075,
-            "readiness_mean": 2.8075,
-            "maturity_mean": 2.8456
+            "n": 28,
+            "barrier_mean": 2.7612,
+            "readiness_mean": 2.8878,
+            "maturity_mean": 3.0759
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 59,
-            "barrier_mean": 2.7616,
-            "readiness_mean": 2.9976,
-            "maturity_mean": 2.9227
+            "n": 85,
+            "barrier_mean": 2.7294,
+            "readiness_mean": 3.0118,
+            "maturity_mean": 2.9714
           },
           {
             "group": "Medium (500-4999)",
-            "n": 32,
-            "barrier_mean": 2.7101,
-            "readiness_mean": 3.1451,
-            "maturity_mean": 3.1295
+            "n": 70,
+            "barrier_mean": 2.679,
+            "readiness_mean": 3.2406,
+            "maturity_mean": 3.2441
           },
           {
             "group": "Large (5000+)",
-            "n": 28,
-            "barrier_mean": 2.8872,
-            "readiness_mean": 3.2678,
-            "maturity_mean": 3.3694
+            "n": 45,
+            "barrier_mean": 2.963,
+            "readiness_mean": 3.2082,
+            "maturity_mean": 3.3556
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 24,
-          "nontech_n": 78,
+          "tech_n": 48,
+          "nontech_n": 124,
           "constructs": {
             "barriers": {
-              "t": -0.8219,
+              "t": -0.4999,
               "p": 0.0,
-              "df": 34.3,
-              "mean_diff_ci_lower": -0.1405,
-              "mean_diff_ci_upper": -0.1405,
+              "df": 75.7,
+              "mean_diff_ci_lower": -0.0632,
+              "mean_diff_ci_upper": -0.0632,
               "sig": true
             },
             "readiness": {
-              "t": 2.2654,
+              "t": 3.5528,
               "p": 0.0,
-              "df": 39.71,
-              "mean_diff_ci_lower": 0.3166,
-              "mean_diff_ci_upper": 0.3166,
+              "df": 92.04,
+              "mean_diff_ci_lower": 0.3734,
+              "mean_diff_ci_upper": 0.3734,
               "sig": true
             },
             "maturity": {
-              "t": 1.9309,
+              "t": 1.9843,
               "p": 0.0,
-              "df": 36.23,
-              "mean_diff_ci_lower": 0.3703,
-              "mean_diff_ci_upper": 0.3703,
+              "df": 86.84,
+              "mean_diff_ci_lower": 0.2586,
+              "mean_diff_ci_upper": 0.2586,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 28,
-          "small_medium_n": 91,
+          "large_n": 45,
+          "small_medium_n": 155,
           "constructs": {
             "barriers": {
-              "t": 1.0182,
+              "t": 2.232,
               "p": 0.0,
-              "df": 45.6,
-              "mean_diff_ci_lower": 0.1437,
-              "mean_diff_ci_upper": 0.1437,
+              "df": 72.2,
+              "mean_diff_ci_lower": 0.2564,
+              "mean_diff_ci_upper": 0.2564,
               "sig": true
             },
             "readiness": {
-              "t": 1.4342,
+              "t": 0.7606,
               "p": 0.0,
-              "df": 38.57,
-              "mean_diff_ci_lower": 0.2183,
-              "mean_diff_ci_upper": 0.2183,
+              "df": 64.39,
+              "mean_diff_ci_lower": 0.0931,
+              "mean_diff_ci_upper": 0.0931,
               "sig": true
             },
             "maturity": {
-              "t": 2.1429,
+              "t": 1.8682,
               "p": 0.0,
-              "df": 43.22,
-              "mean_diff_ci_lower": 0.374,
-              "mean_diff_ci_upper": 0.374,
+              "df": 66.2,
+              "mean_diff_ci_lower": 0.2611,
+              "mean_diff_ci_upper": 0.2611,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [24, 78, 17],
+          "group_ns": [48, 124, 28],
           "constructs": {
             "barriers": {
-              "f": 0.8001,
-              "p": 0.4518,
+              "f": 0.1444,
+              "p": 0.8656,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "readiness": {
-              "f": 4.6728,
-              "p": 0.0112,
+              "f": 8.2256,
+              "p": 0.0004,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": true
             },
             "maturity": {
-              "f": 2.9352,
-              "p": 0.0571,
+              "f": 2.0546,
+              "p": 0.1309,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [59, 32, 28],
+          "group_ns": [85, 70, 45],
           "constructs": {
             "barriers": {
-              "f": 0.5673,
-              "p": 0.5686,
+              "f": 2.5541,
+              "p": 0.0803,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "readiness": {
-              "f": 1.8527,
-              "p": 0.1614,
+              "f": 2.6376,
+              "p": 0.0741,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "maturity": {
-              "f": 3.1413,
-              "p": 0.0469,
+              "f": 4.3854,
+              "p": 0.0137,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": true
             }
           }
@@ -1129,40 +1132,41 @@
     "v2_finished": {
       "demographics": {
         "roles": {
-          "Other": 25,
-          "CSO": 16,
-          "CIO": 16,
-          "CEO": 14,
-          "COO": 13,
-          "CRO": 9,
-          "CHRO": 7,
-          "CTO": 7,
-          "CMO": 6,
-          "CFO": 6
+          "Other": 38,
+          "CIO": 33,
+          "COO": 22,
+          "CSO": 20,
+          "CEO": 18,
+          "CMO": 15,
+          "CHRO": 14,
+          "CTO": 14,
+          "CFO": 12,
+          "CRO": 12,
+          "Unknown": 2
         },
         "org_sizes": {
-          "<100": 24,
-          "100-499": 35,
-          "500-999": 12,
-          "1000-4999": 20,
-          "5000-9999": 12,
-          "10000+": 16
+          "<100": 33,
+          "100-499": 52,
+          "500-999": 29,
+          "1000-4999": 41,
+          "5000-9999": 18,
+          "10000+": 27
         },
         "profit_models": {
-          "For-Profit": 90,
-          "Non-Profit": 22,
-          "Government/Public Sector": 7
+          "For-Profit": 151,
+          "Non-Profit": 36,
+          "Government/Public Sector": 13
         },
         "tech_vs_nontech": {
-          "technical": 24,
-          "non_technical": 78,
-          "other": 17
+          "technical": 48,
+          "non_technical": 124,
+          "other": 28
         },
         "other_roles": {
-          "total": 25,
+          "total": 38,
           "categories": {
-            "Director": 12,
-            "Uncategorized": "<5",
+            "Director": 18,
+            "Uncategorized": 5,
             "Manager / Program Lead": "<5",
             "C-Suite Adjacent": "<5"
           }
@@ -1170,69 +1174,69 @@
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 24,
-          "nontech_n": 78,
+          "tech_n": 48,
+          "nontech_n": 124,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6481,
-              "tech_mean_ci_lower": 2.6481,
-              "tech_mean_ci_upper": 2.6481,
-              "nontech_mean": 2.7886,
-              "nontech_mean_ci_lower": 2.7886,
-              "nontech_mean_ci_upper": 2.7886,
-              "d": -0.2071,
-              "d_ci_lower": -0.7177,
-              "d_ci_upper": 0.2779
+              "tech_mean": 2.7193,
+              "tech_mean_ci_lower": 2.7193,
+              "tech_mean_ci_upper": 2.7193,
+              "nontech_mean": 2.7825,
+              "nontech_mean_ci_lower": 2.7825,
+              "nontech_mean_ci_upper": 2.7825,
+              "d": -0.0906,
+              "d_ci_lower": -0.4455,
+              "d_ci_upper": 0.2712
             },
             "readiness": {
-              "tech_mean": 3.3919,
-              "tech_mean_ci_lower": 3.3919,
-              "tech_mean_ci_upper": 3.3919,
-              "nontech_mean": 3.0752,
-              "nontech_mean_ci_lower": 3.0752,
-              "nontech_mean_ci_upper": 3.0752,
-              "d": 0.5166,
-              "d_ci_lower": 0.0886,
-              "d_ci_upper": 0.9916
+              "tech_mean": 3.4457,
+              "tech_mean_ci_lower": 3.4457,
+              "tech_mean_ci_upper": 3.4457,
+              "nontech_mean": 3.0723,
+              "nontech_mean_ci_lower": 3.0723,
+              "nontech_mean_ci_upper": 3.0723,
+              "d": 0.5832,
+              "d_ci_lower": 0.284,
+              "d_ci_upper": 0.9214
             },
             "maturity": {
-              "tech_mean": 3.4062,
-              "tech_mean_ci_lower": 3.4062,
-              "tech_mean_ci_upper": 3.4063,
-              "nontech_mean": 3.0359,
-              "nontech_mean_ci_lower": 3.0359,
-              "nontech_mean_ci_upper": 3.0359,
-              "d": 0.4675,
-              "d_ci_lower": -0.0044,
-              "d_ci_upper": 0.9472
+              "tech_mean": 3.3523,
+              "tech_mean_ci_lower": 3.3523,
+              "tech_mean_ci_upper": 3.3523,
+              "nontech_mean": 3.0937,
+              "nontech_mean_ci_lower": 3.0937,
+              "nontech_mean_ci_upper": 3.0937,
+              "d": 0.3348,
+              "d_ci_lower": 0.0173,
+              "d_ci_upper": 0.6927
             }
           }
         },
         "large_vs_small": {
-          "large_n": 28,
-          "small_medium_n": 91,
+          "large_n": 45,
+          "small_medium_n": 155,
           "constructs": {
             "barriers": {
-              "large_mean": 2.8872,
-              "large_mean_ci_lower": 2.8872,
-              "large_mean_ci_upper": 2.8872,
-              "small_medium_mean": 2.7435,
-              "small_medium_mean_ci_lower": 2.7435,
-              "small_medium_mean_ci_upper": 2.7435,
-              "d": 0.2179,
-              "d_ci_lower": -0.1926,
-              "d_ci_upper": 0.6394
+              "large_mean": 2.963,
+              "large_mean_ci_lower": 2.963,
+              "large_mean_ci_upper": 2.963,
+              "small_medium_mean": 2.7067,
+              "small_medium_mean_ci_lower": 2.7067,
+              "small_medium_mean_ci_upper": 2.7067,
+              "d": 0.3756,
+              "d_ci_lower": 0.025,
+              "d_ci_upper": 0.737
             },
             "readiness": {
-              "large_mean": 3.2678,
-              "large_mean_ci_lower": 3.2678,
-              "large_mean_ci_upper": 3.2678,
-              "small_medium_mean": 3.0495,
-              "small_medium_mean_ci_lower": 3.0495,
-              "small_medium_mean_ci_upper": 3.0495,
-              "d": 0.3462,
-              "d_ci_lower": -0.0968,
-              "d_ci_upper": 0.7993
+              "large_mean": 3.2082,
+              "large_mean_ci_lower": 3.2082,
+              "large_mean_ci_upper": 3.2082,
+              "small_medium_mean": 3.1151,
+              "small_medium_mean_ci_lower": 3.1151,
+              "small_medium_mean_ci_upper": 3.1151,
+              "d": 0.1394,
+              "d_ci_lower": -0.2345,
+              "d_ci_upper": 0.5116
             }
           }
         }
@@ -1241,161 +1245,161 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 24,
-            "barrier_mean": 2.6481,
-            "readiness_mean": 3.3919,
-            "maturity_mean": 3.4062
+            "n": 48,
+            "barrier_mean": 2.7193,
+            "readiness_mean": 3.4457,
+            "maturity_mean": 3.3523
           },
           {
             "group": "Non-Technical",
-            "n": 78,
-            "barrier_mean": 2.7886,
-            "readiness_mean": 3.0752,
-            "maturity_mean": 3.0359
+            "n": 124,
+            "barrier_mean": 2.7825,
+            "readiness_mean": 3.0723,
+            "maturity_mean": 3.0937
           },
           {
             "group": "Other",
-            "n": 17,
-            "barrier_mean": 2.9075,
-            "readiness_mean": 2.8075,
-            "maturity_mean": 2.8456
+            "n": 28,
+            "barrier_mean": 2.7612,
+            "readiness_mean": 2.8878,
+            "maturity_mean": 3.0759
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 59,
-            "barrier_mean": 2.7616,
-            "readiness_mean": 2.9976,
-            "maturity_mean": 2.9227
+            "n": 85,
+            "barrier_mean": 2.7294,
+            "readiness_mean": 3.0118,
+            "maturity_mean": 2.9714
           },
           {
             "group": "Medium (500-4999)",
-            "n": 32,
-            "barrier_mean": 2.7101,
-            "readiness_mean": 3.1451,
-            "maturity_mean": 3.1295
+            "n": 70,
+            "barrier_mean": 2.679,
+            "readiness_mean": 3.2406,
+            "maturity_mean": 3.2441
           },
           {
             "group": "Large (5000+)",
-            "n": 28,
-            "barrier_mean": 2.8872,
-            "readiness_mean": 3.2678,
-            "maturity_mean": 3.3694
+            "n": 45,
+            "barrier_mean": 2.963,
+            "readiness_mean": 3.2082,
+            "maturity_mean": 3.3556
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 24,
-          "nontech_n": 78,
+          "tech_n": 48,
+          "nontech_n": 124,
           "constructs": {
             "barriers": {
-              "t": -0.8219,
+              "t": -0.4999,
               "p": 0.0,
-              "df": 34.3,
-              "mean_diff_ci_lower": -0.1405,
-              "mean_diff_ci_upper": -0.1405,
+              "df": 75.7,
+              "mean_diff_ci_lower": -0.0632,
+              "mean_diff_ci_upper": -0.0632,
               "sig": true
             },
             "readiness": {
-              "t": 2.2654,
+              "t": 3.5528,
               "p": 0.0,
-              "df": 39.71,
-              "mean_diff_ci_lower": 0.3166,
-              "mean_diff_ci_upper": 0.3166,
+              "df": 92.04,
+              "mean_diff_ci_lower": 0.3734,
+              "mean_diff_ci_upper": 0.3734,
               "sig": true
             },
             "maturity": {
-              "t": 1.9309,
+              "t": 1.9843,
               "p": 0.0,
-              "df": 36.23,
-              "mean_diff_ci_lower": 0.3703,
-              "mean_diff_ci_upper": 0.3703,
+              "df": 86.84,
+              "mean_diff_ci_lower": 0.2586,
+              "mean_diff_ci_upper": 0.2586,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 28,
-          "small_medium_n": 91,
+          "large_n": 45,
+          "small_medium_n": 155,
           "constructs": {
             "barriers": {
-              "t": 1.0182,
+              "t": 2.232,
               "p": 0.0,
-              "df": 45.6,
-              "mean_diff_ci_lower": 0.1437,
-              "mean_diff_ci_upper": 0.1437,
+              "df": 72.2,
+              "mean_diff_ci_lower": 0.2564,
+              "mean_diff_ci_upper": 0.2564,
               "sig": true
             },
             "readiness": {
-              "t": 1.4342,
+              "t": 0.7606,
               "p": 0.0,
-              "df": 38.57,
-              "mean_diff_ci_lower": 0.2183,
-              "mean_diff_ci_upper": 0.2183,
+              "df": 64.39,
+              "mean_diff_ci_lower": 0.0931,
+              "mean_diff_ci_upper": 0.0931,
               "sig": true
             },
             "maturity": {
-              "t": 2.1429,
+              "t": 1.8682,
               "p": 0.0,
-              "df": 43.22,
-              "mean_diff_ci_lower": 0.374,
-              "mean_diff_ci_upper": 0.374,
+              "df": 66.2,
+              "mean_diff_ci_lower": 0.2611,
+              "mean_diff_ci_upper": 0.2611,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [24, 78, 17],
+          "group_ns": [48, 124, 28],
           "constructs": {
             "barriers": {
-              "f": 0.8001,
-              "p": 0.4518,
+              "f": 0.1444,
+              "p": 0.8656,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "readiness": {
-              "f": 4.6728,
-              "p": 0.0112,
+              "f": 8.2256,
+              "p": 0.0004,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": true
             },
             "maturity": {
-              "f": 2.9352,
-              "p": 0.0571,
+              "f": 2.0546,
+              "p": 0.1309,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [59, 32, 28],
+          "group_ns": [85, 70, 45],
           "constructs": {
             "barriers": {
-              "f": 0.5673,
-              "p": 0.5686,
+              "f": 2.5541,
+              "p": 0.0803,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "readiness": {
-              "f": 1.8527,
-              "p": 0.1614,
+              "f": 2.6376,
+              "p": 0.0741,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "maturity": {
-              "f": 3.1413,
-              "p": 0.0469,
+              "f": 4.3854,
+              "p": 0.0137,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": true
             }
           }
@@ -1405,40 +1409,41 @@
     "v2_all": {
       "demographics": {
         "roles": {
-          "Other": 25,
-          "CSO": 16,
-          "CIO": 16,
-          "CEO": 14,
-          "COO": 13,
-          "CRO": 9,
-          "CHRO": 7,
-          "CTO": 7,
-          "CMO": 6,
-          "CFO": 6
+          "Other": 38,
+          "CIO": 33,
+          "COO": 22,
+          "CSO": 20,
+          "CEO": 18,
+          "CMO": 15,
+          "CHRO": 14,
+          "CTO": 14,
+          "CFO": 12,
+          "CRO": 12,
+          "Unknown": 2
         },
         "org_sizes": {
-          "<100": 24,
-          "100-499": 35,
-          "500-999": 12,
-          "1000-4999": 20,
-          "5000-9999": 12,
-          "10000+": 16
+          "<100": 33,
+          "100-499": 52,
+          "500-999": 29,
+          "1000-4999": 41,
+          "5000-9999": 18,
+          "10000+": 27
         },
         "profit_models": {
-          "For-Profit": 90,
-          "Non-Profit": 22,
-          "Government/Public Sector": 7
+          "For-Profit": 151,
+          "Non-Profit": 36,
+          "Government/Public Sector": 13
         },
         "tech_vs_nontech": {
-          "technical": 24,
-          "non_technical": 78,
-          "other": 17
+          "technical": 48,
+          "non_technical": 124,
+          "other": 28
         },
         "other_roles": {
-          "total": 25,
+          "total": 38,
           "categories": {
-            "Director": 12,
-            "Uncategorized": "<5",
+            "Director": 18,
+            "Uncategorized": 5,
             "Manager / Program Lead": "<5",
             "C-Suite Adjacent": "<5"
           }
@@ -1446,69 +1451,69 @@
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 24,
-          "nontech_n": 78,
+          "tech_n": 48,
+          "nontech_n": 124,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6481,
-              "tech_mean_ci_lower": 2.6481,
-              "tech_mean_ci_upper": 2.6481,
-              "nontech_mean": 2.7886,
-              "nontech_mean_ci_lower": 2.7886,
-              "nontech_mean_ci_upper": 2.7886,
-              "d": -0.2071,
-              "d_ci_lower": -0.7177,
-              "d_ci_upper": 0.2779
+              "tech_mean": 2.7193,
+              "tech_mean_ci_lower": 2.7193,
+              "tech_mean_ci_upper": 2.7193,
+              "nontech_mean": 2.7825,
+              "nontech_mean_ci_lower": 2.7825,
+              "nontech_mean_ci_upper": 2.7825,
+              "d": -0.0906,
+              "d_ci_lower": -0.4455,
+              "d_ci_upper": 0.2712
             },
             "readiness": {
-              "tech_mean": 3.3919,
-              "tech_mean_ci_lower": 3.3919,
-              "tech_mean_ci_upper": 3.3919,
-              "nontech_mean": 3.0752,
-              "nontech_mean_ci_lower": 3.0752,
-              "nontech_mean_ci_upper": 3.0752,
-              "d": 0.5166,
-              "d_ci_lower": 0.0886,
-              "d_ci_upper": 0.9916
+              "tech_mean": 3.4457,
+              "tech_mean_ci_lower": 3.4457,
+              "tech_mean_ci_upper": 3.4457,
+              "nontech_mean": 3.0723,
+              "nontech_mean_ci_lower": 3.0723,
+              "nontech_mean_ci_upper": 3.0723,
+              "d": 0.5832,
+              "d_ci_lower": 0.284,
+              "d_ci_upper": 0.9214
             },
             "maturity": {
-              "tech_mean": 3.4062,
-              "tech_mean_ci_lower": 3.4062,
-              "tech_mean_ci_upper": 3.4063,
-              "nontech_mean": 3.0359,
-              "nontech_mean_ci_lower": 3.0359,
-              "nontech_mean_ci_upper": 3.0359,
-              "d": 0.4675,
-              "d_ci_lower": -0.0044,
-              "d_ci_upper": 0.9472
+              "tech_mean": 3.3523,
+              "tech_mean_ci_lower": 3.3523,
+              "tech_mean_ci_upper": 3.3523,
+              "nontech_mean": 3.0937,
+              "nontech_mean_ci_lower": 3.0937,
+              "nontech_mean_ci_upper": 3.0937,
+              "d": 0.3348,
+              "d_ci_lower": 0.0173,
+              "d_ci_upper": 0.6927
             }
           }
         },
         "large_vs_small": {
-          "large_n": 28,
-          "small_medium_n": 91,
+          "large_n": 45,
+          "small_medium_n": 155,
           "constructs": {
             "barriers": {
-              "large_mean": 2.8872,
-              "large_mean_ci_lower": 2.8872,
-              "large_mean_ci_upper": 2.8872,
-              "small_medium_mean": 2.7435,
-              "small_medium_mean_ci_lower": 2.7435,
-              "small_medium_mean_ci_upper": 2.7435,
-              "d": 0.2179,
-              "d_ci_lower": -0.1926,
-              "d_ci_upper": 0.6394
+              "large_mean": 2.963,
+              "large_mean_ci_lower": 2.963,
+              "large_mean_ci_upper": 2.963,
+              "small_medium_mean": 2.7067,
+              "small_medium_mean_ci_lower": 2.7067,
+              "small_medium_mean_ci_upper": 2.7067,
+              "d": 0.3756,
+              "d_ci_lower": 0.025,
+              "d_ci_upper": 0.737
             },
             "readiness": {
-              "large_mean": 3.2678,
-              "large_mean_ci_lower": 3.2678,
-              "large_mean_ci_upper": 3.2678,
-              "small_medium_mean": 3.0495,
-              "small_medium_mean_ci_lower": 3.0495,
-              "small_medium_mean_ci_upper": 3.0495,
-              "d": 0.3462,
-              "d_ci_lower": -0.0968,
-              "d_ci_upper": 0.7993
+              "large_mean": 3.2082,
+              "large_mean_ci_lower": 3.2082,
+              "large_mean_ci_upper": 3.2082,
+              "small_medium_mean": 3.1151,
+              "small_medium_mean_ci_lower": 3.1151,
+              "small_medium_mean_ci_upper": 3.1151,
+              "d": 0.1394,
+              "d_ci_lower": -0.2345,
+              "d_ci_upper": 0.5116
             }
           }
         }
@@ -1517,161 +1522,161 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 24,
-            "barrier_mean": 2.6481,
-            "readiness_mean": 3.3919,
-            "maturity_mean": 3.4062
+            "n": 48,
+            "barrier_mean": 2.7193,
+            "readiness_mean": 3.4457,
+            "maturity_mean": 3.3523
           },
           {
             "group": "Non-Technical",
-            "n": 78,
-            "barrier_mean": 2.7886,
-            "readiness_mean": 3.0752,
-            "maturity_mean": 3.0359
+            "n": 124,
+            "barrier_mean": 2.7825,
+            "readiness_mean": 3.0723,
+            "maturity_mean": 3.0937
           },
           {
             "group": "Other",
-            "n": 17,
-            "barrier_mean": 2.9075,
-            "readiness_mean": 2.8075,
-            "maturity_mean": 2.8456
+            "n": 28,
+            "barrier_mean": 2.7612,
+            "readiness_mean": 2.8878,
+            "maturity_mean": 3.0759
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 59,
-            "barrier_mean": 2.7616,
-            "readiness_mean": 2.9976,
-            "maturity_mean": 2.9227
+            "n": 85,
+            "barrier_mean": 2.7294,
+            "readiness_mean": 3.0118,
+            "maturity_mean": 2.9714
           },
           {
             "group": "Medium (500-4999)",
-            "n": 32,
-            "barrier_mean": 2.7101,
-            "readiness_mean": 3.1451,
-            "maturity_mean": 3.1295
+            "n": 70,
+            "barrier_mean": 2.679,
+            "readiness_mean": 3.2406,
+            "maturity_mean": 3.2441
           },
           {
             "group": "Large (5000+)",
-            "n": 28,
-            "barrier_mean": 2.8872,
-            "readiness_mean": 3.2678,
-            "maturity_mean": 3.3694
+            "n": 45,
+            "barrier_mean": 2.963,
+            "readiness_mean": 3.2082,
+            "maturity_mean": 3.3556
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 24,
-          "nontech_n": 78,
+          "tech_n": 48,
+          "nontech_n": 124,
           "constructs": {
             "barriers": {
-              "t": -0.8219,
+              "t": -0.4999,
               "p": 0.0,
-              "df": 34.3,
-              "mean_diff_ci_lower": -0.1405,
-              "mean_diff_ci_upper": -0.1405,
+              "df": 75.7,
+              "mean_diff_ci_lower": -0.0632,
+              "mean_diff_ci_upper": -0.0632,
               "sig": true
             },
             "readiness": {
-              "t": 2.2654,
+              "t": 3.5528,
               "p": 0.0,
-              "df": 39.71,
-              "mean_diff_ci_lower": 0.3166,
-              "mean_diff_ci_upper": 0.3166,
+              "df": 92.04,
+              "mean_diff_ci_lower": 0.3734,
+              "mean_diff_ci_upper": 0.3734,
               "sig": true
             },
             "maturity": {
-              "t": 1.9309,
+              "t": 1.9843,
               "p": 0.0,
-              "df": 36.23,
-              "mean_diff_ci_lower": 0.3703,
-              "mean_diff_ci_upper": 0.3703,
+              "df": 86.84,
+              "mean_diff_ci_lower": 0.2586,
+              "mean_diff_ci_upper": 0.2586,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 28,
-          "small_medium_n": 91,
+          "large_n": 45,
+          "small_medium_n": 155,
           "constructs": {
             "barriers": {
-              "t": 1.0182,
+              "t": 2.232,
               "p": 0.0,
-              "df": 45.6,
-              "mean_diff_ci_lower": 0.1437,
-              "mean_diff_ci_upper": 0.1437,
+              "df": 72.2,
+              "mean_diff_ci_lower": 0.2564,
+              "mean_diff_ci_upper": 0.2564,
               "sig": true
             },
             "readiness": {
-              "t": 1.4342,
+              "t": 0.7606,
               "p": 0.0,
-              "df": 38.57,
-              "mean_diff_ci_lower": 0.2183,
-              "mean_diff_ci_upper": 0.2183,
+              "df": 64.39,
+              "mean_diff_ci_lower": 0.0931,
+              "mean_diff_ci_upper": 0.0931,
               "sig": true
             },
             "maturity": {
-              "t": 2.1429,
+              "t": 1.8682,
               "p": 0.0,
-              "df": 43.22,
-              "mean_diff_ci_lower": 0.374,
-              "mean_diff_ci_upper": 0.374,
+              "df": 66.2,
+              "mean_diff_ci_lower": 0.2611,
+              "mean_diff_ci_upper": 0.2611,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [24, 78, 17],
+          "group_ns": [48, 124, 28],
           "constructs": {
             "barriers": {
-              "f": 0.8001,
-              "p": 0.4518,
+              "f": 0.1444,
+              "p": 0.8656,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "readiness": {
-              "f": 4.6728,
-              "p": 0.0112,
+              "f": 8.2256,
+              "p": 0.0004,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": true
             },
             "maturity": {
-              "f": 2.9352,
-              "p": 0.0571,
+              "f": 2.0546,
+              "p": 0.1309,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [59, 32, 28],
+          "group_ns": [85, 70, 45],
           "constructs": {
             "barriers": {
-              "f": 0.5673,
-              "p": 0.5686,
+              "f": 2.5541,
+              "p": 0.0803,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "readiness": {
-              "f": 1.8527,
-              "p": 0.1614,
+              "f": 2.6376,
+              "p": 0.0741,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": false
             },
             "maturity": {
-              "f": 3.1413,
-              "p": 0.0469,
+              "f": 4.3854,
+              "p": 0.0137,
               "df_between": 2,
-              "df_within": 116,
+              "df_within": 197,
               "sig": true
             }
           }
@@ -1682,22 +1687,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 0.97,
-      "p_value": 0.9869,
+      "chi2": 1.36,
+      "p_value": 0.9682,
       "df": 6,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 5.64,
-      "p_value": 0.9852,
+      "chi2": 7.22,
+      "p_value": 0.9511,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 4.8,
-      "p_value": 0.5702,
+      "chi2": 2.7,
+      "p_value": 0.8456,
       "df": 6,
       "error": null
     },
@@ -1705,24 +1710,24 @@
       "labels": ["For-Profit", "Non-Profit", "Government/Public Sector"],
       "groups": {
         "Conservative Clean": {
-          "For-Profit": 33,
-          "Non-Profit": 9,
-          "Government/Public Sector": 7
+          "For-Profit": 56,
+          "Non-Profit": 15,
+          "Government/Public Sector": 8
         },
         "Flexible Clean": {
-          "For-Profit": 47,
-          "Non-Profit": 12,
-          "Government/Public Sector": 7
+          "For-Profit": 81,
+          "Non-Profit": 24,
+          "Government/Public Sector": 11
         },
         "Prolific Accepted": {
-          "For-Profit": 90,
-          "Non-Profit": 22,
-          "Government/Public Sector": 7
+          "For-Profit": 151,
+          "Non-Profit": 36,
+          "Government/Public Sector": 13
         },
         "All V2 Finished": {
-          "For-Profit": 90,
-          "Non-Profit": 22,
-          "Government/Public Sector": 7
+          "For-Profit": 151,
+          "Non-Profit": 36,
+          "Government/Public Sector": 13
         }
       }
     }
@@ -1764,5 +1769,5 @@
       "examples": ""
     }
   ],
-  "last_updated": "2026-04-10T21:12:34.926122Z"
+  "last_updated": "2026-04-11T02:06:57.374176Z"
 }

--- a/src/data/data-audit.json
+++ b/src/data/data-audit.json
@@ -1,22 +1,22 @@
 {
   "disposition_counts": {
-    "INCOMPLETE": 67,
+    "INCOMPLETE": 68,
     "CLEAN": 84,
-    "FLAG-SMEAL": 48,
+    "FLAG-SMEAL": 49,
     "FLAG-SPEED": 7,
     "FLAG-PARTIAL-STRAIGHTLINING": 33,
-    "FLAG-SINGLE-IRI": 79,
-    "AUTO-EXCLUDE": 116,
+    "FLAG-SINGLE-IRI": 80,
+    "AUTO-EXCLUDE": 117,
     "FLAG-RECAPTCHA": 3
   },
   "iri_pass_rates": {
-    "barrier": 0.4897025171624714,
-    "readiness": 0.5926773455377574,
-    "maturity": 0.6887871853546911
+    "barrier": 0.4875283446712018,
+    "readiness": 0.5918367346938775,
+    "maturity": 0.6893424036281179
   },
   "duration_stats": {
-    "mean": 659.4256292906178,
-    "median": 532,
+    "mean": 657.4625850340136,
+    "median": 530,
     "q25": 318,
     "q75": 792,
     "min": 2,
@@ -27,70 +27,70 @@
     "partial_flagged": 132
   },
   "sample_sizes": {
-    "total": 437,
-    "complete": 370,
+    "total": 441,
+    "complete": 373,
     "clean": 84
   },
   "waterfall_steps": [
     {
       "step": 0,
       "name": "INCOMPLETE",
-      "count": 67,
-      "cumulative_excluded": 67
+      "count": 68,
+      "cumulative_excluded": 68
     },
     {
       "step": 1,
       "name": "FLAG-AUTH-FAIL",
       "count": 0,
-      "cumulative_excluded": 67
+      "cumulative_excluded": 68
     },
     {
       "step": 2,
       "name": "FLAG-AUTH-MIXED",
       "count": 0,
-      "cumulative_excluded": 67
+      "cumulative_excluded": 68
     },
     {
       "step": 3,
       "name": "AUTO-EXCLUDE",
-      "count": 116,
-      "cumulative_excluded": 183
+      "count": 117,
+      "cumulative_excluded": 185
     },
     {
       "step": 4,
       "name": "FLAG-SPEED",
       "count": 7,
-      "cumulative_excluded": 190
+      "cumulative_excluded": 192
     },
     {
       "step": 5,
       "name": "FLAG-SINGLE-IRI",
-      "count": 79,
-      "cumulative_excluded": 269
+      "count": 80,
+      "cumulative_excluded": 272
     },
     {
       "step": 6,
       "name": "FLAG-SMEAL",
-      "count": 48,
-      "cumulative_excluded": 317
+      "count": 49,
+      "cumulative_excluded": 321
     },
     {
       "step": 7,
       "name": "FLAG-RECAPTCHA",
       "count": 3,
-      "cumulative_excluded": 320
+      "cumulative_excluded": 324
     },
     {
       "step": 8,
       "name": "FLAG-STRAIGHTLINING",
       "count": 0,
-      "cumulative_excluded": 320
+      "cumulative_excluded": 324
     },
     {
       "step": 9,
       "name": "FLAG-PARTIAL-STRAIGHTLINING",
       "count": 33,
-      "cumulative_excluded": 353
+      "cumulative_excluded": 357
     },
     {
       "step": 10,

--- a/src/data/disposition-summary.json
+++ b/src/data/disposition-summary.json
@@ -1,40 +1,40 @@
 {
-  "updatedAt": "2026-04-10T21:16:41.023126+00:00",
-  "last_updated": "2026-04-10T21:16:41.023138+00:00",
+  "updatedAt": "2026-04-11T02:10:06.297613+00:00",
+  "last_updated": "2026-04-11T02:10:06.297629+00:00",
   "study": {
     "id": "69c17630acada6abeead2da5",
     "name": "Technology Adoption Barriers Survey (2026)",
     "status": "ACTIVE",
     "totalAvailablePlaces": 500,
-    "placesTaken": 268,
-    "averageRewardPerHour": 3986.55,
+    "placesTaken": 270,
+    "averageRewardPerHour": 3994.65,
     "averageTimeTaken": 10,
     "reward": 700,
     "publishedAt": "2026-03-23T18:00:28.650000Z"
   },
   "completionProgress": {
     "target": 500,
-    "completed": 268,
+    "completed": 270,
     "approved": 234,
-    "awaitingReview": 34,
-    "percentComplete": 53.6
+    "awaitingReview": 36,
+    "percentComplete": 54.0
   },
-  "totalResponses": 455,
-  "uniqueParticipants": 437,
+  "totalResponses": 457,
+  "uniqueParticipants": 441,
   "duplicatesRemoved": 0,
   "dispositions": {
-    "INCOMPLETE": 67,
+    "INCOMPLETE": 68,
     "CLEAN": 84,
-    "FLAG-SMEAL": 48,
+    "FLAG-SMEAL": 49,
     "FLAG-SPEED": 7,
     "FLAG-PARTIAL-STRAIGHTLINING": 33,
-    "FLAG-SINGLE-IRI": 79,
-    "AUTO-EXCLUDE": 116,
+    "FLAG-SINGLE-IRI": 80,
+    "AUTO-EXCLUDE": 117,
     "FLAG-RECAPTCHA": 3
   },
   "dispositionByStatus": {
     "INCOMPLETE": {
-      "RETURNED": 61,
+      "RETURNED": 62,
       "TIMED-OUT": 6
     },
     "CLEAN": {
@@ -43,7 +43,7 @@
     },
     "FLAG-SMEAL": {
       "APPROVED": 40,
-      "AWAITING REVIEW": 6,
+      "AWAITING REVIEW": 7,
       "RETURNED": 2
     },
     "FLAG-SPEED": {
@@ -57,11 +57,11 @@
     "FLAG-SINGLE-IRI": {
       "RETURNED": 7,
       "APPROVED": 67,
-      "AWAITING REVIEW": 5
+      "AWAITING REVIEW": 6
     },
     "AUTO-EXCLUDE": {
       "REJECTED": 29,
-      "AWAITING REVIEW": 21,
+      "AWAITING REVIEW": 22,
       "RETURNED": 63,
       "APPROVED": 3
     },
@@ -73,7 +73,7 @@
     "IRI3_SPEED": 13,
     "IRI3": 28,
     "IRI2_SPEED": 11,
-    "IRI2": 50,
+    "IRI2": 51,
     "SPEED_IRI": 14
   },
   "actions": {
@@ -81,15 +81,15 @@
     "rejected": 29,
     "returned": 152,
     "timedOut": 6,
-    "awaitingReview": 34,
+    "awaitingReview": 36,
     "active": 0,
     "messaged": 0
   },
   "iriPassRates": {
-    "barrier": 57.6,
+    "barrier": 57.4,
     "readiness": 69.7,
-    "maturity": 81.4,
-    "denominator": 370
+    "maturity": 81.5,
+    "denominator": 373
   },
   "studyId": "69c17630acada6abeead2da5",
   "studyName": "Technology Adoption Barriers Survey (2026)"

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -4,31 +4,31 @@
       "key": "conservative_clean",
       "label": "Conservative Clean",
       "description": "Prolific APPROVED + all quality checks (IRI, duration >= 540s, reCAPTCHA, straightlining, auth)",
-      "n": 82
+      "n": 83
     },
     {
       "key": "flexible_clean",
       "label": "Flexible Clean",
       "description": "Prolific APPROVED + basic quality (all 3 IRIs + duration >= 480s)",
-      "n": 129
+      "n": 130
     },
     {
       "key": "prolific_accepted",
       "label": "Prolific Accepted",
       "description": "All deduplicated V2 rows with Prolific APPROVED status",
-      "n": 233
+      "n": 234
     },
     {
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 370
+      "n": 373
     },
     {
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 437
+      "n": 441
     }
   ],
   "metrics": [
@@ -36,108 +36,108 @@
       "key": "barrier_mean",
       "label": "Barrier Grand Mean",
       "values": {
-        "conservative_clean": 2.8315,
-        "flexible_clean": 2.8196,
-        "prolific_accepted": 2.7821,
-        "v2_finished": 2.7436,
-        "v2_all": 2.7492
+        "conservative_clean": 2.8409,
+        "flexible_clean": 2.8257,
+        "prolific_accepted": 2.7857,
+        "v2_finished": 2.7494,
+        "v2_all": 2.7549
       }
     },
     {
       "key": "barrier_sd",
       "label": "Barrier SD",
       "values": {
-        "conservative_clean": 0.6291,
-        "flexible_clean": 0.7143,
-        "prolific_accepted": 0.7136,
-        "v2_finished": 0.771,
-        "v2_all": 0.7747
+        "conservative_clean": 0.631,
+        "flexible_clean": 0.7149,
+        "prolific_accepted": 0.7141,
+        "v2_finished": 0.7709,
+        "v2_all": 0.7745
       }
     },
     {
       "key": "readiness_mean",
       "label": "Readiness Grand Mean",
       "values": {
-        "conservative_clean": 3.0543,
-        "flexible_clean": 3.0971,
-        "prolific_accepted": 3.1398,
-        "v2_finished": 3.249,
-        "v2_all": 3.249
+        "conservative_clean": 3.0622,
+        "flexible_clean": 3.1018,
+        "prolific_accepted": 3.1422,
+        "v2_finished": 3.2497,
+        "v2_all": 3.2497
       }
     },
     {
       "key": "readiness_sd",
       "label": "Readiness SD",
       "values": {
-        "conservative_clean": 0.5742,
-        "flexible_clean": 0.6525,
-        "prolific_accepted": 0.6722,
-        "v2_finished": 0.7142,
-        "v2_all": 0.7132
+        "conservative_clean": 0.5751,
+        "flexible_clean": 0.6521,
+        "prolific_accepted": 0.6718,
+        "v2_finished": 0.7137,
+        "v2_all": 0.7127
       }
     },
     {
       "key": "maturity_mean",
       "label": "Maturity Grand Mean",
       "values": {
-        "conservative_clean": 3.0276,
-        "flexible_clean": 3.0592,
-        "prolific_accepted": 3.1525,
-        "v2_finished": 3.2706,
-        "v2_all": 3.2706
+        "conservative_clean": 3.0424,
+        "flexible_clean": 3.0684,
+        "prolific_accepted": 3.1572,
+        "v2_finished": 3.2712,
+        "v2_all": 3.2712
       }
     },
     {
       "key": "maturity_sd",
       "label": "Maturity SD",
       "values": {
-        "conservative_clean": 0.7027,
-        "flexible_clean": 0.793,
-        "prolific_accepted": 0.8043,
-        "v2_finished": 0.8056,
-        "v2_all": 0.8056
+        "conservative_clean": 0.7112,
+        "flexible_clean": 0.7968,
+        "prolific_accepted": 0.8058,
+        "v2_finished": 0.805,
+        "v2_all": 0.805
       }
     },
     {
       "key": "corr_br",
       "label": "B-R Correlation",
       "values": {
-        "conservative_clean": -0.477,
-        "flexible_clean": -0.4558,
-        "prolific_accepted": -0.3408,
-        "v2_finished": -0.3146,
-        "v2_all": -0.3144
+        "conservative_clean": -0.452,
+        "flexible_clean": -0.4442,
+        "prolific_accepted": -0.3351,
+        "v2_finished": -0.3127,
+        "v2_all": -0.3125
       }
     },
     {
       "key": "corr_bm",
       "label": "B-M Correlation",
       "values": {
-        "conservative_clean": -0.2419,
-        "flexible_clean": -0.3244,
-        "prolific_accepted": -0.2819,
-        "v2_finished": -0.3039,
-        "v2_all": -0.3039
+        "conservative_clean": -0.2098,
+        "flexible_clean": -0.3074,
+        "prolific_accepted": -0.2733,
+        "v2_finished": -0.3026,
+        "v2_all": -0.3026
       }
     },
     {
       "key": "corr_rm",
       "label": "R-M Correlation",
       "values": {
-        "conservative_clean": 0.5789,
-        "flexible_clean": 0.6926,
-        "prolific_accepted": 0.7094,
-        "v2_finished": 0.7319,
-        "v2_all": 0.7319
+        "conservative_clean": 0.5876,
+        "flexible_clean": 0.6951,
+        "prolific_accepted": 0.7104,
+        "v2_finished": 0.7336,
+        "v2_all": 0.7336
       }
     },
     {
       "key": "alpha_barriers",
       "label": "Alpha Barriers",
       "values": {
-        "conservative_clean": 0.8555,
-        "flexible_clean": 0.8758,
-        "prolific_accepted": 0.8763,
+        "conservative_clean": 0.8557,
+        "flexible_clean": 0.8759,
+        "prolific_accepted": 0.8765,
         "v2_finished": 0.9005,
         "v2_all": 0.9019
       }
@@ -146,9 +146,9 @@
       "key": "alpha_readiness",
       "label": "Alpha Readiness",
       "values": {
-        "conservative_clean": 0.8696,
-        "flexible_clean": 0.9152,
-        "prolific_accepted": 0.9193,
+        "conservative_clean": 0.87,
+        "flexible_clean": 0.9149,
+        "prolific_accepted": 0.9191,
         "v2_finished": 0.9301,
         "v2_all": 0.9301
       }
@@ -157,11 +157,11 @@
       "key": "alpha_maturity",
       "label": "Alpha Maturity",
       "values": {
-        "conservative_clean": 0.8282,
-        "flexible_clean": 0.8808,
-        "prolific_accepted": 0.8886,
-        "v2_finished": 0.8901,
-        "v2_all": 0.8901
+        "conservative_clean": 0.8327,
+        "flexible_clean": 0.8818,
+        "prolific_accepted": 0.8889,
+        "v2_finished": 0.8899,
+        "v2_all": 0.8899
       }
     }
   ],
@@ -305,7 +305,7 @@
       "demographics": {
         "roles": {
           "Other": 14,
-          "CIO": 11,
+          "CIO": 12,
           "COO": 10,
           "CEO": 10,
           "CMO": 9,
@@ -316,7 +316,7 @@
           "CRO": 3
         },
         "org_sizes": {
-          "<100": 10,
+          "<100": 11,
           "100-499": 29,
           "500-999": 8,
           "1000-4999": 18,
@@ -324,12 +324,12 @@
           "10000+": 11
         },
         "profit_models": {
-          "For-Profit": 58,
+          "For-Profit": 59,
           "Non-Profit": 15,
           "Government/Public Sector": 9
         },
         "tech_vs_nontech": {
-          "technical": 15,
+          "technical": 16,
           "non_technical": 55,
           "other": 12
         },
@@ -344,69 +344,69 @@
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 15,
+          "tech_n": 16,
           "nontech_n": 55,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7222,
-              "tech_mean_ci_lower": 2.7222,
-              "tech_mean_ci_upper": 2.7222,
+              "tech_mean": 2.7778,
+              "tech_mean_ci_lower": 2.7778,
+              "tech_mean_ci_upper": 2.7778,
               "nontech_mean": 2.8923,
               "nontech_mean_ci_lower": 2.8923,
               "nontech_mean_ci_upper": 2.8923,
-              "d": -0.2556,
-              "d_ci_lower": -0.8392,
-              "d_ci_upper": 0.3417
+              "d": -0.1712,
+              "d_ci_lower": -0.773,
+              "d_ci_upper": 0.4436
             },
             "readiness": {
-              "tech_mean": 3.325,
-              "tech_mean_ci_lower": 3.325,
-              "tech_mean_ci_upper": 3.325,
+              "tech_mean": 3.3488,
+              "tech_mean_ci_lower": 3.3488,
+              "tech_mean_ci_upper": 3.3488,
               "nontech_mean": 3.0071,
               "nontech_mean_ci_lower": 3.0071,
               "nontech_mean_ci_upper": 3.0071,
-              "d": 0.5543,
-              "d_ci_lower": 0.0161,
-              "d_ci_upper": 1.1792
+              "d": 0.5984,
+              "d_ci_lower": 0.0817,
+              "d_ci_upper": 1.2143
             },
             "maturity": {
-              "tech_mean": 3.1083,
-              "tech_mean_ci_lower": 3.1083,
-              "tech_mean_ci_upper": 3.1083,
+              "tech_mean": 3.1797,
+              "tech_mean_ci_lower": 3.1797,
+              "tech_mean_ci_upper": 3.1797,
               "nontech_mean": 2.9844,
               "nontech_mean_ci_lower": 2.9844,
               "nontech_mean_ci_upper": 2.9844,
-              "d": 0.1755,
-              "d_ci_lower": -0.4474,
-              "d_ci_upper": 0.7883
+              "d": 0.2736,
+              "d_ci_lower": -0.3259,
+              "d_ci_upper": 0.9033
             }
           }
         },
         "large_vs_small": {
           "large_n": 17,
-          "small_medium_n": 65,
+          "small_medium_n": 66,
           "constructs": {
             "barriers": {
               "large_mean": 3.0919,
               "large_mean_ci_lower": 3.0919,
               "large_mean_ci_upper": 3.0919,
-              "small_medium_mean": 2.7634,
-              "small_medium_mean_ci_lower": 2.7634,
-              "small_medium_mean_ci_upper": 2.7634,
-              "d": 0.5311,
-              "d_ci_lower": 0.0462,
-              "d_ci_upper": 1.0707
+              "small_medium_mean": 2.7763,
+              "small_medium_mean_ci_lower": 2.7763,
+              "small_medium_mean_ci_upper": 2.7763,
+              "d": 0.5077,
+              "d_ci_lower": 0.0298,
+              "d_ci_upper": 1.0077
             },
             "readiness": {
               "large_mean": 3.0222,
               "large_mean_ci_lower": 3.0222,
               "large_mean_ci_upper": 3.0222,
-              "small_medium_mean": 3.0627,
-              "small_medium_mean_ci_lower": 3.0627,
-              "small_medium_mean_ci_upper": 3.0627,
-              "d": -0.0702,
-              "d_ci_lower": -0.6538,
-              "d_ci_upper": 0.4677
+              "small_medium_mean": 3.0725,
+              "small_medium_mean_ci_lower": 3.0725,
+              "small_medium_mean_ci_upper": 3.0725,
+              "d": -0.087,
+              "d_ci_lower": -0.6485,
+              "d_ci_upper": 0.4637
             }
           }
         }
@@ -415,10 +415,10 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 15,
-            "barrier_mean": 2.7222,
-            "readiness_mean": 3.325,
-            "maturity_mean": 3.1083
+            "n": 16,
+            "barrier_mean": 2.7778,
+            "readiness_mean": 3.3488,
+            "maturity_mean": 3.1797
           },
           {
             "group": "Non-Technical",
@@ -438,10 +438,10 @@
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 39,
-            "barrier_mean": 2.818,
-            "readiness_mean": 3.0701,
-            "maturity_mean": 2.9573
+            "n": 40,
+            "barrier_mean": 2.8378,
+            "readiness_mean": 3.086,
+            "maturity_mean": 2.9896
           },
           {
             "group": "Medium (500-4999)",
@@ -461,115 +461,115 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 15,
+          "tech_n": 16,
           "nontech_n": 55,
           "constructs": {
             "barriers": {
-              "t": -0.8204,
+              "t": -0.5611,
               "p": 0.0,
-              "df": 20.46,
-              "mean_diff_ci_lower": -0.1701,
-              "mean_diff_ci_upper": -0.1701,
+              "df": 22.19,
+              "mean_diff_ci_lower": -0.1145,
+              "mean_diff_ci_upper": -0.1145,
               "sig": true
             },
             "readiness": {
-              "t": 1.9345,
+              "t": 2.1632,
               "p": 0.0,
-              "df": 22.76,
-              "mean_diff_ci_lower": 0.3179,
-              "mean_diff_ci_upper": 0.3179,
+              "df": 25.41,
+              "mean_diff_ci_lower": 0.3417,
+              "mean_diff_ci_upper": 0.3417,
               "sig": true
             },
             "maturity": {
-              "t": 0.5469,
+              "t": 0.8641,
               "p": 0.0,
-              "df": 19.8,
-              "mean_diff_ci_lower": 0.124,
-              "mean_diff_ci_upper": 0.124,
+              "df": 21.24,
+              "mean_diff_ci_lower": 0.1953,
+              "mean_diff_ci_upper": 0.1953,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 17,
-          "small_medium_n": 65,
+          "small_medium_n": 66,
           "constructs": {
             "barriers": {
-              "t": 2.099,
+              "t": 2.0178,
               "p": 0.0,
-              "df": 27.77,
-              "mean_diff_ci_lower": 0.3285,
-              "mean_diff_ci_upper": 0.3285,
+              "df": 27.74,
+              "mean_diff_ci_lower": 0.3156,
+              "mean_diff_ci_upper": 0.3156,
               "sig": true
             },
             "readiness": {
-              "t": -0.2451,
+              "t": -0.3043,
               "p": 0.0,
-              "df": 23.54,
-              "mean_diff_ci_lower": -0.0406,
-              "mean_diff_ci_upper": -0.0406,
+              "df": 23.46,
+              "mean_diff_ci_lower": -0.0503,
+              "mean_diff_ci_upper": -0.0503,
               "sig": true
             },
             "maturity": {
-              "t": 1.6271,
+              "t": 1.5311,
               "p": 0.0,
-              "df": 22.09,
-              "mean_diff_ci_lower": 0.3431,
-              "mean_diff_ci_upper": 0.3431,
+              "df": 22.26,
+              "mean_diff_ci_lower": 0.3235,
+              "mean_diff_ci_upper": 0.3235,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [15, 55, 12],
+          "group_ns": [16, 55, 12],
           "constructs": {
             "barriers": {
-              "f": 0.7833,
-              "p": 0.4604,
+              "f": 0.6004,
+              "p": 0.551,
               "df_between": 2,
-              "df_within": 79,
+              "df_within": 80,
               "sig": false
             },
             "readiness": {
-              "f": 2.1853,
-              "p": 0.1192,
+              "f": 2.6467,
+              "p": 0.0771,
               "df_between": 2,
-              "df_within": 79,
+              "df_within": 80,
               "sig": false
             },
             "maturity": {
-              "f": 0.3129,
-              "p": 0.7322,
+              "f": 0.556,
+              "p": 0.5757,
               "df_between": 2,
-              "df_within": 79,
+              "df_within": 80,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [39, 26, 17],
+          "group_ns": [40, 26, 17],
           "constructs": {
             "barriers": {
-              "f": 2.2729,
-              "p": 0.1097,
+              "f": 2.2393,
+              "p": 0.1132,
               "df_between": 2,
-              "df_within": 79,
+              "df_within": 80,
               "sig": false
             },
             "readiness": {
-              "f": 0.0406,
-              "p": 0.9602,
+              "f": 0.0779,
+              "p": 0.9252,
               "df_between": 2,
-              "df_within": 79,
+              "df_within": 80,
               "sig": false
             },
             "maturity": {
-              "f": 1.631,
-              "p": 0.2023,
+              "f": 1.4314,
+              "p": 0.245,
               "df_between": 2,
-              "df_within": 79,
+              "df_within": 80,
               "sig": false
             }
           }
@@ -579,7 +579,7 @@
     "flexible_clean": {
       "demographics": {
         "roles": {
-          "CIO": 22,
+          "CIO": 23,
           "Other": 20,
           "COO": 16,
           "CEO": 13,
@@ -591,7 +591,7 @@
           "CTO": 7
         },
         "org_sizes": {
-          "<100": 18,
+          "<100": 19,
           "100-499": 40,
           "500-999": 17,
           "1000-4999": 30,
@@ -599,12 +599,12 @@
           "10000+": 16
         },
         "profit_models": {
-          "For-Profit": 88,
+          "For-Profit": 89,
           "Non-Profit": 27,
           "Government/Public Sector": 14
         },
         "tech_vs_nontech": {
-          "technical": 29,
+          "technical": 30,
           "non_technical": 84,
           "other": 16
         },
@@ -620,69 +620,69 @@
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 29,
+          "tech_n": 30,
           "nontech_n": 84,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6475,
-              "tech_mean_ci_lower": 2.6475,
-              "tech_mean_ci_upper": 2.6475,
+              "tech_mean": 2.6796,
+              "tech_mean_ci_lower": 2.6796,
+              "tech_mean_ci_upper": 2.6796,
               "nontech_mean": 2.8803,
               "nontech_mean_ci_lower": 2.8803,
               "nontech_mean_ci_upper": 2.8803,
-              "d": -0.3173,
-              "d_ci_lower": -0.7473,
-              "d_ci_upper": 0.1078
+              "d": -0.2727,
+              "d_ci_lower": -0.6907,
+              "d_ci_upper": 0.1443
             },
             "readiness": {
-              "tech_mean": 3.4173,
-              "tech_mean_ci_lower": 3.4173,
-              "tech_mean_ci_upper": 3.4173,
+              "tech_mean": 3.4269,
+              "tech_mean_ci_lower": 3.4269,
+              "tech_mean_ci_upper": 3.4269,
               "nontech_mean": 3.0294,
               "nontech_mean_ci_lower": 3.0294,
               "nontech_mean_ci_upper": 3.0294,
-              "d": 0.5982,
-              "d_ci_lower": 0.2165,
-              "d_ci_upper": 1.014
+              "d": 0.6152,
+              "d_ci_lower": 0.2295,
+              "d_ci_upper": 1.0308
             },
             "maturity": {
-              "tech_mean": 3.2716,
-              "tech_mean_ci_lower": 3.2716,
-              "tech_mean_ci_upper": 3.2716,
+              "tech_mean": 3.3042,
+              "tech_mean_ci_lower": 3.3042,
+              "tech_mean_ci_upper": 3.3042,
               "nontech_mean": 3.0091,
               "nontech_mean_ci_lower": 3.0091,
               "nontech_mean_ci_upper": 3.0091,
-              "d": 0.3292,
-              "d_ci_lower": -0.0769,
-              "d_ci_upper": 0.7522
+              "d": 0.3693,
+              "d_ci_lower": -0.0463,
+              "d_ci_upper": 0.77
             }
           }
         },
         "large_vs_small": {
           "large_n": 24,
-          "small_medium_n": 105,
+          "small_medium_n": 106,
           "constructs": {
             "barriers": {
               "large_mean": 3.0883,
               "large_mean_ci_lower": 3.0883,
               "large_mean_ci_upper": 3.0883,
-              "small_medium_mean": 2.7582,
-              "small_medium_mean_ci_lower": 2.7582,
-              "small_medium_mean_ci_upper": 2.7582,
-              "d": 0.4679,
-              "d_ci_lower": 0.0137,
-              "d_ci_upper": 0.9164
+              "small_medium_mean": 2.7663,
+              "small_medium_mean_ci_lower": 2.7663,
+              "small_medium_mean_ci_upper": 2.7663,
+              "d": 0.4557,
+              "d_ci_lower": 0.0135,
+              "d_ci_upper": 0.9076
             },
             "readiness": {
               "large_mean": 2.9544,
               "large_mean_ci_lower": 2.9544,
               "large_mean_ci_upper": 2.9544,
-              "small_medium_mean": 3.1297,
-              "small_medium_mean_ci_lower": 3.1297,
-              "small_medium_mean_ci_upper": 3.1297,
-              "d": -0.2691,
-              "d_ci_lower": -0.7557,
-              "d_ci_upper": 0.2123
+              "small_medium_mean": 3.1351,
+              "small_medium_mean_ci_lower": 3.1351,
+              "small_medium_mean_ci_upper": 3.1351,
+              "d": -0.2776,
+              "d_ci_lower": -0.7586,
+              "d_ci_upper": 0.1849
             }
           }
         }
@@ -691,10 +691,10 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 29,
-            "barrier_mean": 2.6475,
-            "readiness_mean": 3.4173,
-            "maturity_mean": 3.2716
+            "n": 30,
+            "barrier_mean": 2.6796,
+            "readiness_mean": 3.4269,
+            "maturity_mean": 3.3042
           },
           {
             "group": "Non-Technical",
@@ -714,10 +714,10 @@
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 58,
-            "barrier_mean": 2.7581,
-            "readiness_mean": 3.119,
-            "maturity_mean": 2.9648
+            "n": 59,
+            "barrier_mean": 2.7726,
+            "readiness_mean": 3.1289,
+            "maturity_mean": 2.9866
           },
           {
             "group": "Medium (500-4999)",
@@ -737,115 +737,115 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 29,
+          "tech_n": 30,
           "nontech_n": 84,
           "constructs": {
             "barriers": {
-              "t": -1.4988,
+              "t": -1.2958,
               "p": 0.0,
-              "df": 50.25,
-              "mean_diff_ci_lower": -0.2328,
-              "mean_diff_ci_upper": -0.2328,
+              "df": 52.15,
+              "mean_diff_ci_lower": -0.2006,
+              "mean_diff_ci_upper": -0.2006,
               "sig": true
             },
             "readiness": {
-              "t": 3.0025,
+              "t": 3.1398,
               "p": 0.0,
-              "df": 56.63,
-              "mean_diff_ci_lower": 0.3879,
-              "mean_diff_ci_upper": 0.3879,
+              "df": 60.31,
+              "mean_diff_ci_lower": 0.3975,
+              "mean_diff_ci_upper": 0.3975,
               "sig": true
             },
             "maturity": {
-              "t": 1.5995,
+              "t": 1.8052,
               "p": 0.0,
-              "df": 53.03,
-              "mean_diff_ci_lower": 0.2624,
-              "mean_diff_ci_upper": 0.2624,
+              "df": 55.1,
+              "mean_diff_ci_lower": 0.2951,
+              "mean_diff_ci_upper": 0.2951,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 24,
-          "small_medium_n": 105,
+          "small_medium_n": 106,
           "constructs": {
             "barriers": {
-              "t": 2.1136,
+              "t": 2.0631,
               "p": 0.0,
-              "df": 35.18,
-              "mean_diff_ci_lower": 0.33,
-              "mean_diff_ci_upper": 0.33,
+              "df": 35.11,
+              "mean_diff_ci_lower": 0.322,
+              "mean_diff_ci_upper": 0.322,
               "sig": true
             },
             "readiness": {
-              "t": -1.1293,
+              "t": -1.1654,
               "p": 0.0,
-              "df": 32.53,
-              "mean_diff_ci_lower": -0.1753,
-              "mean_diff_ci_upper": -0.1753,
+              "df": 32.41,
+              "mean_diff_ci_lower": -0.1807,
+              "mean_diff_ci_upper": -0.1807,
               "sig": true
             },
             "maturity": {
-              "t": 0.4307,
+              "t": 0.3733,
               "p": 0.0,
-              "df": 31.14,
-              "mean_diff_ci_lower": 0.0856,
-              "mean_diff_ci_upper": 0.0856,
+              "df": 31.18,
+              "mean_diff_ci_lower": 0.0742,
+              "mean_diff_ci_upper": 0.0742,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [29, 84, 16],
+          "group_ns": [30, 84, 16],
           "constructs": {
             "barriers": {
-              "f": 1.1479,
-              "p": 0.3206,
+              "f": 0.8717,
+              "p": 0.4207,
               "df_between": 2,
-              "df_within": 126,
+              "df_within": 127,
               "sig": false
             },
             "readiness": {
-              "f": 5.219,
-              "p": 0.0066,
+              "f": 5.6139,
+              "p": 0.0046,
               "df_between": 2,
-              "df_within": 126,
+              "df_within": 127,
               "sig": true
             },
             "maturity": {
-              "f": 1.4044,
-              "p": 0.2493,
+              "f": 1.7829,
+              "p": 0.1723,
               "df_between": 2,
-              "df_within": 126,
+              "df_within": 127,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [58, 47, 24],
+          "group_ns": [59, 47, 24],
           "constructs": {
             "barriers": {
-              "f": 2.1216,
-              "p": 0.1241,
+              "f": 2.0216,
+              "p": 0.1367,
               "df_between": 2,
-              "df_within": 126,
+              "df_within": 127,
               "sig": false
             },
             "readiness": {
-              "f": 0.7192,
-              "p": 0.4891,
+              "f": 0.7545,
+              "p": 0.4723,
               "df_between": 2,
-              "df_within": 126,
+              "df_within": 127,
               "sig": false
             },
             "maturity": {
-              "f": 0.7457,
-              "p": 0.4765,
+              "f": 0.5671,
+              "p": 0.5686,
               "df_between": 2,
-              "df_within": 126,
+              "df_within": 127,
               "sig": false
             }
           }
@@ -856,7 +856,7 @@
       "demographics": {
         "roles": {
           "Other": 46,
-          "CIO": 36,
+          "CIO": 37,
           "COO": 24,
           "CSO": 22,
           "CEO": 20,
@@ -868,7 +868,7 @@
           "Unknown": 2
         },
         "org_sizes": {
-          "<100": 41,
+          "<100": 42,
           "100-499": 57,
           "500-999": 34,
           "1000-4999": 48,
@@ -876,12 +876,12 @@
           "10000+": 33
         },
         "profit_models": {
-          "For-Profit": 173,
+          "For-Profit": 174,
           "Non-Profit": 41,
           "Government/Public Sector": 19
         },
         "tech_vs_nontech": {
-          "technical": 52,
+          "technical": 53,
           "non_technical": 146,
           "other": 35
         },
@@ -897,69 +897,69 @@
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 52,
+          "tech_n": 53,
           "nontech_n": 146,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7185,
-              "tech_mean_ci_lower": 2.7185,
-              "tech_mean_ci_upper": 2.7185,
+              "tech_mean": 2.7353,
+              "tech_mean_ci_lower": 2.7353,
+              "tech_mean_ci_upper": 2.7353,
               "nontech_mean": 2.8094,
               "nontech_mean_ci_lower": 2.8094,
               "nontech_mean_ci_upper": 2.8094,
-              "d": -0.125,
-              "d_ci_lower": -0.4406,
-              "d_ci_upper": 0.2117
+              "d": -0.1017,
+              "d_ci_lower": -0.4345,
+              "d_ci_upper": 0.2342
             },
             "readiness": {
-              "tech_mean": 3.4295,
-              "tech_mean_ci_lower": 3.4295,
-              "tech_mean_ci_upper": 3.4295,
+              "tech_mean": 3.4347,
+              "tech_mean_ci_lower": 3.4347,
+              "tech_mean_ci_upper": 3.4347,
               "nontech_mean": 3.09,
               "nontech_mean_ci_lower": 3.09,
               "nontech_mean_ci_upper": 3.09,
-              "d": 0.5145,
-              "d_ci_lower": 0.2232,
-              "d_ci_upper": 0.8408
+              "d": 0.5235,
+              "d_ci_lower": 0.2286,
+              "d_ci_upper": 0.8339
             },
             "maturity": {
-              "tech_mean": 3.3372,
-              "tech_mean_ci_lower": 3.3372,
-              "tech_mean_ci_upper": 3.3372,
+              "tech_mean": 3.3544,
+              "tech_mean_ci_lower": 3.3544,
+              "tech_mean_ci_upper": 3.3544,
               "nontech_mean": 3.1121,
               "nontech_mean_ci_lower": 3.1121,
               "nontech_mean_ci_upper": 3.1121,
-              "d": 0.2812,
-              "d_ci_lower": -0.0244,
-              "d_ci_upper": 0.6129
+              "d": 0.3025,
+              "d_ci_lower": -0.0053,
+              "d_ci_upper": 0.6362
             }
           }
         },
         "large_vs_small": {
           "large_n": 53,
-          "small_medium_n": 180,
+          "small_medium_n": 181,
           "constructs": {
             "barriers": {
               "large_mean": 2.9026,
               "large_mean_ci_lower": 2.9026,
               "large_mean_ci_upper": 2.9026,
-              "small_medium_mean": 2.7466,
-              "small_medium_mean_ci_lower": 2.7466,
-              "small_medium_mean_ci_upper": 2.7466,
-              "d": 0.219,
-              "d_ci_lower": -0.0801,
-              "d_ci_upper": 0.5456
+              "small_medium_mean": 2.7514,
+              "small_medium_mean_ci_lower": 2.7514,
+              "small_medium_mean_ci_upper": 2.7514,
+              "d": 0.2121,
+              "d_ci_lower": -0.0832,
+              "d_ci_upper": 0.5226
             },
             "readiness": {
               "large_mean": 3.1666,
               "large_mean_ci_lower": 3.1666,
               "large_mean_ci_upper": 3.1666,
-              "small_medium_mean": 3.1318,
-              "small_medium_mean_ci_lower": 3.1318,
-              "small_medium_mean_ci_upper": 3.1318,
-              "d": 0.0516,
-              "d_ci_lower": -0.2792,
-              "d_ci_upper": 0.3937
+              "small_medium_mean": 3.135,
+              "small_medium_mean_ci_lower": 3.135,
+              "small_medium_mean_ci_upper": 3.135,
+              "d": 0.0469,
+              "d_ci_lower": -0.2843,
+              "d_ci_upper": 0.3913
             }
           }
         }
@@ -968,10 +968,10 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 52,
-            "barrier_mean": 2.7185,
-            "readiness_mean": 3.4295,
-            "maturity_mean": 3.3372
+            "n": 53,
+            "barrier_mean": 2.7353,
+            "readiness_mean": 3.4347,
+            "maturity_mean": 3.3544
           },
           {
             "group": "Non-Technical",
@@ -991,10 +991,10 @@
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 98,
-            "barrier_mean": 2.7432,
-            "readiness_mean": 3.0542,
-            "maturity_mean": 2.9879
+            "n": 99,
+            "barrier_mean": 2.752,
+            "readiness_mean": 3.0608,
+            "maturity_mean": 3.0007
           },
           {
             "group": "Medium (500-4999)",
@@ -1014,115 +1014,115 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 52,
+          "tech_n": 53,
           "nontech_n": 146,
           "constructs": {
             "barriers": {
-              "t": -0.7587,
+              "t": -0.6208,
               "p": 0.0,
-              "df": 86.63,
-              "mean_diff_ci_lower": -0.0909,
-              "mean_diff_ci_upper": -0.0909,
+              "df": 88.7,
+              "mean_diff_ci_lower": -0.074,
+              "mean_diff_ci_upper": -0.074,
               "sig": true
             },
             "readiness": {
-              "t": 3.2873,
+              "t": 3.3791,
               "p": 0.0,
-              "df": 95.31,
-              "mean_diff_ci_lower": 0.3395,
-              "mean_diff_ci_upper": 0.3395,
+              "df": 98.67,
+              "mean_diff_ci_lower": 0.3447,
+              "mean_diff_ci_upper": 0.3447,
               "sig": true
             },
             "maturity": {
-              "t": 1.7457,
+              "t": 1.8887,
               "p": 0.0,
-              "df": 90.22,
-              "mean_diff_ci_lower": 0.2251,
-              "mean_diff_ci_upper": 0.2251,
+              "df": 92.46,
+              "mean_diff_ci_lower": 0.2423,
+              "mean_diff_ci_upper": 0.2423,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 53,
-          "small_medium_n": 180,
+          "small_medium_n": 181,
           "constructs": {
             "barriers": {
-              "t": 1.415,
+              "t": 1.3721,
               "p": 0.0,
-              "df": 86.23,
-              "mean_diff_ci_lower": 0.156,
-              "mean_diff_ci_upper": 0.156,
+              "df": 86.13,
+              "mean_diff_ci_lower": 0.1512,
+              "mean_diff_ci_upper": 0.1512,
               "sig": true
             },
             "readiness": {
-              "t": 0.3042,
+              "t": 0.2766,
               "p": 0.0,
-              "df": 76.11,
-              "mean_diff_ci_lower": 0.0347,
-              "mean_diff_ci_upper": 0.0347,
+              "df": 75.95,
+              "mean_diff_ci_lower": 0.0316,
+              "mean_diff_ci_upper": 0.0316,
               "sig": true
             },
             "maturity": {
-              "t": 1.7726,
+              "t": 1.7241,
               "p": 0.0,
-              "df": 79.17,
-              "mean_diff_ci_lower": 0.2331,
-              "mean_diff_ci_upper": 0.2331,
+              "df": 79.2,
+              "mean_diff_ci_lower": 0.2268,
+              "mean_diff_ci_upper": 0.2268,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [52, 146, 35],
+          "group_ns": [53, 146, 35],
           "constructs": {
             "barriers": {
-              "f": 0.3241,
-              "p": 0.7235,
+              "f": 0.2284,
+              "p": 0.7959,
               "df_between": 2,
-              "df_within": 230,
+              "df_within": 231,
               "sig": false
             },
             "readiness": {
-              "f": 7.5623,
-              "p": 0.0007,
+              "f": 7.876,
+              "p": 0.0005,
               "df_between": 2,
-              "df_within": 230,
+              "df_within": 231,
               "sig": true
             },
             "maturity": {
-              "f": 1.8737,
-              "p": 0.1559,
+              "f": 2.1685,
+              "p": 0.1167,
               "df_between": 2,
-              "df_within": 230,
+              "df_within": 231,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [98, 82, 53],
+          "group_ns": [99, 82, 53],
           "constructs": {
             "barriers": {
-              "f": 0.9802,
-              "p": 0.3768,
+              "f": 0.9181,
+              "p": 0.4007,
               "df_between": 2,
-              "df_within": 230,
+              "df_within": 231,
               "sig": false
             },
             "readiness": {
-              "f": 1.4966,
-              "p": 0.2261,
+              "f": 1.3845,
+              "p": 0.2525,
               "df_between": 2,
-              "df_within": 230,
+              "df_within": 231,
               "sig": false
             },
             "maturity": {
-              "f": 3.8837,
-              "p": 0.0219,
+              "f": 3.5616,
+              "p": 0.03,
               "df_between": 2,
-              "df_within": 230,
+              "df_within": 231,
               "sig": true
             }
           }
@@ -1132,10 +1132,10 @@
     "v2_finished": {
       "demographics": {
         "roles": {
-          "Other": 66,
+          "Other": 68,
           "CIO": 58,
           "CEO": 38,
-          "COO": 34,
+          "COO": 35,
           "CTO": 34,
           "CFO": 33,
           "CSO": 31,
@@ -1146,28 +1146,28 @@
         },
         "org_sizes": {
           "<100": 57,
-          "100-499": 99,
+          "100-499": 102,
           "500-999": 57,
           "1000-4999": 73,
           "5000-9999": 31,
           "10000+": 53
         },
         "profit_models": {
-          "For-Profit": 278,
+          "For-Profit": 281,
           "Non-Profit": 62,
           "Government/Public Sector": 30
         },
         "tech_vs_nontech": {
           "technical": 93,
-          "non_technical": 227,
-          "other": 50
+          "non_technical": 228,
+          "other": 52
         },
         "other_roles": {
-          "total": 66,
+          "total": 68,
           "categories": {
-            "Director": 27,
+            "Director": 28,
             "Uncategorized": 10,
-            "Manager / Program Lead": 6,
+            "Manager / Program Lead": 7,
             "C-Suite Adjacent": "<5"
           }
         }
@@ -1175,68 +1175,68 @@
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 93,
-          "nontech_n": 227,
+          "nontech_n": 228,
           "constructs": {
             "barriers": {
               "tech_mean": 2.6789,
               "tech_mean_ci_lower": 2.6789,
               "tech_mean_ci_upper": 2.6789,
-              "nontech_mean": 2.7673,
-              "nontech_mean_ci_lower": 2.7673,
-              "nontech_mean_ci_upper": 2.7673,
-              "d": -0.1121,
-              "d_ci_lower": -0.3612,
-              "d_ci_upper": 0.1326
+              "nontech_mean": 2.7691,
+              "nontech_mean_ci_lower": 2.7691,
+              "nontech_mean_ci_upper": 2.7691,
+              "d": -0.1144,
+              "d_ci_lower": -0.3568,
+              "d_ci_upper": 0.1302
             },
             "readiness": {
               "tech_mean": 3.4641,
               "tech_mean_ci_lower": 3.4641,
               "tech_mean_ci_upper": 3.4641,
-              "nontech_mean": 3.2136,
-              "nontech_mean_ci_lower": 3.2136,
-              "nontech_mean_ci_upper": 3.2136,
-              "d": 0.354,
-              "d_ci_lower": 0.1037,
-              "d_ci_upper": 0.5984
+              "nontech_mean": 3.2142,
+              "nontech_mean_ci_lower": 3.2142,
+              "nontech_mean_ci_upper": 3.2142,
+              "d": 0.3537,
+              "d_ci_lower": 0.1141,
+              "d_ci_upper": 0.5902
             },
             "maturity": {
               "tech_mean": 3.4117,
               "tech_mean_ci_lower": 3.4117,
               "tech_mean_ci_upper": 3.4117,
-              "nontech_mean": 3.248,
-              "nontech_mean_ci_lower": 3.248,
-              "nontech_mean_ci_upper": 3.248,
-              "d": 0.2038,
-              "d_ci_lower": -0.0288,
-              "d_ci_upper": 0.4469
+              "nontech_mean": 3.2491,
+              "nontech_mean_ci_lower": 3.2491,
+              "nontech_mean_ci_upper": 3.2491,
+              "d": 0.2027,
+              "d_ci_lower": -0.0383,
+              "d_ci_upper": 0.4464
             }
           }
         },
         "large_vs_small": {
           "large_n": 84,
-          "small_medium_n": 286,
+          "small_medium_n": 289,
           "constructs": {
             "barriers": {
               "large_mean": 2.8781,
               "large_mean_ci_lower": 2.8781,
               "large_mean_ci_upper": 2.8781,
-              "small_medium_mean": 2.7041,
-              "small_medium_mean_ci_lower": 2.7041,
-              "small_medium_mean_ci_upper": 2.7041,
-              "d": 0.2263,
-              "d_ci_lower": -0.0116,
-              "d_ci_upper": 0.485
+              "small_medium_mean": 2.712,
+              "small_medium_mean_ci_lower": 2.712,
+              "small_medium_mean_ci_upper": 2.712,
+              "d": 0.216,
+              "d_ci_lower": -0.019,
+              "d_ci_upper": 0.4611
             },
             "readiness": {
               "large_mean": 3.2641,
               "large_mean_ci_lower": 3.2641,
               "large_mean_ci_upper": 3.2641,
-              "small_medium_mean": 3.2445,
-              "small_medium_mean_ci_lower": 3.2445,
-              "small_medium_mean_ci_upper": 3.2445,
-              "d": 0.0275,
-              "d_ci_lower": -0.2296,
-              "d_ci_upper": 0.2708
+              "small_medium_mean": 3.2454,
+              "small_medium_mean_ci_lower": 3.2454,
+              "small_medium_mean_ci_upper": 3.2454,
+              "d": 0.0262,
+              "d_ci_lower": -0.2241,
+              "d_ci_upper": 0.2675
             }
           }
         }
@@ -1252,26 +1252,26 @@
           },
           {
             "group": "Non-Technical",
-            "n": 227,
-            "barrier_mean": 2.7673,
-            "readiness_mean": 3.2136,
-            "maturity_mean": 3.248
+            "n": 228,
+            "barrier_mean": 2.7691,
+            "readiness_mean": 3.2142,
+            "maturity_mean": 3.2491
           },
           {
             "group": "Other",
-            "n": 50,
-            "barrier_mean": 2.7566,
-            "readiness_mean": 3.0047,
-            "maturity_mean": 3.1079
+            "n": 52,
+            "barrier_mean": 2.7894,
+            "readiness_mean": 3.0172,
+            "maturity_mean": 3.1139
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 156,
-            "barrier_mean": 2.6721,
-            "readiness_mean": 3.1719,
-            "maturity_mean": 3.1492
+            "n": 159,
+            "barrier_mean": 2.687,
+            "readiness_mean": 3.1749,
+            "maturity_mean": 3.1529
           },
           {
             "group": "Medium (500-4999)",
@@ -1292,114 +1292,114 @@
       "inferential": {
         "t_tests_tech_vs_nontech": {
           "tech_n": 93,
-          "nontech_n": 227,
+          "nontech_n": 228,
           "constructs": {
             "barriers": {
-              "t": -0.8971,
+              "t": -0.9159,
               "p": 0.0,
-              "df": 165.94,
-              "mean_diff_ci_lower": -0.0884,
-              "mean_diff_ci_upper": -0.0884,
+              "df": 165.42,
+              "mean_diff_ci_lower": -0.0901,
+              "mean_diff_ci_upper": -0.0901,
               "sig": true
             },
             "readiness": {
-              "t": 2.8944,
+              "t": 2.891,
               "p": 0.0,
-              "df": 173.63,
-              "mean_diff_ci_lower": 0.2505,
-              "mean_diff_ci_upper": 0.2505,
+              "df": 173.0,
+              "mean_diff_ci_lower": 0.2499,
+              "mean_diff_ci_upper": 0.2499,
               "sig": true
             },
             "maturity": {
-              "t": 1.6873,
+              "t": 1.6781,
               "p": 0.0,
-              "df": 178.48,
-              "mean_diff_ci_lower": 0.1637,
-              "mean_diff_ci_upper": 0.1637,
+              "df": 177.84,
+              "mean_diff_ci_lower": 0.1626,
+              "mean_diff_ci_upper": 0.1626,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 84,
-          "small_medium_n": 286,
+          "small_medium_n": 289,
           "constructs": {
             "barriers": {
-              "t": 1.8309,
+              "t": 1.7499,
               "p": 0.0,
-              "df": 136.28,
-              "mean_diff_ci_lower": 0.174,
-              "mean_diff_ci_upper": 0.174,
+              "df": 135.77,
+              "mean_diff_ci_lower": 0.1661,
+              "mean_diff_ci_upper": 0.1661,
               "sig": true
             },
             "readiness": {
-              "t": 0.215,
+              "t": 0.205,
               "p": 0.0,
-              "df": 130.25,
-              "mean_diff_ci_lower": 0.0196,
-              "mean_diff_ci_upper": 0.0196,
+              "df": 129.69,
+              "mean_diff_ci_lower": 0.0187,
+              "mean_diff_ci_upper": 0.0187,
               "sig": true
             },
             "maturity": {
-              "t": 1.2103,
+              "t": 1.2018,
               "p": 0.0,
-              "df": 129.62,
-              "mean_diff_ci_lower": 0.1249,
-              "mean_diff_ci_upper": 0.1249,
+              "df": 129.05,
+              "mean_diff_ci_lower": 0.1239,
+              "mean_diff_ci_upper": 0.1239,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [93, 227, 50],
+          "group_ns": [93, 228, 52],
           "constructs": {
             "barriers": {
-              "f": 0.4404,
-              "p": 0.6441,
+              "f": 0.5317,
+              "p": 0.5881,
               "df_between": 2,
-              "df_within": 367,
+              "df_within": 370,
               "sig": false
             },
             "readiness": {
-              "f": 7.6289,
-              "p": 0.0006,
+              "f": 7.4313,
+              "p": 0.0007,
               "df_between": 2,
-              "df_within": 366,
+              "df_within": 369,
               "sig": true
             },
             "maturity": {
-              "f": 2.5357,
-              "p": 0.0806,
+              "f": 2.4953,
+              "p": 0.0839,
               "df_between": 2,
-              "df_within": 366,
+              "df_within": 369,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [156, 130, 84],
+          "group_ns": [159, 130, 84],
           "constructs": {
             "barriers": {
-              "f": 1.959,
-              "p": 0.1425,
+              "f": 1.7025,
+              "p": 0.1837,
               "df_between": 2,
-              "df_within": 367,
+              "df_within": 370,
               "sig": false
             },
             "readiness": {
-              "f": 1.8148,
-              "p": 0.1643,
+              "f": 1.7613,
+              "p": 0.1733,
               "df_between": 2,
-              "df_within": 366,
+              "df_within": 369,
               "sig": false
             },
             "maturity": {
-              "f": 3.1102,
-              "p": 0.0458,
+              "f": 3.0407,
+              "p": 0.049,
               "df_between": 2,
-              "df_within": 366,
+              "df_within": 369,
               "sig": true
             }
           }
@@ -1409,11 +1409,11 @@
     "v2_all": {
       "demographics": {
         "roles": {
-          "Other": 68,
-          "Unknown": 63,
+          "Other": 70,
+          "Unknown": 64,
           "CIO": 59,
           "CEO": 38,
-          "COO": 35,
+          "COO": 36,
           "CFO": 34,
           "CTO": 34,
           "CSO": 33,
@@ -1423,28 +1423,28 @@
         },
         "org_sizes": {
           "<100": 58,
-          "100-499": 102,
+          "100-499": 105,
           "500-999": 59,
           "1000-4999": 74,
           "5000-9999": 32,
           "10000+": 54
         },
         "profit_models": {
-          "For-Profit": 286,
+          "For-Profit": 289,
           "Non-Profit": 63,
           "Government/Public Sector": 30
         },
         "tech_vs_nontech": {
           "technical": 94,
-          "non_technical": 233,
-          "other": 110
+          "non_technical": 234,
+          "other": 113
         },
         "other_roles": {
-          "total": 68,
+          "total": 70,
           "categories": {
-            "Director": 27,
+            "Director": 28,
             "Uncategorized": 12,
-            "Manager / Program Lead": 6,
+            "Manager / Program Lead": 7,
             "C-Suite Adjacent": "<5"
           }
         }
@@ -1452,68 +1452,68 @@
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 94,
-          "nontech_n": 233,
+          "nontech_n": 234,
           "constructs": {
             "barriers": {
               "tech_mean": 2.6789,
               "tech_mean_ci_lower": 2.6789,
               "tech_mean_ci_upper": 2.6789,
-              "nontech_mean": 2.7718,
-              "nontech_mean_ci_lower": 2.7718,
-              "nontech_mean_ci_upper": 2.7718,
-              "d": -0.1173,
-              "d_ci_lower": -0.3662,
-              "d_ci_upper": 0.1238
+              "nontech_mean": 2.7735,
+              "nontech_mean_ci_lower": 2.7735,
+              "nontech_mean_ci_upper": 2.7735,
+              "d": -0.1196,
+              "d_ci_lower": -0.3696,
+              "d_ci_upper": 0.1322
             },
             "readiness": {
               "tech_mean": 3.4641,
               "tech_mean_ci_lower": 3.4641,
               "tech_mean_ci_upper": 3.4641,
-              "nontech_mean": 3.2138,
-              "nontech_mean_ci_lower": 3.2138,
-              "nontech_mean_ci_upper": 3.2138,
-              "d": 0.3542,
-              "d_ci_lower": 0.1189,
-              "d_ci_upper": 0.6058
+              "nontech_mean": 3.2144,
+              "nontech_mean_ci_lower": 3.2144,
+              "nontech_mean_ci_upper": 3.2144,
+              "d": 0.3539,
+              "d_ci_lower": 0.1159,
+              "d_ci_upper": 0.5979
             },
             "maturity": {
               "tech_mean": 3.4117,
               "tech_mean_ci_lower": 3.4117,
               "tech_mean_ci_upper": 3.4117,
-              "nontech_mean": 3.248,
-              "nontech_mean_ci_lower": 3.248,
-              "nontech_mean_ci_upper": 3.248,
-              "d": 0.2038,
-              "d_ci_lower": -0.0288,
-              "d_ci_upper": 0.4469
+              "nontech_mean": 3.2491,
+              "nontech_mean_ci_lower": 3.2491,
+              "nontech_mean_ci_upper": 3.2491,
+              "d": 0.2027,
+              "d_ci_lower": -0.0383,
+              "d_ci_upper": 0.4464
             }
           }
         },
         "large_vs_small": {
           "large_n": 86,
-          "small_medium_n": 351,
+          "small_medium_n": 355,
           "constructs": {
             "barriers": {
               "large_mean": 2.888,
               "large_mean_ci_lower": 2.888,
               "large_mean_ci_upper": 2.888,
-              "small_medium_mean": 2.7084,
-              "small_medium_mean_ci_lower": 2.7084,
-              "small_medium_mean_ci_upper": 2.7084,
-              "d": 0.2327,
-              "d_ci_lower": -0.0215,
-              "d_ci_upper": 0.4726
+              "small_medium_mean": 2.7161,
+              "small_medium_mean_ci_lower": 2.7161,
+              "small_medium_mean_ci_upper": 2.7161,
+              "d": 0.2226,
+              "d_ci_lower": -0.0143,
+              "d_ci_upper": 0.4654
             },
             "readiness": {
               "large_mean": 3.2641,
               "large_mean_ci_lower": 3.2641,
               "large_mean_ci_upper": 3.2641,
-              "small_medium_mean": 3.2446,
-              "small_medium_mean_ci_lower": 3.2446,
-              "small_medium_mean_ci_upper": 3.2446,
-              "d": 0.0274,
-              "d_ci_lower": -0.2188,
-              "d_ci_upper": 0.271
+              "small_medium_mean": 3.2455,
+              "small_medium_mean_ci_lower": 3.2455,
+              "small_medium_mean_ci_upper": 3.2455,
+              "d": 0.0261,
+              "d_ci_lower": -0.2367,
+              "d_ci_upper": 0.2704
             }
           }
         }
@@ -1529,26 +1529,26 @@
           },
           {
             "group": "Non-Technical",
-            "n": 233,
-            "barrier_mean": 2.7718,
-            "readiness_mean": 3.2138,
-            "maturity_mean": 3.248
+            "n": 234,
+            "barrier_mean": 2.7735,
+            "readiness_mean": 3.2144,
+            "maturity_mean": 3.2491
           },
           {
             "group": "Other",
-            "n": 110,
-            "barrier_mean": 2.7755,
-            "readiness_mean": 3.0047,
-            "maturity_mean": 3.1079
+            "n": 113,
+            "barrier_mean": 2.807,
+            "readiness_mean": 3.0172,
+            "maturity_mean": 3.1139
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 160,
-            "barrier_mean": 2.6861,
-            "readiness_mean": 3.1725,
-            "maturity_mean": 3.1492
+            "n": 163,
+            "barrier_mean": 2.7006,
+            "readiness_mean": 3.1755,
+            "maturity_mean": 3.1529
           },
           {
             "group": "Medium (500-4999)",
@@ -1569,114 +1569,114 @@
       "inferential": {
         "t_tests_tech_vs_nontech": {
           "tech_n": 94,
-          "nontech_n": 233,
+          "nontech_n": 234,
           "constructs": {
             "barriers": {
-              "t": -0.9428,
+              "t": -0.9611,
               "p": 0.0,
-              "df": 165.98,
-              "mean_diff_ci_lower": -0.0929,
-              "mean_diff_ci_upper": -0.0929,
+              "df": 165.47,
+              "mean_diff_ci_lower": -0.0946,
+              "mean_diff_ci_upper": -0.0946,
               "sig": true
             },
             "readiness": {
-              "t": 2.8955,
+              "t": 2.8921,
               "p": 0.0,
-              "df": 172.99,
-              "mean_diff_ci_lower": 0.2503,
-              "mean_diff_ci_upper": 0.2503,
+              "df": 172.36,
+              "mean_diff_ci_lower": 0.2497,
+              "mean_diff_ci_upper": 0.2497,
               "sig": true
             },
             "maturity": {
-              "t": 1.6873,
+              "t": 1.6781,
               "p": 0.0,
-              "df": 178.48,
-              "mean_diff_ci_lower": 0.1637,
-              "mean_diff_ci_upper": 0.1637,
+              "df": 177.84,
+              "mean_diff_ci_lower": 0.1626,
+              "mean_diff_ci_upper": 0.1626,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 86,
-          "small_medium_n": 351,
+          "small_medium_n": 355,
           "constructs": {
             "barriers": {
-              "t": 1.8976,
+              "t": 1.8178,
               "p": 0.0,
-              "df": 138.48,
-              "mean_diff_ci_lower": 0.1797,
-              "mean_diff_ci_upper": 0.1797,
+              "df": 137.96,
+              "mean_diff_ci_lower": 0.1719,
+              "mean_diff_ci_upper": 0.1719,
               "sig": true
             },
             "readiness": {
-              "t": 0.2143,
+              "t": 0.2043,
               "p": 0.0,
-              "df": 129.92,
-              "mean_diff_ci_lower": 0.0196,
-              "mean_diff_ci_upper": 0.0196,
+              "df": 129.36,
+              "mean_diff_ci_lower": 0.0186,
+              "mean_diff_ci_upper": 0.0186,
               "sig": true
             },
             "maturity": {
-              "t": 1.2103,
+              "t": 1.2018,
               "p": 0.0,
-              "df": 129.62,
-              "mean_diff_ci_lower": 0.1249,
-              "mean_diff_ci_upper": 0.1249,
+              "df": 129.05,
+              "mean_diff_ci_lower": 0.1239,
+              "mean_diff_ci_upper": 0.1239,
               "sig": true
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [94, 233, 110],
+          "group_ns": [94, 234, 113],
           "constructs": {
             "barriers": {
-              "f": 0.5086,
-              "p": 0.6017,
+              "f": 0.633,
+              "p": 0.5316,
               "df_between": 2,
-              "df_within": 371,
+              "df_within": 374,
               "sig": false
             },
             "readiness": {
-              "f": 7.6471,
-              "p": 0.0006,
+              "f": 7.4488,
+              "p": 0.0007,
               "df_between": 2,
-              "df_within": 367,
+              "df_within": 370,
               "sig": true
             },
             "maturity": {
-              "f": 2.5357,
-              "p": 0.0806,
+              "f": 2.4953,
+              "p": 0.0839,
               "df_between": 2,
-              "df_within": 366,
+              "df_within": 369,
               "sig": false
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [160, 133, 86],
+          "group_ns": [163, 133, 86],
           "constructs": {
             "barriers": {
-              "f": 1.9196,
-              "p": 0.1481,
+              "f": 1.7002,
+              "p": 0.1841,
               "df_between": 2,
-              "df_within": 371,
+              "df_within": 374,
               "sig": false
             },
             "readiness": {
-              "f": 1.8112,
-              "p": 0.1649,
+              "f": 1.758,
+              "p": 0.1738,
               "df_between": 2,
-              "df_within": 367,
+              "df_within": 370,
               "sig": false
             },
             "maturity": {
-              "f": 3.1102,
-              "p": 0.0458,
+              "f": 3.0407,
+              "p": 0.049,
               "df_between": 2,
-              "df_within": 366,
+              "df_within": 369,
               "sig": true
             }
           }
@@ -1687,22 +1687,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 2.52,
-      "p_value": 0.8667,
+      "chi2": 1.86,
+      "p_value": 0.9318,
       "df": 6,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 7.98,
-      "p_value": 0.9245,
+      "chi2": 7.49,
+      "p_value": 0.9426,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 3.04,
-      "p_value": 0.8038,
+      "chi2": 2.99,
+      "p_value": 0.8098,
       "df": 6,
       "error": null
     },
@@ -1710,22 +1710,22 @@
       "labels": ["For-Profit", "Non-Profit", "Government/Public Sector"],
       "groups": {
         "Conservative Clean": {
-          "For-Profit": 58,
+          "For-Profit": 59,
           "Non-Profit": 15,
           "Government/Public Sector": 9
         },
         "Flexible Clean": {
-          "For-Profit": 88,
+          "For-Profit": 89,
           "Non-Profit": 27,
           "Government/Public Sector": 14
         },
         "Prolific Accepted": {
-          "For-Profit": 173,
+          "For-Profit": 174,
           "Non-Profit": 41,
           "Government/Public Sector": 19
         },
         "All V2 Finished": {
-          "For-Profit": 278,
+          "For-Profit": 281,
           "Non-Profit": 62,
           "Government/Public Sector": 30
         }
@@ -1769,5 +1769,5 @@
       "examples": ""
     }
   ],
-  "last_updated": "2026-04-10T21:10:12.447916Z"
+  "last_updated": "2026-04-11T02:05:17.780226Z"
 }


### PR DESCRIPTION
Automated update from the unified daily pipeline.

**Data flow**: Qualtrics export → Prolific enrichment →
disposition waterfall → analysis suite → CRP dataset (N=200) →
approve CLEAN → dashboard summary.

All statistics computed across 5 sample definitions.
CRP dataset: N=200 tiered selection + NIST de-identification.