### PR TITLE
Fix duplicate series navigation in right sidebar

### DIFF
--- a/src/app/making-of-tabs/layout.tsx
+++ b/src/app/making-of-tabs/layout.tsx
@@ -4,29 +4,13 @@ import { usePathname } from 'next/navigation'
 import Breadcrumbs from '@/components/breadcrumbs'
 import PrevNextCards from '@/components/prev-next-cards'
 import ReadingProgressBar from '@/components/reading-progress-bar'
-import UnifiedNavigation, { type SeriesNavItem } from '@/components/unified-navigation'
-import {
-  makingOfTabsSeries,
-  flattenMakingOfTabsSeries,
-  type MakingOfTabsItem,
-} from '@/data/making-of-tabs-series'
+import UnifiedNavigation from '@/components/unified-navigation'
+import { flattenMakingOfTabsSeries } from '@/data/making-of-tabs-series'
 import { normalizePath } from '@/lib/normalizePath'
-
-function mapToNavItems(items: MakingOfTabsItem[], currentPath: string): SeriesNavItem[] {
-  return items.map((item) => ({
-    title: item.title,
-    href: item.href,
-    isCurrent: !item.isGroup && normalizePath(item.href) === currentPath,
-    isGroup: item.isGroup,
-    children: item.children ? mapToNavItems(item.children, currentPath) : undefined,
-  }))
-}
 
 export default function MakingOfTabsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const currentPath = normalizePath(pathname)
-
-  const seriesNavItems = mapToNavItems(makingOfTabsSeries, currentPath)
 
   const flat = flattenMakingOfTabsSeries()
   const currentIndex = flat.findIndex((item) => normalizePath(item.href) === currentPath)
@@ -40,7 +24,7 @@ export default function MakingOfTabsLayout({ children }: { children: React.React
         {children}
         <PrevNextCards prev={prev} next={next} className="mt-12" />
       </div>
-      <UnifiedNavigation seriesItems={seriesNavItems} seriesLabel="Making of TABS" />
+      <UnifiedNavigation />
       <ReadingProgressBar />
     </>
   )

--- a/src/app/results/layout.tsx
+++ b/src/app/results/layout.tsx
@@ -4,25 +4,13 @@ import { usePathname } from 'next/navigation'
 import Breadcrumbs from '@/components/breadcrumbs'
 import PrevNextCards from '@/components/prev-next-cards'
 import ReadingProgressBar from '@/components/reading-progress-bar'
-import UnifiedNavigation, { type SeriesNavItem } from '@/components/unified-navigation'
-import { resultsSeries, flattenResultsSeries, type ResultsSeriesItem } from '@/data/results-series'
+import UnifiedNavigation from '@/components/unified-navigation'
+import { flattenResultsSeries } from '@/data/results-series'
 import { normalizePath } from '@/lib/normalizePath'
-
-function mapToNavItems(items: ResultsSeriesItem[], currentPath: string): SeriesNavItem[] {
-  return items.map((item) => ({
-    title: item.title,
-    href: item.href,
-    isCurrent: !item.isGroup && normalizePath(item.href) === currentPath,
-    isGroup: item.isGroup,
-    children: item.children ? mapToNavItems(item.children, currentPath) : undefined,
-  }))
-}
 
 export default function ResultsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const currentPath = normalizePath(pathname)
-
-  const seriesNavItems = mapToNavItems(resultsSeries, currentPath)
 
   const flat = flattenResultsSeries()
   const currentIndex = flat.findIndex((item) => normalizePath(item.href) === currentPath)
@@ -36,7 +24,7 @@ export default function ResultsLayout({ children }: { children: React.ReactNode 
         {children}
         <PrevNextCards prev={prev} next={next} className="mt-12" />
       </div>
-      <UnifiedNavigation seriesItems={seriesNavItems} seriesLabel="Results" />
+      <UnifiedNavigation />
       <ReadingProgressBar />
     </>
   )


### PR DESCRIPTION
## Summary
- Removes series navigation from the right-side UnifiedNavigation on Results and Making of TABS pages
- The left persistent sidebar already renders series nav from sidebar-navigation.ts
- UnifiedNavigation now only shows "On This Page" TOC on the right
- Cleans up unused imports and mapToNavItems helper functions

Closes #1534

## Test plan
- [x] `npm test` - 531 tests pass
- [x] `npm run build` - static export clean
- [x] `npm run lint` - 0 errors
- [ ] Visual: Results pages show series nav only in left sidebar, TOC only on right
- [ ] Visual: Making of TABS pages same - no duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)