### PR TITLE
Add On This Page TOC to all 42 bibliography pages

### DIFF
--- a/scripts/validate-bibliography-references.py
+++ b/scripts/validate-bibliography-references.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Validate bibliography page references against the Zotero library.
+
+This script:
+1. Extracts author-year pairs from each bibliography page's References <ol>
+2. Queries Zotero (cloud API) for matching items
+3. Reports unmatched references that need to be added to Zotero
+4. Optionally checks that matched items are in the correct collection
+
+Usage:
+  python scripts/validate-bibliography-references.py          # cloud API (CI)
+  python scripts/validate-bibliography-references.py --local   # local Zotero desktop
+
+Environment (cloud mode):
+  ZOTERO_API_KEY   - API key
+  ZOTERO_USER_ID   - User ID (1527234)
+
+Exit codes:
+  0 - All references validated
+  1 - Unmatched references found (warning mode)
+  2 - Script error
+"""
+
+import glob
+import json
+import os
+import re
+import sys
+from typing import Optional
+
+
+def extract_references_from_tsx(filepath: str) -> list[dict]:
+    """Extract reference entries from a bibliography page's References section."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Find the References <ol> block
+    ref_match = re.search(
+        r">References</h2>.*?<ol[^>]*>(.*?)</ol>", content, re.DOTALL
+    )
+    if not ref_match:
+        return []
+
+    ol_content = ref_match.group(1)
+
+    # Extract each <li> content
+    refs = []
+    for li_match in re.finditer(r"<li>(.*?)</li>", ol_content, re.DOTALL):
+        raw = li_match.group(1)
+        # Strip JSX tags and entities
+        text = re.sub(r"<[^>]+>", "", raw)
+        text = re.sub(r"\{[^}]*\}", " ", text)  # {' '} etc
+        text = text.replace("&amp;", "&")
+        text = text.replace("&ldquo;", '"').replace("&rdquo;", '"')
+        text = text.replace("&lsquo;", "'").replace("&rsquo;", "'")
+        text = text.replace("&apos;", "'")
+        text = text.replace("&ndash;", "-").replace("&mdash;", "-")
+        text = re.sub(r"\s+", " ", text).strip()
+
+        # Extract author-year pattern
+        # APA: Author, A. B. (Year).
+        # Also handles: Author, A. B., & Author, C. D. (Year).
+        author_year = re.match(
+            r"^(.+?)\s*\((\d{4})\)\.", text
+        )
+        if author_year:
+            authors = author_year.group(1).strip().rstrip(",")
+            year = author_year.group(2)
+            # Get first author last name
+            first_author = authors.split(",")[0].strip()
+            refs.append(
+                {
+                    "first_author": first_author,
+                    "year": year,
+                    "authors_raw": authors,
+                    "full_text": text[:120],
+                }
+            )
+        else:
+            # Try to extract any year
+            year_match = re.search(r"\((\d{4})\)", text)
+            refs.append(
+                {
+                    "first_author": text.split(",")[0].split(".")[0].strip()
+                    if "," in text[:40]
+                    else text[:30],
+                    "year": year_match.group(1) if year_match else "????",
+                    "authors_raw": "",
+                    "full_text": text[:120],
+                }
+            )
+
+    return refs
+
+
+def get_zotero_client(local: bool = False):
+    """Get a pyzotero client configured for cloud or local access."""
+    try:
+        from pyzotero import zotero
+    except ImportError:
+        print("ERROR: pyzotero not installed. Run: pip install pyzotero==1.11.0")
+        sys.exit(2)
+
+    if local:
+        zot = zotero.Zotero(0, "user")
+        zot.endpoint = "http://localhost:23119/api"
+        return zot
+
+    user_id = os.environ.get("ZOTERO_USER_ID")
+    api_key = os.environ.get("ZOTERO_API_KEY")
+    if not user_id or not api_key:
+        print("ERROR: ZOTERO_USER_ID and ZOTERO_API_KEY must be set")
+        sys.exit(2)
+
+    return zotero.Zotero(int(user_id), "user", api_key)
+
+
+def build_zotero_index(zot, collection_keys: list[str]) -> dict:
+    """Build a lookup index from Zotero items: (last_name_lower, year) -> item."""
+    index = {}
+    all_items = []
+
+    for key in collection_keys:
+        try:
+            items = zot.collection_items(key, limit=100, itemType="-attachment || note")
+            all_items.extend(items)
+        except Exception as e:
+            print(f"  Warning: could not fetch collection {key}: {e}")
+
+    for item in all_items:
+        data = item.get("data", {})
+        creators = data.get("creators", [])
+        date = data.get("date", "")
+        year_match = re.search(r"(\d{4})", date)
+        year = year_match.group(1) if year_match else ""
+
+        for creator in creators:
+            last_name = creator.get("lastName", "").lower()
+            if last_name and year:
+                lookup_key = (last_name, year)
+                if lookup_key not in index:
+                    index[lookup_key] = data
+                break  # Only index by first author
+
+    return index, len(all_items)
+
+
+def validate_page(
+    filepath: str, refs: list[dict], zotero_index: dict
+) -> list[dict]:
+    """Check each reference against the Zotero index. Return unmatched."""
+    unmatched = []
+    for ref in refs:
+        first_author_lower = ref["first_author"].lower()
+        year = ref["year"]
+        lookup = (first_author_lower, year)
+
+        if lookup not in zotero_index:
+            # Try partial match (in case of name variants)
+            found = False
+            for (name, yr), _ in zotero_index.items():
+                if yr == year and (
+                    name.startswith(first_author_lower[:4])
+                    or first_author_lower.startswith(name[:4])
+                ):
+                    found = True
+                    break
+            if not found:
+                unmatched.append(ref)
+
+    return unmatched
+
+
+def main():
+    local = "--local" in sys.argv
+    dry_run = "--dry-run" in sys.argv
+    verbose = "--verbose" in sys.argv or "-v" in sys.argv
+
+    print("=" * 60)
+    print("Bibliography References vs Zotero Validation")
+    print("=" * 60)
+
+    # Find all bibliography pages
+    pages = sorted(glob.glob("src/app/bibliography-*/page.tsx"))
+    print(f"\nFound {len(pages)} bibliography pages")
+
+    # Extract references from all pages
+    all_page_refs = {}
+    total_refs = 0
+    pages_with_refs = 0
+    pages_without_refs = 0
+
+    for page in pages:
+        slug = os.path.basename(os.path.dirname(page))
+        refs = extract_references_from_tsx(page)
+        if refs:
+            all_page_refs[slug] = refs
+            total_refs += len(refs)
+            pages_with_refs += 1
+        else:
+            pages_without_refs += 1
+            if verbose:
+                print(f"  WARNING: {slug} has no References section")
+
+    print(f"  {pages_with_refs} pages with References ({total_refs} total entries)")
+    if pages_without_refs:
+        print(f"  {pages_without_refs} pages WITHOUT References")
+
+    if dry_run:
+        print("\n--- DRY RUN: Extracted references ---")
+        for slug, refs in all_page_refs.items():
+            print(f"\n{slug} ({len(refs)} refs):")
+            for ref in refs:
+                print(f"  [{ref['first_author']}, {ref['year']}] {ref['full_text']}")
+        return
+
+    # Connect to Zotero
+    print(f"\nConnecting to Zotero ({'local' if local else 'cloud'})...")
+    zot = get_zotero_client(local)
+
+    # Build index from bibliography collections
+    collection_keys = [
+        "CW5CU2Z2",  # Bibliography Branch 1
+        "QRAH48GW",  # Bibliography Branch 2
+        "4N7NAXWR",  # Website Citations (parent)
+        "BIM6DVJ5",  # Individual Technology Adoption Models (source)
+        "D3RV9FU5",  # Organizational Technology Adoption Models (source)
+    ]
+
+    print("Building Zotero reference index...")
+    zotero_index, item_count = build_zotero_index(zot, collection_keys)
+    print(f"  Indexed {len(zotero_index)} unique (author, year) pairs from {item_count} items")
+
+    # Validate each page
+    print("\nValidating references...\n")
+    total_unmatched = 0
+    results = []
+
+    for slug, refs in sorted(all_page_refs.items()):
+        unmatched = validate_page(slug, refs, zotero_index)
+        status = "PASS" if not unmatched else f"WARN ({len(unmatched)} unmatched)"
+        results.append((slug, len(refs), len(unmatched), unmatched))
+        total_unmatched += len(unmatched)
+
+        if unmatched or verbose:
+            print(f"{'PASS' if not unmatched else 'WARN'} {slug} ({len(refs)} refs, {len(unmatched)} unmatched)")
+            for ref in unmatched:
+                print(f"     NOT IN ZOTERO: [{ref['first_author']}, {ref['year']}] {ref['full_text'][:80]}")
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    matched = total_refs - total_unmatched
+    print(f"Total references: {total_refs}")
+    print(f"Matched in Zotero: {matched} ({matched * 100 // total_refs}%)")
+    print(f"Unmatched: {total_unmatched}")
+    print(f"Pages checked: {len(all_page_refs)}")
+
+    if total_unmatched > 0:
+        print(f"\n{'!' * 60}")
+        print(f"  {total_unmatched} references need to be added to Zotero")
+        print(f"{'!' * 60}")
+
+    # Write JSON report for CI
+    report = {
+        "total_pages": len(pages),
+        "pages_with_refs": pages_with_refs,
+        "pages_without_refs": pages_without_refs,
+        "total_refs": total_refs,
+        "matched": matched,
+        "unmatched": total_unmatched,
+        "unmatched_details": [
+            {
+                "page": slug,
+                "ref": f"{ref['first_author']} ({ref['year']})",
+                "text": ref["full_text"][:100],
+            }
+            for slug, _, _, unmatched in results
+            for ref in unmatched
+        ],
+    }
+
+    report_path = os.environ.get(
+        "VALIDATION_REPORT_PATH", "bibliography-validation-report.json"
+    )
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"\nReport written to {report_path}")
+
+    # Exit with warning code if unmatched (non-blocking for now)
+    if total_unmatched > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/bibliography-1-1-theory-of-reasoned-action-tra-fishbein-ajzen-1975/page.tsx
+++ b/src/app/bibliography-1-1-theory-of-reasoned-action-tra-fishbein-ajzen-1975/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Theory of Reasoned Action (TRA) - Fishbein & Ajzen (1975)',
@@ -754,6 +755,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -11,6 +11,7 @@ import {
   BODY_OL_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Decomposed TPB - Taylor & Todd (1995)',
@@ -1032,6 +1033,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-11-task-technology-fit-ttf-goodhue-thompson-1995/page.tsx
+++ b/src/app/bibliography-1-11-task-technology-fit-ttf-goodhue-thompson-1995/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Task-Technology Fit (TTF) - Goodhue & Thompson (1995)',
@@ -481,6 +482,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
+++ b/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Technology Readiness Index (TRI) - Parasuraman (2000)',
@@ -620,6 +621,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-13-technology-acceptance-model-2-tam2-venkatesh-davis-2000/page.tsx
+++ b/src/app/bibliography-1-13-technology-acceptance-model-2-tam2-venkatesh-davis-2000/page.tsx
@@ -7,6 +7,7 @@ import {
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Technology Acceptance Model 2 (TAM2) - Venkatesh & Davis (2000)',
@@ -457,6 +458,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-14-expectation-confirmation-model-ecm-bhattacherjee-2001/page.tsx
+++ b/src/app/bibliography-1-14-expectation-confirmation-model-ecm-bhattacherjee-2001/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Expectation-Confirmation Model (ECM) - Bhattacherjee (2001)',
@@ -620,6 +621,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
+++ b/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
@@ -7,6 +7,7 @@ import {
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title:
@@ -493,6 +494,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-16-math-venkatesh-brown-2001/page.tsx
+++ b/src/app/bibliography-1-16-math-venkatesh-brown-2001/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title:
@@ -585,6 +586,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Value-Based Adoption Model - Kim et al. (2007)',
@@ -742,6 +743,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-18-tram-lin-2007/page.tsx
+++ b/src/app/bibliography-1-18-tram-lin-2007/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Technology Readiness and Acceptance Model (TRAM) - Lin et al. (2007)',
@@ -606,6 +607,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
+++ b/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
@@ -7,6 +7,7 @@ import {
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Technology Acceptance Model 3 (TAM3) - Venkatesh & Bala (2008)',
@@ -466,6 +467,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-2-diffusion-of-innovations-rogers/page.tsx
+++ b/src/app/bibliography-1-2-diffusion-of-innovations-rogers/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Diffusion of Innovations - Rogers',
@@ -671,6 +672,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-20-utaut2-venkatesh-2012/page.tsx
+++ b/src/app/bibliography-1-20-utaut2-venkatesh-2012/page.tsx
@@ -7,6 +7,7 @@ import {
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title:
@@ -416,6 +417,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-21-technology-readiness-index-2-tri-2-parasuraman-colby-2015/page.tsx
+++ b/src/app/bibliography-1-21-technology-readiness-index-2-tri-2-parasuraman-colby-2015/page.tsx
@@ -8,6 +8,7 @@ import {
   H2_CLASSES,
   H3_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Technology Readiness Index 2.0 (TRI 2.0) - Parasuraman & Colby (2015)',
@@ -632,6 +633,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
+++ b/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Social Cognitive Theory (SCT) - Bandura (1986)',
@@ -734,6 +735,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-4-model-of-innovation-resistance-ram-sheth-1989/page.tsx
+++ b/src/app/bibliography-1-4-model-of-innovation-resistance-ram-sheth-1989/page.tsx
@@ -8,6 +8,7 @@ import {
   H2_CLASSES,
   H3_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Model of Innovation Resistance - Ram & Sheth (1989)',
@@ -470,6 +471,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-5-status-quo-bias-samuelson-zeckhauser-1988/page.tsx
+++ b/src/app/bibliography-1-5-status-quo-bias-samuelson-zeckhauser-1988/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Status Quo Bias - Samuelson & Zeckhauser (1988)',
@@ -613,6 +614,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-6-technology-acceptance-model-tam-davis-1989/page.tsx
+++ b/src/app/bibliography-1-6-technology-acceptance-model-tam-davis-1989/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Technology Acceptance Model (TAM) - Davis (1989)',
@@ -701,6 +702,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
+++ b/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Theory of Planned Behavior (TPB) - Ajzen (1991)',
@@ -844,6 +845,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-8-personal-computing-acceptance-thompson-1991/page.tsx
+++ b/src/app/bibliography-1-8-personal-computing-acceptance-thompson-1991/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Personal Computing Acceptance - Thompson et al. (1991)',
@@ -624,6 +625,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -9,6 +9,7 @@ import {
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Intrinsic & Extrinsic Motivation - Davis et al. (1992)',
@@ -734,6 +735,7 @@ const BibliographyArticlePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: A Resource-Based View (RBV) - Wernerfelt (1984)',
@@ -477,6 +478,7 @@ const ResourceBasedViewPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-10-tafim-dod-1994/page.tsx
+++ b/src/app/bibliography-2-10-tafim-dod-1994/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title:
@@ -446,6 +447,7 @@ const TAFIMPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-11-gartner-hype-cycle-fenn-1995/page.tsx
+++ b/src/app/bibliography-2-11-gartner-hype-cycle-fenn-1995/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Gartner Hype Cycle - Fenn (1995)',
@@ -486,6 +487,7 @@ const GartnerHypeCyclePage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-12-togaf-the-open-group-1995/page.tsx
+++ b/src/app/bibliography-2-12-togaf-the-open-group-1995/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: TOGAF - The Open Group Architecture Framework (1995)',
@@ -522,6 +523,7 @@ const TOGAFPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-13-dodaf-dod-2003/page.tsx
+++ b/src/app/bibliography-2-13-dodaf-dod-2003/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: DoDAF - Department of Defense Architecture Framework (2003)',
@@ -555,6 +556,7 @@ const DoDAFPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx
+++ b/src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: CMMI - Capability Maturity Model Integration (Chrissis et al., 2005)',
@@ -551,6 +552,7 @@ const CMMIPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-15-it-cmf-innovation-value-institute-2016/page.tsx
+++ b/src/app/bibliography-2-15-it-cmf-innovation-value-institute-2016/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title:
@@ -518,6 +519,7 @@ const ITCMFPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-16-aws-caf-ai-2024/page.tsx
+++ b/src/app/bibliography-2-16-aws-caf-ai-2024/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: AWS Cloud Adoption Framework for AI/ML (CAF-AI) - AWS (2024)',
@@ -367,6 +368,7 @@ const AWSCAFAIPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-17-aws-etf-prescriptive-guidance-2024/page.tsx
+++ b/src/app/bibliography-2-17-aws-etf-prescriptive-guidance-2024/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title:
@@ -374,6 +375,7 @@ const AWSETFPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-18-microsoft-cloud-adoption-framework-2025/page.tsx
+++ b/src/app/bibliography-2-18-microsoft-cloud-adoption-framework-2025/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Microsoft Cloud Adoption Framework for Azure (CAF) (2025)',
@@ -380,6 +381,7 @@ const MicrosoftCAFPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-19-microsoft-ai-adoption-framework-2025/page.tsx
+++ b/src/app/bibliography-2-19-microsoft-ai-adoption-framework-2025/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Microsoft AI Adoption Framework (2025)',
@@ -427,6 +428,7 @@ const MicrosoftAIAdoptionPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
+++ b/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: VRIO Framework - Barney (1991)',
@@ -623,6 +624,7 @@ const VRIOFrameworkPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-20-gartner-hype-cycle-methodology-2025/page.tsx
+++ b/src/app/bibliography-2-20-gartner-hype-cycle-methodology-2025/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Gartner Hype Cycle Research Methodology (2025)',
@@ -246,6 +247,7 @@ const GartnerHypeCycleMethodologyPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
+++ b/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Diffusion of Innovations - Organizational Perspective - Rogers (1962)',
@@ -261,6 +262,7 @@ const DiffusionOrganizationalPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
+++ b/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
@@ -9,6 +9,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Dynamic Capabilities Framework - Teece, Pisano, & Shuen (1997)',
@@ -542,6 +543,7 @@ const DynamicCapabilitiesPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-4-total-quality-management-tqm-deming-1982/page.tsx
+++ b/src/app/bibliography-2-4-total-quality-management-tqm-deming-1982/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Total Quality Management (TQM) - Deming (1982)',
@@ -380,6 +381,7 @@ const TQMDemingPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
+++ b/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Capability Maturity Model (CMM) - Humphrey (1989)',
@@ -385,6 +386,7 @@ const CMMHumphreyPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title:
@@ -403,6 +404,7 @@ const TOEFrameworkPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-7-it-implementation-research-cooper-zmud-1990/page.tsx
+++ b/src/app/bibliography-2-7-it-implementation-research-cooper-zmud-1990/page.tsx
@@ -11,6 +11,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: IT Implementation Research - Cooper & Zmud (1990)',
@@ -431,6 +432,7 @@ const CooperZmudPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Business Process Redesign (BPR) - Davenport & Short (1990)',
@@ -406,6 +407,7 @@ const DavenportShortBPRPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }

--- a/src/app/bibliography-2-9-business-process-reengineering-hammer-champy-1993/page.tsx
+++ b/src/app/bibliography-2-9-business-process-reengineering-hammer-champy-1993/page.tsx
@@ -10,6 +10,7 @@ import {
   REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
+import ArticleTOC from '@/components/article-toc'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Business Process Reengineering (BPR) - Hammer & Champy (1993)',
@@ -462,6 +463,7 @@ const HammerChampyBPRPage = () => {
           </Link>
         </section>
       </article>
+      <ArticleTOC />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- Adds the `ArticleTOC` component to all 42 bibliography pages
- Matches the pattern already used on the 17 article pages
- Bibliography pages previously had no "On This Page" table of contents

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` - 0 errors
- [ ] Visual: bibliography pages now show "On This Page" headings on the right side

🤖 Generated with [Claude Code](https://claude.com/claude-code)