### PR TITLE
Update daily pipeline data

### DIFF
--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -345,33 +345,33 @@
           "constructs": {
             "barriers": {
               "tech_mean": 2.7438,
-              "tech_mean_ci_lower": 2.7438,
-              "tech_mean_ci_upper": 2.7438,
+              "tech_mean_ci_lower": 2.4094,
+              "tech_mean_ci_upper": 3.0782,
               "nontech_mean": 2.8346,
-              "nontech_mean_ci_lower": 2.8346,
-              "nontech_mean_ci_upper": 2.8346,
+              "nontech_mean_ci_lower": 2.6752,
+              "nontech_mean_ci_upper": 2.994,
               "d": -0.1432,
               "d_ci_lower": -0.7119,
               "d_ci_upper": 0.4117
             },
             "readiness": {
               "tech_mean": 3.2185,
-              "tech_mean_ci_lower": 3.2185,
-              "tech_mean_ci_upper": 3.2185,
+              "tech_mean_ci_lower": 2.9332,
+              "tech_mean_ci_upper": 3.5039,
               "nontech_mean": 2.9981,
-              "nontech_mean_ci_lower": 2.9981,
-              "nontech_mean_ci_upper": 2.9981,
+              "nontech_mean_ci_lower": 2.8494,
+              "nontech_mean_ci_upper": 3.1468,
               "d": 0.3807,
               "d_ci_lower": -0.1246,
               "d_ci_upper": 0.898
             },
             "maturity": {
               "tech_mean": 3.1389,
-              "tech_mean_ci_lower": 3.1389,
-              "tech_mean_ci_upper": 3.1389,
+              "tech_mean_ci_lower": 2.7648,
+              "tech_mean_ci_upper": 3.513,
               "nontech_mean": 3.0003,
-              "nontech_mean_ci_lower": 3.0003,
-              "nontech_mean_ci_upper": 3.0003,
+              "nontech_mean_ci_lower": 2.8213,
+              "nontech_mean_ci_upper": 3.1792,
               "d": 0.195,
               "d_ci_lower": -0.3684,
               "d_ci_upper": 0.7406
@@ -384,22 +384,22 @@
           "constructs": {
             "barriers": {
               "large_mean": 3.0919,
-              "large_mean_ci_lower": 3.0919,
-              "large_mean_ci_upper": 3.0919,
+              "large_mean_ci_lower": 2.8049,
+              "large_mean_ci_upper": 3.3789,
               "small_medium_mean": 2.7377,
-              "small_medium_mean_ci_lower": 2.7377,
-              "small_medium_mean_ci_upper": 2.7377,
+              "small_medium_mean_ci_lower": 2.5771,
+              "small_medium_mean_ci_upper": 2.8982,
               "d": 0.5736,
               "d_ci_lower": 0.0948,
               "d_ci_upper": 1.0824
             },
             "readiness": {
               "large_mean": 3.0222,
-              "large_mean_ci_lower": 3.0222,
-              "large_mean_ci_upper": 3.0222,
+              "large_mean_ci_lower": 2.7046,
+              "large_mean_ci_upper": 3.3398,
               "small_medium_mean": 3.0555,
-              "small_medium_mean_ci_lower": 3.0555,
-              "small_medium_mean_ci_upper": 3.0555,
+              "small_medium_mean_ci_lower": 2.9087,
+              "small_medium_mean_ci_upper": 3.2023,
               "d": -0.0568,
               "d_ci_lower": -0.5973,
               "d_ci_upper": 0.5216
@@ -455,27 +455,27 @@
           "constructs": {
             "barriers": {
               "t": -0.5115,
-              "p": 0.0,
+              "p": 0.6133,
               "df": 26.21,
-              "mean_diff_ci_lower": -0.0907,
-              "mean_diff_ci_upper": -0.0907,
-              "sig": true
+              "mean_diff_ci_lower": -0.4553,
+              "mean_diff_ci_upper": 0.2738,
+              "sig": false
             },
             "readiness": {
               "t": 1.4287,
-              "p": 0.0,
+              "p": 0.1641,
               "df": 28.1,
-              "mean_diff_ci_lower": 0.2205,
-              "mean_diff_ci_upper": 0.2205,
-              "sig": true
+              "mean_diff_ci_lower": -0.0956,
+              "mean_diff_ci_upper": 0.5365,
+              "sig": false
             },
             "maturity": {
               "t": 0.698,
-              "p": 0.0,
+              "p": 0.4913,
               "df": 26.27,
-              "mean_diff_ci_lower": 0.1386,
-              "mean_diff_ci_upper": 0.1386,
-              "sig": true
+              "mean_diff_ci_lower": -0.2694,
+              "mean_diff_ci_upper": 0.5467,
+              "sig": false
             }
           }
         },
@@ -485,27 +485,27 @@
           "constructs": {
             "barriers": {
               "t": 2.2504,
-              "p": 0.0,
+              "p": 0.0324,
               "df": 28.32,
-              "mean_diff_ci_lower": 0.3542,
-              "mean_diff_ci_upper": 0.3542,
+              "mean_diff_ci_lower": 0.032,
+              "mean_diff_ci_upper": 0.6765,
               "sig": true
             },
             "readiness": {
               "t": -0.1996,
-              "p": 0.0,
+              "p": 0.8435,
               "df": 24.24,
-              "mean_diff_ci_lower": -0.0333,
-              "mean_diff_ci_upper": -0.0333,
-              "sig": true
+              "mean_diff_ci_lower": -0.3775,
+              "mean_diff_ci_upper": 0.3109,
+              "sig": false
             },
             "maturity": {
               "t": 1.6095,
-              "p": 0.0,
+              "p": 0.1214,
               "df": 22.52,
-              "mean_diff_ci_lower": 0.3412,
-              "mean_diff_ci_upper": 0.3412,
-              "sig": true
+              "mean_diff_ci_lower": -0.0979,
+              "mean_diff_ci_upper": 0.7802,
+              "sig": false
             }
           }
         },
@@ -515,24 +515,24 @@
           "constructs": {
             "barriers": {
               "f": 0.2849,
-              "p": 0.0,
+              "p": 0.595,
               "df_between": 1,
               "df_within": 77,
-              "sig": true
+              "sig": false
             },
             "readiness": {
               "f": 2.0142,
-              "p": 0.0,
+              "p": 0.1599,
               "df_between": 1,
               "df_within": 77,
-              "sig": true
+              "sig": false
             },
             "maturity": {
               "f": 0.5287,
-              "p": 0.0,
+              "p": 0.4694,
               "df_between": 1,
               "df_within": 77,
-              "sig": true
+              "sig": false
             }
           }
         },
@@ -609,33 +609,33 @@
           "constructs": {
             "barriers": {
               "tech_mean": 2.6667,
-              "tech_mean_ci_lower": 2.6667,
-              "tech_mean_ci_upper": 2.6667,
+              "tech_mean_ci_lower": 2.419,
+              "tech_mean_ci_upper": 2.9143,
               "nontech_mean": 2.8357,
-              "nontech_mean_ci_lower": 2.8357,
-              "nontech_mean_ci_upper": 2.8357,
+              "nontech_mean_ci_lower": 2.6949,
+              "nontech_mean_ci_upper": 2.9766,
               "d": -0.2564,
               "d_ci_lower": -0.6691,
               "d_ci_upper": 0.1555
             },
             "readiness": {
               "tech_mean": 3.3488,
-              "tech_mean_ci_lower": 3.3488,
-              "tech_mean_ci_upper": 3.3488,
+              "tech_mean_ci_lower": 3.1358,
+              "tech_mean_ci_upper": 3.5618,
               "nontech_mean": 2.9727,
-              "nontech_mean_ci_lower": 2.9727,
-              "nontech_mean_ci_upper": 2.9727,
+              "nontech_mean_ci_lower": 2.8408,
+              "nontech_mean_ci_upper": 3.1047,
               "d": 0.6233,
               "d_ci_lower": 0.2268,
               "d_ci_upper": 1.051
             },
             "maturity": {
               "tech_mean": 3.2734,
-              "tech_mean_ci_lower": 3.2734,
-              "tech_mean_ci_upper": 3.2734,
+              "tech_mean_ci_lower": 3.0148,
+              "tech_mean_ci_upper": 3.5321,
               "nontech_mean": 2.9808,
-              "nontech_mean_ci_lower": 2.9808,
-              "nontech_mean_ci_upper": 2.9808,
+              "nontech_mean_ci_lower": 2.8179,
+              "nontech_mean_ci_upper": 3.1437,
               "d": 0.3945,
               "d_ci_lower": 0.0095,
               "d_ci_upper": 0.7967
@@ -648,22 +648,22 @@
           "constructs": {
             "barriers": {
               "large_mean": 3.215,
-              "large_mean_ci_lower": 3.215,
-              "large_mean_ci_upper": 3.215,
+              "large_mean_ci_lower": 2.9693,
+              "large_mean_ci_upper": 3.4607,
               "small_medium_mean": 2.6894,
-              "small_medium_mean_ci_lower": 2.6894,
-              "small_medium_mean_ci_upper": 2.6894,
+              "small_medium_mean_ci_lower": 2.557,
+              "small_medium_mean_ci_upper": 2.8218,
               "d": 0.8335,
               "d_ci_lower": 0.4138,
               "d_ci_upper": 1.2952
             },
             "readiness": {
               "large_mean": 2.8808,
-              "large_mean_ci_lower": 2.8808,
-              "large_mean_ci_upper": 2.8808,
+              "large_mean_ci_lower": 2.5795,
+              "large_mean_ci_upper": 3.182,
               "small_medium_mean": 3.1223,
-              "small_medium_mean_ci_lower": 3.1223,
-              "small_medium_mean_ci_upper": 3.1223,
+              "small_medium_mean_ci_lower": 2.9984,
+              "small_medium_mean_ci_upper": 3.2462,
               "d": -0.3899,
               "d_ci_lower": -0.8729,
               "d_ci_upper": 0.1109
@@ -719,27 +719,27 @@
           "constructs": {
             "barriers": {
               "t": -1.2027,
-              "p": 0.0,
+              "p": 0.2344,
               "df": 53.35,
-              "mean_diff_ci_lower": -0.1691,
-              "mean_diff_ci_upper": -0.1691,
-              "sig": true
+              "mean_diff_ci_lower": -0.451,
+              "mean_diff_ci_upper": 0.1128,
+              "sig": false
             },
             "readiness": {
               "t": 3.0399,
-              "p": 0.0,
+              "p": 0.0036,
               "df": 57.57,
-              "mean_diff_ci_lower": 0.3761,
-              "mean_diff_ci_upper": 0.3761,
+              "mean_diff_ci_lower": 0.1284,
+              "mean_diff_ci_upper": 0.6237,
               "sig": true
             },
             "maturity": {
               "t": 1.9383,
-              "p": 0.0,
+              "p": 0.0574,
               "df": 58.46,
-              "mean_diff_ci_lower": 0.2926,
-              "mean_diff_ci_upper": 0.2926,
-              "sig": true
+              "mean_diff_ci_lower": -0.0095,
+              "mean_diff_ci_upper": 0.5947,
+              "sig": false
             }
           }
         },
@@ -749,27 +749,27 @@
           "constructs": {
             "barriers": {
               "t": 3.8737,
-              "p": 0.0,
+              "p": 0.0004,
               "df": 35.69,
-              "mean_diff_ci_lower": 0.5255,
-              "mean_diff_ci_upper": 0.5255,
+              "mean_diff_ci_lower": 0.2503,
+              "mean_diff_ci_upper": 0.8008,
               "sig": true
             },
             "readiness": {
               "t": -1.5312,
-              "p": 0.0,
+              "p": 0.1365,
               "df": 29.29,
-              "mean_diff_ci_lower": -0.2415,
-              "mean_diff_ci_upper": -0.2415,
-              "sig": true
+              "mean_diff_ci_lower": -0.5639,
+              "mean_diff_ci_upper": 0.0809,
+              "sig": false
             },
             "maturity": {
               "t": -0.0031,
-              "p": 0.0,
+              "p": 0.9976,
               "df": 27.38,
-              "mean_diff_ci_lower": -0.0006,
-              "mean_diff_ci_upper": -0.0006,
-              "sig": true
+              "mean_diff_ci_lower": -0.4254,
+              "mean_diff_ci_upper": 0.4241,
+              "sig": false
             }
           }
         },
@@ -779,24 +779,24 @@
           "constructs": {
             "barriers": {
               "f": 1.523,
-              "p": 0.0,
+              "p": 0.2197,
               "df_between": 1,
               "df_within": 114,
-              "sig": true
+              "sig": false
             },
             "readiness": {
               "f": 9.0035,
-              "p": 0.0,
+              "p": 0.0033,
               "df_between": 1,
               "df_within": 114,
               "sig": true
             },
             "maturity": {
               "f": 3.606,
-              "p": 0.0,
+              "p": 0.0601,
               "df_between": 1,
               "df_within": 114,
-              "sig": true
+              "sig": false
             }
           }
         },
@@ -874,33 +874,33 @@
           "constructs": {
             "barriers": {
               "tech_mean": 2.7416,
-              "tech_mean_ci_lower": 2.7416,
-              "tech_mean_ci_upper": 2.7416,
+              "tech_mean_ci_lower": 2.5326,
+              "tech_mean_ci_upper": 2.9505,
               "nontech_mean": 2.7726,
-              "nontech_mean_ci_lower": 2.7726,
-              "nontech_mean_ci_upper": 2.7726,
+              "nontech_mean_ci_lower": 2.6641,
+              "nontech_mean_ci_upper": 2.881,
               "d": -0.0449,
               "d_ci_lower": -0.3768,
               "d_ci_upper": 0.2864
             },
             "readiness": {
               "tech_mean": 3.4247,
-              "tech_mean_ci_lower": 3.4247,
-              "tech_mean_ci_upper": 3.4247,
+              "tech_mean_ci_lower": 3.2548,
+              "tech_mean_ci_upper": 3.5946,
               "nontech_mean": 3.032,
-              "nontech_mean_ci_lower": 3.032,
-              "nontech_mean_ci_upper": 3.032,
+              "nontech_mean_ci_lower": 2.925,
+              "nontech_mean_ci_upper": 3.139,
               "d": 0.6079,
               "d_ci_lower": 0.3169,
               "d_ci_upper": 0.9382
             },
             "maturity": {
               "tech_mean": 3.3827,
-              "tech_mean_ci_lower": 3.3827,
-              "tech_mean_ci_upper": 3.3827,
+              "tech_mean_ci_lower": 3.1743,
+              "tech_mean_ci_upper": 3.5911,
               "nontech_mean": 3.0706,
-              "nontech_mean_ci_lower": 3.0706,
-              "nontech_mean_ci_upper": 3.0706,
+              "nontech_mean_ci_lower": 2.9431,
+              "nontech_mean_ci_upper": 3.198,
               "d": 0.4027,
               "d_ci_lower": 0.1,
               "d_ci_upper": 0.7482
@@ -913,22 +913,22 @@
           "constructs": {
             "barriers": {
               "large_mean": 2.963,
-              "large_mean_ci_lower": 2.963,
-              "large_mean_ci_upper": 2.963,
+              "large_mean_ci_lower": 2.7598,
+              "large_mean_ci_upper": 3.1663,
               "small_medium_mean": 2.7067,
-              "small_medium_mean_ci_lower": 2.7067,
-              "small_medium_mean_ci_upper": 2.7067,
+              "small_medium_mean_ci_lower": 2.5981,
+              "small_medium_mean_ci_upper": 2.8153,
               "d": 0.3756,
               "d_ci_lower": 0.025,
               "d_ci_upper": 0.737
             },
             "readiness": {
               "large_mean": 3.2082,
-              "large_mean_ci_lower": 3.2082,
-              "large_mean_ci_upper": 3.2082,
+              "large_mean_ci_lower": 2.9847,
+              "large_mean_ci_upper": 3.4317,
               "small_medium_mean": 3.1151,
-              "small_medium_mean_ci_lower": 3.1151,
-              "small_medium_mean_ci_upper": 3.1151,
+              "small_medium_mean_ci_lower": 3.0128,
+              "small_medium_mean_ci_upper": 3.2174,
               "d": 0.1394,
               "d_ci_lower": -0.2345,
               "d_ci_upper": 0.5116
@@ -984,26 +984,26 @@
           "constructs": {
             "barriers": {
               "t": -0.2635,
-              "p": 0.0,
+              "p": 0.7928,
               "df": 82.62,
-              "mean_diff_ci_lower": -0.031,
-              "mean_diff_ci_upper": -0.031,
-              "sig": true
+              "mean_diff_ci_lower": -0.2652,
+              "mean_diff_ci_upper": 0.2031,
+              "sig": false
             },
             "readiness": {
               "t": 3.9083,
-              "p": 0.0,
+              "p": 0.0002,
               "df": 97.4,
-              "mean_diff_ci_lower": 0.3927,
-              "mean_diff_ci_upper": 0.3927,
+              "mean_diff_ci_lower": 0.1933,
+              "mean_diff_ci_upper": 0.5922,
               "sig": true
             },
             "maturity": {
               "t": 2.5538,
-              "p": 0.0,
+              "p": 0.0123,
               "df": 94.82,
-              "mean_diff_ci_lower": 0.3122,
-              "mean_diff_ci_upper": 0.3122,
+              "mean_diff_ci_lower": 0.0695,
+              "mean_diff_ci_upper": 0.5549,
               "sig": true
             }
           }
@@ -1014,27 +1014,27 @@
           "constructs": {
             "barriers": {
               "t": 2.232,
-              "p": 0.0,
+              "p": 0.0287,
               "df": 72.2,
-              "mean_diff_ci_lower": 0.2564,
-              "mean_diff_ci_upper": 0.2564,
+              "mean_diff_ci_lower": 0.0274,
+              "mean_diff_ci_upper": 0.4854,
               "sig": true
             },
             "readiness": {
               "t": 0.7606,
-              "p": 0.0,
+              "p": 0.4497,
               "df": 64.39,
-              "mean_diff_ci_lower": 0.0931,
-              "mean_diff_ci_upper": 0.0931,
-              "sig": true
+              "mean_diff_ci_lower": -0.1514,
+              "mean_diff_ci_upper": 0.3376,
+              "sig": false
             },
             "maturity": {
               "t": 1.8682,
-              "p": 0.0,
+              "p": 0.0662,
               "df": 66.2,
-              "mean_diff_ci_lower": 0.2611,
-              "mean_diff_ci_upper": 0.2611,
-              "sig": true
+              "mean_diff_ci_lower": -0.0179,
+              "mean_diff_ci_upper": 0.5401,
+              "sig": false
             }
           }
         },
@@ -1044,21 +1044,21 @@
           "constructs": {
             "barriers": {
               "f": 0.0785,
-              "p": 0.0,
+              "p": 0.7796,
               "df_between": 1,
               "df_within": 198,
-              "sig": true
+              "sig": false
             },
             "readiness": {
               "f": 14.3964,
-              "p": 0.0,
+              "p": 0.0002,
               "df_between": 1,
               "df_within": 198,
               "sig": true
             },
             "maturity": {
               "f": 6.3177,
-              "p": 0.0,
+              "p": 0.0128,
               "df_between": 1,
               "df_within": 198,
               "sig": true
@@ -1139,33 +1139,33 @@
           "constructs": {
             "barriers": {
               "tech_mean": 2.7416,
-              "tech_mean_ci_lower": 2.7416,
-              "tech_mean_ci_upper": 2.7416,
+              "tech_mean_ci_lower": 2.5326,
+              "tech_mean_ci_upper": 2.9505,
               "nontech_mean": 2.7726,
-              "nontech_mean_ci_lower": 2.7726,
-              "nontech_mean_ci_upper": 2.7726,
+              "nontech_mean_ci_lower": 2.6641,
+              "nontech_mean_ci_upper": 2.881,
               "d": -0.0449,
               "d_ci_lower": -0.3768,
               "d_ci_upper": 0.2864
             },
             "readiness": {
               "tech_mean": 3.4247,
-              "tech_mean_ci_lower": 3.4247,
-              "tech_mean_ci_upper": 3.4247,
+              "tech_mean_ci_lower": 3.2548,
+              "tech_mean_ci_upper": 3.5946,
               "nontech_mean": 3.032,
-              "nontech_mean_ci_lower": 3.032,
-              "nontech_mean_ci_upper": 3.032,
+              "nontech_mean_ci_lower": 2.925,
+              "nontech_mean_ci_upper": 3.139,
               "d": 0.6079,
               "d_ci_lower": 0.3169,
               "d_ci_upper": 0.9382
             },
             "maturity": {
               "tech_mean": 3.3827,
-              "tech_mean_ci_lower": 3.3827,
-              "tech_mean_ci_upper": 3.3827,
+              "tech_mean_ci_lower": 3.1743,
+              "tech_mean_ci_upper": 3.5911,
               "nontech_mean": 3.0706,
-              "nontech_mean_ci_lower": 3.0706,
-              "nontech_mean_ci_upper": 3.0706,
+              "nontech_mean_ci_lower": 2.9431,
+              "nontech_mean_ci_upper": 3.198,
               "d": 0.4027,
               "d_ci_lower": 0.1,
               "d_ci_upper": 0.7482
@@ -1178,22 +1178,22 @@
           "constructs": {
             "barriers": {
               "large_mean": 2.963,
-              "large_mean_ci_lower": 2.963,
-              "large_mean_ci_upper": 2.963,
+              "large_mean_ci_lower": 2.7598,
+              "large_mean_ci_upper": 3.1663,
               "small_medium_mean": 2.7067,
-              "small_medium_mean_ci_lower": 2.7067,
-              "small_medium_mean_ci_upper": 2.7067,
+              "small_medium_mean_ci_lower": 2.5981,
+              "small_medium_mean_ci_upper": 2.8153,
               "d": 0.3756,
               "d_ci_lower": 0.025,
               "d_ci_upper": 0.737
             },
             "readiness": {
               "large_mean": 3.2082,
-              "large_mean_ci_lower": 3.2082,
-              "large_mean_ci_upper": 3.2082,
+              "large_mean_ci_lower": 2.9847,
+              "large_mean_ci_upper": 3.4317,
               "small_medium_mean": 3.1151,
-              "small_medium_mean_ci_lower": 3.1151,
-              "small_medium_mean_ci_upper": 3.1151,
+              "small_medium_mean_ci_lower": 3.0128,
+              "small_medium_mean_ci_upper": 3.2174,
               "d": 0.1394,
               "d_ci_lower": -0.2345,
               "d_ci_upper": 0.5116
@@ -1249,26 +1249,26 @@
           "constructs": {
             "barriers": {
               "t": -0.2635,
-              "p": 0.0,
+              "p": 0.7928,
               "df": 82.62,
-              "mean_diff_ci_lower": -0.031,
-              "mean_diff_ci_upper": -0.031,
-              "sig": true
+              "mean_diff_ci_lower": -0.2652,
+              "mean_diff_ci_upper": 0.2031,
+              "sig": false
             },
             "readiness": {
               "t": 3.9083,
-              "p": 0.0,
+              "p": 0.0002,
               "df": 97.4,
-              "mean_diff_ci_lower": 0.3927,
-              "mean_diff_ci_upper": 0.3927,
+              "mean_diff_ci_lower": 0.1933,
+              "mean_diff_ci_upper": 0.5922,
               "sig": true
             },
             "maturity": {
               "t": 2.5538,
-              "p": 0.0,
+              "p": 0.0123,
               "df": 94.82,
-              "mean_diff_ci_lower": 0.3122,
-              "mean_diff_ci_upper": 0.3122,
+              "mean_diff_ci_lower": 0.0695,
+              "mean_diff_ci_upper": 0.5549,
               "sig": true
             }
           }
@@ -1279,27 +1279,27 @@
           "constructs": {
             "barriers": {
               "t": 2.232,
-              "p": 0.0,
+              "p": 0.0287,
               "df": 72.2,
-              "mean_diff_ci_lower": 0.2564,
-              "mean_diff_ci_upper": 0.2564,
+              "mean_diff_ci_lower": 0.0274,
+              "mean_diff_ci_upper": 0.4854,
               "sig": true
             },
             "readiness": {
               "t": 0.7606,
-              "p": 0.0,
+              "p": 0.4497,
               "df": 64.39,
-              "mean_diff_ci_lower": 0.0931,
-              "mean_diff_ci_upper": 0.0931,
-              "sig": true
+              "mean_diff_ci_lower": -0.1514,
+              "mean_diff_ci_upper": 0.3376,
+              "sig": false
             },
             "maturity": {
               "t": 1.8682,
-              "p": 0.0,
+              "p": 0.0662,
               "df": 66.2,
-              "mean_diff_ci_lower": 0.2611,
-              "mean_diff_ci_upper": 0.2611,
-              "sig": true
+              "mean_diff_ci_lower": -0.0179,
+              "mean_diff_ci_upper": 0.5401,
+              "sig": false
             }
           }
         },
@@ -1309,21 +1309,21 @@
           "constructs": {
             "barriers": {
               "f": 0.0785,
-              "p": 0.0,
+              "p": 0.7796,
               "df_between": 1,
               "df_within": 198,
-              "sig": true
+              "sig": false
             },
             "readiness": {
               "f": 14.3964,
-              "p": 0.0,
+              "p": 0.0002,
               "df_between": 1,
               "df_within": 198,
               "sig": true
             },
             "maturity": {
               "f": 6.3177,
-              "p": 0.0,
+              "p": 0.0128,
               "df_between": 1,
               "df_within": 198,
               "sig": true
@@ -1404,33 +1404,33 @@
           "constructs": {
             "barriers": {
               "tech_mean": 2.7416,
-              "tech_mean_ci_lower": 2.7416,
-              "tech_mean_ci_upper": 2.7416,
+              "tech_mean_ci_lower": 2.5326,
+              "tech_mean_ci_upper": 2.9505,
               "nontech_mean": 2.7726,
-              "nontech_mean_ci_lower": 2.7726,
-              "nontech_mean_ci_upper": 2.7726,
+              "nontech_mean_ci_lower": 2.6641,
+              "nontech_mean_ci_upper": 2.881,
               "d": -0.0449,
               "d_ci_lower": -0.3768,
               "d_ci_upper": 0.2864
             },
             "readiness": {
               "tech_mean": 3.4247,
-              "tech_mean_ci_lower": 3.4247,
-              "tech_mean_ci_upper": 3.4247,
+              "tech_mean_ci_lower": 3.2548,
+              "tech_mean_ci_upper": 3.5946,
               "nontech_mean": 3.032,
-              "nontech_mean_ci_lower": 3.032,
-              "nontech_mean_ci_upper": 3.032,
+              "nontech_mean_ci_lower": 2.925,
+              "nontech_mean_ci_upper": 3.139,
               "d": 0.6079,
               "d_ci_lower": 0.3169,
               "d_ci_upper": 0.9382
             },
             "maturity": {
               "tech_mean": 3.3827,
-              "tech_mean_ci_lower": 3.3827,
-              "tech_mean_ci_upper": 3.3827,
+              "tech_mean_ci_lower": 3.1743,
+              "tech_mean_ci_upper": 3.5911,
               "nontech_mean": 3.0706,
-              "nontech_mean_ci_lower": 3.0706,
-              "nontech_mean_ci_upper": 3.0706,
+              "nontech_mean_ci_lower": 2.9431,
+              "nontech_mean_ci_upper": 3.198,
               "d": 0.4027,
               "d_ci_lower": 0.1,
               "d_ci_upper": 0.7482
@@ -1443,22 +1443,22 @@
           "constructs": {
             "barriers": {
               "large_mean": 2.963,
-              "large_mean_ci_lower": 2.963,
-              "large_mean_ci_upper": 2.963,
+              "large_mean_ci_lower": 2.7598,
+              "large_mean_ci_upper": 3.1663,
               "small_medium_mean": 2.7067,
-              "small_medium_mean_ci_lower": 2.7067,
-              "small_medium_mean_ci_upper": 2.7067,
+              "small_medium_mean_ci_lower": 2.5981,
+              "small_medium_mean_ci_upper": 2.8153,
               "d": 0.3756,
               "d_ci_lower": 0.025,
               "d_ci_upper": 0.737
             },
             "readiness": {
               "large_mean": 3.2082,
-              "large_mean_ci_lower": 3.2082,
-              "large_mean_ci_upper": 3.2082,
+              "large_mean_ci_lower": 2.9847,
+              "large_mean_ci_upper": 3.4317,
               "small_medium_mean": 3.1151,
-              "small_medium_mean_ci_lower": 3.1151,
-              "small_medium_mean_ci_upper": 3.1151,
+              "small_medium_mean_ci_lower": 3.0128,
+              "small_medium_mean_ci_upper": 3.2174,
               "d": 0.1394,
               "d_ci_lower": -0.2345,
               "d_ci_upper": 0.5116
@@ -1514,26 +1514,26 @@
           "constructs": {
             "barriers": {
               "t": -0.2635,
-              "p": 0.0,
+              "p": 0.7928,
               "df": 82.62,
-              "mean_diff_ci_lower": -0.031,
-              "mean_diff_ci_upper": -0.031,
-              "sig": true
+              "mean_diff_ci_lower": -0.2652,
+              "mean_diff_ci_upper": 0.2031,
+              "sig": false
             },
             "readiness": {
               "t": 3.9083,
-              "p": 0.0,
+              "p": 0.0002,
               "df": 97.4,
-              "mean_diff_ci_lower": 0.3927,
-              "mean_diff_ci_upper": 0.3927,
+              "mean_diff_ci_lower": 0.1933,
+              "mean_diff_ci_upper": 0.5922,
               "sig": true
             },
             "maturity": {
               "t": 2.5538,
-              "p": 0.0,
+              "p": 0.0123,
               "df": 94.82,
-              "mean_diff_ci_lower": 0.3122,
-              "mean_diff_ci_upper": 0.3122,
+              "mean_diff_ci_lower": 0.0695,
+              "mean_diff_ci_upper": 0.5549,
               "sig": true
             }
           }
@@ -1544,27 +1544,27 @@
           "constructs": {
             "barriers": {
               "t": 2.232,
-              "p": 0.0,
+              "p": 0.0287,
               "df": 72.2,
-              "mean_diff_ci_lower": 0.2564,
-              "mean_diff_ci_upper": 0.2564,
+              "mean_diff_ci_lower": 0.0274,
+              "mean_diff_ci_upper": 0.4854,
               "sig": true
             },
             "readiness": {
               "t": 0.7606,
-              "p": 0.0,
+              "p": 0.4497,
               "df": 64.39,
-              "mean_diff_ci_lower": 0.0931,
-              "mean_diff_ci_upper": 0.0931,
-              "sig": true
+              "mean_diff_ci_lower": -0.1514,
+              "mean_diff_ci_upper": 0.3376,
+              "sig": false
             },
             "maturity": {
               "t": 1.8682,
-              "p": 0.0,
+              "p": 0.0662,
               "df": 66.2,
-              "mean_diff_ci_lower": 0.2611,
-              "mean_diff_ci_upper": 0.2611,
-              "sig": true
+              "mean_diff_ci_lower": -0.0179,
+              "mean_diff_ci_upper": 0.5401,
+              "sig": false
             }
           }
         },
@@ -1574,21 +1574,21 @@
           "constructs": {
             "barriers": {
               "f": 0.0785,
-              "p": 0.0,
+              "p": 0.7796,
               "df_between": 1,
               "df_within": 198,
-              "sig": true
+              "sig": false
             },
             "readiness": {
               "f": 14.3964,
-              "p": 0.0,
+              "p": 0.0002,
               "df_between": 1,
               "df_within": 198,
               "sig": true
             },
             "maturity": {
               "f": 6.3177,
-              "p": 0.0,
+              "p": 0.0128,
               "df_between": 1,
               "df_within": 198,
               "sig": true
@@ -1710,5 +1710,5 @@
       "examples": ""
     }
   ],
-  "last_updated": "2026-04-12T10:46:41.813282Z"
+  "last_updated": "2026-04-12T20:42:39.168007Z"
 }

--- a/src/data/data-audit.json
+++ b/src/data/data-audit.json
@@ -1,35 +1,35 @@
 {
   "disposition_counts": {
     "INCOMPLETE": 69,
-    "CLEAN": 85,
+    "CLEAN": 86,
     "FLAG-SMEAL": 50,
     "FLAG-SPEED": 8,
-    "FLAG-PARTIAL-STRAIGHTLINING": 33,
+    "FLAG-PARTIAL-STRAIGHTLINING": 34,
     "FLAG-SINGLE-IRI": 80,
-    "AUTO-EXCLUDE": 119,
+    "AUTO-EXCLUDE": 121,
     "FLAG-RECAPTCHA": 3
   },
   "iri_pass_rates": {
-    "barrier": 0.4899328859060403,
-    "readiness": 0.5906040268456376,
-    "maturity": 0.6890380313199105
+    "barrier": 0.49002217294900224,
+    "readiness": 0.5898004434589801,
+    "maturity": 0.6895787139689579
   },
   "duration_stats": {
-    "mean": 657.1163310961969,
-    "median": 530,
+    "mean": 658.7538802660754,
+    "median": 536,
     "q25": 318,
-    "q75": 794,
+    "q75": 810,
     "min": 2,
     "max": 5935
   },
   "straightlining_stats": {
     "full_block_flagged": 15,
-    "partial_flagged": 134
+    "partial_flagged": 136
   },
   "sample_sizes": {
-    "total": 447,
-    "complete": 378,
-    "clean": 85
+    "total": 451,
+    "complete": 382,
+    "clean": 86
   },
   "waterfall_steps": [
     {
@@ -53,50 +53,50 @@
     {
       "step": 3,
       "name": "AUTO-EXCLUDE",
-      "count": 119,
-      "cumulative_excluded": 188
+      "count": 121,
+      "cumulative_excluded": 190
     },
     {
       "step": 4,
       "name": "FLAG-SPEED",
       "count": 8,
-      "cumulative_excluded": 196
+      "cumulative_excluded": 198
     },
     {
       "step": 5,
       "name": "FLAG-SINGLE-IRI",
       "count": 80,
-      "cumulative_excluded": 276
+      "cumulative_excluded": 278
     },
     {
       "step": 6,
       "name": "FLAG-SMEAL",
       "count": 50,
-      "cumulative_excluded": 326
+      "cumulative_excluded": 328
     },
     {
       "step": 7,
       "name": "FLAG-RECAPTCHA",
       "count": 3,
-      "cumulative_excluded": 329
+      "cumulative_excluded": 331
     },
     {
       "step": 8,
       "name": "FLAG-STRAIGHTLINING",
       "count": 0,
-      "cumulative_excluded": 329
+      "cumulative_excluded": 331
     },
     {
       "step": 9,
       "name": "FLAG-PARTIAL-STRAIGHTLINING",
-      "count": 33,
-      "cumulative_excluded": 362
+      "count": 34,
+      "cumulative_excluded": 365
     },
     {
       "step": 10,
       "name": "CLEAN",
-      "count": 85,
-      "cumulative_excluded": 85
+      "count": 86,
+      "cumulative_excluded": 86
     }
   ]
 }

--- a/src/data/disposition-summary.json
+++ b/src/data/disposition-summary.json
@@ -1,35 +1,35 @@
 {
-  "updatedAt": "2026-04-12T10:50:56.220252+00:00",
-  "last_updated": "2026-04-12T10:50:56.220267+00:00",
+  "updatedAt": "2026-04-12T20:46:45.960617+00:00",
+  "last_updated": "2026-04-12T20:46:45.960633+00:00",
   "study": {
     "id": "69c17630acada6abeead2da5",
     "name": "Technology Adoption Barriers Survey (2026)",
     "status": "ACTIVE",
     "totalAvailablePlaces": 500,
-    "placesTaken": 275,
-    "averageRewardPerHour": 3986.55,
+    "placesTaken": 278,
+    "averageRewardPerHour": 3974.4,
     "averageTimeTaken": 10,
     "reward": 700,
     "publishedAt": "2026-03-23T18:00:28.650000Z"
   },
   "completionProgress": {
     "target": 500,
-    "completed": 275,
-    "approved": 235,
-    "awaitingReview": 40,
-    "percentComplete": 55.0
+    "completed": 278,
+    "approved": 236,
+    "awaitingReview": 42,
+    "percentComplete": 55.6
   },
-  "totalResponses": 464,
-  "uniqueParticipants": 447,
+  "totalResponses": 469,
+  "uniqueParticipants": 451,
   "duplicatesRemoved": 0,
   "dispositions": {
     "INCOMPLETE": 69,
-    "CLEAN": 85,
+    "CLEAN": 86,
     "FLAG-SMEAL": 50,
     "FLAG-SPEED": 8,
-    "FLAG-PARTIAL-STRAIGHTLINING": 33,
+    "FLAG-PARTIAL-STRAIGHTLINING": 34,
     "FLAG-SINGLE-IRI": 80,
-    "AUTO-EXCLUDE": 119,
+    "AUTO-EXCLUDE": 121,
     "FLAG-RECAPTCHA": 3
   },
   "dispositionByStatus": {
@@ -38,7 +38,7 @@
       "TIMED-OUT": 6
     },
     "CLEAN": {
-      "APPROVED": 84,
+      "APPROVED": 85,
       "RETURNED": 1
     },
     "FLAG-SMEAL": {
@@ -53,7 +53,7 @@
     },
     "FLAG-PARTIAL-STRAIGHTLINING": {
       "APPROVED": 32,
-      "AWAITING REVIEW": 1
+      "AWAITING REVIEW": 2
     },
     "FLAG-SINGLE-IRI": {
       "RETURNED": 7,
@@ -62,8 +62,8 @@
     },
     "AUTO-EXCLUDE": {
       "REJECTED": 29,
-      "AWAITING REVIEW": 24,
-      "RETURNED": 63,
+      "AWAITING REVIEW": 25,
+      "RETURNED": 64,
       "APPROVED": 3
     },
     "FLAG-RECAPTCHA": {
@@ -72,25 +72,25 @@
   },
   "autoExcludeBreakdown": {
     "IRI3_SPEED": 13,
-    "IRI3": 28,
+    "IRI3": 29,
     "IRI2_SPEED": 11,
-    "IRI2": 53,
+    "IRI2": 54,
     "SPEED_IRI": 14
   },
   "actions": {
-    "approved": 235,
+    "approved": 236,
     "rejected": 29,
-    "returned": 154,
+    "returned": 156,
     "timedOut": 6,
-    "awaitingReview": 40,
+    "awaitingReview": 42,
     "active": 0,
     "messaged": 0
   },
   "iriPassRates": {
-    "barrier": 57.7,
-    "readiness": 69.6,
-    "maturity": 81.5,
-    "denominator": 378
+    "barrier": 57.6,
+    "readiness": 69.4,
+    "maturity": 81.4,
+    "denominator": 382
   },
   "studyId": "69c17630acada6abeead2da5",
   "studyName": "Technology Adoption Barriers Survey (2026)"

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -22,13 +22,13 @@
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 378
+      "n": 382
     },
     {
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 447
+      "n": 451
     }
   ],
   "metrics": [
@@ -39,8 +39,8 @@
         "conservative_clean": 2.8289,
         "flexible_clean": 2.8181,
         "prolific_accepted": 2.7816,
-        "v2_finished": 2.7472,
-        "v2_all": 2.7526
+        "v2_finished": 2.7453,
+        "v2_all": 2.7507
       }
     },
     {
@@ -50,8 +50,8 @@
         "conservative_clean": 0.6368,
         "flexible_clean": 0.7174,
         "prolific_accepted": 0.7153,
-        "v2_finished": 0.7711,
-        "v2_all": 0.7747
+        "v2_finished": 0.7684,
+        "v2_all": 0.772
       }
     },
     {
@@ -61,8 +61,8 @@
         "conservative_clean": 3.0635,
         "flexible_clean": 3.1023,
         "prolific_accepted": 3.1423,
-        "v2_finished": 3.2518,
-        "v2_all": 3.2518
+        "v2_finished": 3.2539,
+        "v2_all": 3.254
       }
     },
     {
@@ -72,8 +72,8 @@
         "conservative_clean": 0.5718,
         "flexible_clean": 0.6497,
         "prolific_accepted": 0.6703,
-        "v2_finished": 0.7099,
-        "v2_all": 0.7089
+        "v2_finished": 0.7126,
+        "v2_all": 0.7116
       }
     },
     {
@@ -83,8 +83,8 @@
         "conservative_clean": 3.0374,
         "flexible_clean": 3.065,
         "prolific_accepted": 3.1549,
-        "v2_finished": 3.2727,
-        "v2_all": 3.2727
+        "v2_finished": 3.2722,
+        "v2_all": 3.2722
       }
     },
     {
@@ -94,8 +94,8 @@
         "conservative_clean": 0.7084,
         "flexible_clean": 0.7947,
         "prolific_accepted": 0.8048,
-        "v2_finished": 0.8039,
-        "v2_all": 0.8039
+        "v2_finished": 0.806,
+        "v2_all": 0.806
       }
     },
     {
@@ -105,8 +105,8 @@
         "conservative_clean": -0.4489,
         "flexible_clean": -0.4421,
         "prolific_accepted": -0.3341,
-        "v2_finished": -0.3119,
-        "v2_all": -0.3116
+        "v2_finished": -0.3161,
+        "v2_all": -0.3159
       }
     },
     {
@@ -116,8 +116,8 @@
         "conservative_clean": -0.1951,
         "flexible_clean": -0.2989,
         "prolific_accepted": -0.2682,
-        "v2_finished": -0.2998,
-        "v2_all": -0.2998
+        "v2_finished": -0.3032,
+        "v2_all": -0.3032
       }
     },
     {
@@ -127,8 +127,8 @@
         "conservative_clean": 0.5848,
         "flexible_clean": 0.6937,
         "prolific_accepted": 0.7096,
-        "v2_finished": 0.7333,
-        "v2_all": 0.7333
+        "v2_finished": 0.7366,
+        "v2_all": 0.7366
       }
     },
     {
@@ -138,8 +138,8 @@
         "conservative_clean": 0.859,
         "flexible_clean": 0.8773,
         "prolific_accepted": 0.8772,
-        "v2_finished": 0.9004,
-        "v2_all": 0.9017
+        "v2_finished": 0.899,
+        "v2_all": 0.9004
       }
     },
     {
@@ -149,8 +149,8 @@
         "conservative_clean": 0.8684,
         "flexible_clean": 0.9142,
         "prolific_accepted": 0.9186,
-        "v2_finished": 0.9294,
-        "v2_all": 0.9294
+        "v2_finished": 0.9297,
+        "v2_all": 0.9297
       }
     },
     {
@@ -160,8 +160,8 @@
         "conservative_clean": 0.8304,
         "flexible_clean": 0.8805,
         "prolific_accepted": 0.8882,
-        "v2_finished": 0.8893,
-        "v2_all": 0.8893
+        "v2_finished": 0.8906,
+        "v2_all": 0.8906
       }
     }
   ],
@@ -345,33 +345,33 @@
           "constructs": {
             "barriers": {
               "tech_mean": 2.7895,
-              "tech_mean_ci_lower": 2.7895,
-              "tech_mean_ci_upper": 2.7895,
+              "tech_mean_ci_lower": 2.4602,
+              "tech_mean_ci_upper": 3.1187,
               "nontech_mean": 2.8405,
-              "nontech_mean_ci_lower": 2.8405,
-              "nontech_mean_ci_upper": 2.8405,
+              "nontech_mean_ci_lower": 2.6849,
+              "nontech_mean_ci_upper": 2.996,
               "d": -0.0797,
               "d_ci_lower": -0.6447,
               "d_ci_upper": 0.4929
             },
             "readiness": {
               "tech_mean": 3.2442,
-              "tech_mean_ci_lower": 3.2442,
-              "tech_mean_ci_upper": 3.2442,
+              "tech_mean_ci_lower": 2.9701,
+              "tech_mean_ci_upper": 3.5183,
               "nontech_mean": 3.0107,
-              "nontech_mean_ci_lower": 3.0107,
-              "nontech_mean_ci_upper": 3.0107,
+              "nontech_mean_ci_lower": 2.8704,
+              "nontech_mean_ci_upper": 3.151,
               "d": 0.4119,
               "d_ci_lower": -0.0923,
               "d_ci_upper": 0.9606
             },
             "maturity": {
               "tech_mean": 3.1974,
-              "tech_mean_ci_lower": 3.1974,
-              "tech_mean_ci_upper": 3.1974,
+              "tech_mean_ci_lower": 2.8242,
+              "tech_mean_ci_upper": 3.5706,
               "nontech_mean": 2.9906,
-              "nontech_mean_ci_lower": 2.9906,
-              "nontech_mean_ci_upper": 2.9906,
+              "nontech_mean_ci_lower": 2.8203,
+              "nontech_mean_ci_upper": 3.1609,
               "d": 0.2923,
               "d_ci_lower": -0.2392,
               "d_ci_upper": 0.8383
@@ -384,22 +384,22 @@
           "constructs": {
             "barriers": {
               "large_mean": 3.0919,
-              "large_mean_ci_lower": 3.0919,
-              "large_mean_ci_upper": 3.0919,
+              "large_mean_ci_lower": 2.8049,
+              "large_mean_ci_upper": 3.3789,
               "small_medium_mean": 2.7622,
-              "small_medium_mean_ci_lower": 2.7622,
-              "small_medium_mean_ci_upper": 2.7622,
+              "small_medium_mean_ci_lower": 2.6056,
+              "small_medium_mean_ci_upper": 2.9188,
               "d": 0.5263,
               "d_ci_lower": 0.0816,
               "d_ci_upper": 1.0216
             },
             "readiness": {
               "large_mean": 3.0222,
-              "large_mean_ci_lower": 3.0222,
-              "large_mean_ci_upper": 3.0222,
+              "large_mean_ci_lower": 2.7046,
+              "large_mean_ci_upper": 3.3398,
               "small_medium_mean": 3.074,
-              "small_medium_mean_ci_lower": 3.074,
-              "small_medium_mean_ci_upper": 3.074,
+              "small_medium_mean_ci_lower": 2.9365,
+              "small_medium_mean_ci_upper": 3.2116,
               "d": -0.0902,
               "d_ci_lower": -0.6674,
               "d_ci_upper": 0.5177
@@ -455,27 +455,27 @@
           "constructs": {
             "barriers": {
               "t": -0.2915,
-              "p": 0.0,
+              "p": 0.7729,
               "df": 27.51,
-              "mean_diff_ci_lower": -0.051,
-              "mean_diff_ci_upper": -0.051,
-              "sig": true
+              "mean_diff_ci_lower": -0.4097,
+              "mean_diff_ci_upper": 0.3077,
+              "sig": false
             },
             "readiness": {
               "t": 1.5757,
-              "p": 0.0,
+              "p": 0.1258,
               "df": 29.25,
-              "mean_diff_ci_lower": 0.2335,
-              "mean_diff_ci_upper": 0.2335,
-              "sig": true
+              "mean_diff_ci_lower": -0.0694,
+              "mean_diff_ci_upper": 0.5364,
+              "sig": false
             },
             "maturity": {
               "t": 1.0493,
-              "p": 0.0,
+              "p": 0.3034,
               "df": 26.85,
-              "mean_diff_ci_lower": 0.2067,
-              "mean_diff_ci_upper": 0.2067,
-              "sig": true
+              "mean_diff_ci_lower": -0.1976,
+              "mean_diff_ci_upper": 0.6111,
+              "sig": false
             }
           }
         },
@@ -485,27 +485,27 @@
           "constructs": {
             "barriers": {
               "t": 2.1071,
-              "p": 0.0,
+              "p": 0.0443,
               "df": 27.78,
-              "mean_diff_ci_lower": 0.3297,
-              "mean_diff_ci_upper": 0.3297,
+              "mean_diff_ci_lower": 0.0091,
+              "mean_diff_ci_upper": 0.6503,
               "sig": true
             },
             "readiness": {
               "t": -0.3145,
-              "p": 0.0,
+              "p": 0.7559,
               "df": 23.23,
-              "mean_diff_ci_lower": -0.0519,
-              "mean_diff_ci_upper": -0.0519,
-              "sig": true
+              "mean_diff_ci_lower": -0.3928,
+              "mean_diff_ci_upper": 0.2891,
+              "sig": false
             },
             "maturity": {
               "t": 1.559,
-              "p": 0.0,
+              "p": 0.1332,
               "df": 22.09,
-              "mean_diff_ci_lower": 0.3287,
-              "mean_diff_ci_upper": 0.3287,
-              "sig": true
+              "mean_diff_ci_lower": -0.1084,
+              "mean_diff_ci_upper": 0.7659,
+              "sig": false
             }
           }
         },
@@ -515,24 +515,24 @@
           "constructs": {
             "barriers": {
               "f": 0.0933,
-              "p": 0.0,
+              "p": 0.7608,
               "df_between": 1,
               "df_within": 82,
-              "sig": true
+              "sig": false
             },
             "readiness": {
               "f": 2.4949,
-              "p": 0.0,
+              "p": 0.1181,
               "df_between": 1,
               "df_within": 82,
-              "sig": true
+              "sig": false
             },
             "maturity": {
               "f": 1.2562,
-              "p": 0.0,
+              "p": 0.2656,
               "df_between": 1,
               "df_within": 82,
-              "sig": true
+              "sig": false
             }
           }
         },
@@ -609,33 +609,33 @@
           "constructs": {
             "barriers": {
               "tech_mean": 2.6953,
-              "tech_mean_ci_lower": 2.6953,
-              "tech_mean_ci_upper": 2.6953,
+              "tech_mean_ci_lower": 2.4486,
+              "tech_mean_ci_upper": 2.942,
               "nontech_mean": 2.8595,
-              "nontech_mean_ci_lower": 2.8595,
-              "nontech_mean_ci_upper": 2.8595,
+              "nontech_mean_ci_lower": 2.7145,
+              "nontech_mean_ci_upper": 3.0045,
               "d": -0.2291,
               "d_ci_lower": -0.6,
               "d_ci_upper": 0.1388
             },
             "readiness": {
               "tech_mean": 3.3596,
-              "tech_mean_ci_lower": 3.3596,
-              "tech_mean_ci_upper": 3.3596,
+              "tech_mean_ci_lower": 3.1523,
+              "tech_mean_ci_upper": 3.5669,
               "nontech_mean": 3.0157,
-              "nontech_mean_ci_lower": 3.0157,
-              "nontech_mean_ci_upper": 3.0157,
+              "nontech_mean_ci_lower": 2.8854,
+              "nontech_mean_ci_upper": 3.1461,
               "d": 0.5419,
               "d_ci_lower": 0.1743,
               "d_ci_upper": 0.9466
             },
             "maturity": {
               "tech_mean": 3.303,
-              "tech_mean_ci_lower": 3.303,
-              "tech_mean_ci_upper": 3.303,
+              "tech_mean_ci_lower": 3.0455,
+              "tech_mean_ci_upper": 3.5605,
               "nontech_mean": 2.9849,
-              "nontech_mean_ci_lower": 2.9849,
-              "nontech_mean_ci_upper": 2.9849,
+              "nontech_mean_ci_lower": 2.8236,
+              "nontech_mean_ci_upper": 3.1461,
               "d": 0.405,
               "d_ci_lower": 0.0524,
               "d_ci_upper": 0.7917
@@ -648,22 +648,22 @@
           "constructs": {
             "barriers": {
               "large_mean": 3.0883,
-              "large_mean_ci_lower": 3.0883,
-              "large_mean_ci_upper": 3.0883,
+              "large_mean_ci_lower": 2.7987,
+              "large_mean_ci_upper": 3.3778,
               "small_medium_mean": 2.7575,
-              "small_medium_mean_ci_lower": 2.7575,
-              "small_medium_mean_ci_upper": 2.7575,
+              "small_medium_mean_ci_lower": 2.6208,
+              "small_medium_mean_ci_upper": 2.8943,
               "d": 0.4667,
               "d_ci_lower": 0.0367,
               "d_ci_upper": 0.9126
             },
             "readiness": {
               "large_mean": 2.9544,
-              "large_mean_ci_lower": 2.9544,
-              "large_mean_ci_upper": 2.9544,
+              "large_mean_ci_lower": 2.6606,
+              "large_mean_ci_upper": 3.2482,
               "small_medium_mean": 3.1355,
-              "small_medium_mean_ci_lower": 3.1355,
-              "small_medium_mean_ci_upper": 3.1355,
+              "small_medium_mean_ci_lower": 3.0133,
+              "small_medium_mean_ci_upper": 3.2577,
               "d": -0.2793,
               "d_ci_lower": -0.7413,
               "d_ci_upper": 0.1735
@@ -719,26 +719,26 @@
           "constructs": {
             "barriers": {
               "t": -1.1607,
-              "p": 0.0,
+              "p": 0.2506,
               "df": 57.03,
-              "mean_diff_ci_lower": -0.1642,
-              "mean_diff_ci_upper": -0.1642,
-              "sig": true
+              "mean_diff_ci_lower": -0.4475,
+              "mean_diff_ci_upper": 0.1191,
+              "sig": false
             },
             "readiness": {
               "t": 2.839,
-              "p": 0.0,
+              "p": 0.0061,
               "df": 60.73,
-              "mean_diff_ci_lower": 0.3439,
-              "mean_diff_ci_upper": 0.3439,
+              "mean_diff_ci_lower": 0.1016,
+              "mean_diff_ci_upper": 0.5861,
               "sig": true
             },
             "maturity": {
               "t": 2.1174,
-              "p": 0.0,
+              "p": 0.0383,
               "df": 60.48,
-              "mean_diff_ci_lower": 0.3182,
-              "mean_diff_ci_upper": 0.3182,
+              "mean_diff_ci_lower": 0.0176,
+              "mean_diff_ci_upper": 0.6187,
               "sig": true
             }
           }
@@ -749,27 +749,27 @@
           "constructs": {
             "barriers": {
               "t": 2.1196,
-              "p": 0.0,
+              "p": 0.0412,
               "df": 35.08,
-              "mean_diff_ci_lower": 0.3307,
-              "mean_diff_ci_upper": 0.3307,
+              "mean_diff_ci_lower": 0.014,
+              "mean_diff_ci_upper": 0.6475,
               "sig": true
             },
             "readiness": {
               "t": -1.1697,
-              "p": 0.0,
+              "p": 0.2507,
               "df": 32.23,
-              "mean_diff_ci_lower": -0.1811,
-              "mean_diff_ci_upper": -0.1811,
-              "sig": true
+              "mean_diff_ci_lower": -0.4964,
+              "mean_diff_ci_upper": 0.1342,
+              "sig": false
             },
             "maturity": {
               "t": 0.394,
-              "p": 0.0,
+              "p": 0.6963,
               "df": 31.04,
-              "mean_diff_ci_lower": 0.0782,
-              "mean_diff_ci_upper": 0.0782,
-              "sig": true
+              "mean_diff_ci_lower": -0.3265,
+              "mean_diff_ci_upper": 0.4829,
+              "sig": false
             }
           }
         },
@@ -779,21 +779,21 @@
           "constructs": {
             "barriers": {
               "f": 1.296,
-              "p": 0.0,
+              "p": 0.257,
               "df_between": 1,
               "df_within": 129,
-              "sig": true
+              "sig": false
             },
             "readiness": {
               "f": 7.2499,
-              "p": 0.0,
+              "p": 0.008,
               "df_between": 1,
               "df_within": 129,
               "sig": true
             },
             "maturity": {
               "f": 4.0501,
-              "p": 0.0,
+              "p": 0.0463,
               "df_between": 1,
               "df_within": 129,
               "sig": true
@@ -874,33 +874,33 @@
           "constructs": {
             "barriers": {
               "tech_mean": 2.7543,
-              "tech_mean_ci_lower": 2.7543,
-              "tech_mean_ci_upper": 2.7543,
+              "tech_mean_ci_lower": 2.5592,
+              "tech_mean_ci_upper": 2.9493,
               "nontech_mean": 2.7906,
-              "nontech_mean_ci_lower": 2.7906,
-              "nontech_mean_ci_upper": 2.7906,
+              "nontech_mean_ci_lower": 2.6855,
+              "nontech_mean_ci_upper": 2.8956,
               "d": -0.0507,
               "d_ci_lower": -0.3627,
               "d_ci_upper": 0.243
             },
             "readiness": {
               "tech_mean": 3.4165,
-              "tech_mean_ci_lower": 3.4165,
-              "tech_mean_ci_upper": 3.4165,
+              "tech_mean_ci_lower": 3.2503,
+              "tech_mean_ci_upper": 3.5827,
               "nontech_mean": 3.0525,
-              "nontech_mean_ci_lower": 3.0525,
-              "nontech_mean_ci_upper": 3.0525,
+              "nontech_mean_ci_lower": 2.9546,
+              "nontech_mean_ci_upper": 3.1503,
               "d": 0.5575,
               "d_ci_lower": 0.276,
               "d_ci_upper": 0.8608
             },
             "maturity": {
               "tech_mean": 3.3821,
-              "tech_mean_ci_lower": 3.3821,
-              "tech_mean_ci_upper": 3.3821,
+              "tech_mean_ci_lower": 3.1743,
+              "tech_mean_ci_upper": 3.5899,
               "nontech_mean": 3.0805,
-              "nontech_mean_ci_lower": 3.0805,
-              "nontech_mean_ci_upper": 3.0805,
+              "nontech_mean_ci_lower": 2.9622,
+              "nontech_mean_ci_upper": 3.1988,
               "d": 0.3789,
               "d_ci_lower": 0.071,
               "d_ci_upper": 0.6997
@@ -913,22 +913,22 @@
           "constructs": {
             "barriers": {
               "large_mean": 2.9026,
-              "large_mean_ci_lower": 2.9026,
-              "large_mean_ci_upper": 2.9026,
+              "large_mean_ci_lower": 2.709,
+              "large_mean_ci_upper": 3.0962,
               "small_medium_mean": 2.7464,
-              "small_medium_mean_ci_lower": 2.7464,
-              "small_medium_mean_ci_upper": 2.7464,
+              "small_medium_mean_ci_lower": 2.6415,
+              "small_medium_mean_ci_upper": 2.8512,
               "d": 0.2189,
               "d_ci_lower": -0.0698,
               "d_ci_upper": 0.5627
             },
             "readiness": {
               "large_mean": 3.1666,
-              "large_mean_ci_lower": 3.1666,
-              "large_mean_ci_upper": 3.1666,
+              "large_mean_ci_lower": 2.9589,
+              "large_mean_ci_upper": 3.3742,
               "small_medium_mean": 3.1352,
-              "small_medium_mean_ci_lower": 3.1352,
-              "small_medium_mean_ci_upper": 3.1352,
+              "small_medium_mean_ci_lower": 3.0407,
+              "small_medium_mean_ci_upper": 3.2298,
               "d": 0.0467,
               "d_ci_lower": -0.3007,
               "d_ci_upper": 0.3823
@@ -984,26 +984,26 @@
           "constructs": {
             "barriers": {
               "t": -0.3271,
-              "p": 0.0,
+              "p": 0.7443,
               "df": 93.46,
-              "mean_diff_ci_lower": -0.0363,
-              "mean_diff_ci_upper": -0.0363,
-              "sig": true
+              "mean_diff_ci_lower": -0.2567,
+              "mean_diff_ci_upper": 0.1841,
+              "sig": false
             },
             "readiness": {
               "t": 3.7653,
-              "p": 0.0,
+              "p": 0.0003,
               "df": 100.78,
-              "mean_diff_ci_lower": 0.364,
-              "mean_diff_ci_upper": 0.364,
+              "mean_diff_ci_lower": 0.1722,
+              "mean_diff_ci_upper": 0.5558,
               "sig": true
             },
             "maturity": {
               "t": 2.5165,
-              "p": 0.0,
+              "p": 0.0135,
               "df": 97.88,
-              "mean_diff_ci_lower": 0.3016,
-              "mean_diff_ci_upper": 0.3016,
+              "mean_diff_ci_lower": 0.0638,
+              "mean_diff_ci_upper": 0.5394,
               "sig": true
             }
           }
@@ -1014,27 +1014,27 @@
           "constructs": {
             "barriers": {
               "t": 1.4182,
-              "p": 0.0,
+              "p": 0.1597,
               "df": 86.07,
-              "mean_diff_ci_lower": 0.1562,
-              "mean_diff_ci_upper": 0.1562,
-              "sig": true
+              "mean_diff_ci_lower": -0.0627,
+              "mean_diff_ci_upper": 0.3752,
+              "sig": false
             },
             "readiness": {
               "t": 0.2749,
-              "p": 0.0,
+              "p": 0.7842,
               "df": 75.68,
-              "mean_diff_ci_lower": 0.0313,
-              "mean_diff_ci_upper": 0.0313,
-              "sig": true
+              "mean_diff_ci_lower": -0.1958,
+              "mean_diff_ci_upper": 0.2585,
+              "sig": false
             },
             "maturity": {
               "t": 1.7457,
-              "p": 0.0,
+              "p": 0.0847,
               "df": 78.96,
-              "mean_diff_ci_lower": 0.2294,
-              "mean_diff_ci_upper": 0.2294,
-              "sig": true
+              "mean_diff_ci_lower": -0.0322,
+              "mean_diff_ci_upper": 0.491,
+              "sig": false
             }
           }
         },
@@ -1044,21 +1044,21 @@
           "constructs": {
             "barriers": {
               "f": 0.1121,
-              "p": 0.0,
+              "p": 0.738,
               "df_between": 1,
               "df_within": 233,
-              "sig": true
+              "sig": false
             },
             "readiness": {
               "f": 13.5772,
-              "p": 0.0,
+              "p": 0.0003,
               "df_between": 1,
               "df_within": 233,
               "sig": true
             },
             "maturity": {
               "f": 6.2728,
-              "p": 0.0,
+              "p": 0.0129,
               "df_between": 1,
               "df_within": 233,
               "sig": true
@@ -1097,106 +1097,106 @@
     "v2_finished": {
       "demographics": {
         "roles": {
-          "Other": 70,
+          "Other": 72,
           "CIO": 58,
-          "CEO": 38,
+          "CEO": 39,
           "CTO": 36,
           "COO": 35,
           "CFO": 33,
           "CSO": 31,
-          "CMO": 25,
+          "CMO": 26,
           "CHRO": 24,
           "CRO": 23,
           "CISO": 5
         },
         "org_sizes": {
           "<100": 57,
-          "100-499": 104,
-          "500-999": 57,
+          "100-499": 106,
+          "500-999": 58,
           "1000-4999": 75,
           "5000-9999": 31,
-          "10000+": 54
+          "10000+": 55
         },
         "profit_models": {
-          "For-Profit": 286,
-          "Non-Profit": 62,
+          "For-Profit": 289,
+          "Non-Profit": 63,
           "Government/Public Sector": 30
         },
         "tech_vs_nontech": {
           "technical": 104,
-          "non_technical": 274,
+          "non_technical": 278,
           "other": 0
         },
         "other_roles": {
-          "total": 70,
+          "total": 72,
           "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 104,
-          "nontech_n": 274,
+          "nontech_n": 278,
           "constructs": {
             "barriers": {
               "tech_mean": 2.6877,
-              "tech_mean_ci_lower": 2.6877,
-              "tech_mean_ci_upper": 2.6877,
-              "nontech_mean": 2.7697,
-              "nontech_mean_ci_lower": 2.7697,
-              "nontech_mean_ci_upper": 2.7697,
-              "d": -0.1063,
-              "d_ci_lower": -0.3389,
-              "d_ci_upper": 0.1193
+              "tech_mean_ci_lower": 2.5342,
+              "tech_mean_ci_upper": 2.8413,
+              "nontech_mean": 2.7668,
+              "nontech_mean_ci_lower": 2.677,
+              "nontech_mean_ci_upper": 2.8566,
+              "d": -0.1029,
+              "d_ci_lower": -0.321,
+              "d_ci_upper": 0.1324
             },
             "readiness": {
               "tech_mean": 3.4591,
-              "tech_mean_ci_lower": 3.4591,
-              "tech_mean_ci_upper": 3.4591,
-              "nontech_mean": 3.1728,
-              "nontech_mean_ci_lower": 3.1728,
-              "nontech_mean_ci_upper": 3.1728,
-              "d": 0.4095,
-              "d_ci_lower": 0.1922,
-              "d_ci_upper": 0.6502
+              "tech_mean_ci_lower": 3.3231,
+              "tech_mean_ci_upper": 3.5951,
+              "nontech_mean": 3.1769,
+              "nontech_mean_ci_lower": 3.0937,
+              "nontech_mean_ci_upper": 3.2601,
+              "d": 0.4018,
+              "d_ci_lower": 0.1784,
+              "d_ci_upper": 0.6265
             },
             "maturity": {
               "tech_mean": 3.433,
-              "tech_mean_ci_lower": 3.433,
-              "tech_mean_ci_upper": 3.433,
-              "nontech_mean": 3.2113,
-              "nontech_mean_ci_lower": 3.2113,
-              "nontech_mean_ci_upper": 3.2113,
-              "d": 0.2776,
-              "d_ci_lower": 0.0585,
-              "d_ci_upper": 0.497
+              "tech_mean_ci_lower": 3.284,
+              "tech_mean_ci_upper": 3.582,
+              "nontech_mean": 3.2116,
+              "nontech_mean_ci_lower": 3.1152,
+              "nontech_mean_ci_upper": 3.308,
+              "d": 0.2765,
+              "d_ci_lower": 0.0615,
+              "d_ci_upper": 0.4986
             }
           }
         },
         "large_vs_small": {
-          "large_n": 85,
-          "small_medium_n": 293,
+          "large_n": 86,
+          "small_medium_n": 296,
           "constructs": {
             "barriers": {
-              "large_mean": 2.871,
-              "large_mean_ci_lower": 2.871,
-              "large_mean_ci_upper": 2.871,
-              "small_medium_mean": 2.7112,
-              "small_medium_mean_ci_lower": 2.7112,
-              "small_medium_mean_ci_upper": 2.7112,
-              "d": 0.2078,
-              "d_ci_lower": -0.0348,
-              "d_ci_upper": 0.4462
+              "large_mean": 2.8635,
+              "large_mean_ci_lower": 2.7003,
+              "large_mean_ci_upper": 3.0267,
+              "small_medium_mean": 2.7109,
+              "small_medium_mean_ci_lower": 2.6231,
+              "small_medium_mean_ci_upper": 2.7988,
+              "d": 0.199,
+              "d_ci_lower": -0.0324,
+              "d_ci_upper": 0.4475
             },
             "readiness": {
-              "large_mean": 3.2707,
-              "large_mean_ci_lower": 3.2707,
-              "large_mean_ci_upper": 3.2707,
-              "small_medium_mean": 3.2462,
-              "small_medium_mean_ci_lower": 3.2462,
-              "small_medium_mean_ci_upper": 3.2462,
-              "d": 0.0344,
-              "d_ci_lower": -0.215,
-              "d_ci_upper": 0.2794
+              "large_mean": 3.2785,
+              "large_mean_ci_lower": 3.1196,
+              "large_mean_ci_upper": 3.4374,
+              "small_medium_mean": 3.2468,
+              "small_medium_mean_ci_lower": 3.166,
+              "small_medium_mean_ci_upper": 3.3276,
+              "d": 0.0445,
+              "d_ci_lower": -0.2016,
+              "d_ci_upper": 0.2949
             }
           }
         }
@@ -1212,147 +1212,147 @@
           },
           {
             "group": "Non-Technical",
-            "n": 274,
-            "barrier_mean": 2.7697,
-            "readiness_mean": 3.1728,
-            "maturity_mean": 3.2113
+            "n": 278,
+            "barrier_mean": 2.7668,
+            "readiness_mean": 3.1769,
+            "maturity_mean": 3.2116
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 161,
-            "barrier_mean": 2.6882,
-            "readiness_mean": 3.1789,
-            "maturity_mean": 3.1535
+            "n": 163,
+            "barrier_mean": 2.6913,
+            "readiness_mean": 3.1721,
+            "maturity_mean": 3.1449
           },
           {
             "group": "Medium (500-4999)",
-            "n": 132,
-            "barrier_mean": 2.7393,
-            "readiness_mean": 3.329,
-            "maturity_mean": 3.3483
+            "n": 133,
+            "barrier_mean": 2.735,
+            "readiness_mean": 3.339,
+            "maturity_mean": 3.357
           },
           {
             "group": "Large (5000+)",
-            "n": 85,
-            "barrier_mean": 2.871,
-            "readiness_mean": 3.2707,
-            "maturity_mean": 3.3804
+            "n": 86,
+            "barrier_mean": 2.8635,
+            "readiness_mean": 3.2785,
+            "maturity_mean": 3.3818
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
           "tech_n": 104,
-          "nontech_n": 274,
+          "nontech_n": 278,
           "constructs": {
             "barriers": {
-              "t": -0.9093,
-              "p": 0.0,
-              "df": 180.64,
-              "mean_diff_ci_lower": -0.082,
-              "mean_diff_ci_upper": -0.082,
-              "sig": true
+              "t": -0.8801,
+              "p": 0.38,
+              "df": 178.9,
+              "mean_diff_ci_lower": -0.2564,
+              "mean_diff_ci_upper": 0.0982,
+              "sig": false
             },
             "readiness": {
-              "t": 3.5529,
-              "p": 0.0,
-              "df": 186.07,
-              "mean_diff_ci_lower": 0.2863,
-              "mean_diff_ci_upper": 0.2863,
+              "t": 3.5026,
+              "p": 0.0006,
+              "df": 186.04,
+              "mean_diff_ci_lower": 0.1232,
+              "mean_diff_ci_upper": 0.4411,
               "sig": true
             },
             "maturity": {
               "t": 2.4694,
-              "p": 0.0,
-              "df": 196.43,
-              "mean_diff_ci_lower": 0.2217,
-              "mean_diff_ci_upper": 0.2217,
+              "p": 0.0144,
+              "df": 195.9,
+              "mean_diff_ci_lower": 0.0446,
+              "mean_diff_ci_upper": 0.3983,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 85,
-          "small_medium_n": 293,
+          "large_n": 86,
+          "small_medium_n": 296,
           "constructs": {
             "barriers": {
-              "t": 1.6969,
-              "p": 0.0,
-              "df": 137.72,
-              "mean_diff_ci_lower": 0.1598,
-              "mean_diff_ci_upper": 0.1598,
-              "sig": true
+              "t": 1.6323,
+              "p": 0.1049,
+              "df": 139.21,
+              "mean_diff_ci_lower": -0.0322,
+              "mean_diff_ci_upper": 0.3373,
+              "sig": false
             },
             "readiness": {
-              "t": 0.2708,
-              "p": 0.0,
-              "df": 130.8,
-              "mean_diff_ci_lower": 0.0245,
-              "mean_diff_ci_upper": 0.0245,
-              "sig": true
+              "t": 0.3531,
+              "p": 0.7246,
+              "df": 133.07,
+              "mean_diff_ci_lower": -0.146,
+              "mean_diff_ci_upper": 0.2095,
+              "sig": false
             },
             "maturity": {
-              "t": 1.3552,
-              "p": 0.0,
-              "df": 129.82,
-              "mean_diff_ci_lower": 0.1393,
-              "mean_diff_ci_upper": 0.1393,
-              "sig": true
+              "t": 1.3917,
+              "p": 0.1663,
+              "df": 132.52,
+              "mean_diff_ci_lower": -0.0597,
+              "mean_diff_ci_upper": 0.3431,
+              "sig": false
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical"],
-          "group_ns": [104, 274],
+          "group_ns": [104, 278],
           "constructs": {
             "barriers": {
-              "f": 0.8517,
-              "p": 0.0,
+              "f": 0.8015,
+              "p": 0.3712,
               "df_between": 1,
-              "df_within": 376,
-              "sig": true
+              "df_within": 380,
+              "sig": false
             },
             "readiness": {
-              "f": 12.6314,
-              "p": 0.0,
+              "f": 12.2067,
+              "p": 0.0005,
               "df_between": 1,
-              "df_within": 375,
+              "df_within": 379,
               "sig": true
             },
             "maturity": {
-              "f": 5.7961,
-              "p": 0.0,
+              "f": 5.774,
+              "p": 0.0167,
               "df_between": 1,
-              "df_within": 374,
+              "df_within": 378,
               "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [161, 132, 85],
+          "group_ns": [163, 133, 86],
           "constructs": {
             "barriers": {
-              "f": 1.58,
-              "p": 0.2073,
+              "f": 1.4352,
+              "p": 0.2394,
               "df_between": 2,
-              "df_within": 375,
+              "df_within": 379,
               "sig": false
             },
             "readiness": {
-              "f": 1.6613,
-              "p": 0.1913,
+              "f": 2.0797,
+              "p": 0.1264,
               "df_between": 2,
-              "df_within": 374,
+              "df_within": 378,
               "sig": false
             },
             "maturity": {
-              "f": 3.1378,
-              "p": 0.0445,
+              "f": 3.5958,
+              "p": 0.0284,
               "df_between": 2,
-              "df_within": 373,
+              "df_within": 377,
               "sig": true
             }
           }
@@ -1362,107 +1362,107 @@
     "v2_all": {
       "demographics": {
         "roles": {
-          "Other": 73,
+          "Other": 75,
           "CIO": 59,
           "Unknown": 59,
-          "CEO": 38,
+          "CEO": 39,
           "COO": 36,
           "CTO": 36,
           "CFO": 34,
           "CSO": 33,
-          "CMO": 25,
+          "CMO": 26,
           "CHRO": 25,
           "CRO": 24,
           "CISO": 5
         },
         "org_sizes": {
           "<100": 58,
-          "100-499": 108,
-          "500-999": 59,
+          "100-499": 110,
+          "500-999": 60,
           "1000-4999": 76,
           "5000-9999": 32,
-          "10000+": 55
+          "10000+": 56
         },
         "profit_models": {
-          "For-Profit": 294,
-          "Non-Profit": 64,
+          "For-Profit": 297,
+          "Non-Profit": 65,
           "Government/Public Sector": 30
         },
         "tech_vs_nontech": {
           "technical": 105,
-          "non_technical": 283,
+          "non_technical": 287,
           "other": 59
         },
         "other_roles": {
-          "total": 73,
+          "total": 75,
           "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 105,
-          "nontech_n": 283,
+          "nontech_n": 287,
           "constructs": {
             "barriers": {
               "tech_mean": 2.6877,
-              "tech_mean_ci_lower": 2.6877,
-              "tech_mean_ci_upper": 2.6877,
-              "nontech_mean": 2.7768,
-              "nontech_mean_ci_lower": 2.7768,
-              "nontech_mean_ci_upper": 2.7768,
-              "d": -0.115,
-              "d_ci_lower": -0.3397,
-              "d_ci_upper": 0.118
+              "tech_mean_ci_lower": 2.5342,
+              "tech_mean_ci_upper": 2.8413,
+              "nontech_mean": 2.7739,
+              "nontech_mean_ci_lower": 2.6841,
+              "nontech_mean_ci_upper": 2.8636,
+              "d": -0.1116,
+              "d_ci_lower": -0.3436,
+              "d_ci_upper": 0.1191
             },
             "readiness": {
               "tech_mean": 3.4591,
-              "tech_mean_ci_lower": 3.4591,
-              "tech_mean_ci_upper": 3.4591,
-              "nontech_mean": 3.1731,
-              "nontech_mean_ci_lower": 3.1731,
-              "nontech_mean_ci_upper": 3.1731,
-              "d": 0.4096,
-              "d_ci_lower": 0.1884,
-              "d_ci_upper": 0.6338
+              "tech_mean_ci_lower": 3.3231,
+              "tech_mean_ci_upper": 3.5951,
+              "nontech_mean": 3.1772,
+              "nontech_mean_ci_lower": 3.0943,
+              "nontech_mean_ci_upper": 3.2601,
+              "d": 0.4019,
+              "d_ci_lower": 0.1816,
+              "d_ci_upper": 0.6234
             },
             "maturity": {
               "tech_mean": 3.433,
-              "tech_mean_ci_lower": 3.433,
-              "tech_mean_ci_upper": 3.433,
-              "nontech_mean": 3.2113,
-              "nontech_mean_ci_lower": 3.2113,
-              "nontech_mean_ci_upper": 3.2113,
-              "d": 0.2776,
-              "d_ci_lower": 0.0585,
-              "d_ci_upper": 0.497
+              "tech_mean_ci_lower": 3.284,
+              "tech_mean_ci_upper": 3.582,
+              "nontech_mean": 3.2116,
+              "nontech_mean_ci_lower": 3.1152,
+              "nontech_mean_ci_upper": 3.308,
+              "d": 0.2765,
+              "d_ci_lower": 0.0615,
+              "d_ci_upper": 0.4986
             }
           }
         },
         "large_vs_small": {
-          "large_n": 87,
-          "small_medium_n": 360,
+          "large_n": 88,
+          "small_medium_n": 363,
           "constructs": {
             "barriers": {
-              "large_mean": 2.8809,
-              "large_mean_ci_lower": 2.8809,
-              "large_mean_ci_upper": 2.8809,
-              "small_medium_mean": 2.7153,
-              "small_medium_mean_ci_lower": 2.7153,
-              "small_medium_mean_ci_upper": 2.7153,
-              "d": 0.2145,
-              "d_ci_lower": -0.0342,
-              "d_ci_upper": 0.4681
+              "large_mean": 2.8734,
+              "large_mean_ci_lower": 2.7109,
+              "large_mean_ci_upper": 3.0359,
+              "small_medium_mean": 2.715,
+              "small_medium_mean_ci_lower": 2.6271,
+              "small_medium_mean_ci_upper": 2.8029,
+              "d": 0.2057,
+              "d_ci_lower": -0.0333,
+              "d_ci_upper": 0.4479
             },
             "readiness": {
-              "large_mean": 3.2707,
-              "large_mean_ci_lower": 3.2707,
-              "large_mean_ci_upper": 3.2707,
-              "small_medium_mean": 3.2463,
-              "small_medium_mean_ci_lower": 3.2463,
-              "small_medium_mean_ci_upper": 3.2463,
-              "d": 0.0344,
-              "d_ci_lower": -0.2173,
-              "d_ci_upper": 0.2841
+              "large_mean": 3.2785,
+              "large_mean_ci_lower": 3.1196,
+              "large_mean_ci_upper": 3.4374,
+              "small_medium_mean": 3.2468,
+              "small_medium_mean_ci_lower": 3.1663,
+              "small_medium_mean_ci_upper": 3.3274,
+              "d": 0.0444,
+              "d_ci_lower": -0.1975,
+              "d_ci_upper": 0.2912
             }
           }
         }
@@ -1478,10 +1478,10 @@
           },
           {
             "group": "Non-Technical",
-            "n": 283,
-            "barrier_mean": 2.7768,
-            "readiness_mean": 3.1731,
-            "maturity_mean": 3.2113
+            "n": 287,
+            "barrier_mean": 2.7739,
+            "readiness_mean": 3.1772,
+            "maturity_mean": 3.2116
           },
           {
             "group": "Unclassified",
@@ -1494,138 +1494,138 @@
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 166,
-            "barrier_mean": 2.7015,
-            "readiness_mean": 3.1794,
-            "maturity_mean": 3.1535
+            "n": 168,
+            "barrier_mean": 2.7045,
+            "readiness_mean": 3.1726,
+            "maturity_mean": 3.1449
           },
           {
             "group": "Medium (500-4999)",
-            "n": 135,
-            "barrier_mean": 2.7321,
-            "readiness_mean": 3.329,
-            "maturity_mean": 3.3483
+            "n": 136,
+            "barrier_mean": 2.7279,
+            "readiness_mean": 3.339,
+            "maturity_mean": 3.357
           },
           {
             "group": "Large (5000+)",
-            "n": 87,
-            "barrier_mean": 2.8809,
-            "readiness_mean": 3.2707,
-            "maturity_mean": 3.3804
+            "n": 88,
+            "barrier_mean": 2.8734,
+            "readiness_mean": 3.2785,
+            "maturity_mean": 3.3818
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
           "tech_n": 105,
-          "nontech_n": 283,
+          "nontech_n": 287,
           "constructs": {
             "barriers": {
-              "t": -0.9884,
-              "p": 0.0,
-              "df": 180.62,
-              "mean_diff_ci_lower": -0.0891,
-              "mean_diff_ci_upper": -0.0891,
-              "sig": true
+              "t": -0.9587,
+              "p": 0.339,
+              "df": 178.9,
+              "mean_diff_ci_lower": -0.2634,
+              "mean_diff_ci_upper": 0.0912,
+              "sig": false
             },
             "readiness": {
-              "t": 3.5522,
-              "p": 0.0,
-              "df": 185.51,
-              "mean_diff_ci_lower": 0.286,
-              "mean_diff_ci_upper": 0.286,
+              "t": 3.502,
+              "p": 0.0006,
+              "df": 185.48,
+              "mean_diff_ci_lower": 0.1231,
+              "mean_diff_ci_upper": 0.4406,
               "sig": true
             },
             "maturity": {
               "t": 2.4694,
-              "p": 0.0,
-              "df": 196.43,
-              "mean_diff_ci_lower": 0.2217,
-              "mean_diff_ci_upper": 0.2217,
+              "p": 0.0144,
+              "df": 195.9,
+              "mean_diff_ci_lower": 0.0446,
+              "mean_diff_ci_upper": 0.3983,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 87,
-          "small_medium_n": 360,
+          "large_n": 88,
+          "small_medium_n": 363,
           "constructs": {
             "barriers": {
-              "t": 1.765,
-              "p": 0.0,
-              "df": 139.88,
-              "mean_diff_ci_lower": 0.1657,
-              "mean_diff_ci_upper": 0.1657,
-              "sig": true
+              "t": 1.7005,
+              "p": 0.0912,
+              "df": 141.37,
+              "mean_diff_ci_lower": -0.0258,
+              "mean_diff_ci_upper": 0.3426,
+              "sig": false
             },
             "readiness": {
-              "t": 0.2702,
-              "p": 0.0,
-              "df": 130.47,
-              "mean_diff_ci_lower": 0.0244,
-              "mean_diff_ci_upper": 0.0244,
-              "sig": true
+              "t": 0.3526,
+              "p": 0.725,
+              "df": 132.74,
+              "mean_diff_ci_lower": -0.146,
+              "mean_diff_ci_upper": 0.2093,
+              "sig": false
             },
             "maturity": {
-              "t": 1.3552,
-              "p": 0.0,
-              "df": 129.82,
-              "mean_diff_ci_lower": 0.1393,
-              "mean_diff_ci_upper": 0.1393,
-              "sig": true
+              "t": 1.3917,
+              "p": 0.1663,
+              "df": 132.52,
+              "mean_diff_ci_lower": -0.0597,
+              "mean_diff_ci_upper": 0.3431,
+              "sig": false
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Unclassified"],
-          "group_ns": [105, 283, 59],
+          "group_ns": [105, 287, 59],
           "constructs": {
             "barriers": {
-              "f": 1.0008,
-              "p": 0.0,
+              "f": 0.9459,
+              "p": 0.3314,
+              "df_between": 1,
+              "df_within": 384,
+              "sig": false
+            },
+            "readiness": {
+              "f": 12.2224,
+              "p": 0.0005,
               "df_between": 1,
               "df_within": 380,
               "sig": true
             },
-            "readiness": {
-              "f": 12.6469,
-              "p": 0.0,
-              "df_between": 1,
-              "df_within": 376,
-              "sig": true
-            },
             "maturity": {
-              "f": 5.7961,
-              "p": 0.0,
+              "f": 5.774,
+              "p": 0.0167,
               "df_between": 1,
-              "df_within": 374,
+              "df_within": 378,
               "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [166, 135, 87],
+          "group_ns": [168, 136, 88],
           "constructs": {
             "barriers": {
-              "f": 1.5859,
-              "p": 0.2061,
+              "f": 1.4562,
+              "p": 0.2344,
+              "df_between": 2,
+              "df_within": 383,
+              "sig": false
+            },
+            "readiness": {
+              "f": 2.0764,
+              "p": 0.1268,
               "df_between": 2,
               "df_within": 379,
               "sig": false
             },
-            "readiness": {
-              "f": 1.6582,
-              "p": 0.1919,
-              "df_between": 2,
-              "df_within": 375,
-              "sig": false
-            },
             "maturity": {
-              "f": 3.1378,
-              "p": 0.0445,
+              "f": 3.5958,
+              "p": 0.0284,
               "df_between": 2,
-              "df_within": 373,
+              "df_within": 377,
               "sig": true
             }
           }
@@ -1636,22 +1636,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 1.2,
-      "p_value": 0.7529,
+      "chi2": 1.03,
+      "p_value": 0.7945,
       "df": 3,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 7.61,
-      "p_value": 0.9383,
+      "chi2": 7.81,
+      "p_value": 0.9313,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 3.05,
-      "p_value": 0.8026,
+      "chi2": 3.07,
+      "p_value": 0.7994,
       "df": 6,
       "error": null
     },
@@ -1674,8 +1674,8 @@
           "Government/Public Sector": 19
         },
         "All V2 Finished": {
-          "For-Profit": 286,
-          "Non-Profit": 62,
+          "For-Profit": 289,
+          "Non-Profit": 63,
           "Government/Public Sector": 30
         }
       }
@@ -1718,5 +1718,5 @@
       "examples": ""
     }
   ],
-  "last_updated": "2026-04-12T10:44:17.289135Z"
+  "last_updated": "2026-04-12T20:40:16.478003Z"
 }


### PR DESCRIPTION
Automated update from the unified daily pipeline.

**Data flow**: Qualtrics export → Prolific enrichment →
disposition waterfall → analysis suite → CRP dataset (N=200) →
approve CLEAN → dashboard summary.

All statistics computed across 5 sample definitions.
CRP dataset: N=200 tiered selection + NIST de-identification.