### PR TITLE
fix: reduce Copilot review rounds to 7 and add 60s cooldown

### DIFF
--- a/.github/workflows/auto-review-on-ready.yml
+++ b/.github/workflows/auto-review-on-ready.yml
@@ -26,10 +26,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "PR #${{ github.event.pull_request.number }} marked ready for review"
-          echo "Dispatching Copilot review cycle (up to 14 rounds)..."
+          echo "Dispatching Copilot review cycle (up to 7 rounds)..."
           gh workflow run copilot-review-cycle.yml \
             -R ${{ github.repository }} \
             -f pr_number=${{ github.event.pull_request.number }} \
             -f round=1 \
-            -f max_rounds=14
+            -f max_rounds=7
           echo "Review cycle dispatched."

--- a/.github/workflows/copilot-review-cycle.yml
+++ b/.github/workflows/copilot-review-cycle.yml
@@ -19,7 +19,7 @@ on:
         description: 'Maximum review rounds'
         required: false
         type: number
-        default: 14
+        default: 7
       auto_merge:
         description: 'Auto-merge PR when review passes and CI is green'
         required: false
@@ -71,6 +71,6 @@ jobs:
           GH_TOKEN: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           ROUND: ${{ github.event.inputs.round || '1' }}
-          MAX_ROUNDS: ${{ github.event.inputs.max_rounds || '14' }}
+          MAX_ROUNDS: ${{ github.event.inputs.max_rounds || '7' }}
           AUTO_MERGE: ${{ github.event.inputs.auto_merge || 'false' }}
           REPO_NAME: ${{ github.repository }}

--- a/scripts/copilot-review-cycle.ts
+++ b/scripts/copilot-review-cycle.ts
@@ -317,6 +317,9 @@ function assignCopilotToFix(repo: string, prNumber: string, comments: ReviewComm
   }
 }
 
+/** Cooldown between rounds to avoid hitting Copilot review API rate limits. */
+const ROUND_COOLDOWN_MS = 60_000
+
 function dispatchNextRound(
   repo: string,
   prNumber: string,
@@ -324,6 +327,10 @@ function dispatchNextRound(
   maxRounds: number,
   autoMerge: boolean
 ): void {
+  console.log(
+    `Cooldown: waiting ${ROUND_COOLDOWN_MS / 1000}s before dispatching round ${nextRound}/${maxRounds}...`
+  )
+  execSync(`sleep ${ROUND_COOLDOWN_MS / 1000}`, { stdio: 'inherit' })
   console.log(`Dispatching round ${nextRound}/${maxRounds}...`)
   gh(
     `workflow run copilot-review-cycle.yml -R ${repo} ` +


### PR DESCRIPTION
## Summary

- Reduce default max review rounds from 14 to 7 (workflow default, auto-review dispatch, fallback env var)
- Add 60-second cooldown before each `dispatchNextRound()` call to space out Copilot review API requests

## Problem

The review cycle was firing 44+ times per day on TABS alone, with bursts of 9-11 runs/hour during overnight Copilot agent work. This triggered 429 rate limits on the Copilot review API, blocking all automated review requests across ALL repos - not just TABS.

## Files changed

- `.github/workflows/copilot-review-cycle.yml` - default 14 -> 7, fallback 14 -> 7
- `.github/workflows/auto-review-on-ready.yml` - dispatch 14 -> 7
- `scripts/copilot-review-cycle.ts` - 60s cooldown in `dispatchNextRound()`

## Test plan

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (531/531)
- [x] `npm run build` succeeds
- [ ] Verify next review cycle runs with 7 max rounds and 60s delay between rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)