### PR TITLE
Update daily pipeline data

### DIFF
--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -329,56 +329,52 @@
           "Government/Public Sector": 8
         },
         "tech_vs_nontech": {
-          "technical": 15,
-          "non_technical": 53,
-          "other": 11
+          "technical": 18,
+          "non_technical": 61,
+          "other": 0
         },
         "other_roles": {
           "total": 13,
-          "categories": {
-            "Director": 7,
-            "Uncategorized": "<5",
-            "Manager / Program Lead": "<5"
-          }
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 15,
-          "nontech_n": 53,
+          "tech_n": 18,
+          "nontech_n": 61,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7222,
-              "tech_mean_ci_lower": 2.7222,
-              "tech_mean_ci_upper": 2.7222,
-              "nontech_mean": 2.8683,
-              "nontech_mean_ci_lower": 2.8683,
-              "nontech_mean_ci_upper": 2.8683,
-              "d": -0.2194,
-              "d_ci_lower": -0.8422,
-              "d_ci_upper": 0.3866
+              "tech_mean": 2.7438,
+              "tech_mean_ci_lower": 2.7438,
+              "tech_mean_ci_upper": 2.7438,
+              "nontech_mean": 2.8346,
+              "nontech_mean_ci_lower": 2.8346,
+              "nontech_mean_ci_upper": 2.8346,
+              "d": -0.1432,
+              "d_ci_lower": -0.7119,
+              "d_ci_upper": 0.4117
             },
             "readiness": {
-              "tech_mean": 3.325,
-              "tech_mean_ci_lower": 3.325,
-              "tech_mean_ci_upper": 3.325,
-              "nontech_mean": 2.9941,
-              "nontech_mean_ci_lower": 2.9941,
-              "nontech_mean_ci_upper": 2.9941,
-              "d": 0.5718,
-              "d_ci_lower": 0.0347,
-              "d_ci_upper": 1.2552
+              "tech_mean": 3.2185,
+              "tech_mean_ci_lower": 3.2185,
+              "tech_mean_ci_upper": 3.2185,
+              "nontech_mean": 2.9981,
+              "nontech_mean_ci_lower": 2.9981,
+              "nontech_mean_ci_upper": 2.9981,
+              "d": 0.3807,
+              "d_ci_lower": -0.1246,
+              "d_ci_upper": 0.898
             },
             "maturity": {
-              "tech_mean": 3.1083,
-              "tech_mean_ci_lower": 3.1083,
-              "tech_mean_ci_upper": 3.1083,
-              "nontech_mean": 2.9885,
-              "nontech_mean_ci_lower": 2.9885,
-              "nontech_mean_ci_upper": 2.9885,
-              "d": 0.1691,
-              "d_ci_lower": -0.4335,
-              "d_ci_upper": 0.8358
+              "tech_mean": 3.1389,
+              "tech_mean_ci_lower": 3.1389,
+              "tech_mean_ci_upper": 3.1389,
+              "nontech_mean": 3.0003,
+              "nontech_mean_ci_lower": 3.0003,
+              "nontech_mean_ci_upper": 3.0003,
+              "d": 0.195,
+              "d_ci_lower": -0.3684,
+              "d_ci_upper": 0.7406
             }
           }
         },
@@ -415,24 +411,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 15,
-            "barrier_mean": 2.7222,
-            "readiness_mean": 3.325,
-            "maturity_mean": 3.1083
+            "n": 18,
+            "barrier_mean": 2.7438,
+            "readiness_mean": 3.2185,
+            "maturity_mean": 3.1389
           },
           {
             "group": "Non-Technical",
-            "n": 53,
-            "barrier_mean": 2.8683,
-            "readiness_mean": 2.9941,
-            "maturity_mean": 2.9885
-          },
-          {
-            "group": "Other",
-            "n": 11,
-            "barrier_mean": 2.6768,
-            "readiness_mean": 2.9323,
-            "maturity_mean": 3.1364
+            "n": 61,
+            "barrier_mean": 2.8346,
+            "readiness_mean": 2.9981,
+            "maturity_mean": 3.0003
           }
         ],
         "by_org_size": [
@@ -461,31 +450,31 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 15,
-          "nontech_n": 53,
+          "tech_n": 18,
+          "nontech_n": 61,
           "constructs": {
             "barriers": {
-              "t": -0.7024,
+              "t": -0.5115,
               "p": 0.0,
-              "df": 20.7,
-              "mean_diff_ci_lower": -0.1461,
-              "mean_diff_ci_upper": -0.1461,
+              "df": 26.21,
+              "mean_diff_ci_lower": -0.0907,
+              "mean_diff_ci_upper": -0.0907,
               "sig": true
             },
             "readiness": {
-              "t": 2.0,
+              "t": 1.4287,
               "p": 0.0,
-              "df": 23.31,
-              "mean_diff_ci_lower": 0.3309,
-              "mean_diff_ci_upper": 0.3309,
+              "df": 28.1,
+              "mean_diff_ci_lower": 0.2205,
+              "mean_diff_ci_upper": 0.2205,
               "sig": true
             },
             "maturity": {
-              "t": 0.5269,
+              "t": 0.698,
               "p": 0.0,
-              "df": 20.05,
-              "mean_diff_ci_lower": 0.1198,
-              "mean_diff_ci_upper": 0.1198,
+              "df": 26.27,
+              "mean_diff_ci_lower": 0.1386,
+              "mean_diff_ci_upper": 0.1386,
               "sig": true
             }
           }
@@ -521,29 +510,29 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [15, 53, 11],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [18, 61],
           "constructs": {
             "barriers": {
-              "f": 0.6091,
-              "p": 0.5465,
-              "df_between": 2,
-              "df_within": 76,
-              "sig": false
+              "f": 0.2849,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 77,
+              "sig": true
             },
             "readiness": {
-              "f": 2.2031,
-              "p": 0.1175,
-              "df_between": 2,
-              "df_within": 76,
-              "sig": false
+              "f": 2.0142,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 77,
+              "sig": true
             },
             "maturity": {
-              "f": 0.3007,
-              "p": 0.7412,
-              "df_between": 2,
-              "df_within": 76,
-              "sig": false
+              "f": 0.5287,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 77,
+              "sig": true
             }
           }
         },
@@ -604,57 +593,52 @@
           "Government/Public Sector": 11
         },
         "tech_vs_nontech": {
-          "technical": 29,
-          "non_technical": 73,
-          "other": 14
+          "technical": 32,
+          "non_technical": 84,
+          "other": 0
         },
         "other_roles": {
           "total": 18,
-          "categories": {
-            "Director": 9,
-            "Uncategorized": "<5",
-            "Manager / Program Lead": "<5",
-            "C-Suite Adjacent": "<5"
-          }
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 29,
-          "nontech_n": 73,
+          "tech_n": 32,
+          "nontech_n": 84,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6475,
-              "tech_mean_ci_lower": 2.6475,
-              "tech_mean_ci_upper": 2.6475,
-              "nontech_mean": 2.8512,
-              "nontech_mean_ci_lower": 2.8512,
-              "nontech_mean_ci_upper": 2.8512,
-              "d": -0.3018,
-              "d_ci_lower": -0.75,
-              "d_ci_upper": 0.1235
+              "tech_mean": 2.6667,
+              "tech_mean_ci_lower": 2.6667,
+              "tech_mean_ci_upper": 2.6667,
+              "nontech_mean": 2.8357,
+              "nontech_mean_ci_lower": 2.8357,
+              "nontech_mean_ci_upper": 2.8357,
+              "d": -0.2564,
+              "d_ci_lower": -0.6691,
+              "d_ci_upper": 0.1555
             },
             "readiness": {
-              "tech_mean": 3.4173,
-              "tech_mean_ci_lower": 3.4173,
-              "tech_mean_ci_upper": 3.4173,
-              "nontech_mean": 2.9869,
-              "nontech_mean_ci_lower": 2.9869,
-              "nontech_mean_ci_upper": 2.9869,
-              "d": 0.7117,
-              "d_ci_lower": 0.3005,
-              "d_ci_upper": 1.1617
+              "tech_mean": 3.3488,
+              "tech_mean_ci_lower": 3.3488,
+              "tech_mean_ci_upper": 3.3488,
+              "nontech_mean": 2.9727,
+              "nontech_mean_ci_lower": 2.9727,
+              "nontech_mean_ci_upper": 2.9727,
+              "d": 0.6233,
+              "d_ci_lower": 0.2268,
+              "d_ci_upper": 1.051
             },
             "maturity": {
-              "tech_mean": 3.2716,
-              "tech_mean_ci_lower": 3.2716,
-              "tech_mean_ci_upper": 3.2716,
-              "nontech_mean": 2.9985,
-              "nontech_mean_ci_lower": 2.9985,
-              "nontech_mean_ci_upper": 2.9985,
-              "d": 0.3685,
-              "d_ci_lower": -0.0678,
-              "d_ci_upper": 0.8034
+              "tech_mean": 3.2734,
+              "tech_mean_ci_lower": 3.2734,
+              "tech_mean_ci_upper": 3.2734,
+              "nontech_mean": 2.9808,
+              "nontech_mean_ci_lower": 2.9808,
+              "nontech_mean_ci_upper": 2.9808,
+              "d": 0.3945,
+              "d_ci_lower": 0.0095,
+              "d_ci_upper": 0.7967
             }
           }
         },
@@ -691,24 +675,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 29,
-            "barrier_mean": 2.6475,
-            "readiness_mean": 3.4173,
-            "maturity_mean": 3.2716
+            "n": 32,
+            "barrier_mean": 2.6667,
+            "readiness_mean": 3.3488,
+            "maturity_mean": 3.2734
           },
           {
             "group": "Non-Technical",
-            "n": 73,
-            "barrier_mean": 2.8512,
-            "readiness_mean": 2.9869,
-            "maturity_mean": 2.9985
-          },
-          {
-            "group": "Other",
-            "n": 14,
-            "barrier_mean": 2.7585,
-            "readiness_mean": 2.8375,
-            "maturity_mean": 2.9554
+            "n": 84,
+            "barrier_mean": 2.8357,
+            "readiness_mean": 2.9727,
+            "maturity_mean": 2.9808
           }
         ],
         "by_org_size": [
@@ -737,31 +714,31 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 29,
-          "nontech_n": 73,
+          "tech_n": 32,
+          "nontech_n": 84,
           "constructs": {
             "barriers": {
-              "t": -1.3274,
+              "t": -1.2027,
               "p": 0.0,
-              "df": 47.98,
-              "mean_diff_ci_lower": -0.2037,
-              "mean_diff_ci_upper": -0.2037,
+              "df": 53.35,
+              "mean_diff_ci_lower": -0.1691,
+              "mean_diff_ci_upper": -0.1691,
               "sig": true
             },
             "readiness": {
-              "t": 3.3484,
+              "t": 3.0399,
               "p": 0.0,
-              "df": 55.18,
-              "mean_diff_ci_lower": 0.4304,
-              "mean_diff_ci_upper": 0.4304,
+              "df": 57.57,
+              "mean_diff_ci_lower": 0.3761,
+              "mean_diff_ci_upper": 0.3761,
               "sig": true
             },
             "maturity": {
-              "t": 1.6767,
+              "t": 1.9383,
               "p": 0.0,
-              "df": 51.36,
-              "mean_diff_ci_lower": 0.2731,
-              "mean_diff_ci_upper": 0.2731,
+              "df": 58.46,
+              "mean_diff_ci_lower": 0.2926,
+              "mean_diff_ci_upper": 0.2926,
               "sig": true
             }
           }
@@ -797,29 +774,29 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [29, 73, 14],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [32, 84],
           "constructs": {
             "barriers": {
-              "f": 1.0026,
-              "p": 0.3702,
-              "df_between": 2,
-              "df_within": 113,
-              "sig": false
+              "f": 1.523,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 114,
+              "sig": true
             },
             "readiness": {
-              "f": 6.7131,
-              "p": 0.0018,
-              "df_between": 2,
-              "df_within": 113,
+              "f": 9.0035,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 114,
               "sig": true
             },
             "maturity": {
-              "f": 1.5494,
-              "p": 0.2168,
-              "df_between": 2,
-              "df_within": 113,
-              "sig": false
+              "f": 3.606,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 114,
+              "sig": true
             }
           }
         },
@@ -865,7 +842,7 @@
           "CTO": 14,
           "CFO": 12,
           "CRO": 12,
-          "Unknown": 2
+          "CISO": 2
         },
         "org_sizes": {
           "<100": 33,
@@ -881,57 +858,52 @@
           "Government/Public Sector": 13
         },
         "tech_vs_nontech": {
-          "technical": 48,
-          "non_technical": 124,
-          "other": 28
+          "technical": 53,
+          "non_technical": 147,
+          "other": 0
         },
         "other_roles": {
           "total": 38,
-          "categories": {
-            "Director": 18,
-            "Uncategorized": 5,
-            "Manager / Program Lead": "<5",
-            "C-Suite Adjacent": "<5"
-          }
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 48,
-          "nontech_n": 124,
+          "tech_n": 53,
+          "nontech_n": 147,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7193,
-              "tech_mean_ci_lower": 2.7193,
-              "tech_mean_ci_upper": 2.7193,
-              "nontech_mean": 2.7825,
-              "nontech_mean_ci_lower": 2.7825,
-              "nontech_mean_ci_upper": 2.7825,
-              "d": -0.0906,
-              "d_ci_lower": -0.4455,
-              "d_ci_upper": 0.2712
+              "tech_mean": 2.7416,
+              "tech_mean_ci_lower": 2.7416,
+              "tech_mean_ci_upper": 2.7416,
+              "nontech_mean": 2.7726,
+              "nontech_mean_ci_lower": 2.7726,
+              "nontech_mean_ci_upper": 2.7726,
+              "d": -0.0449,
+              "d_ci_lower": -0.3768,
+              "d_ci_upper": 0.2864
             },
             "readiness": {
-              "tech_mean": 3.4457,
-              "tech_mean_ci_lower": 3.4457,
-              "tech_mean_ci_upper": 3.4457,
-              "nontech_mean": 3.0723,
-              "nontech_mean_ci_lower": 3.0723,
-              "nontech_mean_ci_upper": 3.0723,
-              "d": 0.5832,
-              "d_ci_lower": 0.284,
-              "d_ci_upper": 0.9214
+              "tech_mean": 3.4247,
+              "tech_mean_ci_lower": 3.4247,
+              "tech_mean_ci_upper": 3.4247,
+              "nontech_mean": 3.032,
+              "nontech_mean_ci_lower": 3.032,
+              "nontech_mean_ci_upper": 3.032,
+              "d": 0.6079,
+              "d_ci_lower": 0.3169,
+              "d_ci_upper": 0.9382
             },
             "maturity": {
-              "tech_mean": 3.3523,
-              "tech_mean_ci_lower": 3.3523,
-              "tech_mean_ci_upper": 3.3523,
-              "nontech_mean": 3.0937,
-              "nontech_mean_ci_lower": 3.0937,
-              "nontech_mean_ci_upper": 3.0937,
-              "d": 0.3348,
-              "d_ci_lower": 0.0173,
-              "d_ci_upper": 0.6927
+              "tech_mean": 3.3827,
+              "tech_mean_ci_lower": 3.3827,
+              "tech_mean_ci_upper": 3.3827,
+              "nontech_mean": 3.0706,
+              "nontech_mean_ci_lower": 3.0706,
+              "nontech_mean_ci_upper": 3.0706,
+              "d": 0.4027,
+              "d_ci_lower": 0.1,
+              "d_ci_upper": 0.7482
             }
           }
         },
@@ -968,24 +940,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 48,
-            "barrier_mean": 2.7193,
-            "readiness_mean": 3.4457,
-            "maturity_mean": 3.3523
+            "n": 53,
+            "barrier_mean": 2.7416,
+            "readiness_mean": 3.4247,
+            "maturity_mean": 3.3827
           },
           {
             "group": "Non-Technical",
-            "n": 124,
-            "barrier_mean": 2.7825,
-            "readiness_mean": 3.0723,
-            "maturity_mean": 3.0937
-          },
-          {
-            "group": "Other",
-            "n": 28,
-            "barrier_mean": 2.7612,
-            "readiness_mean": 2.8878,
-            "maturity_mean": 3.0759
+            "n": 147,
+            "barrier_mean": 2.7726,
+            "readiness_mean": 3.032,
+            "maturity_mean": 3.0706
           }
         ],
         "by_org_size": [
@@ -1014,31 +979,31 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 48,
-          "nontech_n": 124,
+          "tech_n": 53,
+          "nontech_n": 147,
           "constructs": {
             "barriers": {
-              "t": -0.4999,
+              "t": -0.2635,
               "p": 0.0,
-              "df": 75.7,
-              "mean_diff_ci_lower": -0.0632,
-              "mean_diff_ci_upper": -0.0632,
+              "df": 82.62,
+              "mean_diff_ci_lower": -0.031,
+              "mean_diff_ci_upper": -0.031,
               "sig": true
             },
             "readiness": {
-              "t": 3.5528,
+              "t": 3.9083,
               "p": 0.0,
-              "df": 92.04,
-              "mean_diff_ci_lower": 0.3734,
-              "mean_diff_ci_upper": 0.3734,
+              "df": 97.4,
+              "mean_diff_ci_lower": 0.3927,
+              "mean_diff_ci_upper": 0.3927,
               "sig": true
             },
             "maturity": {
-              "t": 1.9843,
+              "t": 2.5538,
               "p": 0.0,
-              "df": 86.84,
-              "mean_diff_ci_lower": 0.2586,
-              "mean_diff_ci_upper": 0.2586,
+              "df": 94.82,
+              "mean_diff_ci_lower": 0.3122,
+              "mean_diff_ci_upper": 0.3122,
               "sig": true
             }
           }
@@ -1074,29 +1039,29 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [48, 124, 28],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [53, 147],
           "constructs": {
             "barriers": {
-              "f": 0.1444,
-              "p": 0.8656,
-              "df_between": 2,
-              "df_within": 197,
-              "sig": false
+              "f": 0.0785,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
+              "sig": true
             },
             "readiness": {
-              "f": 8.2256,
-              "p": 0.0004,
-              "df_between": 2,
-              "df_within": 197,
+              "f": 14.3964,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
               "sig": true
             },
             "maturity": {
-              "f": 2.0546,
-              "p": 0.1309,
-              "df_between": 2,
-              "df_within": 197,
-              "sig": false
+              "f": 6.3177,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
+              "sig": true
             }
           }
         },
@@ -1142,7 +1107,7 @@
           "CTO": 14,
           "CFO": 12,
           "CRO": 12,
-          "Unknown": 2
+          "CISO": 2
         },
         "org_sizes": {
           "<100": 33,
@@ -1158,57 +1123,52 @@
           "Government/Public Sector": 13
         },
         "tech_vs_nontech": {
-          "technical": 48,
-          "non_technical": 124,
-          "other": 28
+          "technical": 53,
+          "non_technical": 147,
+          "other": 0
         },
         "other_roles": {
           "total": 38,
-          "categories": {
-            "Director": 18,
-            "Uncategorized": 5,
-            "Manager / Program Lead": "<5",
-            "C-Suite Adjacent": "<5"
-          }
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 48,
-          "nontech_n": 124,
+          "tech_n": 53,
+          "nontech_n": 147,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7193,
-              "tech_mean_ci_lower": 2.7193,
-              "tech_mean_ci_upper": 2.7193,
-              "nontech_mean": 2.7825,
-              "nontech_mean_ci_lower": 2.7825,
-              "nontech_mean_ci_upper": 2.7825,
-              "d": -0.0906,
-              "d_ci_lower": -0.4455,
-              "d_ci_upper": 0.2712
+              "tech_mean": 2.7416,
+              "tech_mean_ci_lower": 2.7416,
+              "tech_mean_ci_upper": 2.7416,
+              "nontech_mean": 2.7726,
+              "nontech_mean_ci_lower": 2.7726,
+              "nontech_mean_ci_upper": 2.7726,
+              "d": -0.0449,
+              "d_ci_lower": -0.3768,
+              "d_ci_upper": 0.2864
             },
             "readiness": {
-              "tech_mean": 3.4457,
-              "tech_mean_ci_lower": 3.4457,
-              "tech_mean_ci_upper": 3.4457,
-              "nontech_mean": 3.0723,
-              "nontech_mean_ci_lower": 3.0723,
-              "nontech_mean_ci_upper": 3.0723,
-              "d": 0.5832,
-              "d_ci_lower": 0.284,
-              "d_ci_upper": 0.9214
+              "tech_mean": 3.4247,
+              "tech_mean_ci_lower": 3.4247,
+              "tech_mean_ci_upper": 3.4247,
+              "nontech_mean": 3.032,
+              "nontech_mean_ci_lower": 3.032,
+              "nontech_mean_ci_upper": 3.032,
+              "d": 0.6079,
+              "d_ci_lower": 0.3169,
+              "d_ci_upper": 0.9382
             },
             "maturity": {
-              "tech_mean": 3.3523,
-              "tech_mean_ci_lower": 3.3523,
-              "tech_mean_ci_upper": 3.3523,
-              "nontech_mean": 3.0937,
-              "nontech_mean_ci_lower": 3.0937,
-              "nontech_mean_ci_upper": 3.0937,
-              "d": 0.3348,
-              "d_ci_lower": 0.0173,
-              "d_ci_upper": 0.6927
+              "tech_mean": 3.3827,
+              "tech_mean_ci_lower": 3.3827,
+              "tech_mean_ci_upper": 3.3827,
+              "nontech_mean": 3.0706,
+              "nontech_mean_ci_lower": 3.0706,
+              "nontech_mean_ci_upper": 3.0706,
+              "d": 0.4027,
+              "d_ci_lower": 0.1,
+              "d_ci_upper": 0.7482
             }
           }
         },
@@ -1245,24 +1205,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 48,
-            "barrier_mean": 2.7193,
-            "readiness_mean": 3.4457,
-            "maturity_mean": 3.3523
+            "n": 53,
+            "barrier_mean": 2.7416,
+            "readiness_mean": 3.4247,
+            "maturity_mean": 3.3827
           },
           {
             "group": "Non-Technical",
-            "n": 124,
-            "barrier_mean": 2.7825,
-            "readiness_mean": 3.0723,
-            "maturity_mean": 3.0937
-          },
-          {
-            "group": "Other",
-            "n": 28,
-            "barrier_mean": 2.7612,
-            "readiness_mean": 2.8878,
-            "maturity_mean": 3.0759
+            "n": 147,
+            "barrier_mean": 2.7726,
+            "readiness_mean": 3.032,
+            "maturity_mean": 3.0706
           }
         ],
         "by_org_size": [
@@ -1291,31 +1244,31 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 48,
-          "nontech_n": 124,
+          "tech_n": 53,
+          "nontech_n": 147,
           "constructs": {
             "barriers": {
-              "t": -0.4999,
+              "t": -0.2635,
               "p": 0.0,
-              "df": 75.7,
-              "mean_diff_ci_lower": -0.0632,
-              "mean_diff_ci_upper": -0.0632,
+              "df": 82.62,
+              "mean_diff_ci_lower": -0.031,
+              "mean_diff_ci_upper": -0.031,
               "sig": true
             },
             "readiness": {
-              "t": 3.5528,
+              "t": 3.9083,
               "p": 0.0,
-              "df": 92.04,
-              "mean_diff_ci_lower": 0.3734,
-              "mean_diff_ci_upper": 0.3734,
+              "df": 97.4,
+              "mean_diff_ci_lower": 0.3927,
+              "mean_diff_ci_upper": 0.3927,
               "sig": true
             },
             "maturity": {
-              "t": 1.9843,
+              "t": 2.5538,
               "p": 0.0,
-              "df": 86.84,
-              "mean_diff_ci_lower": 0.2586,
-              "mean_diff_ci_upper": 0.2586,
+              "df": 94.82,
+              "mean_diff_ci_lower": 0.3122,
+              "mean_diff_ci_upper": 0.3122,
               "sig": true
             }
           }
@@ -1351,29 +1304,29 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [48, 124, 28],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [53, 147],
           "constructs": {
             "barriers": {
-              "f": 0.1444,
-              "p": 0.8656,
-              "df_between": 2,
-              "df_within": 197,
-              "sig": false
+              "f": 0.0785,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
+              "sig": true
             },
             "readiness": {
-              "f": 8.2256,
-              "p": 0.0004,
-              "df_between": 2,
-              "df_within": 197,
+              "f": 14.3964,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
               "sig": true
             },
             "maturity": {
-              "f": 2.0546,
-              "p": 0.1309,
-              "df_between": 2,
-              "df_within": 197,
-              "sig": false
+              "f": 6.3177,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
+              "sig": true
             }
           }
         },
@@ -1419,7 +1372,7 @@
           "CTO": 14,
           "CFO": 12,
           "CRO": 12,
-          "Unknown": 2
+          "CISO": 2
         },
         "org_sizes": {
           "<100": 33,
@@ -1435,57 +1388,52 @@
           "Government/Public Sector": 13
         },
         "tech_vs_nontech": {
-          "technical": 48,
-          "non_technical": 124,
-          "other": 28
+          "technical": 53,
+          "non_technical": 147,
+          "other": 0
         },
         "other_roles": {
           "total": 38,
-          "categories": {
-            "Director": 18,
-            "Uncategorized": 5,
-            "Manager / Program Lead": "<5",
-            "C-Suite Adjacent": "<5"
-          }
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 48,
-          "nontech_n": 124,
+          "tech_n": 53,
+          "nontech_n": 147,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7193,
-              "tech_mean_ci_lower": 2.7193,
-              "tech_mean_ci_upper": 2.7193,
-              "nontech_mean": 2.7825,
-              "nontech_mean_ci_lower": 2.7825,
-              "nontech_mean_ci_upper": 2.7825,
-              "d": -0.0906,
-              "d_ci_lower": -0.4455,
-              "d_ci_upper": 0.2712
+              "tech_mean": 2.7416,
+              "tech_mean_ci_lower": 2.7416,
+              "tech_mean_ci_upper": 2.7416,
+              "nontech_mean": 2.7726,
+              "nontech_mean_ci_lower": 2.7726,
+              "nontech_mean_ci_upper": 2.7726,
+              "d": -0.0449,
+              "d_ci_lower": -0.3768,
+              "d_ci_upper": 0.2864
             },
             "readiness": {
-              "tech_mean": 3.4457,
-              "tech_mean_ci_lower": 3.4457,
-              "tech_mean_ci_upper": 3.4457,
-              "nontech_mean": 3.0723,
-              "nontech_mean_ci_lower": 3.0723,
-              "nontech_mean_ci_upper": 3.0723,
-              "d": 0.5832,
-              "d_ci_lower": 0.284,
-              "d_ci_upper": 0.9214
+              "tech_mean": 3.4247,
+              "tech_mean_ci_lower": 3.4247,
+              "tech_mean_ci_upper": 3.4247,
+              "nontech_mean": 3.032,
+              "nontech_mean_ci_lower": 3.032,
+              "nontech_mean_ci_upper": 3.032,
+              "d": 0.6079,
+              "d_ci_lower": 0.3169,
+              "d_ci_upper": 0.9382
             },
             "maturity": {
-              "tech_mean": 3.3523,
-              "tech_mean_ci_lower": 3.3523,
-              "tech_mean_ci_upper": 3.3523,
-              "nontech_mean": 3.0937,
-              "nontech_mean_ci_lower": 3.0937,
-              "nontech_mean_ci_upper": 3.0937,
-              "d": 0.3348,
-              "d_ci_lower": 0.0173,
-              "d_ci_upper": 0.6927
+              "tech_mean": 3.3827,
+              "tech_mean_ci_lower": 3.3827,
+              "tech_mean_ci_upper": 3.3827,
+              "nontech_mean": 3.0706,
+              "nontech_mean_ci_lower": 3.0706,
+              "nontech_mean_ci_upper": 3.0706,
+              "d": 0.4027,
+              "d_ci_lower": 0.1,
+              "d_ci_upper": 0.7482
             }
           }
         },
@@ -1522,24 +1470,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 48,
-            "barrier_mean": 2.7193,
-            "readiness_mean": 3.4457,
-            "maturity_mean": 3.3523
+            "n": 53,
+            "barrier_mean": 2.7416,
+            "readiness_mean": 3.4247,
+            "maturity_mean": 3.3827
           },
           {
             "group": "Non-Technical",
-            "n": 124,
-            "barrier_mean": 2.7825,
-            "readiness_mean": 3.0723,
-            "maturity_mean": 3.0937
-          },
-          {
-            "group": "Other",
-            "n": 28,
-            "barrier_mean": 2.7612,
-            "readiness_mean": 2.8878,
-            "maturity_mean": 3.0759
+            "n": 147,
+            "barrier_mean": 2.7726,
+            "readiness_mean": 3.032,
+            "maturity_mean": 3.0706
           }
         ],
         "by_org_size": [
@@ -1568,31 +1509,31 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 48,
-          "nontech_n": 124,
+          "tech_n": 53,
+          "nontech_n": 147,
           "constructs": {
             "barriers": {
-              "t": -0.4999,
+              "t": -0.2635,
               "p": 0.0,
-              "df": 75.7,
-              "mean_diff_ci_lower": -0.0632,
-              "mean_diff_ci_upper": -0.0632,
+              "df": 82.62,
+              "mean_diff_ci_lower": -0.031,
+              "mean_diff_ci_upper": -0.031,
               "sig": true
             },
             "readiness": {
-              "t": 3.5528,
+              "t": 3.9083,
               "p": 0.0,
-              "df": 92.04,
-              "mean_diff_ci_lower": 0.3734,
-              "mean_diff_ci_upper": 0.3734,
+              "df": 97.4,
+              "mean_diff_ci_lower": 0.3927,
+              "mean_diff_ci_upper": 0.3927,
               "sig": true
             },
             "maturity": {
-              "t": 1.9843,
+              "t": 2.5538,
               "p": 0.0,
-              "df": 86.84,
-              "mean_diff_ci_lower": 0.2586,
-              "mean_diff_ci_upper": 0.2586,
+              "df": 94.82,
+              "mean_diff_ci_lower": 0.3122,
+              "mean_diff_ci_upper": 0.3122,
               "sig": true
             }
           }
@@ -1628,29 +1569,29 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [48, 124, 28],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [53, 147],
           "constructs": {
             "barriers": {
-              "f": 0.1444,
-              "p": 0.8656,
-              "df_between": 2,
-              "df_within": 197,
-              "sig": false
+              "f": 0.0785,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
+              "sig": true
             },
             "readiness": {
-              "f": 8.2256,
-              "p": 0.0004,
-              "df_between": 2,
-              "df_within": 197,
+              "f": 14.3964,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
               "sig": true
             },
             "maturity": {
-              "f": 2.0546,
-              "p": 0.1309,
-              "df_between": 2,
-              "df_within": 197,
-              "sig": false
+              "f": 6.3177,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 198,
+              "sig": true
             }
           }
         },
@@ -1687,9 +1628,9 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 1.36,
-      "p_value": 0.9682,
-      "df": 6,
+      "chi2": 0.61,
+      "p_value": 0.8941,
+      "df": 3,
       "error": null
     },
     "organization_size": {
@@ -1769,5 +1710,5 @@
       "examples": ""
     }
   ],
-  "last_updated": "2026-04-11T10:46:19.561725Z"
+  "last_updated": "2026-04-11T23:56:45.066834Z"
 }

--- a/src/data/data-audit.json
+++ b/src/data/data-audit.json
@@ -1,22 +1,22 @@
 {
   "disposition_counts": {
-    "INCOMPLETE": 68,
-    "CLEAN": 84,
-    "FLAG-SMEAL": 49,
-    "FLAG-SPEED": 7,
+    "INCOMPLETE": 69,
+    "CLEAN": 85,
+    "FLAG-SMEAL": 50,
+    "FLAG-SPEED": 8,
     "FLAG-PARTIAL-STRAIGHTLINING": 33,
     "FLAG-SINGLE-IRI": 80,
     "AUTO-EXCLUDE": 117,
     "FLAG-RECAPTCHA": 3
   },
   "iri_pass_rates": {
-    "barrier": 0.4875283446712018,
-    "readiness": 0.5918367346938775,
-    "maturity": 0.6893424036281179
+    "barrier": 0.4898876404494382,
+    "readiness": 0.5932584269662922,
+    "maturity": 0.6898876404494382
   },
   "duration_stats": {
-    "mean": 657.4625850340136,
-    "median": 530,
+    "mean": 655.2022471910112,
+    "median": 529,
     "q25": 318,
     "q75": 792,
     "min": 2,
@@ -27,76 +27,76 @@
     "partial_flagged": 132
   },
   "sample_sizes": {
-    "total": 441,
-    "complete": 373,
-    "clean": 84
+    "total": 445,
+    "complete": 376,
+    "clean": 85
   },
   "waterfall_steps": [
     {
       "step": 0,
       "name": "INCOMPLETE",
-      "count": 68,
-      "cumulative_excluded": 68
+      "count": 69,
+      "cumulative_excluded": 69
     },
     {
       "step": 1,
       "name": "FLAG-AUTH-FAIL",
       "count": 0,
-      "cumulative_excluded": 68
+      "cumulative_excluded": 69
     },
     {
       "step": 2,
       "name": "FLAG-AUTH-MIXED",
       "count": 0,
-      "cumulative_excluded": 68
+      "cumulative_excluded": 69
     },
     {
       "step": 3,
       "name": "AUTO-EXCLUDE",
       "count": 117,
-      "cumulative_excluded": 185
+      "cumulative_excluded": 186
     },
     {
       "step": 4,
       "name": "FLAG-SPEED",
-      "count": 7,
-      "cumulative_excluded": 192
+      "count": 8,
+      "cumulative_excluded": 194
     },
     {
       "step": 5,
       "name": "FLAG-SINGLE-IRI",
       "count": 80,
-      "cumulative_excluded": 272
+      "cumulative_excluded": 274
     },
     {
       "step": 6,
       "name": "FLAG-SMEAL",
-      "count": 49,
-      "cumulative_excluded": 321
+      "count": 50,
+      "cumulative_excluded": 324
     },
     {
       "step": 7,
       "name": "FLAG-RECAPTCHA",
       "count": 3,
-      "cumulative_excluded": 324
+      "cumulative_excluded": 327
     },
     {
       "step": 8,
       "name": "FLAG-STRAIGHTLINING",
       "count": 0,
-      "cumulative_excluded": 324
+      "cumulative_excluded": 327
     },
     {
       "step": 9,
       "name": "FLAG-PARTIAL-STRAIGHTLINING",
       "count": 33,
-      "cumulative_excluded": 357
+      "cumulative_excluded": 360
     },
     {
       "step": 10,
       "name": "CLEAN",
-      "count": 84,
-      "cumulative_excluded": 84
+      "count": 85,
+      "cumulative_excluded": 85
     }
   ]
 }

--- a/src/data/disposition-summary.json
+++ b/src/data/disposition-summary.json
@@ -1,12 +1,12 @@
 {
-  "updatedAt": "2026-04-11T10:50:30.864834+00:00",
-  "last_updated": "2026-04-11T10:50:30.864843+00:00",
+  "updatedAt": "2026-04-12T00:00:43.728943+00:00",
+  "last_updated": "2026-04-12T00:00:43.728956+00:00",
   "study": {
     "id": "69c17630acada6abeead2da5",
     "name": "Technology Adoption Barriers Survey (2026)",
     "status": "ACTIVE",
     "totalAvailablePlaces": 500,
-    "placesTaken": 270,
+    "placesTaken": 273,
     "averageRewardPerHour": 3994.65,
     "averageTimeTaken": 10,
     "reward": 700,
@@ -14,19 +14,19 @@
   },
   "completionProgress": {
     "target": 500,
-    "completed": 270,
+    "completed": 273,
     "approved": 234,
-    "awaitingReview": 36,
-    "percentComplete": 54.0
+    "awaitingReview": 39,
+    "percentComplete": 54.6
   },
-  "totalResponses": 457,
-  "uniqueParticipants": 441,
+  "totalResponses": 462,
+  "uniqueParticipants": 445,
   "duplicatesRemoved": 0,
   "dispositions": {
-    "INCOMPLETE": 68,
-    "CLEAN": 84,
-    "FLAG-SMEAL": 49,
-    "FLAG-SPEED": 7,
+    "INCOMPLETE": 69,
+    "CLEAN": 85,
+    "FLAG-SMEAL": 50,
+    "FLAG-SPEED": 8,
     "FLAG-PARTIAL-STRAIGHTLINING": 33,
     "FLAG-SINGLE-IRI": 80,
     "AUTO-EXCLUDE": 117,
@@ -34,21 +34,23 @@
   },
   "dispositionByStatus": {
     "INCOMPLETE": {
-      "RETURNED": 62,
+      "RETURNED": 63,
       "TIMED-OUT": 6
     },
     "CLEAN": {
       "APPROVED": 83,
+      "AWAITING REVIEW": 1,
       "RETURNED": 1
     },
     "FLAG-SMEAL": {
       "APPROVED": 40,
-      "AWAITING REVIEW": 7,
+      "AWAITING REVIEW": 8,
       "RETURNED": 2
     },
     "FLAG-SPEED": {
       "RETURNED": 1,
-      "APPROVED": 6
+      "APPROVED": 6,
+      "AWAITING REVIEW": 1
     },
     "FLAG-PARTIAL-STRAIGHTLINING": {
       "APPROVED": 32,
@@ -79,17 +81,17 @@
   "actions": {
     "approved": 234,
     "rejected": 29,
-    "returned": 152,
+    "returned": 154,
     "timedOut": 6,
-    "awaitingReview": 36,
+    "awaitingReview": 39,
     "active": 0,
     "messaged": 0
   },
   "iriPassRates": {
-    "barrier": 57.4,
-    "readiness": 69.7,
-    "maturity": 81.5,
-    "denominator": 373
+    "barrier": 57.7,
+    "readiness": 69.9,
+    "maturity": 81.6,
+    "denominator": 376
   },
   "studyId": "69c17630acada6abeead2da5",
   "studyName": "Technology Adoption Barriers Survey (2026)"

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -22,13 +22,13 @@
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 373
+      "n": 376
     },
     {
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 441
+      "n": 445
     }
   ],
   "metrics": [
@@ -39,8 +39,8 @@
         "conservative_clean": 2.8409,
         "flexible_clean": 2.8257,
         "prolific_accepted": 2.7857,
-        "v2_finished": 2.7494,
-        "v2_all": 2.7549
+        "v2_finished": 2.7433,
+        "v2_all": 2.7488
       }
     },
     {
@@ -50,8 +50,8 @@
         "conservative_clean": 0.631,
         "flexible_clean": 0.7149,
         "prolific_accepted": 0.7141,
-        "v2_finished": 0.7709,
-        "v2_all": 0.7745
+        "v2_finished": 0.7711,
+        "v2_all": 0.7747
       }
     },
     {
@@ -61,8 +61,8 @@
         "conservative_clean": 3.0622,
         "flexible_clean": 3.1018,
         "prolific_accepted": 3.1422,
-        "v2_finished": 3.2497,
-        "v2_all": 3.2497
+        "v2_finished": 3.2517,
+        "v2_all": 3.2518
       }
     },
     {
@@ -72,8 +72,8 @@
         "conservative_clean": 0.5751,
         "flexible_clean": 0.6521,
         "prolific_accepted": 0.6718,
-        "v2_finished": 0.7137,
-        "v2_all": 0.7127
+        "v2_finished": 0.7116,
+        "v2_all": 0.7107
       }
     },
     {
@@ -83,8 +83,8 @@
         "conservative_clean": 3.0424,
         "flexible_clean": 3.0684,
         "prolific_accepted": 3.1572,
-        "v2_finished": 3.2712,
-        "v2_all": 3.2712
+        "v2_finished": 3.2727,
+        "v2_all": 3.2727
       }
     },
     {
@@ -94,8 +94,8 @@
         "conservative_clean": 0.7112,
         "flexible_clean": 0.7968,
         "prolific_accepted": 0.8058,
-        "v2_finished": 0.805,
-        "v2_all": 0.805
+        "v2_finished": 0.8049,
+        "v2_all": 0.8049
       }
     },
     {
@@ -105,8 +105,8 @@
         "conservative_clean": -0.452,
         "flexible_clean": -0.4442,
         "prolific_accepted": -0.3351,
-        "v2_finished": -0.3127,
-        "v2_all": -0.3125
+        "v2_finished": -0.3133,
+        "v2_all": -0.3131
       }
     },
     {
@@ -116,8 +116,8 @@
         "conservative_clean": -0.2098,
         "flexible_clean": -0.3074,
         "prolific_accepted": -0.2733,
-        "v2_finished": -0.3026,
-        "v2_all": -0.3026
+        "v2_finished": -0.3,
+        "v2_all": -0.3
       }
     },
     {
@@ -127,8 +127,8 @@
         "conservative_clean": 0.5876,
         "flexible_clean": 0.6951,
         "prolific_accepted": 0.7104,
-        "v2_finished": 0.7336,
-        "v2_all": 0.7336
+        "v2_finished": 0.7334,
+        "v2_all": 0.7334
       }
     },
     {
@@ -149,8 +149,8 @@
         "conservative_clean": 0.87,
         "flexible_clean": 0.9149,
         "prolific_accepted": 0.9191,
-        "v2_finished": 0.9301,
-        "v2_all": 0.9301
+        "v2_finished": 0.9295,
+        "v2_all": 0.9295
       }
     },
     {
@@ -160,8 +160,8 @@
         "conservative_clean": 0.8327,
         "flexible_clean": 0.8818,
         "prolific_accepted": 0.8889,
-        "v2_finished": 0.8899,
-        "v2_all": 0.8899
+        "v2_finished": 0.8894,
+        "v2_all": 0.8894
       }
     }
   ],
@@ -329,56 +329,52 @@
           "Government/Public Sector": 9
         },
         "tech_vs_nontech": {
-          "technical": 16,
-          "non_technical": 55,
-          "other": 12
+          "technical": 19,
+          "non_technical": 64,
+          "other": 0
         },
         "other_roles": {
           "total": 14,
-          "categories": {
-            "Director": 8,
-            "Uncategorized": "<5",
-            "Manager / Program Lead": "<5"
-          }
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 16,
-          "nontech_n": 55,
+          "tech_n": 19,
+          "nontech_n": 64,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7778,
-              "tech_mean_ci_lower": 2.7778,
-              "tech_mean_ci_upper": 2.7778,
-              "nontech_mean": 2.8923,
-              "nontech_mean_ci_lower": 2.8923,
-              "nontech_mean_ci_upper": 2.8923,
-              "d": -0.1712,
-              "d_ci_lower": -0.773,
-              "d_ci_upper": 0.4436
+              "tech_mean": 2.7895,
+              "tech_mean_ci_lower": 2.7895,
+              "tech_mean_ci_upper": 2.7895,
+              "nontech_mean": 2.8562,
+              "nontech_mean_ci_lower": 2.8562,
+              "nontech_mean_ci_upper": 2.8562,
+              "d": -0.1052,
+              "d_ci_lower": -0.6426,
+              "d_ci_upper": 0.4666
             },
             "readiness": {
-              "tech_mean": 3.3488,
-              "tech_mean_ci_lower": 3.3488,
-              "tech_mean_ci_upper": 3.3488,
-              "nontech_mean": 3.0071,
-              "nontech_mean_ci_lower": 3.0071,
-              "nontech_mean_ci_upper": 3.0071,
-              "d": 0.5984,
-              "d_ci_lower": 0.0817,
-              "d_ci_upper": 1.2143
+              "tech_mean": 3.2442,
+              "tech_mean_ci_lower": 3.2442,
+              "tech_mean_ci_upper": 3.2442,
+              "nontech_mean": 3.0081,
+              "nontech_mean_ci_lower": 3.0081,
+              "nontech_mean_ci_upper": 3.0081,
+              "d": 0.4142,
+              "d_ci_lower": -0.115,
+              "d_ci_upper": 0.9658
             },
             "maturity": {
-              "tech_mean": 3.1797,
-              "tech_mean_ci_lower": 3.1797,
-              "tech_mean_ci_upper": 3.1797,
-              "nontech_mean": 2.9844,
-              "nontech_mean_ci_lower": 2.9844,
-              "nontech_mean_ci_upper": 2.9844,
-              "d": 0.2736,
-              "d_ci_lower": -0.3259,
-              "d_ci_upper": 0.9033
+              "tech_mean": 3.1974,
+              "tech_mean_ci_lower": 3.1974,
+              "tech_mean_ci_upper": 3.1974,
+              "nontech_mean": 2.9963,
+              "nontech_mean_ci_lower": 2.9963,
+              "nontech_mean_ci_upper": 2.9963,
+              "d": 0.283,
+              "d_ci_lower": -0.2782,
+              "d_ci_upper": 0.8557
             }
           }
         },
@@ -415,24 +411,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 16,
-            "barrier_mean": 2.7778,
-            "readiness_mean": 3.3488,
-            "maturity_mean": 3.1797
+            "n": 19,
+            "barrier_mean": 2.7895,
+            "readiness_mean": 3.2442,
+            "maturity_mean": 3.1974
           },
           {
             "group": "Non-Technical",
-            "n": 55,
-            "barrier_mean": 2.8923,
-            "readiness_mean": 3.0071,
-            "maturity_mean": 2.9844
-          },
-          {
-            "group": "Other",
-            "n": 12,
-            "barrier_mean": 2.6898,
-            "readiness_mean": 2.9324,
-            "maturity_mean": 3.125
+            "n": 64,
+            "barrier_mean": 2.8562,
+            "readiness_mean": 3.0081,
+            "maturity_mean": 2.9963
           }
         ],
         "by_org_size": [
@@ -461,31 +450,31 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 16,
-          "nontech_n": 55,
+          "tech_n": 19,
+          "nontech_n": 64,
           "constructs": {
             "barriers": {
-              "t": -0.5611,
+              "t": -0.3818,
               "p": 0.0,
-              "df": 22.19,
-              "mean_diff_ci_lower": -0.1145,
-              "mean_diff_ci_upper": -0.1145,
+              "df": 27.4,
+              "mean_diff_ci_lower": -0.0667,
+              "mean_diff_ci_upper": -0.0667,
               "sig": true
             },
             "readiness": {
-              "t": 2.1632,
+              "t": 1.5878,
               "p": 0.0,
-              "df": 25.41,
-              "mean_diff_ci_lower": 0.3417,
-              "mean_diff_ci_upper": 0.3417,
+              "df": 29.6,
+              "mean_diff_ci_lower": 0.236,
+              "mean_diff_ci_upper": 0.236,
               "sig": true
             },
             "maturity": {
-              "t": 0.8641,
+              "t": 1.0178,
               "p": 0.0,
-              "df": 21.24,
-              "mean_diff_ci_lower": 0.1953,
-              "mean_diff_ci_upper": 0.1953,
+              "df": 27.09,
+              "mean_diff_ci_lower": 0.201,
+              "mean_diff_ci_upper": 0.201,
               "sig": true
             }
           }
@@ -521,29 +510,29 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [16, 55, 12],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [19, 64],
           "constructs": {
             "barriers": {
-              "f": 0.6004,
-              "p": 0.551,
-              "df_between": 2,
-              "df_within": 80,
-              "sig": false
+              "f": 0.1622,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 81,
+              "sig": true
             },
             "readiness": {
-              "f": 2.6467,
-              "p": 0.0771,
-              "df_between": 2,
-              "df_within": 80,
-              "sig": false
+              "f": 2.5132,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 81,
+              "sig": true
             },
             "maturity": {
-              "f": 0.556,
-              "p": 0.5757,
-              "df_between": 2,
-              "df_within": 80,
-              "sig": false
+              "f": 1.173,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 81,
+              "sig": true
             }
           }
         },
@@ -604,57 +593,52 @@
           "Government/Public Sector": 14
         },
         "tech_vs_nontech": {
-          "technical": 30,
-          "non_technical": 84,
-          "other": 16
+          "technical": 33,
+          "non_technical": 97,
+          "other": 0
         },
         "other_roles": {
           "total": 20,
-          "categories": {
-            "Director": 10,
-            "Uncategorized": "<5",
-            "Manager / Program Lead": "<5",
-            "C-Suite Adjacent": "<5"
-          }
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 30,
-          "nontech_n": 84,
+          "tech_n": 33,
+          "nontech_n": 97,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6796,
-              "tech_mean_ci_lower": 2.6796,
-              "tech_mean_ci_upper": 2.6796,
-              "nontech_mean": 2.8803,
-              "nontech_mean_ci_lower": 2.8803,
-              "nontech_mean_ci_upper": 2.8803,
-              "d": -0.2727,
-              "d_ci_lower": -0.6907,
-              "d_ci_upper": 0.1443
+              "tech_mean": 2.6953,
+              "tech_mean_ci_lower": 2.6953,
+              "tech_mean_ci_upper": 2.6953,
+              "nontech_mean": 2.8701,
+              "nontech_mean_ci_lower": 2.8701,
+              "nontech_mean_ci_upper": 2.8701,
+              "d": -0.2449,
+              "d_ci_lower": -0.6115,
+              "d_ci_upper": 0.1333
             },
             "readiness": {
-              "tech_mean": 3.4269,
-              "tech_mean_ci_lower": 3.4269,
-              "tech_mean_ci_upper": 3.4269,
-              "nontech_mean": 3.0294,
-              "nontech_mean_ci_lower": 3.0294,
-              "nontech_mean_ci_upper": 3.0294,
-              "d": 0.6152,
-              "d_ci_lower": 0.2295,
-              "d_ci_upper": 1.0308
+              "tech_mean": 3.3596,
+              "tech_mean_ci_lower": 3.3596,
+              "tech_mean_ci_upper": 3.3596,
+              "nontech_mean": 3.0141,
+              "nontech_mean_ci_lower": 3.0141,
+              "nontech_mean_ci_upper": 3.0141,
+              "d": 0.5425,
+              "d_ci_lower": 0.1675,
+              "d_ci_upper": 0.9275
             },
             "maturity": {
-              "tech_mean": 3.3042,
-              "tech_mean_ci_lower": 3.3042,
-              "tech_mean_ci_upper": 3.3042,
-              "nontech_mean": 3.0091,
-              "nontech_mean_ci_lower": 3.0091,
-              "nontech_mean_ci_upper": 3.0091,
-              "d": 0.3693,
-              "d_ci_lower": -0.0463,
-              "d_ci_upper": 0.77
+              "tech_mean": 3.303,
+              "tech_mean_ci_lower": 3.303,
+              "tech_mean_ci_upper": 3.303,
+              "nontech_mean": 2.9886,
+              "nontech_mean_ci_lower": 2.9886,
+              "nontech_mean_ci_upper": 2.9886,
+              "d": 0.3991,
+              "d_ci_lower": 0.0432,
+              "d_ci_upper": 0.7816
             }
           }
         },
@@ -691,24 +675,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 30,
-            "barrier_mean": 2.6796,
-            "readiness_mean": 3.4269,
-            "maturity_mean": 3.3042
+            "n": 33,
+            "barrier_mean": 2.6953,
+            "readiness_mean": 3.3596,
+            "maturity_mean": 3.303
           },
           {
             "group": "Non-Technical",
-            "n": 84,
-            "barrier_mean": 2.8803,
-            "readiness_mean": 3.0294,
-            "maturity_mean": 3.0091
-          },
-          {
-            "group": "Other",
-            "n": 16,
-            "barrier_mean": 2.813,
-            "readiness_mean": 2.8721,
-            "maturity_mean": 2.9375
+            "n": 97,
+            "barrier_mean": 2.8701,
+            "readiness_mean": 3.0141,
+            "maturity_mean": 2.9886
           }
         ],
         "by_org_size": [
@@ -737,31 +714,31 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 30,
-          "nontech_n": 84,
+          "tech_n": 33,
+          "nontech_n": 97,
           "constructs": {
             "barriers": {
-              "t": -1.2958,
+              "t": -1.2356,
               "p": 0.0,
-              "df": 52.15,
-              "mean_diff_ci_lower": -0.2006,
-              "mean_diff_ci_upper": -0.2006,
+              "df": 56.99,
+              "mean_diff_ci_lower": -0.1748,
+              "mean_diff_ci_upper": -0.1748,
               "sig": true
             },
             "readiness": {
-              "t": 3.1398,
+              "t": 2.8442,
               "p": 0.0,
-              "df": 60.31,
-              "mean_diff_ci_lower": 0.3975,
-              "mean_diff_ci_upper": 0.3975,
+              "df": 61.28,
+              "mean_diff_ci_lower": 0.3455,
+              "mean_diff_ci_upper": 0.3455,
               "sig": true
             },
             "maturity": {
-              "t": 1.8052,
+              "t": 2.0871,
               "p": 0.0,
-              "df": 55.1,
-              "mean_diff_ci_lower": 0.2951,
-              "mean_diff_ci_upper": 0.2951,
+              "df": 60.99,
+              "mean_diff_ci_lower": 0.3145,
+              "mean_diff_ci_upper": 0.3145,
               "sig": true
             }
           }
@@ -797,29 +774,29 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [30, 84, 16],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [33, 97],
           "constructs": {
             "barriers": {
-              "f": 0.8717,
-              "p": 0.4207,
-              "df_between": 2,
-              "df_within": 127,
-              "sig": false
+              "f": 1.477,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 128,
+              "sig": true
             },
             "readiness": {
-              "f": 5.6139,
-              "p": 0.0046,
-              "df_between": 2,
-              "df_within": 127,
+              "f": 7.248,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 128,
               "sig": true
             },
             "maturity": {
-              "f": 1.7829,
-              "p": 0.1723,
-              "df_between": 2,
-              "df_within": 127,
-              "sig": false
+              "f": 3.9218,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 128,
+              "sig": true
             }
           }
         },
@@ -865,7 +842,7 @@
           "CFO": 17,
           "CTO": 15,
           "CRO": 15,
-          "Unknown": 2
+          "CISO": 2
         },
         "org_sizes": {
           "<100": 42,
@@ -881,57 +858,52 @@
           "Government/Public Sector": 19
         },
         "tech_vs_nontech": {
-          "technical": 53,
-          "non_technical": 146,
-          "other": 35
+          "technical": 58,
+          "non_technical": 176,
+          "other": 0
         },
         "other_roles": {
           "total": 46,
-          "categories": {
-            "Director": 22,
-            "Uncategorized": 7,
-            "Manager / Program Lead": "<5",
-            "C-Suite Adjacent": "<5"
-          }
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 53,
-          "nontech_n": 146,
+          "tech_n": 58,
+          "nontech_n": 176,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7353,
-              "tech_mean_ci_lower": 2.7353,
-              "tech_mean_ci_upper": 2.7353,
-              "nontech_mean": 2.8094,
-              "nontech_mean_ci_lower": 2.8094,
-              "nontech_mean_ci_upper": 2.8094,
-              "d": -0.1017,
-              "d_ci_lower": -0.4345,
-              "d_ci_upper": 0.2342
+              "tech_mean": 2.7543,
+              "tech_mean_ci_lower": 2.7543,
+              "tech_mean_ci_upper": 2.7543,
+              "nontech_mean": 2.796,
+              "nontech_mean_ci_lower": 2.796,
+              "nontech_mean_ci_upper": 2.796,
+              "d": -0.0584,
+              "d_ci_lower": -0.3528,
+              "d_ci_upper": 0.2547
             },
             "readiness": {
-              "tech_mean": 3.4347,
-              "tech_mean_ci_lower": 3.4347,
-              "tech_mean_ci_upper": 3.4347,
-              "nontech_mean": 3.09,
-              "nontech_mean_ci_lower": 3.09,
-              "nontech_mean_ci_upper": 3.09,
-              "d": 0.5235,
-              "d_ci_lower": 0.2286,
-              "d_ci_upper": 0.8339
+              "tech_mean": 3.4165,
+              "tech_mean_ci_lower": 3.4165,
+              "tech_mean_ci_upper": 3.4165,
+              "nontech_mean": 3.0518,
+              "nontech_mean_ci_lower": 3.0518,
+              "nontech_mean_ci_upper": 3.0518,
+              "d": 0.5574,
+              "d_ci_lower": 0.2709,
+              "d_ci_upper": 0.8559
             },
             "maturity": {
-              "tech_mean": 3.3544,
-              "tech_mean_ci_lower": 3.3544,
-              "tech_mean_ci_upper": 3.3544,
-              "nontech_mean": 3.1121,
-              "nontech_mean_ci_lower": 3.1121,
-              "nontech_mean_ci_upper": 3.1121,
-              "d": 0.3025,
-              "d_ci_lower": -0.0053,
-              "d_ci_upper": 0.6362
+              "tech_mean": 3.3821,
+              "tech_mean_ci_lower": 3.3821,
+              "tech_mean_ci_upper": 3.3821,
+              "nontech_mean": 3.0831,
+              "nontech_mean_ci_lower": 3.0831,
+              "nontech_mean_ci_upper": 3.0831,
+              "d": 0.3751,
+              "d_ci_lower": 0.0762,
+              "d_ci_upper": 0.6858
             }
           }
         },
@@ -968,24 +940,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 53,
-            "barrier_mean": 2.7353,
-            "readiness_mean": 3.4347,
-            "maturity_mean": 3.3544
+            "n": 58,
+            "barrier_mean": 2.7543,
+            "readiness_mean": 3.4165,
+            "maturity_mean": 3.3821
           },
           {
             "group": "Non-Technical",
-            "n": 146,
-            "barrier_mean": 2.8094,
-            "readiness_mean": 3.09,
-            "maturity_mean": 3.1121
-          },
-          {
-            "group": "Other",
-            "n": 35,
-            "barrier_mean": 2.7629,
-            "readiness_mean": 2.9167,
-            "maturity_mean": 3.0464
+            "n": 176,
+            "barrier_mean": 2.796,
+            "readiness_mean": 3.0518,
+            "maturity_mean": 3.0831
           }
         ],
         "by_org_size": [
@@ -1014,31 +979,31 @@
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 53,
-          "nontech_n": 146,
+          "tech_n": 58,
+          "nontech_n": 176,
           "constructs": {
             "barriers": {
-              "t": -0.6208,
+              "t": -0.3761,
               "p": 0.0,
-              "df": 88.7,
-              "mean_diff_ci_lower": -0.074,
-              "mean_diff_ci_upper": -0.074,
+              "df": 93.47,
+              "mean_diff_ci_lower": -0.0417,
+              "mean_diff_ci_upper": -0.0417,
               "sig": true
             },
             "readiness": {
-              "t": 3.3791,
+              "t": 3.767,
               "p": 0.0,
-              "df": 98.67,
-              "mean_diff_ci_lower": 0.3447,
-              "mean_diff_ci_upper": 0.3447,
+              "df": 101.26,
+              "mean_diff_ci_lower": 0.3647,
+              "mean_diff_ci_upper": 0.3647,
               "sig": true
             },
             "maturity": {
-              "t": 1.8887,
+              "t": 2.4919,
               "p": 0.0,
-              "df": 92.46,
-              "mean_diff_ci_lower": 0.2423,
-              "mean_diff_ci_upper": 0.2423,
+              "df": 98.26,
+              "mean_diff_ci_lower": 0.299,
+              "mean_diff_ci_upper": 0.299,
               "sig": true
             }
           }
@@ -1074,29 +1039,29 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [53, 146, 35],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [58, 176],
           "constructs": {
             "barriers": {
-              "f": 0.2284,
-              "p": 0.7959,
-              "df_between": 2,
-              "df_within": 231,
-              "sig": false
+              "f": 0.1485,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 232,
+              "sig": true
             },
             "readiness": {
-              "f": 7.876,
-              "p": 0.0005,
-              "df_between": 2,
-              "df_within": 231,
+              "f": 13.5545,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 232,
               "sig": true
             },
             "maturity": {
-              "f": 2.1685,
-              "p": 0.1167,
-              "df_between": 2,
-              "df_within": 231,
-              "sig": false
+              "f": 6.1393,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 232,
+              "sig": true
             }
           }
         },
@@ -1132,111 +1097,106 @@
     "v2_finished": {
       "demographics": {
         "roles": {
-          "Other": 68,
+          "Other": 70,
           "CIO": 58,
           "CEO": 38,
           "COO": 35,
-          "CTO": 34,
+          "CTO": 35,
           "CFO": 33,
           "CSO": 31,
           "CMO": 25,
           "CHRO": 24,
           "CRO": 22,
-          "Unknown": 5
+          "CISO": 5
         },
         "org_sizes": {
           "<100": 57,
-          "100-499": 102,
+          "100-499": 103,
           "500-999": 57,
-          "1000-4999": 73,
+          "1000-4999": 74,
           "5000-9999": 31,
-          "10000+": 53
+          "10000+": 54
         },
         "profit_models": {
-          "For-Profit": 281,
+          "For-Profit": 284,
           "Non-Profit": 62,
           "Government/Public Sector": 30
         },
         "tech_vs_nontech": {
-          "technical": 93,
-          "non_technical": 228,
-          "other": 52
+          "technical": 103,
+          "non_technical": 273,
+          "other": 0
         },
         "other_roles": {
-          "total": 68,
-          "categories": {
-            "Director": 28,
-            "Uncategorized": 10,
-            "Manager / Program Lead": 7,
-            "C-Suite Adjacent": "<5"
-          }
+          "total": 70,
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 93,
-          "nontech_n": 228,
+          "tech_n": 103,
+          "nontech_n": 273,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6789,
-              "tech_mean_ci_lower": 2.6789,
-              "tech_mean_ci_upper": 2.6789,
-              "nontech_mean": 2.7691,
-              "nontech_mean_ci_lower": 2.7691,
-              "nontech_mean_ci_upper": 2.7691,
-              "d": -0.1144,
-              "d_ci_lower": -0.3568,
-              "d_ci_upper": 0.1302
+              "tech_mean": 2.6825,
+              "tech_mean_ci_lower": 2.6825,
+              "tech_mean_ci_upper": 2.6825,
+              "nontech_mean": 2.7662,
+              "nontech_mean_ci_lower": 2.7662,
+              "nontech_mean_ci_upper": 2.7662,
+              "d": -0.1085,
+              "d_ci_lower": -0.3399,
+              "d_ci_upper": 0.1228
             },
             "readiness": {
-              "tech_mean": 3.4641,
-              "tech_mean_ci_lower": 3.4641,
-              "tech_mean_ci_upper": 3.4641,
-              "nontech_mean": 3.2142,
-              "nontech_mean_ci_lower": 3.2142,
-              "nontech_mean_ci_upper": 3.2142,
-              "d": 0.3537,
-              "d_ci_lower": 0.1141,
-              "d_ci_upper": 0.5902
+              "tech_mean": 3.463,
+              "tech_mean_ci_lower": 3.463,
+              "tech_mean_ci_upper": 3.463,
+              "nontech_mean": 3.1717,
+              "nontech_mean_ci_lower": 3.1717,
+              "nontech_mean_ci_upper": 3.1717,
+              "d": 0.4157,
+              "d_ci_lower": 0.2004,
+              "d_ci_upper": 0.6516
             },
             "maturity": {
-              "tech_mean": 3.4117,
-              "tech_mean_ci_lower": 3.4117,
-              "tech_mean_ci_upper": 3.4117,
-              "nontech_mean": 3.2491,
-              "nontech_mean_ci_lower": 3.2491,
-              "nontech_mean_ci_upper": 3.2491,
-              "d": 0.2027,
-              "d_ci_lower": -0.0383,
-              "d_ci_upper": 0.4464
+              "tech_mean": 3.4348,
+              "tech_mean_ci_lower": 3.4348,
+              "tech_mean_ci_upper": 3.4348,
+              "nontech_mean": 3.2113,
+              "nontech_mean_ci_lower": 3.2113,
+              "nontech_mean_ci_upper": 3.2113,
+              "d": 0.2794,
+              "d_ci_lower": 0.0675,
+              "d_ci_upper": 0.5074
             }
           }
         },
         "large_vs_small": {
-          "large_n": 84,
-          "small_medium_n": 289,
+          "large_n": 85,
+          "small_medium_n": 291,
           "constructs": {
             "barriers": {
-              "large_mean": 2.8781,
-              "large_mean_ci_lower": 2.8781,
-              "large_mean_ci_upper": 2.8781,
-              "small_medium_mean": 2.712,
-              "small_medium_mean_ci_lower": 2.712,
-              "small_medium_mean_ci_upper": 2.712,
-              "d": 0.216,
-              "d_ci_lower": -0.019,
-              "d_ci_upper": 0.4611
+              "large_mean": 2.871,
+              "large_mean_ci_lower": 2.871,
+              "large_mean_ci_upper": 2.871,
+              "small_medium_mean": 2.706,
+              "small_medium_mean_ci_lower": 2.706,
+              "small_medium_mean_ci_upper": 2.706,
+              "d": 0.2147,
+              "d_ci_lower": -0.0297,
+              "d_ci_upper": 0.4587
             },
             "readiness": {
-              "large_mean": 3.2641,
-              "large_mean_ci_lower": 3.2641,
-              "large_mean_ci_upper": 3.2641,
-              "small_medium_mean": 3.2454,
-              "small_medium_mean_ci_lower": 3.2454,
-              "small_medium_mean_ci_upper": 3.2454,
-              "d": 0.0262,
-              "d_ci_lower": -0.2241,
-              "d_ci_upper": 0.2675
+              "large_mean": 3.2707,
+              "large_mean_ci_lower": 3.2707,
+              "large_mean_ci_upper": 3.2707,
+              "small_medium_mean": 3.2462,
+              "small_medium_mean_ci_lower": 3.2462,
+              "small_medium_mean_ci_upper": 3.2462,
+              "d": 0.0344,
+              "d_ci_lower": -0.2104,
+              "d_ci_upper": 0.2791
             }
           }
         }
@@ -1245,161 +1205,154 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 93,
-            "barrier_mean": 2.6789,
-            "readiness_mean": 3.4641,
-            "maturity_mean": 3.4117
+            "n": 103,
+            "barrier_mean": 2.6825,
+            "readiness_mean": 3.463,
+            "maturity_mean": 3.4348
           },
           {
             "group": "Non-Technical",
-            "n": 228,
-            "barrier_mean": 2.7691,
-            "readiness_mean": 3.2142,
-            "maturity_mean": 3.2491
-          },
-          {
-            "group": "Other",
-            "n": 52,
-            "barrier_mean": 2.7894,
-            "readiness_mean": 3.0172,
-            "maturity_mean": 3.1139
+            "n": 273,
+            "barrier_mean": 2.7662,
+            "readiness_mean": 3.1717,
+            "maturity_mean": 3.2113
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 159,
-            "barrier_mean": 2.687,
-            "readiness_mean": 3.1749,
-            "maturity_mean": 3.1529
+            "n": 160,
+            "barrier_mean": 2.6817,
+            "readiness_mean": 3.1771,
+            "maturity_mean": 3.1535
           },
           {
             "group": "Medium (500-4999)",
-            "n": 130,
-            "barrier_mean": 2.7426,
-            "readiness_mean": 3.3323,
-            "maturity_mean": 3.3547
+            "n": 131,
+            "barrier_mean": 2.7356,
+            "readiness_mean": 3.3311,
+            "maturity_mean": 3.349
           },
           {
             "group": "Large (5000+)",
-            "n": 84,
-            "barrier_mean": 2.8781,
-            "readiness_mean": 3.2641,
-            "maturity_mean": 3.3671
+            "n": 85,
+            "barrier_mean": 2.871,
+            "readiness_mean": 3.2707,
+            "maturity_mean": 3.3804
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 93,
-          "nontech_n": 228,
+          "tech_n": 103,
+          "nontech_n": 273,
           "constructs": {
             "barriers": {
-              "t": -0.9159,
+              "t": -0.9229,
               "p": 0.0,
-              "df": 165.42,
-              "mean_diff_ci_lower": -0.0901,
-              "mean_diff_ci_upper": -0.0901,
+              "df": 177.91,
+              "mean_diff_ci_lower": -0.0837,
+              "mean_diff_ci_upper": -0.0837,
               "sig": true
             },
             "readiness": {
-              "t": 2.891,
+              "t": 3.5895,
               "p": 0.0,
-              "df": 173.0,
-              "mean_diff_ci_lower": 0.2499,
-              "mean_diff_ci_upper": 0.2499,
+              "df": 183.55,
+              "mean_diff_ci_lower": 0.2912,
+              "mean_diff_ci_upper": 0.2912,
               "sig": true
             },
             "maturity": {
-              "t": 1.6781,
+              "t": 2.4728,
               "p": 0.0,
-              "df": 177.84,
-              "mean_diff_ci_lower": 0.1626,
-              "mean_diff_ci_upper": 0.1626,
+              "df": 192.93,
+              "mean_diff_ci_lower": 0.2235,
+              "mean_diff_ci_upper": 0.2235,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 84,
-          "small_medium_n": 289,
+          "large_n": 85,
+          "small_medium_n": 291,
           "constructs": {
             "barriers": {
-              "t": 1.7499,
+              "t": 1.7512,
               "p": 0.0,
-              "df": 135.77,
-              "mean_diff_ci_lower": 0.1661,
-              "mean_diff_ci_upper": 0.1661,
+              "df": 138.05,
+              "mean_diff_ci_lower": 0.1651,
+              "mean_diff_ci_upper": 0.1651,
               "sig": true
             },
             "readiness": {
-              "t": 0.205,
+              "t": 0.2712,
               "p": 0.0,
-              "df": 129.69,
-              "mean_diff_ci_lower": 0.0187,
-              "mean_diff_ci_upper": 0.0187,
+              "df": 131.43,
+              "mean_diff_ci_lower": 0.0245,
+              "mean_diff_ci_upper": 0.0245,
               "sig": true
             },
             "maturity": {
-              "t": 1.2018,
+              "t": 1.3546,
               "p": 0.0,
-              "df": 129.05,
-              "mean_diff_ci_lower": 0.1239,
-              "mean_diff_ci_upper": 0.1239,
+              "df": 130.14,
+              "mean_diff_ci_lower": 0.1393,
+              "mean_diff_ci_upper": 0.1393,
               "sig": true
             }
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [93, 228, 52],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [103, 273],
           "constructs": {
             "barriers": {
-              "f": 0.5317,
-              "p": 0.5881,
-              "df_between": 2,
-              "df_within": 370,
-              "sig": false
+              "f": 0.8803,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 374,
+              "sig": true
             },
             "readiness": {
-              "f": 7.4313,
-              "p": 0.0007,
-              "df_between": 2,
-              "df_within": 369,
+              "f": 12.913,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 373,
               "sig": true
             },
             "maturity": {
-              "f": 2.4953,
-              "p": 0.0839,
-              "df_between": 2,
-              "df_within": 369,
-              "sig": false
+              "f": 5.8335,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 373,
+              "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [159, 130, 84],
+          "group_ns": [160, 131, 85],
           "constructs": {
             "barriers": {
-              "f": 1.7025,
-              "p": 0.1837,
+              "f": 1.6897,
+              "p": 0.186,
               "df_between": 2,
-              "df_within": 370,
+              "df_within": 373,
               "sig": false
             },
             "readiness": {
-              "f": 1.7613,
-              "p": 0.1733,
+              "f": 1.7248,
+              "p": 0.1796,
               "df_between": 2,
-              "df_within": 369,
+              "df_within": 372,
               "sig": false
             },
             "maturity": {
-              "f": 3.0407,
-              "p": 0.049,
+              "f": 3.1367,
+              "p": 0.0446,
               "df_between": 2,
-              "df_within": 369,
+              "df_within": 372,
               "sig": true
             }
           }
@@ -1409,111 +1362,107 @@
     "v2_all": {
       "demographics": {
         "roles": {
-          "Other": 70,
-          "Unknown": 64,
+          "Other": 73,
           "CIO": 59,
+          "Unknown": 59,
           "CEO": 38,
           "COO": 36,
+          "CTO": 35,
           "CFO": 34,
-          "CTO": 34,
           "CSO": 33,
           "CMO": 25,
           "CHRO": 25,
-          "CRO": 23
+          "CRO": 23,
+          "CISO": 5
         },
         "org_sizes": {
           "<100": 58,
-          "100-499": 105,
+          "100-499": 107,
           "500-999": 59,
-          "1000-4999": 74,
+          "1000-4999": 75,
           "5000-9999": 32,
-          "10000+": 54
+          "10000+": 55
         },
         "profit_models": {
-          "For-Profit": 289,
-          "Non-Profit": 63,
+          "For-Profit": 292,
+          "Non-Profit": 64,
           "Government/Public Sector": 30
         },
         "tech_vs_nontech": {
-          "technical": 94,
-          "non_technical": 234,
-          "other": 113
+          "technical": 104,
+          "non_technical": 282,
+          "other": 59
         },
         "other_roles": {
-          "total": 70,
-          "categories": {
-            "Director": 28,
-            "Uncategorized": 12,
-            "Manager / Program Lead": 7,
-            "C-Suite Adjacent": "<5"
-          }
+          "total": 73,
+          "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 94,
-          "nontech_n": 234,
+          "tech_n": 104,
+          "nontech_n": 282,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6789,
-              "tech_mean_ci_lower": 2.6789,
-              "tech_mean_ci_upper": 2.6789,
-              "nontech_mean": 2.7735,
-              "nontech_mean_ci_lower": 2.7735,
-              "nontech_mean_ci_upper": 2.7735,
-              "d": -0.1196,
-              "d_ci_lower": -0.3696,
-              "d_ci_upper": 0.1322
+              "tech_mean": 2.6825,
+              "tech_mean_ci_lower": 2.6825,
+              "tech_mean_ci_upper": 2.6825,
+              "nontech_mean": 2.7734,
+              "nontech_mean_ci_lower": 2.7734,
+              "nontech_mean_ci_upper": 2.7734,
+              "d": -0.1173,
+              "d_ci_lower": -0.3498,
+              "d_ci_upper": 0.112
             },
             "readiness": {
-              "tech_mean": 3.4641,
-              "tech_mean_ci_lower": 3.4641,
-              "tech_mean_ci_upper": 3.4641,
-              "nontech_mean": 3.2144,
-              "nontech_mean_ci_lower": 3.2144,
-              "nontech_mean_ci_upper": 3.2144,
-              "d": 0.3539,
-              "d_ci_lower": 0.1159,
-              "d_ci_upper": 0.5979
+              "tech_mean": 3.463,
+              "tech_mean_ci_lower": 3.463,
+              "tech_mean_ci_upper": 3.463,
+              "nontech_mean": 3.1721,
+              "nontech_mean_ci_lower": 3.1721,
+              "nontech_mean_ci_upper": 3.1721,
+              "d": 0.4158,
+              "d_ci_lower": 0.1906,
+              "d_ci_upper": 0.6513
             },
             "maturity": {
-              "tech_mean": 3.4117,
-              "tech_mean_ci_lower": 3.4117,
-              "tech_mean_ci_upper": 3.4117,
-              "nontech_mean": 3.2491,
-              "nontech_mean_ci_lower": 3.2491,
-              "nontech_mean_ci_upper": 3.2491,
-              "d": 0.2027,
-              "d_ci_lower": -0.0383,
-              "d_ci_upper": 0.4464
+              "tech_mean": 3.4348,
+              "tech_mean_ci_lower": 3.4348,
+              "tech_mean_ci_upper": 3.4348,
+              "nontech_mean": 3.2113,
+              "nontech_mean_ci_lower": 3.2113,
+              "nontech_mean_ci_upper": 3.2113,
+              "d": 0.2794,
+              "d_ci_lower": 0.0675,
+              "d_ci_upper": 0.5074
             }
           }
         },
         "large_vs_small": {
-          "large_n": 86,
-          "small_medium_n": 355,
+          "large_n": 87,
+          "small_medium_n": 358,
           "constructs": {
             "barriers": {
-              "large_mean": 2.888,
-              "large_mean_ci_lower": 2.888,
-              "large_mean_ci_upper": 2.888,
-              "small_medium_mean": 2.7161,
-              "small_medium_mean_ci_lower": 2.7161,
-              "small_medium_mean_ci_upper": 2.7161,
-              "d": 0.2226,
-              "d_ci_lower": -0.0143,
-              "d_ci_upper": 0.4654
+              "large_mean": 2.8809,
+              "large_mean_ci_lower": 2.8809,
+              "large_mean_ci_upper": 2.8809,
+              "small_medium_mean": 2.7101,
+              "small_medium_mean_ci_lower": 2.7101,
+              "small_medium_mean_ci_upper": 2.7101,
+              "d": 0.2212,
+              "d_ci_lower": -0.0175,
+              "d_ci_upper": 0.459
             },
             "readiness": {
-              "large_mean": 3.2641,
-              "large_mean_ci_lower": 3.2641,
-              "large_mean_ci_upper": 3.2641,
-              "small_medium_mean": 3.2455,
-              "small_medium_mean_ci_lower": 3.2455,
-              "small_medium_mean_ci_upper": 3.2455,
-              "d": 0.0261,
-              "d_ci_lower": -0.2367,
-              "d_ci_upper": 0.2704
+              "large_mean": 3.2707,
+              "large_mean_ci_lower": 3.2707,
+              "large_mean_ci_upper": 3.2707,
+              "small_medium_mean": 3.2462,
+              "small_medium_mean_ci_lower": 3.2462,
+              "small_medium_mean_ci_upper": 3.2462,
+              "d": 0.0344,
+              "d_ci_lower": -0.216,
+              "d_ci_upper": 0.2796
             }
           }
         }
@@ -1522,161 +1471,161 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 94,
-            "barrier_mean": 2.6789,
-            "readiness_mean": 3.4641,
-            "maturity_mean": 3.4117
+            "n": 104,
+            "barrier_mean": 2.6825,
+            "readiness_mean": 3.463,
+            "maturity_mean": 3.4348
           },
           {
             "group": "Non-Technical",
-            "n": 234,
-            "barrier_mean": 2.7735,
-            "readiness_mean": 3.2144,
-            "maturity_mean": 3.2491
+            "n": 282,
+            "barrier_mean": 2.7734,
+            "readiness_mean": 3.1721,
+            "maturity_mean": 3.2113
           },
           {
-            "group": "Other",
-            "n": 113,
-            "barrier_mean": 2.807,
-            "readiness_mean": 3.0172,
-            "maturity_mean": 3.1139
+            "group": "Unclassified",
+            "n": 59,
+            "barrier_mean": null,
+            "readiness_mean": null,
+            "maturity_mean": null
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 163,
-            "barrier_mean": 2.7006,
-            "readiness_mean": 3.1755,
-            "maturity_mean": 3.1529
+            "n": 165,
+            "barrier_mean": 2.6952,
+            "readiness_mean": 3.1777,
+            "maturity_mean": 3.1535
           },
           {
             "group": "Medium (500-4999)",
-            "n": 133,
-            "barrier_mean": 2.7352,
-            "readiness_mean": 3.3323,
-            "maturity_mean": 3.3547
+            "n": 134,
+            "barrier_mean": 2.7284,
+            "readiness_mean": 3.3311,
+            "maturity_mean": 3.349
           },
           {
             "group": "Large (5000+)",
-            "n": 86,
-            "barrier_mean": 2.888,
-            "readiness_mean": 3.2641,
-            "maturity_mean": 3.3671
+            "n": 87,
+            "barrier_mean": 2.8809,
+            "readiness_mean": 3.2707,
+            "maturity_mean": 3.3804
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 94,
-          "nontech_n": 234,
+          "tech_n": 104,
+          "nontech_n": 282,
           "constructs": {
             "barriers": {
-              "t": -0.9611,
+              "t": -1.0024,
               "p": 0.0,
-              "df": 165.47,
-              "mean_diff_ci_lower": -0.0946,
-              "mean_diff_ci_upper": -0.0946,
+              "df": 177.89,
+              "mean_diff_ci_lower": -0.0909,
+              "mean_diff_ci_upper": -0.0909,
               "sig": true
             },
             "readiness": {
-              "t": 2.8921,
+              "t": 3.5888,
               "p": 0.0,
-              "df": 172.36,
-              "mean_diff_ci_lower": 0.2497,
-              "mean_diff_ci_upper": 0.2497,
+              "df": 182.99,
+              "mean_diff_ci_lower": 0.2909,
+              "mean_diff_ci_upper": 0.2909,
               "sig": true
             },
             "maturity": {
-              "t": 1.6781,
+              "t": 2.4728,
               "p": 0.0,
-              "df": 177.84,
-              "mean_diff_ci_lower": 0.1626,
-              "mean_diff_ci_upper": 0.1626,
+              "df": 192.93,
+              "mean_diff_ci_lower": 0.2235,
+              "mean_diff_ci_upper": 0.2235,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 86,
-          "small_medium_n": 355,
+          "large_n": 87,
+          "small_medium_n": 358,
           "constructs": {
             "barriers": {
-              "t": 1.8178,
+              "t": 1.8185,
               "p": 0.0,
-              "df": 137.96,
-              "mean_diff_ci_lower": 0.1719,
-              "mean_diff_ci_upper": 0.1719,
+              "df": 140.23,
+              "mean_diff_ci_lower": 0.1708,
+              "mean_diff_ci_upper": 0.1708,
               "sig": true
             },
             "readiness": {
-              "t": 0.2043,
+              "t": 0.2706,
               "p": 0.0,
-              "df": 129.36,
-              "mean_diff_ci_lower": 0.0186,
-              "mean_diff_ci_upper": 0.0186,
+              "df": 131.1,
+              "mean_diff_ci_lower": 0.0245,
+              "mean_diff_ci_upper": 0.0245,
               "sig": true
             },
             "maturity": {
-              "t": 1.2018,
+              "t": 1.3546,
               "p": 0.0,
-              "df": 129.05,
-              "mean_diff_ci_lower": 0.1239,
-              "mean_diff_ci_upper": 0.1239,
+              "df": 130.14,
+              "mean_diff_ci_lower": 0.1393,
+              "mean_diff_ci_upper": 0.1393,
               "sig": true
             }
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Other"],
-          "group_ns": [94, 234, 113],
+          "groups": ["Technical", "Non-Technical", "Unclassified"],
+          "group_ns": [104, 282, 59],
           "constructs": {
             "barriers": {
-              "f": 0.633,
-              "p": 0.5316,
-              "df_between": 2,
-              "df_within": 374,
-              "sig": false
+              "f": 1.0328,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 378,
+              "sig": true
             },
             "readiness": {
-              "f": 7.4488,
-              "p": 0.0007,
-              "df_between": 2,
-              "df_within": 370,
+              "f": 12.9291,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 374,
               "sig": true
             },
             "maturity": {
-              "f": 2.4953,
-              "p": 0.0839,
-              "df_between": 2,
-              "df_within": 369,
-              "sig": false
+              "f": 5.8335,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 373,
+              "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [163, 133, 86],
+          "group_ns": [165, 134, 87],
           "constructs": {
             "barriers": {
-              "f": 1.7002,
-              "p": 0.1841,
+              "f": 1.6902,
+              "p": 0.1859,
               "df_between": 2,
-              "df_within": 374,
+              "df_within": 377,
               "sig": false
             },
             "readiness": {
-              "f": 1.758,
-              "p": 0.1738,
+              "f": 1.7217,
+              "p": 0.1802,
               "df_between": 2,
-              "df_within": 370,
+              "df_within": 373,
               "sig": false
             },
             "maturity": {
-              "f": 3.0407,
-              "p": 0.049,
+              "f": 3.1367,
+              "p": 0.0446,
               "df_between": 2,
-              "df_within": 369,
+              "df_within": 372,
               "sig": true
             }
           }
@@ -1687,22 +1636,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 1.86,
-      "p_value": 0.9318,
-      "df": 6,
+      "chi2": 1.0,
+      "p_value": 0.8017,
+      "df": 3,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 7.49,
-      "p_value": 0.9426,
+      "chi2": 7.43,
+      "p_value": 0.9445,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 2.99,
-      "p_value": 0.8098,
+      "chi2": 3.15,
+      "p_value": 0.7904,
       "df": 6,
       "error": null
     },
@@ -1725,7 +1674,7 @@
           "Government/Public Sector": 19
         },
         "All V2 Finished": {
-          "For-Profit": 281,
+          "For-Profit": 284,
           "Non-Profit": 62,
           "Government/Public Sector": 30
         }
@@ -1769,5 +1718,5 @@
       "examples": ""
     }
   ],
-  "last_updated": "2026-04-11T10:43:56.832829Z"
+  "last_updated": "2026-04-11T23:54:22.845463Z"
 }


### PR DESCRIPTION
Automated update from the unified daily pipeline.

**Data flow**: Qualtrics export → Prolific enrichment →
disposition waterfall → analysis suite → CRP dataset (N=200) →
approve CLEAN → dashboard summary.

All statistics computed across 5 sample definitions.
CRP dataset: N=200 tiered selection + NIST de-identification.