### PR TITLE
fix: add actions:write permission to auto-review dispatcher

### DIFF
--- a/.github/workflows/auto-review-on-ready.yml
+++ b/.github/workflows/auto-review-on-ready.yml
@@ -17,6 +17,8 @@ env:
 jobs:
   dispatch-review:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     if: github.event.pull_request.draft == false
     steps:
       - name: Dispatch review cycle


### PR DESCRIPTION
## Summary

One-line fix: adds `permissions: actions: write` to the `dispatch-review` job in `auto-review-on-ready.yml`.

Closes #1519

## Problem

Every PR marked "ready for review" triggers a `dispatch-review` job that fails with:
```
HTTP 403: Resource not accessible by integration
```
The default GITHUB_TOKEN only gets read permissions from `pull_request` triggers, but `gh workflow run` requires `actions: write`.

## Fix

```yaml
permissions:
  actions: write
```

## Test plan

- [ ] Mark a draft PR ready for review and verify dispatch-review succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)