### PR TITLE
Fix CMO survey redirect smoke test (reverted by Copilot in #1523)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -343,8 +343,8 @@ jobs:
 
           # Legacy redirects between Making of TABS and Results sections
           check_redirect "${SITE_URL}/making-of-tabs/data-analysis" "/results/data-quality" "/making-of-tabs/data-analysis"
-          # CMO Survey legacy making-of-tabs path redirects to the canonical results page
-          check_redirect "${SITE_URL}/making-of-tabs/cmo-survey" "/results/cmo-survey" "/making-of-tabs/cmo-survey"
+          # CMO Survey moved TO making-of-tabs in PR #1516; /results/cmo-survey has a ClientRedirect stub
+          check_redirect "${SITE_URL}/results/cmo-survey" "/making-of-tabs/cmo-survey" "/results/cmo-survey"
           check_redirect "${SITE_URL}/making-of-tabs/reproducible-analysis" "/results/reproducibility" "/making-of-tabs/reproducible-analysis"
           check_redirect "${SITE_URL}/making-of-tabs/integrations/prolific/dashboard" "/results/dashboard" "/making-of-tabs/.../prolific/dashboard"
           check_redirect "${SITE_URL}/barriers/survey-stats" "/results/survey-stats" "/barriers/survey-stats"


### PR DESCRIPTION
## Summary
- Corrects the CMO survey redirect assertion that Copilot incorrectly reverted during the #1523 review cycle (commit 132df5e)
- PR #1516 moved CMO Survey **to** `/making-of-tabs/cmo-survey` with a `ClientRedirect` stub at `/results/cmo-survey`
- Smoke test must check `/results/cmo-survey` -> `/making-of-tabs/cmo-survey`, not the reverse

Closes #1536

## Test plan
- [ ] Post-deploy smoke test passes with 0 redirect failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)