### PR TITLE
docs: standardize bibliography 1-7 TPB (Ajzen, 1991)

### DIFF
--- a/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
+++ b/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
@@ -522,9 +522,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-bandura-1977-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
           </ol>

--- a/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
+++ b/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
@@ -8,12 +8,13 @@ import {
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
+  REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Theory of Planned Behavior (TPB) - Ajzen (1991)',
   description:
-    'Deep dive into Theory of Planned Behavior by Icek Ajzen (1991), exploring its foundational contributions to technology adoption research.',
+    'Deep dive into the Theory of Planned Behavior by Icek Ajzen (1991), exploring attitudes, norms, and perceived control as determinants of intentional behavior.',
 }
 
 const BibliographyArticlePage = () => {
@@ -22,7 +23,7 @@ const BibliographyArticlePage = () => {
       <article className={ARTICLE_CLASSES}>
         <h1 className={H1_CLASSES}>Theory of Planned Behavior (TPB) - Ajzen (1991)</h1>
 
-        {/* Model Identification */}
+        {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Model Identification</h2>
           <div className="space-y-2">
@@ -30,818 +31,555 @@ const BibliographyArticlePage = () => {
               <strong>Model Name:</strong> Theory of Planned Behavior
             </p>
             <p>
-              <strong>Authors:</strong> Icek Ajzen
+              <strong>Model Abbreviation:</strong> TPB
             </p>
             <p>
-              <strong>Publication Date:</strong> 1991
+              <strong>Target of Model:</strong> Individual Intentional Behavior Across Diverse
+              Domains
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Social Psychology, Behavioral Science
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Author:</strong> Icek Ajzen
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 1991
+            </p>
+            <p>
+              <strong>Official Title:</strong> The Theory of Planned Behavior
+            </p>
+            <p>
+              <strong>Journal:</strong> Organizational Behavior and Human Decision Processes
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 50, No. 2
+            </p>
+            <p>
+              <strong>Pages:</strong> 179-211
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Ajzen, I. (1991). The theory of planned behavior. Organizational Behavior and Human
-              Decision Processes, 50 (2), 179-211.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Ajzen, I. (
+                <a href="#ref-ajzen-1991" className="text-tabs-teal-deep hover:underline">
+                  1991
+                </a>
+                ). The theory of planned behavior.{' '}
+                <em>Organizational Behavior and Human Decision Processes</em>, 50(2), 179-211.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Ajzen, Icek. 1991. &ldquo;The Theory of Planned Behavior.&rdquo;
+                <em>Organizational Behavior and Human Decision Processes</em> 50, no. 2: 179-211.
+              </p>
+            </div>
           </div>
         </section>
 
-        {/* Main Content */}
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>Why was the model made?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Ajzen developed the Theory of Planned Behavior to address critical limitations in the
-              Theory of Reasoned Action (TRA) and to provide a more comprehensive framework for
-              understanding and predicting intentional behavior across diverse behavioral domains.
-              The fundamental motivation stemmed from recognizing that the original TRA, while
-              successful in predicting behavior under conditions of volitional control, failed
-              adequately when individuals lacked complete control over behavior performance. The
-              Theory of Reasoned Action had successfully predicted various behaviors including
-              voting, family planning, consumer choice, occupational choice, and weight loss.
-              However, TRA operated under a critical assumption: that behavior results solely from
-              conscious intentions determined by attitudes toward behavior and subjective norms.
-              This assumption proved problematic in real-world contexts where individuals often
-              cannot fully control behavior performance due to resource constraints, skills
-              limitations, environmental obstacles, or structural barriers.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Ajzen recognized that many significant behaviors-including technology adoption-involve
-              elements beyond complete volitional control. While individuals might intend to adopt a
-              technology, environmental factors, organizational policies, technical infrastructure,
-              prerequisite knowledge or skills, or other people’s actions might prevent successful
-              adoption. The original TRA’s inability to incorporate these control factors
-              represented a significant theoretical and practical limitation. The Theory of Planned
-              Behavior was explicitly constructed to overcome this limitation by adding a third
-              predictor variable: perceived behavioral control. By incorporating the extent to which
-              individuals believe they can successfully perform behavior, even when facing
-              obstacles, the TPB created a more nuanced and comprehensive model applicable to
-              behaviors where volitional control varies. Ajzen’s motivation also reflected broader
-              theoretical ambitions. The Theory of Planned Behavior aimed to provide a general
-              framework explaining intentional behavior across diverse domains-not just technology
-              adoption but also health behaviors, educational achievements, environmental actions,
-              interpersonal relationships, and organizational behaviors.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The generality of the framework would enable consistent application across diverse
-              behavioral domains while allowing domain-specific applications addressing particular
-              behavior contexts.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How was the model’s internal validity tested?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Ajzen established the Theory of Planned Behavior’s internal validity through multiple
-              strategies: Theoretical coherence and logical structure: The TPB articulates a clear
-              causal structure with explicitly specified relationships between constructs. The model
-              specifies that perceived behavioral control and subjective norms influence behavior
-              indirectly through intentions, while attitudes influence behavior through intentions.
-              Perceived behavioral control additionally exerts direct effects on behavior when
-              control accurately reflects actual behavioral control. This precisely specified
-              structure enabled clear hypothesis testing and systematic evaluation.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Construct measurement and operational definitions:</strong> Ajzen provided
-                explicit guidance for measuring the three primary predictor constructs (attitudes,
-                subjective norms, perceived behavioral control) and the criterion (intentions and
-                behavior). Each construct was operationalized through multi-item scales with clearly
-                specified theoretical basis. Attitudes were measured as evaluative beliefs about
-                behavior consequences weighted by outcome evaluations. Subjective norms reflected
-                normative beliefs about whether important others thought the person should perform
-                behavior, weighted by motivation to comply with each referent. Perceived behavioral
-                control reflected beliefs about factors facilitating or impeding behavior, weighted
-                by the power of each control factor to affect behavior performance. This operational
-                precision enabled reliable measurement and replication across studies
-              </li>
-              <li>
-                <strong>Empirical support from previous research:</strong> Ajzen grounded the TPB in
-                extensive prior research on attitude-behavior relationships. The Framework of
-                Reasoned Action had generated substantial supportive evidence across numerous
-                behavioral domains. Ajzen’s addition of perceived behavioral control built on
-                established research in self-efficacy, locus of control, and internal versus
-                external barriers to behavior. By building on empirically validated constructs from
-                prior research, the TPB inherited validity support from this extensive literature
-                while addressing known theoretical gaps
-              </li>
-              <li>
-                <strong>Logical extension of established theory:</strong> The TPB represented a
-                logical extension of TRA rather than a radical departure. By maintaining TRA’s core
-                structure (intentions as behavior predictors; attitudes and norms as intention
-                predictors) while adding perceived behavioral control, Ajzen demonstrated that TPB
-                incorporated TRA as a special case (when perceived behavioral control is high or
-                irrelevant). This nested structure enabled comparison between TRA and TPB, with TPB
-                expected to provide superior predictions in contexts where behavioral control varies
-                substantially
-              </li>
-              <li>
-                <strong>Specification of direct versus indirect effects:</strong> The TPB precisely
-                specified which constructs exert indirect effects through intentions (attitudes and
-                subjective norms) and which exert both indirect and direct effects (perceived
-                behavioral control). This specification reflected theoretical reasoning about
-                control factors: when perceived behavioral control accurately reflects actual
-                control, it should affect behavior regardless of intentions, but attitudes and norms
-                affect behavior only through their effects on intentions. This theoretical
-                specificity enabled empirical testing distinguishing TPB from alternative causal
-                structures
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How was the model’s external validity tested?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Theory of Planned Behavior’s external validity was established through its
-              application across diverse behavioral domains and populations: Cross-domain
-              applicability: Ajzen discussed TPB applications across health behaviors (smoking
-              cessation, sexual behavior, physician compliance, weight control), occupational
-              behaviors (career choice, work performance, occupational change), educational
-              behaviors (academic performance, course selection), environmental behaviors, family
-              planning, and consumer behavior. This diversity of application domains demonstrated
-              the model’s generality beyond any single behavioral context. Each domain application
-              produced interpretable findings consistent with TPB predictions, suggesting robust
-              external validity.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Population diversity:</strong> Ajzen documented TPB applications with
-                diverse populations including college students, community members, clinical
-                populations, organizational employees, and international populations. The consistent
-                predictive power across demographic groups, educational levels, and cultural
-                contexts suggested generalizability. While specific beliefs and subjective norms
-                varied across populations (reflecting different values and social influences), the
-                core structure relating attitudes, norms, and perceived control to intentions
-                remained consistent
-              </li>
-              <li>
-                <strong>Behavioral complexity variation:</strong> Ajzen applied TPB to behaviors
-                varying in complexity, from relatively simple discrete behaviors (condom use,
-                voting) to complex ongoing behaviors requiring sustained effort and multiple action
-                sequences (weight loss, exercise, occupational achievement). The model’s predictive
-                success across this complexity range demonstrated external validity spanning diverse
-                behavioral types
-              </li>
-              <li>
-                <strong>Time frame variation:</strong> TPB applications examined behavior prediction
-                across varying time frames, from immediate behavior occurrence to behavior patterns
-                over months or years. While shorter-term predictions proved more accurate
-                (intentions are more stable predictors of immediate behavior), TPB maintained
-                predictive validity across extended time frames. This temporal generality suggested
-                robustness across different behavioral contexts
-              </li>
-              <li>
-                <strong>Real-world versus laboratory behavior:</strong> Ajzen acknowledged TPB
-                testing in both controlled laboratory settings and real-world behavioral contexts.
-                The transition from artificial laboratory conditions to meaningful real-world
-                behaviors (actual occupational choice decisions, genuine health behavior adoption,
-                authentic environmental actions) demonstrated external validity in ecologically
-                meaningful contexts
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How is the model intended to be used in practice?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Ajzen explicitly designed the Theory of Planned Behavior as both theoretical framework
-              and practical tool for predicting and influencing behavior: Behavioral prediction:
-              Organizations and practitioners can use TPB to predict behavioral adoption rates and
-              identify population segments likely to adopt innovations. By measuring attitudes,
-              subjective norms, and perceived behavioral control regarding specific innovations,
-              practitioners can forecast adoption intentions and estimate likely adoption
-              percentages. Populations with positive attitudes toward technologies, perceiving
-              supportive social norms, and believing they can successfully use technologies would
-              show higher predicted adoption rates than populations with negative attitudes,
-              opposing norms, or low perceived control. This predictive capability enables resource
-              allocation, targeting, and adoption program design based on behavior prediction.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Behavior change intervention design:</strong> The TPB specifies exactly
-                which psychosocial factors require change to influence behavior. If behavior change
-                interventions aim to influence adoption intentions, they must target attitudes,
-                subjective norms, or perceived behavioral control. Ajzen proposed that effective
-                interventions require understanding which of these factors most strongly determines
-                behavior intentions and then designing interventions specifically addressing
-                limiting factors. For innovations where lack of favorable attitudes constitutes the
-                primary barrier, interventions should focus on attitude change through information
-                about innovation benefits, testimonials from satisfied users, demonstrations, or
-                experience with innovations. For innovations where subjective norms create barriers
-                (adoption appears inconsistent with important others’ values), interventions should
-                work with social influence through opinion leaders, peer adoption demonstrations, or
-                working with families and social networks. For innovations where perceived
-                behavioral control creates barriers (individuals doubt their ability to use
-                innovations despite favorable attitudes and normative support), interventions should
-                provide training, support systems, environmental modifications facilitating
-                behavior, or step- by-step implementation guidance
-              </li>
-              <li>
-                <strong>Barrier identification and targeting:</strong> The Theory of Planned
-                Behavior provides a structured framework for identifying which barriers to adoption
-                require addressing. By surveying potential adopters’ attitudes, perceived norms, and
-                perceived control, organizations can systematically identify which psychosocial
-                factors limit adoption. If high percentages of potential adopters report favorable
-                attitudes but low perceived control, this diagnostic finding indicates that training
-                and technical support should be priorities. If attitudes are unfavorable but norms
-                and control are positive, this diagnostic finding suggests that information,
-                demonstrations, or persuasive communication addressing specific concerns should
-                precede adoption programs
-              </li>
-              <li>
-                <strong>Intervention development and evaluation:</strong> Organizations can use TPB
-                as intervention development framework ensuring comprehensive approach to behavior
-                change. Before launching adoption initiatives, organizations should measure baseline
-                attitudes, norms, and perceived control to establish targets. Interventions should
-                include strategies addressing identified limitations in all three constructs rather
-                than assuming single- factor interventions. After interventions, re-measurement of
-                the three constructs enables evaluation of whether specific intervention components
-                successfully changed their targeted constructs
-              </li>
-              <li>
-                <strong>Context-specific adaptation:</strong> Ajzen emphasized that while TPB
-                provides general structure, specific beliefs, norms, and control factors vary across
-                contexts and populations. Practitioners should conduct formative research
-                identifying behavioral beliefs (what outcomes individuals associate with innovation
-                adoption), normative beliefs (what important others think about adoption), and
-                control beliefs (what barriers and enablers individuals perceive) specific to their
-                target population and innovation. This formative research enables tailoring TPB
-                application to specific contexts while maintaining theoretical consistency
-              </li>
-              <li>
-                <strong>Segmentation and targeting:</strong> By measuring TPB constructs across
-                populations, organizations can segment populations by adoption readiness.
-                Individuals with positive attitudes, normative support, and high perceived control
-                represent high-adoption-likelihood segments requiring minimal intervention.
-                Individuals with negative attitudes but supporting norms represent segments
-                requiring persuasive information. Individuals with low perceived control despite
-                favorable attitudes and norms represent segments requiring support and enabling
-                systems. This segmentation enables differentiated strategies matching intervention
-                intensity and type to readiness levels
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What does the model measure?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Theory of Planned Behavior operationalizes several primary measurement constructs:
-              Attitudes toward behavior: Measured as overall evaluations of performing the behavior,
-              typically assessed through semantic differential scales capturing evaluative
-              dimensions (good-bad, beneficial-harmful, pleasant- unpleasant). Attitudes reflect
-              underlying beliefs about behavior consequences weighted by evaluations of those
-              consequences.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Subjective norms:</strong> Measured as perceived social pressure to perform
-                or not perform behavior, capturing both normative beliefs (whether important others
-                approve of behavior) and motivation to comply with each referent. Subjective norms
-                reflect the perceived normative expectations of relevant others including family,
-                peers, supervisors, or social groups
-              </li>
-              <li>
-                <strong>Perceived behavioral control:</strong> Measured as beliefs about one’s
-                ability to perform behavior successfully given existing constraints and resources.
-                Reflects both control factors (beliefs about factors facilitating or impeding
-                behavior performance) and power (perceived importance of each control factor).
-                Perceived behavioral control captures both internal factors (self- efficacy, skills,
-                knowledge) and external factors (environmental opportunities, resources,
-                dependencies on others)
-              </li>
-              <li>
-                <strong>Behavioral intention:</strong> Measured as the readiness or plan to perform
-                behavior, typically through direct items about likelihood, expectancy, or plan to
-                perform. Behavioral intention represents the immediate antecedent to actual behavior
-                performance
-              </li>
-              <li>
-                <strong>Actual behavior:</strong> Measured through self-report or behavioral
-                observation, capturing whether individuals actually perform intended behaviors.
-                Behavior measurement must be specific and clearly defined to align with measured
-                intentions (temporal specificity, action specificity, target specificity, context
-                specificity). Belief strength and outcome evaluation (attitudes): The model
-                distinguishes between belief strength (likelihood that behavior produces specific
-                consequences) and outcome evaluation (how desirable each consequence is). Attitude
-                strength results from accumulating products of belief strength and outcome
-                evaluation across all perceived consequences. Normative belief strength and
-                motivation to comply (subjective norms): Distinct from overall attitude, subjective
-                norm reflects normative beliefs about what important referent others expect weighted
-                by motivation to comply with each referent. This separation enables distinguishing
-                between descriptive influence (what others do) and injunctive influence (what others
-                approve). Control belief strength and power (perceived behavioral control): Control
-                beliefs reflect likelihood that specific factors facilitate or hinder behavior
-                performance. Power reflects perceived importance of each control factor. Combined,
-                these determine overall perceived behavioral control
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What are the main strengths of the model?</h3>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>
-                  The Theory of Planned Behavior possesses several significant strengths:
-                </strong>{' '}
-                Theoretical comprehensiveness: By incorporating perceived behavioral control
-                alongside attitudes and subjective norms, TPB creates a more complete theoretical
-                framework than its predecessor. The model acknowledges that behavior results from
-                multiple psychosocial influences: personal evaluation (attitudes), social influence
-                (norms), and self-efficacy (perceived control). This multi-factor approach captures
-                the complexity of behavior determination more adequately than single-factor theories
-              </li>
-              <li>
-                <strong>Clear causal structure:</strong> The TPB articulates explicitly specified
-                causal relationships, enabling precise hypothesis testing and systematic
-                investigation of behavior prediction. The model specifies which constructs affect
-                behavior directly versus indirectly through intentions, enabling comparison with
-                alternative models and testing of theoretical predictions
-              </li>
-              <li>
-                <strong>Logical theoretical foundation:</strong> The TPB builds logically on the
-                Theory of Reasoned Action, maintaining successful TRA elements while addressing
-                documented limitations. The addition of perceived behavioral control follows
-                logically from recognized gaps in TRA’s applicability to behaviors with limited
-                volitional control. This logical extension enhances both theoretical coherence and
-                empirical testability
-              </li>
-              <li>
-                <strong>Practical applicability:</strong> The TPB provides explicit guidance for
-                designing behavior change interventions. By specifying attitudes, norms, and
-                perceived control as change targets, the model directs practitioners toward
-                psychosocial factors requiring modification to influence behavior. This practical
-                utility makes TPB valuable for applied contexts including organizational adoption
-                programs, public health campaigns, and technology diffusion initiatives
-              </li>
-              <li>
-                <strong>Measured flexibility:</strong> The TPB can be applied to any specific
-                behavior by conducting formative research identifying beliefs, norms, and control
-                factors relevant to that particular behavior. This flexibility enables both general
-                applications across behaviors and domain-specific applications tailored to
-                particular contexts. The same theoretical structure accommodates diverse behavioral
-                domains without requiring fundamental model modification
-              </li>
-              <li>
-                <strong>Cross-domain validation:</strong> The TPB has demonstrated predictive
-                validity across numerous behavioral domains, suggesting robust theoretical
-                foundations. This cross-domain consistency indicates the model captures fundamental
-                aspects of behavior determination rather than domain-specific phenomena.
-                Organizations in health, education, environment, workplace, and consumer domains can
-                confidently apply TPB
-              </li>
-              <li>
-                <strong>Distinction of indirect and direct effects:</strong> The specification that
-                perceived behavioral control affects behavior both directly and through intentions
-                reflects more nuanced understanding than single-pathway models. This distinction
-                acknowledges that control factors may affect behavior through behavioral intention
-                (I intend to adopt if I believe I can) but also directly (I am prevented from
-                adopting despite intentions). This specification increases theoretical
-                sophistication and practical insight
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What are the main weaknesses of the model?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Despite considerable strengths, the Theory of Planned Behavior has notable
-              limitations: Measurement circularity concerns: The measurement of perceived behavioral
-              control and actual behavioral control creates potential circularity. If actual
-              behavioral control (external resources, enabling conditions) perfectly corresponds
-              with perceived control beliefs, then perceived behavioral control becomes redundant
-              with actual constraints. However, perceptions of control often diverge from actual
-              control due to overconfidence, pessimism, or inaccurate self-assessment. The model
-              provides limited guidance for ensuring perceived control measures reflect actual
-              control versus biased perceptions. This creates ambiguity regarding what perceived
-              behavioral control actually predicts-behavior directly or behavior constrained by
-              actual control.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Limited attention to structural barriers:</strong> While the TPB
-                acknowledges perceived behavioral control, the model treats structural and
-                environmental barriers primarily through individuals’ perceptions of them. Real
-                structural barriers-lack of technology infrastructure, regulatory prohibitions,
-                economic constraints, organizational policies-may prevent adoption regardless of
-                individual control perceptions. An individual might accurately perceive extremely
-                low control due to massive real barriers, but the model provides limited guidance on
-                removing those structural barriers. The focus on individual psychology potentially
-                understates the importance of organizational, environmental, and structural factors
-                external to individual minds
-              </li>
-              <li>
-                <strong>Temporal dynamics underspecified:</strong> The TPB treats behavior intention
-                at a particular moment and subsequent behavior, but provides limited specification
-                of how intentions change over time or how intention stability varies. For
-                innovations requiring extended implementation periods, intentions may shift between
-                measurement and behavior due to intervening experiences, changed circumstances, or
-                attitude shifts. The model provides less guidance for maintaining intentions across
-                implementation than for predicting immediate behavior. The assumption that
-                intentions remain stable from measurement to behavior performance proves problematic
-                for behaviors unfolding over extended periods
-              </li>
-              <li>
-                <strong>Social influence specificity:</strong> The subjective norms construct
-                aggregates influence from all important referents into a single summary judgment.
-                However, different social influences may affect different adoption aspects or
-                produce conflicting effects. The model provides limited specification of when
-                certain referents dominate influence, how multiple conflicting normative influences
-                are reconciled, or how normative influence processes unfold. Group dynamics,
-                leadership, and social network effects may produce influences not fully captured in
-                the subjective norms measure
-              </li>
-              <li>
-                <strong>Past behavior undertheorized:</strong> The TPB focuses on rational
-                deliberation processes leading to intentions predicting future behavior. However,
-                past behavior often powerfully predicts future behavior through habit, learned
-                patterns, or behavioral trajectory inertia. The model provides limited theoretical
-                mechanism for habit formation and maintenance. For repeated behaviors becoming
-                routinized, the conscious intention-formation processes theorized by TPB may become
-                less central as behavior becomes automatic. The model may inadequately address how
-                innovations become habituated after initial adoption
-              </li>
-              <li>
-                <strong>Affective factors underemphasized:</strong> The TPB’s attitude construct
-                focuses on instrumental evaluations of behavior outcomes rather than emotional or
-                affective responses to behavior. However, emotions often substantially influence
-                behavior. Anxiety about technology use, enjoyment of adoption process, emotional
-                reactions to change, or emotional attachments to existing systems may influence
-                adoption regardless of instrumental attitude assessments. The model downplays
-                affective dimensions of behavior determination
-              </li>
-              <li>
-                <strong>Domain-specific inconsistency:</strong> While TPB demonstrates cross-domain
-                applicability, the relative importance of attitudes, norms, and perceived control
-                varies substantially across domains and behaviors. In some contexts, perceived
-                control dominates prediction; in others, attitudes or norms dominate. The model
-                provides limited guidance for predicting which constructs most strongly determine
-                behavior in particular domains before empirical investigation. This limits ability
-                to tailor interventions efficiently without extensive preliminary measurement
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How does this model differ from older models?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Theory of Planned Behavior represented significant advancement from prior
-              behavioral theories: Expansion of Theory of Reasoned Action: The fundamental
-              difference between TPB and TRA involves the addition of perceived behavioral control.
-              TRA successfully predicted behaviors where individuals possessed volitional control,
-              treating behavior as determined by intentions stemming from attitudes and subjective
-              norms. TPB acknowledged that many real-world behaviors involve elements beyond
-              complete volitional control. By adding perceived behavioral control, TPB creates
-              applicability to broader behavioral domains where obstacles, constraints, and enablers
-              substantially affect behavior. This represents theoretical advancement rather than
-              replacement, with TRA treated as special case of TPB where perceived control is
-              uniformly high.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Specification of control factor effects:</strong> Prior theories of behavior
-                change often treated environmental constraints as mere obstacles to overcome but did
-                not theoretically specify how individuals’ perceptions of control affect behavior
-                determination. TPB explicitly incorporated perceived behavioral control as both
-                indirect pathway (affecting intentions) and direct pathway (directly affecting
-                behavior when perceived control reflects actual control). This dual pathway
-                specification provides more nuanced understanding of how control factors affect
-                behavior
-              </li>
-              <li>
-                <strong>Multi-factor integration:</strong> Earlier behavioral theories often
-                emphasized single factors: attitudes, norms, or self-efficacy. The TPB integrated
-                multiple factors into single coherent framework, recognizing that behavior reflects
-                attitudes toward behavior, normative influences, and perceived ability. This
-                integration acknowledged that comprehensive behavior understanding requires
-                accounting for multiple influence types rather than assuming one factor dominates
-                behavior determination
-              </li>
-              <li>
-                <strong>Measured precision improvement:</strong> The Theory of Planned Behavior
-                improved upon earlier theories through more precise measurement specifications.
-                Rather than treating attitudes as global constructs, TPB specified attitudes should
-                be measured as weighted products of beliefs and evaluations. Rather than treating
-                norms as simple social pressures, TPB distinguished normative beliefs and compliance
-                motivation. Rather than treating control simply as external constraints, TPB
-                distinguished control beliefs from power assessments. This measurement precision
-                enabled more rigorous testing and more informative comparison across populations and
-                contexts
-              </li>
-              <li>
-                <strong>Focus on behavioral intention:</strong> While earlier theories recognized
-                intentions as behavior antecedents, the TPB elevated intention as central
-                construct-the immediate determinant of behavior. This focus on intention as primary
-                mechanism meant that all other factors affect behavior through intention
-                modification (except perceived behavioral control which also has direct effects).
-                This conceptualization shifted focus from proximal behavior determinants toward the
-                intention formation processes actually guiding behavior
-              </li>
-              <li>
-                <strong>Emphasis on belief systems:</strong> The TPB moved beyond treating attitudes
-                and norms as monolithic constructs toward understanding them as built from belief
-                systems. Attitudes reflect belief systems about behavior consequences; norms reflect
-                belief systems about referent expectations; control reflects belief systems about
-                facilitators and barriers. This belief- system emphasis enabled practitioners to
-                identify specific beliefs requiring change and design targeted interventions
-                addressing particular belief content rather than attempting global attitude change
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>
-              What Barriers to Technology Adoption does the model identify?
-            </h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Theory of Planned Behavior identifies multiple categories of barriers to
-              technology adoption, organized around three primary psychosocial determinants:
-              Attitudinal barriers: Unfavorable attitudes toward technology adoption represent
-              primary barriers. Attitudes reflect underlying beliefs about consequences of
-              technology adoption weighted by desirability of those consequences. Attitudinal
-              barriers include beliefs that technology adoption produces undesirable consequences
-              such as increased workload, loss of skills or professional relevance, threat to job
-              security, reduced autonomy, increased surveillance or monitoring, or diminished work
-              satisfaction. When potential adopters believe technology adoption carries these
-              negative consequences, unfavorable attitudes develop creating adoption resistance. For
-              example, workers who believe technology adoption will eliminate their jobs or reduce
-              their professional control develop negative attitudes resisting adoption.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Attitudes also reflect instrumental evaluations:</strong> if adopters
-                believe technology produces low benefits relative to adoption costs or effort
-                requirements, unfavorable attitudes emerge. Technologies perceived as producing
-                minimal productivity improvements relative to learning time and disruption create
-                attitudinal barriers. Attitude barriers additionally emerge when adopters believe
-                technology adoption contradicts their professional values or identity. A
-                craftsperson valuing manual skill mastery might develop negative attitudes toward
-                automation technology perceived as deskilling their profession. Workers valuing
-                human relationships might resist technology reducing interpersonal contact. These
-                value-identity alignment barriers prove particularly resistant to change
-              </li>
-              <li>
-                <strong>Subjective normative barriers:</strong> Social influence and normative
-                expectations create adoption barriers when important referent groups do not support
-                technology adoption. Subjective normative barriers include absence of adoption
-                pressure from supervisors, peers, professional colleagues, or organizational
-                leaders. When influential organizational figures do not advocate or model technology
-                adoption, adoption rates decline substantially. Normative barriers include active
-                resistance from important referents-when supervisors discourage adoption, peers
-                discourage change, or professional networks resist particular technologies, adoption
-                becomes socially costly. Workers adopting technologies their peer groups reject face
-                social exclusion, ridicule, or conflict. Professional communities that resist
-                particular technologies create normative barriers for adoption by individual
-                professionals
-              </li>
-              <li>
-                <strong>
-                  Normative barriers additionally include absence of normative clarity:
-                </strong>{' '}
-                when organizational members lack clear guidance on whether adoption is expected or
-                desired, uncertainty undermines adoption likelihood. Normative barriers further
-                reflect culture clashes between technology cultures and existing organizational
-                cultures: technologies with cultures emphasizing rapid change, flexibility, and
-                innovation adoption create barriers in conservative organizational cultures
-                emphasizing stability and tradition. Technologies requiring interdependent adoption
-                create normative barriers when not all necessary population members adopt
-                simultaneously, creating incomplete networks of adoption. Nurses adopting electronic
-                health records create barriers for colleagues who must interface with non-adopting
-                units, reducing individual motivation for adoption
-              </li>
-              <li>
-                <strong>Perceived behavioral control barriers:</strong> Individuals’ beliefs about
-                their capability to successfully adopt and use technology create substantial
-                adoption barriers
-              </li>
-              <li>
-                <strong>Control barriers include perceived skill insufficiency:</strong> beliefs
-                that learning technology requires skills one lacks or cognitive abilities one cannot
-                develop prevent adoption intention formation. Older workers fearing they cannot
-                learn complex computer interfaces, individuals with limited technical background
-                fearing they cannot master software, or people with learning differences fearing
-                technology incompatibility with their learning style develop negative perceived
-                control
-              </li>
-              <li>
-                <strong>
-                  Control barriers additionally reflect perceived resource insufficiency:
-                </strong>{' '}
-                beliefs that one lacks necessary resources for adoption including time, equipment,
-                financial resources, or organizational support. Workers perceiving they lack
-                training time, technology resources, or organizational technical support report low
-                perceived control undermining adoption likelihood
-              </li>
-              <li>
-                <strong>Control barriers include anxiety and confidence deficits:</strong>{' '}
-                technology anxiety (fear of technology malfunction, data loss, making mistakes, or
-                personal inadequacy) substantially reduces perceived control even among capable
-                individuals. Control barriers additionally include beliefs about environmental and
-                organizational impediments: workers perceiving that organizational policies prohibit
-                adoption, that system incompatibilities prevent technology integration, that their
-                supervisors lack technical expertise to support adoption, or that organizational
-                culture opposes change report low perceived control despite personal capability.
-                These environmental control barriers reflect correct perceptions of actual
-                constraints preventing adoption. Control barriers further include perceived
-                addiction or loss-of- control concerns: beliefs that technology adoption might
-                create problematic dependencies or reduce self-direction create negative perceived
-                control. Workers fearing they will become dependent on technology, unable to work
-                without it, or lose their decision-making autonomy due to technology-driven
-                processes develop control concerns reducing adoption likelihood
-              </li>
-              <li>
-                <strong>Interaction effects among barrier types:</strong> The Theory of Planned
-                Behavior recognizes that these three barrier types interact in creating adoption
-                barriers. When negative attitudes combine with normative pressure against adoption,
-                the adoption barriers prove particularly strong. When control barriers occur
-                alongside negative attitudes, individuals lack both motivation (unfavorable
-                attitudes) and capability (low control) for adoption. When normative pressure for
-                adoption occurs despite individual control barriers, individuals face pressure to
-                adopt despite perceived inability, creating psychological stress. Conversely,
-                positive attitudes can partially overcome normative barriers when personal
-                evaluation sufficiently outweighs social pressure. The TPB implies that
-                comprehensive understanding of adoption barriers requires examining not just single
-                barrier types but interaction patterns revealing which combinations of barriers
-                prove most resistant to change
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>
-              What does the model instruct leaders to do in order to reduce these barriers?
-            </h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Theory of Planned Behavior provides explicit guidance for leaders designing
-              interventions to reduce adoption barriers: Attitude change interventions targeting
-              belief systems: Leaders must identify specific beliefs creating negative attitudes
-              toward technology adoption. Rather than assuming attitudes are unchangeable or
-              attempting global attitude change, the TPB instructs leaders to conduct formative
-              research identifying which belief categories underlie negative attitudes. For
-              technologies perceived as producing undesirable consequences (job loss, increased
-              workload, reduced autonomy), leaders should provide evidence and testimony addressing
-              these specific concerns. Demonstrations showing that technology actually reduces
-              workload rather than increasing it, case studies from adopting organizations showing
-              job transformation rather than elimination, or testimonials from workers successfully
-              adopting technologies addressing specific concerns can shift outcome beliefs. Leaders
-              should also help potential adopters recognize positive consequences and help them
-              develop more favorable evaluations of technology outcomes.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              For technologies perceived as producing insufficient benefits, leaders should
-              articulate concrete benefits including productivity improvements, reduced error rates,
-              better customer service, professional development opportunities, or improved work
-              quality. Communicating benefits in language matching adopter values (career
-              advancement for ambitious professionals, autonomy for those valuing independence,
-              better work-life balance for family-oriented workers) increases persuasiveness.
-              Leaders should identify outcome evaluations moderating adoption and align benefit
-              communication with adopter values. For attitude barriers rooted in identity and values
-              conflicts (technology threatening professional identity or contradicting professional
-              values), leaders should help potential adopters integrate technology use with their
-              professional identities. Reframing technology adoption as enhancement (increasing
-              professional capabilities while maintaining core professional values) rather than
-              replacement (eliminating professional value) can shift evaluations. Involving
-              respected professionals who maintain valued identities while adopting technologies
-              provides identity-aligned role models.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Normative influence interventions: Leaders instructed by TPB should recognize that
-              subjective normative barriers require social influence interventions involving
-              referent groups and organizational cultures. To overcome normative barriers, leaders
-              should secure explicit advocacy and modeling from organizational influencers including
-              high-status organizational leaders, respected supervisors, and professional opinion
-              leaders. When organizational leaders visibly adopt technologies, use them in their
-              work, discuss adoption benefits, and reward adoption among their teams, powerful
-              normative support develops. Leaders should involve respected peers and professional
-              colleagues in adoption planning and implementation, enabling them to serve as peer
-              advocates and role models. Peer-to-peer influence proves particularly powerful because
-              peers share similar concerns, understand practical implementation challenges, and
-              carry credibility within peer networks. Leaders should address cultural conflicts
-              between technology culture and organizational culture explicitly rather than ignoring
-              them.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              When technology adoption requires cultural shifts (toward greater flexibility,
-              data-driven decision-making, or continuous learning), leaders should articulate
-              cultural transitions and help organizational members adapt to new cultural
-              expectations while maintaining valued continuities. Leaders should create normative
-              clarity through explicit communication that adoption is expected, supported, and
-              valued. Ambiguous normative expectations undermine adoption; clear organizational
-              statements about technology adoption as required or strongly supported provide
-              normative pressure supporting adoption. For technologies requiring interdependent
-              adoption, leaders should plan coordinated organizational-wide implementation ensuring
-              that all necessary population members adopt together, creating complete adoption
-              networks with normative support from colleagues facing identical implementation
-              challenges.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Perceived behavioral control interventions: Leaders instructed by the TPB should
-              address perceived control barriers through capability-building and environmental
-              enabling. For skill sufficiency barriers, leaders should provide comprehensive
-              training programs ensuring potential adopters develop necessary capabilities before
-              adoption demands. Rather than assuming adoption will encourage learning, leaders
-              should proactively build skills creating foundation for successful adoption. Training
-              should accommodate diverse learning styles and paces (some learning quickly, others
-              requiring extended practice) ensuring broad capability development. For individuals
-              with significant anxiety or confidence deficits, leaders should provide intensive
-              support including hands-on coaching, extended practice opportunities, peer support
-              systems, and confidence-building experiences. Leaders should provide graduated
-              adoption starting with simple functions and advancing to complex features as
-              confidence builds. For resource insufficiency barriers, leaders should ensure that
-              organizational systems provide necessary resources including access to training,
-              adequate technology, organizational support systems, and time for learning. When
-              individuals lack training time, leaders should provide dedicated learning time rather
-              than expecting learning to occur outside work. When individuals lack necessary
-              equipment or software licenses, leaders should ensure these are provided. When
-              individuals lack organizational support, leaders should identify technical experts
-              available to answer questions and solve problems. Leaders should create support
-              systems including help desks, peer support networks, designated technology champions,
-              and accessible technical expertise. Making support readily available - through email,
-              phone, or in-person consultation - increases perceived control by reducing beliefs
-              that individuals must troubleshoot problems alone. For environmental impediment
-              barriers, leaders should remove actual obstacles to adoption. This may require
-              organizational policy changes, system integration work enabling technology to function
-              within existing systems, or supervisor communication clarifying that adoption is
-              supported despite apparent organizational impediments. When individuals correctly
-              perceive that technology policies prohibit adoption or that system incompatibilities
-              prevent integration, leaders must address these obstacles directly rather than
-              expecting attitude change to overcome real barriers. For anxiety and loss-of-control
-              concerns, leaders should provide education addressing specific fears, demonstrating
-              that technology safeguards protect data, that training maintains user control, and
-              that organizations implement technology in ways preserving human judgment and
-              autonomy. Demonstrating that technology supports rather than replaces human
-              decision-making can alleviate concerns about loss of control.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Multi-factor intervention design: The Theory of Planned Behavior instructs leaders
-              that effective adoption interventions require addressing all three psychosocial
-              barrier types simultaneously. If interventions address only attitudes while ignoring
-              normative or control barriers, adoption remains suboptimal. Leaders should assess
-              baseline attitudes, normative support, and perceived control across potential adopters
-              to identify which barrier types most strongly undermine adoption. This diagnostic
-              assessment guides intervention design ensuring that intervention components match
-              identified barriers. For technologies where negative attitudes constitute primary
-              barriers, intervention intensity should focus on attitude change through persuasive
-              communication, demonstrations, and testimonials. For technologies where normative
-              barriers dominate, intervention intensity should focus on building social support,
-              securing leadership advocacy, and shifting organizational culture. For technologies
-              where perceived control barriers dominate, intervention intensity should focus on
-              capability building and environmental enabling. Leaders should design comprehensive
-              interventions incorporating attitude change, normative influence, and control
-              enhancement elements appropriate to identified barriers.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Monitoring barrier persistence: The TPB instructs leaders to measure attitudes,
-              subjective norms, and perceived control before intervention, during implementation,
-              and after adoption to assess whether specific barriers actually declined through
-              intervention. This ongoing measurement enables mid-course correction if particular
-              barriers prove resistant to intervention. If subjective norms measurements indicate
-              normative barriers persist despite leadership advocacy, leaders should intensify
-              normative interventions. If perceived control measurements indicate skill deficiencies
-              persist despite training, leaders should provide additional training. This
-              measurement-guided approach enables adaptive intervention improving effectiveness
-              through data-driven modifications.
-            </p>
-          </section>
-
-          {/* 7. Following Models or Theories */}
-          <section className={SECTION_CLASSES}>
-            <h2 className={H2_CLASSES}>7. Following Models or Theories</h2>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>Following Models:</strong> Technology Acceptance Model extensions using TPB;
-              Unified Theory of Acceptance and Use of Technology incorporating TPB constructs;
-              Task-Technology Fit models building on TPB; Social cognitive theory extensions of TPB
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>Following Theories:</strong> Protection motivation theory applications;
-              Behavioral change theory extensions; Health behavior adoption models; Organizational
-              behavior change frameworks building on TPB
-            </p>
-          </section>
-
-          {/* Series Navigation */}
-          <section className={SECTION_CLASSES}>
-            <h2 className={H2_CLASSES}>Series Navigation</h2>
-            <p className={PARAGRAPH_CLASSES}>
-              Diffusion of Innovations (Rogers, 1962) - Foundational Framework
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The Theory of Planned Behavior (Ajzen, 1991) - Individual Behavior Prediction
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Perceived Usefulness, Perceived Ease of Use, and User Acceptance of Information
-              Technology (Davis, 1989) - Technology-Specific Acceptance
-            </p>
-          </section>
-
-          <p className="mt-8 text-sm italic text-gray-600">
-            Note: This article provides an overview based on the comprehensive literature review.
-            Readers are encouraged to consult the original publication for complete details.
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Icek Ajzen developed the Theory of Planned Behavior to address critical limitations in
+            the Theory of Reasoned Action and provide a more comprehensive framework for
+            understanding behavior across diverse domains. The fundamental motivation stemmed from
+            recognizing that TRA, while successful in predicting behavior under conditions of
+            volitional control, failed adequately when individuals lacked complete control over
+            behavior performance.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            While TRA successfully predicted voting, family planning, and consumer choice, it
+            operated under an assumption that behavior results solely from conscious intentions
+            determined by attitudes and subjective norms. This assumption proved problematic in
+            real-world contexts where individuals often cannot fully control behavior performance
+            due to resource constraints, skills limitations, environmental obstacles, or structural
+            barriers. Many significant behaviors, including technology adoption, involve elements
+            beyond complete volitional control.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            Ajzen explicitly constructed TPB to overcome this limitation by adding perceived
+            behavioral control - the extent to which individuals believe they can successfully
+            perform behavior even when facing obstacles. By incorporating control perceptions, the
+            TPB creates applicability to behaviors where volitional control varies. Beyond
+            technology adoption, the framework aims to explain intentional behavior across health,
+            education, environment, relationships, and organizational contexts with consistent
+            theoretical structure while allowing domain-specific applications.
           </p>
         </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            TPB operationalizes three primary determinants of behavioral intention:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Attitudes Toward Behavior:</strong> Overall favorable or unfavorable
+              evaluations of performing a specific behavior. Reflect underlying beliefs about
+              behavior consequences weighted by desirability of those consequences.
+            </li>
+            <li>
+              <strong>Subjective Norms:</strong> Perceived social pressure to perform or not perform
+              behavior. Capture perceptions of what important others think the individual should do,
+              weighted by motivation to comply with each referent.
+            </li>
+            <li>
+              <strong>Perceived Behavioral Control:</strong> Beliefs about one&rsquo;s ability to
+              successfully perform behavior given existing constraints and resources. Reflect both
+              internal factors (skills, self-efficacy) and external factors (environmental
+              opportunities, dependencies on others).
+            </li>
+            <li>
+              <strong>Behavioral Intention:</strong> Readiness or plan to perform behavior.
+              Represents the immediate antecedent to actual behavior performance.
+            </li>
+            <li>
+              <strong>Behavior:</strong> The observable action performed, whether individuals
+              actually perform intended behaviors.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            TPB built logically upon several prior theoretical traditions:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Theory of Reasoned Action (Fishbein &amp;{' '}
+                <Link
+                  href="/bibliography-1-1-theory-of-reasoned-action-tra-fishbein-ajzen-1975"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Ajzen, 1975
+                </Link>
+                ):
+              </strong>{' '}
+              Provided the foundational structure where intentions mediate the attitude-behavior
+              relationship.
+            </li>
+            <li>
+              <strong>
+                Self-efficacy theory (
+                <a
+                  id="cite-ref-bandura-1977-1"
+                  href="#ref-bandura-1977"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Bandura, 1977
+                </a>
+                ):
+              </strong>{' '}
+              Established the importance of beliefs about personal capability to perform actions.
+            </li>
+            <li>
+              <strong>Locus of control research:</strong> Documented how individuals&rsquo; beliefs
+              about control over outcomes influence behavior.
+            </li>
+            <li>
+              <strong>Expectancy-value theories:</strong> Grounded the concept that attitudes form
+              from expected consequences weighted by their evaluations.
+            </li>
+            <li>
+              <strong>Behavioral decision theory:</strong> Provided foundations for understanding
+              how people make deliberate behavior choices.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Theory of Planned Behavior specifies that attitudes, subjective norms, and perceived
+            behavioral control determine behavioral intention, which in turn predicts actual
+            behavior. Perceived behavioral control additionally exerts direct effects on behavior
+            when control accurately reflects actual constraints. This hierarchical structure is:
+          </p>
+          <p className={`${PARAGRAPH_CLASSES} font-mono text-sm bg-gray-50 p-3 rounded`}>
+            Attitudes &amp; Subjective Norms &amp; Perceived Control &rarr; Behavioral Intention
+            &rarr; Behavior
+          </p>
+
+          <h3 className={H3_CLASSES}>What does the model measure?</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Attitudes toward behavior:</strong> Evaluative scales capturing
+              favorable/unfavorable judgments of performing specific behaviors.
+            </li>
+            <li>
+              <strong>Subjective norms:</strong> Perceived social pressure and normative
+              expectations from important referent others.
+            </li>
+            <li>
+              <strong>Perceived behavioral control:</strong> Beliefs about factors facilitating or
+              impeding behavior performance and power of each factor.
+            </li>
+            <li>
+              <strong>Behavioral intention:</strong> Readiness and plans to perform behavior
+              measured through likelihood and expectancy items.
+            </li>
+            <li>
+              <strong>Actual behavior:</strong> Whether individuals actually perform intended
+              behaviors, measured through self-report or behavioral observation.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Theoretical comprehensiveness:</strong> Incorporates personal evaluation,
+              social influence, and self-efficacy into single coherent framework.
+            </li>
+            <li>
+              <strong>Clear causal structure:</strong> Articulates explicitly specified
+              relationships enabling precise hypothesis testing and systematic investigation.
+            </li>
+            <li>
+              <strong>Measured flexibility:</strong> Can be applied to any specific behavior by
+              conducting formative research identifying relevant beliefs and control factors.
+            </li>
+            <li>
+              <strong>Cross-domain validation:</strong> Demonstrates predictive validity across
+              health, education, environment, workplace, and consumer domains.
+            </li>
+            <li>
+              <strong>Distinction of indirect and direct effects:</strong> Specifies that perceived
+              control affects behavior both through intentions and directly, reflecting control
+              factor complexity.
+            </li>
+            <li>
+              <strong>Practical intervention guidance:</strong> Explicitly specifies attitudes,
+              norms, and control as change targets, directing practitioners toward psychosocial
+              factors requiring modification.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Measurement circularity concerns:</strong> Perceived and actual behavioral
+              control may coincide or diverge due to biased perceptions, creating ambiguity about
+              what perceived control predicts.
+            </li>
+            <li>
+              <strong>Limited attention to structural barriers:</strong> Treats barriers primarily
+              through individual perceptions; real structural barriers preventing adoption receive
+              less theoretical attention.
+            </li>
+            <li>
+              <strong>Temporal dynamics underspecified:</strong> Provides limited specification of
+              how intentions change over time or how to maintain intentions across extended
+              implementation periods.
+            </li>
+            <li>
+              <strong>Past behavior undertheorized:</strong> Focuses on rational deliberation
+              processes but provides limited mechanism for habit formation and automaticity in
+              repeated behavior.
+            </li>
+            <li>
+              <strong>Affective factors underemphasized:</strong> Attitude construct focuses on
+              instrumental evaluations rather than emotional or affective responses to behavior.
+            </li>
+            <li>
+              <strong>Domain-specific inconsistency:</strong> Relative importance of attitudes,
+              norms, and control varies substantially across domains, limiting ability to predict
+              which factors dominate without empirical investigation.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Control factor integration:</strong> Incorporated perceived behavioral control
+              as explicit construct affecting both intentions and behavior directly.
+            </li>
+            <li>
+              <strong>Theoretical extension accomplishment:</strong> Expanded Theory of Reasoned
+              Action applicability to behaviors beyond volitional control.
+            </li>
+            <li>
+              <strong>Multi-factor integration framework:</strong> Provided model integrating
+              attitudes, norms, and self-efficacy into unified behavioral prediction framework.
+            </li>
+            <li>
+              <strong>Belief system emphasis:</strong> Moved beyond monolithic constructs toward
+              understanding them as built from specific belief systems.
+            </li>
+            <li>
+              <strong>General behavior prediction template:</strong> Established general framework
+              applicable across health, education, environment, workplace, and consumer domains.
+            </li>
+            <li>
+              <strong>Practical intervention specification:</strong> Explicitly specified
+              psychological factors requiring modification to influence behavior, enabling targeted
+              intervention design.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Ajzen established TPB&rsquo;s internal validity through multiple strategies:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Theoretical coherence:</strong> Articulates clear causal structure with
+              explicitly specified relationships between constructs.
+            </li>
+            <li>
+              <strong>Construct operationalization:</strong> Provides explicit measurement guidance
+              for attitudes, norms, and control through multi-item scales with clear theoretical
+              basis.
+            </li>
+            <li>
+              <strong>Empirical grounding:</strong> Builds on extensive self-efficacy, locus of
+              control, and behavioral research, importing validity support from established
+              literature.
+            </li>
+            <li>
+              <strong>Logical extension of established theory:</strong> Maintains TRA core structure
+              while adding perceived behavioral control, demonstrating that TPB incorporates TRA as
+              special case.
+            </li>
+            <li>
+              <strong>Specification precision:</strong> Precisely specifies which constructs exert
+              indirect effects through intentions and which exert direct effects on behavior.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Theory of Planned Behavior established substantial external validity through diverse
+            applications:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Cross-domain applicability:</strong> Demonstrated applicability across health,
+              occupational, educational, environmental, and consumer behaviors.
+            </li>
+            <li>
+              <strong>Population diversity:</strong> Found consistent relationships across
+              demographic groups, educational levels, and cultural contexts.
+            </li>
+            <li>
+              <strong>Behavioral complexity variation:</strong> Applied to simple discrete behaviors
+              through complex sustained behaviors requiring multiple action sequences.
+            </li>
+            <li>
+              <strong>Time frame generalization:</strong> Maintained predictive validity across
+              immediate behavior through months and years of follow-up.
+            </li>
+            <li>
+              <strong>Laboratory and field study convergence:</strong> Found consistent
+              relationships in both controlled settings and real-world behavioral contexts.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            TPB is directly relevant to technology adoption because it explains how attitudes,
+            social influences, and perceived capability determine whether individuals intend to
+            adopt technologies. Unlike simpler models, TPB acknowledges that individuals may intend
+            to adopt but face actual barriers preventing adoption.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified by TPB</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Unfavorable attitudes:</strong> Negative evaluations of adoption consequences
+              including job security threats, autonomy loss, or insufficient benefits relative to
+              effort.
+            </li>
+            <li>
+              <strong>Negative subjective norms:</strong> Lack of adoption pressure or active
+              resistance from supervisors, peers, or organizational leaders.
+            </li>
+            <li>
+              <strong>Low perceived behavioral control:</strong> Beliefs that learning technology
+              requires skills one lacks, that insufficient resources exist, or that organizational
+              impediments prevent adoption.
+            </li>
+            <li>
+              <strong>Technology anxiety and confidence deficits:</strong> Fears of technology
+              malfunction, data loss, or personal inadequacy reducing perceived control despite
+              capability.
+            </li>
+            <li>
+              <strong>Interaction barriers:</strong> Strong negative attitudes combined with
+              normative pressure against adoption, or control barriers occurring alongside negative
+              attitudes.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions TPB Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Attitude change targeting specific beliefs:</strong> Conduct formative
+              research identifying beliefs creating negative attitudes, then design targeted
+              interventions addressing specific concerns.
+            </li>
+            <li>
+              <strong>Normative influence interventions:</strong> Secure explicit advocacy from
+              organizational influencers, involve respected peers in implementation planning,
+              address cultural conflicts explicitly.
+            </li>
+            <li>
+              <strong>Perceived control enhancement:</strong> Provide comprehensive training
+              ensuring capability development, create support systems, remove actual environmental
+              obstacles.
+            </li>
+            <li>
+              <strong>Multi-factor intervention design:</strong> Address all three barrier types
+              simultaneously rather than focusing on single-factor solutions.
+            </li>
+            <li>
+              <strong>Monitoring and adaptive management:</strong> Measure attitudes, norms, and
+              control periodically to assess whether interventions effectively address barriers and
+              enable course correction.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            TPB provided the structural foundation for numerous extensions and integrated models:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Technology Acceptance Model extensions:</strong> Applied TPB structures to
+              technology-specific adoption contexts.
+            </li>
+            <li>
+              <strong>Unified Theory of Acceptance and Use of Technology (UTAUT):</strong>{' '}
+              Integrated TPB with other adoption models into comprehensive framework.
+            </li>
+            <li>
+              <strong>Task-Technology Fit models:</strong> Built on TPB by incorporating how
+              technology characteristics align with job requirements.
+            </li>
+            <li>
+              <strong>Protection Motivation Theory applications:</strong> Extended TPB structures to
+              threat-and-coping contexts.
+            </li>
+            <li>
+              <strong>Health behavior adoption models:</strong> Applied TPB to diverse health
+              behaviors and organizational health promotion.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-ajzen-1991">
+              Ajzen, I. (1991). The theory of planned behavior.{' '}
+              <em>Organizational Behavior and Human Decision Processes</em>, 50(2), 179-211.
+              https://doi.org/10.1016/0749-5978(91)90020-T
+            </li>
+            <li id="ref-bandura-1977">
+              Bandura, A. (1977). Self-efficacy: Toward a unifying theory of behavioral change.
+              <em>Psychological Review</em>, 84(2), 191-215.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-bandura-1977-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+          </ol>
+        </section>
+
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-ajzen-1980">
+              Ajzen, I., &amp; Fishbein, M. (1980). Understanding attitudes and predicting social
+              behavior. Prentice-Hall.
+            </li>
+            <li id="ref-fishbein-1975">
+              Fishbein, M., &amp; Ajzen, I. (1975). Belief, attitude, intention, and behavior: An
+              introduction to theory and research. Addison-Wesley.
+            </li>
+            <li id="ref-triandis-1977">
+              Triandis, H. C. (1977). Interpersonal behavior. Brooks/Cole.
+            </li>
+            <li id="ref-armitage-2001">
+              Armitage, C. J., &amp; Conner, M. (2001). Efficacy of the theory of planned behaviour:
+              A meta-analytic review. <em>British Journal of Social Psychology</em>, 40(4), 471-499.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-6-technology-acceptance-model-tam-davis-1989"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Technology Acceptance Model (Davis)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-8-personal-computing-acceptance-thompson-1991"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Personal Computing Acceptance (Thompson et al.) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>

--- a/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
+++ b/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
@@ -65,6 +65,17 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 179-211
             </p>
+            <p>
+              <strong>DOI:</strong>{' '}
+              <a
+                href="https://doi.org/10.1016/0749-5978(91)90020-T"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.1016/0749-5978(91)90020-T
+              </a>
+            </p>
           </div>
         </section>
 


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 1-7 TPB (Ajzen, 1991) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1559
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)