### PR TITLE
docs: standardize bibliography 1-10 Decomposed TPB (Taylor & Todd, 1995)

### DIFF
--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -8,1028 +8,685 @@ import {
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
-  BODY_OL_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Decomposed TPB - Taylor & Todd (1995)',
+  title: 'Bibliography: Decomposed Theory of Planned Behavior - Taylor & Todd (1995)',
   description:
-    'Deep dive into Understanding Information Technology Usage: A Test of by Shirley Taylor, Peter A. Todd (1995), exploring its foundational contributions to technology adoption research.',
+    'Comprehensive analysis of the Decomposed Theory of Planned Behavior (DTPB), which decomposes attitudinal, normative, and control beliefs into technology-specific multidimensional constructs for predicting IT adoption.',
 }
 
 const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Decomposed TPB - Taylor & Todd (1995)</h1>
+        <h1 className={H1_CLASSES}>
+          Decomposed Theory of Planned Behavior - Taylor &amp; Todd (1995)
+        </h1>
 
-        {/* Model Identification */}
+        {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Model Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Model Name:</strong> Decomposed Theory of Planned Behavior (DTPB)
+              <strong>Model Name:</strong> Understanding Information Technology Usage: A Test of
+              Competing Models
             </p>
+            <p>
+              <strong>Model Abbreviation:</strong> Decomposed Theory of Planned Behavior (DTPB)
+            </p>
+            <p>
+              <strong>Target of Model:</strong> IT Adoption and Usage Behavior Prediction
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Information Systems, Social Psychology,
+              Behavioral Decision Making
+            </p>
+          </div>
+        </section>
+
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
             <p>
               <strong>Authors:</strong> Shirley Taylor, Peter A. Todd
             </p>
             <p>
-              <strong>Publication Date:</strong> 1995
+              <strong>Formal Publication Date:</strong> 1995
+            </p>
+            <p>
+              <strong>Official Title:</strong> Understanding Information Technology Usage: A Test of
+              Competing Models
+            </p>
+            <p>
+              <strong>Journal:</strong> Information Systems Research
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 6, No. 2
+            </p>
+            <p>
+              <strong>Pages:</strong> 144-176
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Taylor, S., & Todd, P. A. (1995). Understanding information technology usage: A test
-              of competing models. Information Systems Research, 6(2), 144-176.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Taylor, S., &amp; Todd, P. A. (
+                <a href="#ref-taylor-1995" className="text-tabs-teal-deep hover:underline">
+                  1995
+                </a>
+                ). Understanding information technology usage: A test of competing models.{' '}
+                <em>Information Systems Research</em>, 6(2), 144-176.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Taylor, Shirley, and Peter A. Todd. 1995. &ldquo;Understanding Information
+                Technology Usage: A Test of Competing Models.&rdquo;{' '}
+                <em>Information Systems Research</em> 6, no. 2: 144-176.
+              </p>
+            </div>
           </div>
         </section>
 
-        {/* Main Content */}
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>Why was the model made?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd developed their competing models framework to address fundamental
-              ambiguities and theoretical gaps in information technology adoption research. By the
-              mid-1990s, multiple theoretical frameworks had been proposed to explain IT
-              adoption-Davis’s Technology Acceptance Model (TAM), the Theory of Planned Behavior
-              (TPB), Thompson et al.’s expected consequences model, and others. However, no
-              comprehensive empirical comparison existed to determine which framework provided
-              superior explanatory power or how different theoretical approaches related to one
-              another. The authors note in their introduction that “different theoretical models
-              have been applied to predict IT usage” but “little research has compared alternative
-              models.” This research gap meant that IS researchers and practitioners lacked clear
-              guidance about which theories offered the most robust understanding of technology
-              adoption.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Organizations also lacked a coherent framework for understanding which factors truly
-              drove IT adoption versus which represented theoretical artifacts or artifacts of
-              measurement approaches. Taylor and Todd recognized three specific research questions
-              their work would address: (1) How do different theoretical models compare in
-              explaining IT usage behavior? (2) Can models be successfully integrated to provide
-              greater explanatory power? (3) What underlying mechanisms explain why individuals
-              adopt or resist information technologies? The motivation was also grounded in
-              theoretical development. The Technology Acceptance Model (TAM) had become increasingly
-              influential but also increasingly critiqued. Critics argued that TAM’s two primary
-              constructs-Perceived Usefulness (PU) and Perceived Ease of Use (PEOU)- might be too
-              simplified and that the theory neglected important factors like social influences,
-              control beliefs, and consequences.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Other frameworks like the Theory of Planned Behavior incorporated additional
-              constructs, but their applicability to IT adoption was less established. Taylor and
-              Todd sought to test whether richer, more complex models would outperform Davis’s
-              simpler TAM. They hypothesized that “the TPB and an extended TAM model would predict
-              usage better than a simple TAM model” because additional constructs capture neglected
-              influences. They posited that understanding IT adoption required examining not only
-              individual perceptions of technology (PU and PEOU) but also social influences, control
-              factors, consequences, and motivational variables. The research was conducted using
-              two distinct technologies in two organizational contexts: email use among MBA students
-              and new information system adoption among academic faculty. This multi-technology,
-              multi-context approach allowed the authors to examine whether findings generalized
-              across different IT adoption scenarios.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How was the model’s internal validity tested?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd employed rigorous quantitative methodology with two separate studies
-              to establish internal validity: Study 1: Email Adoption Among MBA Students The
-              researchers surveyed 108 MBA students who were required to use email as part of their
-              program.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>They measured seven core constructs through multi-item scales:</strong>{' '}
-                Perceived Usefulness (PU): Five items measuring whether email would improve
-                job/academic performance, with Cronbach’s alpha = .94 Perceived Ease of Use (PEOU):
-                Four items assessing perceived learning difficulty and ease of interaction, alpha =
-                .88 Attitude Toward Use: Three items measuring overall evaluations of email, alpha =
-                .93 Subjective Norm: Four items measuring perceived social pressure to use email,
-                alpha = .75 Perceived Behavioral Control (PBC): Four items assessing ability and
-                resources for email use, alpha = .87 Behavioral Intention: Three items measuring
-                intent to use, alpha = .93 Actual Usage: Measured directly through email system
-                logs, providing objective behavioral data The researchers established internal
-                validity through multiple techniques: Convergent and Discriminant Validity: The
-                authors examined factor loadings and construct correlations. All measurement items
-                loaded significantly on their hypothesized constructs (t-values &gt; 2.0), and
-                constructs showed appropriate correlations with one another-related enough to
-                indicate common underlying domain but distinct enough to represent separate
-                dimensions
-              </li>
-              <li>
-                <strong>Scale Reliability:</strong> Cronbach’s alpha coefficients ranged from .75 to
-                .94, demonstrating acceptable reliability. The relatively high alphas indicated that
-                measurement items consistently measured each construct
-              </li>
-              <li>
-                <strong>Measurement Model Assessment:</strong> The authors compared structural
-                equation model specifications using LISREL. They tested whether observed variables
-                loaded appropriately on latent constructs and whether the measurement model fit
-                adequately before examining structural relationships. Study 2: New Information
-                System Among Faculty A second study with 223 academic faculty members adopting a new
-                information system allowed replication and generalization testing: Perceived
-                Usefulness: Five items, alpha = .89 Perceived Ease of Use: Four items, alpha = .81
-                Subjective Norm: Four items, alpha = .78 Perceived Behavioral Control: Four items,
-                alpha = .74 Behavioral Intention: Three items, alpha = .95 Actual Usage: Three items
-                measuring frequency and intensity of use, alpha = .78 Cross-Study Validity: The
-                consistency of measurement approaches across studies allowed meta-analytic
-                comparison of path coefficients and model structures. Similar patterns across
-                different technologies and populations strengthened internal validity evidence
-              </li>
-              <li>
-                <strong>Structural Model Testing:</strong> For each study, the authors tested
-                multiple competing structural models using LISREL and examined multiple
-                goodness-of-fit indices: Chi-square (χ²) values and associated p-values Adjusted
-                goodness-of-fit index (AGFI) Comparative fit index (CFI) Root mean square error of
-                approximation (RMSEA) Standardized root mean square residual (SRMR) The models
-                tested included: Original TAM: PU and PEOU → Attitude → Intention → Usage Extended
-                TAM (TAM2): PU and PEOU → Attitude; PU and Subjective Norm → Intention → Usage
-                Theory of Planned Behavior: Attitude, Subjective Norm, and PBC → Intention → Usage
-                Integrated Model: Combined TAM and TPB elements with specific structural pathways
-                Model Comparison: The authors compared models across multiple criteria: Explained
-                variance in Behavioral Intention (R²) Explained variance in Actual Usage Path
-                coefficient magnitudes and significance Overall model fit statistics All path
-                coefficients were tested for statistical significance using t-statistics derived
-                from LISREL estimation procedures. The models generally showed good fit to the data
-                in both studies, with AGFI values above .85 and CFI values above .90, indicating
-                acceptable structural validity
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How was the model’s external validity tested?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd employed a two-study design specifically to strengthen external
-              validity claims: Multi-Technology Approach: Study 1 examined email adoption-a
-              relatively optional technology where use provided immediate benefits but was not
-              mandatory. Study 2 examined a new information system-a more mandatory technology
-              implemented as part of organizational operations. This contrast allowed testing
-              whether models generalized across voluntary versus mandated adoption contexts. The
-              different technological characteristics created two distinct adoption scenarios: email
-              represented communication technology that users could adopt incrementally and benefit
-              from individual use even without universal organizational adoption. The new
-              information system represented integrated business software where benefits depended on
-              broader organizational adoption and integration.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Multi-Context Sampling:</strong> Study 1 used MBA students in a university
-                setting, representing professional training contexts where email adoption enhances
-                learning efficiency. Study 2 used academic faculty in a university setting,
-                representing knowledge work contexts where the new system integrated with scholarly
-                and administrative functions. While both university-based, the different user
-                populations (students versus faculty) and different organizational roles (learners
-                versus knowledge workers) created variation
-              </li>
-              <li>
-                <strong>Population Diversity Within Studies:</strong> Study 1 included 108 MBA
-                students with varying prior computer experience. Study 2 included 223 faculty
-                members across different academic disciplines with varying technical sophistication.
-                This within-study diversity strengthened generalization claims
-              </li>
-              <li>
-                <strong>Objective Behavioral Measures:</strong> Rather than relying solely on self-
-                reported intentions, both studies measured actual usage: Study 1: Email usage
-                measured through system logs showing frequency and duration of email interaction
-                Study 2: Usage measured through three-item self-report scale of frequency and
-                intensity (though this was less objective than Study 1) The authors note that “usage
-                was measured more directly in Study 1 through system logs… [while Study 2 used]
-                perceptual measures of usage frequency and intensity.” This difference represents a
-                limitation for Study 2’s external validity but allows comparison of findings across
-                objective and subjective measurement approaches
-              </li>
-              <li>
-                <strong>Replication of Patterns:</strong> The authors explicitly designed Study 2 to
-                replicate Study 1 findings in a different context. When similar path coefficients
-                and model structures emerged across both studies despite different technologies and
-                populations, this strengthened confidence that findings represent generalizable
-                principles rather than context-specific artifacts
-              </li>
-              <li>
-                <strong>Temporal Separation:</strong> The studies were conducted at different points
-                in time, with Study 1 representing an emerging email adoption phase and Study 2
-                representing a more mature IT adoption scenario. This temporal variation allowed
-                assessment of whether adoption patterns differ at different innovation diffusion
-                stages
-              </li>
-              <li>
-                <strong>Adequacy of Model Specifications:</strong> The authors tested whether their
-                theoretical models and path specifications fit both datasets adequately. If models
-                were misspecified or context-dependent, fit would diverge significantly across
-                studies. Similar fit indices and path coefficients across contexts provided evidence
-                that models captured fundamental adoption processes not highly dependent on specific
-                contexts
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How is the model intended to be used in practice?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd provided managerial guidance for using their findings to understand
-              and facilitate IT adoption: Model Selection and Assessment: Organizations can use the
-              competing models framework to select which theoretical perspective best matches their
-              adoption context. The authors note that “the extended TAM model performed comparably
-              to the TPB model in predicting usage” and suggest that organizations should assess
-              which factors dominate in their specific context. For mandatory technologies or
-              contexts with strong organizational control, extended TAM elements prove sufficient.
-              For voluntary or discretionary technologies, additional consideration of subjective
-              norms and perceived behavioral control offers greater insight.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Diagnostics for Adoption Barriers:</strong> The competing models identify
-                different leverage points for intervention. If an organization finds that Perceived
-                Usefulness is the limiting factor, training and communication should emphasize
-                functional benefits. If Perceived Ease of Use is low, technical support and system
-                redesign become priorities. If social factors (subjective norms) are inhibitory,
-                organizational communication and champion strategies become essential. The framework
-                guides practitioners to diagnose which specific factors constrain adoption in their
-                organization. “Understanding which factors most strongly predict usage in particular
-                contexts allows targeted intervention” on the most consequential barriers
-              </li>
-              <li>
-                <strong>Expectation Setting About Adoption Patterns:</strong> The models provide
-                insight into typical adoption trajectories. The strong relationship between
-                Perceived Usefulness and Behavioral Intention suggests that users develop intentions
-                based on utility perceptions. The positive effect of Perceived Ease of Use on both
-                Attitude and Usefulness indicates that simple systems that require less learning
-                effort are perceived as more useful. Organizations can use these relationships to
-                forecast adoption patterns. If rollout plans generate low Perceived Usefulness
-                perceptions despite objectively useful functionality, adoption will likely be poor.
-                The model indicates that perception management is as important as objective system
-                quality
-              </li>
-              <li>
-                <strong>Intervention Sequencing:</strong> The models suggest an intervention
-                sequence. First, reduce Perceived Ease of Use barriers through training, simplified
-                interfaces, and accessible support. As users gain capability, Perceived Usefulness
-                becomes increasingly salient-systems that are easier to use are perceived as more
-                useful. Then, as individuals develop intentions to use systems, social norms and
-                organizational support become important for sustaining usage
-              </li>
-              <li>
-                <strong>Normative Strategy Differentiation:</strong> For voluntary technology
-                adoption, Taylor and Todd suggest that “subjective norms significantly predict
-                behavioral intention” indicating that “opinion leaders, peer champions, and visible
-                organizational support matter.” Managers should systematically cultivate these
-                social influences. For mandatory technologies, the findings suggest that usefulness
-                and ease of use dominate, though social factors still contribute. Organizations
-                implementing mandatory systems can rely less on social persuasion and more on
-                ensuring the systems genuinely improve work processes and are easy to use
-              </li>
-              <li>
-                <strong>Comparative Model Assessment:</strong> Organizations can apply each
-                competing model as a diagnostic framework: TAM: Focus on Perceived Usefulness and
-                Perceived Ease of Use. If usage is low despite high scores on these, other factors
-                omitted by TAM may be limiting adoption
-              </li>
-              <li>
-                <strong>Extended TAM:</strong> Include social norm assessment. If organizational
-                norms are negative despite useful systems, norm-building interventions become
-                necessary. TPB: Assess Perceived Behavioral Control. If users doubt their capacity
-                to use systems effectively despite perceiving usefulness, then training and support
-                become critical
-              </li>
-              <li>
-                <strong>Integrated Model:</strong> Assess all factors comprehensively to ensure no
-                major barrier is overlooked
-              </li>
-              <li>
-                <strong>Implementation Planning:</strong> For new IT implementations, organizations
-                can use the competing models framework to design multi-faceted adoption strategies:
-                System Design Phase: Prioritize both usefulness (functionality) and ease of use
-                (interface design) based on the models’ emphasis on these factors Training and
-                Support Design: Design training to build both Perceived Ease of Use and
-                understanding of Perceived Usefulness Organizational Communication: Build subjective
-                norms supporting adoption through visible champion endorsement and management
-                support Resource Provision: Ensure Perceived Behavioral Control is high by providing
-                adequate support, access to systems, training resources, and technical assistance
-                Cross-Technology Application: The research demonstrates that models apply across
-                different technologies (email and integrated information systems). Organizations
-                implementing different IT solutions can use the same competing models framework,
-                adapting emphasis based on technology characteristics and organizational context
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What does the model measure?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd’s framework operationalizes multiple constructs across different
-              theoretical perspectives: Core TAM Constructs: 1.Perceived Usefulness (PU):
-              Operationalized through five items measuring whether the technology improves job
-              performance, increases productivity, and enhances effectiveness.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Example items:</strong> “Using [system] would improve my performance” and “I
-                would find [system] useful in my job.” Measurement uses 5-point scales. Cronbach’s
-                alpha = .94 (Study 1) and .89 (Study 2). 2.Perceived Ease of Use (PEOU): Measured
-                through four items assessing difficulty of learning, interaction ease, and skill
-                requirements
-              </li>
-              <li>
-                <strong>Example items:</strong> “Learning to operate [system] is easy for me” and “I
-                would find [system] easy to use.” Cronbach’s alpha = .88 (Study 1) and .81 (Study
-                2). 3.Attitude Toward Use (ATT): Three items measuring overall evaluative response
-                to the technology
-              </li>
-              <li>
-                <strong>Example items:</strong> “I like working with [system]” and “Using [system]
-                is pleasant.” Cronbach’s alpha = .93 (Study 1)
-              </li>
-              <li>
-                <strong>TPB-Specific Constructs:</strong> 4.Subjective Norm (SN): Four items
-                measuring perceived social pressure and opinions of relevant others
-              </li>
-              <li>
-                <strong>Example items:</strong> “People who are important to me would think I should
-                use [system]” and “My supervisor thinks I should use [system].” Cronbach’s alpha =
-                .75 (Study 1) and .78 (Study 2). 5.Perceived Behavioral Control (PBC): Four items
-                measuring perceived ability to use the system and availability of resources
-              </li>
-              <li>
-                <strong>Example items:</strong> “I would have the resources necessary to use
-                [system]” and “I would have the knowledge necessary to use [system].” Cronbach’s
-                alpha = .87 (Study 1) and .74 (Study 2)
-              </li>
-              <li>
-                <strong>Dependent Variables:</strong> 6.Behavioral Intention (BI): Three items
-                measuring likelihood and willingness to use the technology
-              </li>
-              <li>
-                <strong>Example items:</strong> “I intend to use [system]” and “I will use
-                [system].” Cronbach’s alpha = .93 (Study 1) and .95 (Study 2). 7.Actual Usage: In
-                Study 1, objective system logs measuring frequency and duration of email system
-                access. In Study 2, three self-report items measuring usage frequency and intensity,
-                with alpha = .78
-              </li>
-              <li>
-                <strong>Integration Mechanisms:</strong> The framework measures how these constructs
-                interrelate through multiple pathways: Direct effects: PEOU → Attitude; PU →
-                Attitude; PU → Intention; Attitude → Intention; SN → Intention; PBC → Intention
-                Indirect effects: PEOU influences Intention indirectly through its effect on
-                Attitude and Perceived Usefulness Intention → Usage: The intention-behavior linkage
-                The measurement approach operationalizes competing theoretical mechanisms, allowing
-                empirical comparison of how different factors influence adoption across theoretical
-                perspectives
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What are the main strengths of the model?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd’s competing models framework possesses several important strengths:
-              1.Rigorous Comparative Analysis: The research systematically compares multiple
-              theoretical frameworks using consistent methodology across both models and studies.
-              This comparative approach is more sophisticated than testing single models in
-              isolation, providing evidence-based guidance about which theories provide superior
-              explanations. 2.Multi-Study Validation: The two-study design with different
-              technologies (email versus integrated information system) and populations (students
-              versus faculty) provides stronger evidence than single-study research. When similar
-              findings emerge across contexts, confidence in generalization increases substantially.
-              3.Objective and Subjective Behavior Measurement: Study 1’s measurement of actual email
-              usage through system logs represents a methodological strength. Rather than relying
-              solely on self-reported intentions or usage, the authors measured actual behavior
-              directly, addressing a persistent limitation in IT adoption research. 4.Clear
-              Practical Guidance: The paper translates theoretical findings into managerial
-              implications.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Organizations can use the competing models framework to assess which factors most
-              constrain adoption in their context and select appropriate intervention strategies.
-              5.Sophisticated Statistical Methods: The use of LISREL structural equation modeling
-              and comparison of multiple goodness-of-fit indices (AGFI, CFI, RMSEA, SRMR) represents
-              methodological sophistication. The authors tested complete structural models
-              simultaneously rather than using piecemeal regression analysis, reducing concerns
-              about multicollinearity and specification error. 6.Theory Integration: Rather than
-              arguing that one theory is correct and others wrong, the authors demonstrate how TAM
-              and TPB perspectives complement one another. This integrative approach is more
-              theoretically mature than competitive positioning between frameworks. 7.Specification
-              of Mediating Mechanisms: The research clarifies how constructs relate. For example,
-              the finding that PEOU influences Intention partially through Attitude and partially
-              through Perceived Usefulness reveals the mechanisms through which ease of use affects
-              adoption decisions.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              This mechanistic clarity is more useful than correlation evidence alone. 8.Replication
-              Within Studies: Both studies show consistent patterns, with similar path coefficients
-              and model structures despite different technologies and populations. This consistency
-              strengthens confidence in findings. 9.Attention to Voluntary Versus Mandatory
-              Contexts: The authors note differences in adoption dynamics between voluntary email
-              and mandatory information system adoption, recognizing that adoption context affects
-              which factors dominate. 10.Theoretical Foundation: Rather than empirically discovering
-              relationships, the work is grounded in established theories (Theory of Reasoned
-              Action, Theory of Planned Behavior, Technology Acceptance Model), providing
-              theoretical justification for proposed relationships.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What are the main weaknesses of the model?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Despite its strengths, Taylor and Todd’s framework has notable limitations: 1.Study 1
-              Sample Size and Population: The email study used only 108 MBA students, a relatively
-              small sample from a highly educated, motivated population. MBA students likely have
-              greater computer skills and education than typical IT users, potentially limiting
-              generalizability to broader populations. This narrow population reduces external
-              validity. 2.Study 2 Subjective Usage Measurement: While Study 1 used objective system
-              logs, Study 2 relied on self-reported usage frequency and intensity. Self-report
-              measures are subject to social desirability bias, memory errors, and honest
-              disagreement about usage patterns. The authors acknowledge this difference but do not
-              fully address the validity implications. 3.Cross-Sectional Design: Both studies
-              captured single time points rather than tracking adoption longitudinally.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The models show associations between constructs but cannot definitively establish
-              causality. Reverse causality is possible-for example, frequent users might develop
-              higher Perceived Usefulness perceptions rather than high usefulness perceptions
-              driving usage. 4.Limited Context Variety: While two studies provide more context than
-              one, both occur in university settings. Generalization to corporate, government, or
-              other organizational contexts is unclear. Different organizational cultures,
-              technology maturity levels, and adoption pressures might create different adoption
-              dynamics. 5.Incomplete Model Specification: The paper does not address how models
-              might be moderated by individual differences (e.g., computer anxiety, technology
-              experience, age, education). Different individuals might weight constructs
-              differently, suggesting that a single model specification may not fit all users
-              equally well. 6.Limited Examination of Intention-Behavior Gap: While the models
-              predict behavioral intention well, the transition from intention to actual usage
-              remains incompletely explained.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The authors acknowledge that “behavioral intention is a more proximal predictor of
-              usage than attitude” but note variance in usage even among those with high intentions.
-              7.Technology Characteristics Underspecified: The model does not examine how technology
-              characteristics (complexity, compatibility with existing systems, relative advantage)
-              might moderate relationships between constructs. Simple technologies might show
-              different adoption dynamics than complex ones. 8.Social Influence Operationalization:
-              Subjective norm measurement focuses on perceived social pressure but may not fully
-              capture the rich social influence processes around technology adoption. Peer learning,
-              informal training, and observational learning might operate differently than normative
-              social influence suggests. 9.Perceived Behavioral Control Limitations: PBC measurement
-              focuses on resource availability and capability beliefs but may not fully capture
-              actual behavioral control or objective constraints.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Organizational policies, system access, and technical infrastructure represent
-              objective controls not fully captured by perceptual measures. 10.Limited Examination
-              of System Quality: The models treat Perceived Usefulness as a perception-based
-              construct influenced only by other perceptions. They do not directly measure objective
-              system quality, functionality, or performance. A system’s actual benefits might
-              diverge substantially from perceptions, yet the models focus only on perceptions.
-              11.Insufficient Attention to Experience Effects: The models do not examine how
-              findings might differ at different adoption lifecycle stages. Early adoption when
-              systems are new might show different patterns than sustained adoption as users gain
-              experience.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How does this model differ from older models?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd’s work represents significant theoretical evolution from earlier
-              technology adoption frameworks: 1.Comparative Rather Than Single-Theory Approach:
-              Earlier research typically proposed and tested single theories in isolation. Taylor
-              and Todd explicitly compared TAM, TPB, and integrated approaches, providing
-              evidence-based theory prioritization rather than assumption-based positioning.
-              2.Integration of TAM and TPB: While Davis’s TAM and Ajzen’s TPB were developed in
-              different contexts, Taylor and Todd demonstrated that both frameworks apply to IT
-              adoption and can be integrated. This integration showed that theories from different
-              research traditions can complement one another, advancing theoretical sophistication.
-              3.Explicit Testing of Extended TAM: Earlier TAM research had limited attention to
-              social influences (subjective norms). Taylor and Todd formally tested whether adding
-              subjective norms to TAM improved explanatory power, addressing a recognized
-              theoretical limitation. 4.Multi-Technology Validation: Earlier technology adoption
-              research often tested single technologies (email adoption, database adoption, etc.).
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Testing whether frameworks generalize across email and information systems
-              strengthened evidence for universal adoption principles. 5.Attention to
-              Intention-Behavior Linkage: While older models often stopped at predicting behavioral
-              intention, Taylor and Todd measured actual usage behavior, addressing one criticism of
-              intention-based models. This brought models closer to practical relevance.
-              6.Specification of Indirect Effects: Earlier models often examined only direct effects
-              between constructs. Taylor and Todd specified multiple pathways through which
-              variables influence outcomes (e.g., PEOU affects intention both directly and
-              indirectly through attitude and usefulness), revealing mechanistic complexity.
-              7.Systematic Model Comparison: The paper’s structured comparison of model fit indices
-              across different specifications provided evidence-based guidance about theory
-              selection-advancing beyond authors championing their preferred theory.
-              8.Population-Specific Validation: By testing models across different user populations
-              and technologies, Taylor and Todd acknowledged that adoption might vary by context
-              while also seeking universal principles applying across contexts.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>
-              What Barriers to Technology Adoption does the model identify?
-            </h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd’s competing models framework identifies multiple categories of
-              barriers affecting IT adoption, organized across individual perceptions, social
-              influences, and control factors: 1. Perceived Usefulness Barriers (Individual
-              Cognitive Barriers) The model identifies low Perceived Usefulness as a fundamental
-              barrier. When users do not believe that IT systems will improve their job performance
-              or productivity, adoption remains low regardless of other factors.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>This barrier manifests through several mechanisms:</strong> •Unclear Value
-                Proposition: Users do not understand how systems apply to their work or what
-                benefits they will provide. The model shows strong positive effects of Perceived
-                Usefulness on both Attitude (path = .71 in Study 1, .75 in Study 2) and Intention
-                (path = .40 in Study 1, .42 in Study 2), meaning that failure to understand system
-                benefits fundamentally limits adoption. •Mismatch Between System Functionality and
-                Job Requirements: Systems may be designed for generic use cases but not tailored to
-                specific job functions. If users perceive that the system does not address their
-                actual work priorities, usefulness perceptions remain low. •Perceived Risk or
-                Uncertainty About Benefits: Users may be skeptical that promised benefits will
-                materialize, particularly for complex organizational systems where benefits depend
-                on broader adoption and integration. This skepticism reduces perceived usefulness
-                and thereby intention to use. •Comparison to Existing Workflows: When established
-                workflows are familiar and functional, new systems must demonstrate substantial
-                improvement to be perceived as useful. If improvement is marginal, users perceive
-                low usefulness despite objective functionality. 2. Perceived Ease of Use Barriers
-                (Cognitive and Technical Barriers) The model identifies perceived difficulty as a
-                significant barrier
-              </li>
-              <li>
-                <strong>Perceived Ease of Use affects adoption through multiple pathways:</strong>{' '}
-                •High Learning Curves: Systems perceived as difficult to learn create adoption
-                resistance. The model shows that PEOU influences Attitude (path = .45 in Study 1,
-                .40 in Study 2) and indirectly influences usefulness perceptions. Users who perceive
-                steep learning curves may avoid engaging sufficiently to discover usefulness.
-                •Complex Interfaces: Non-intuitive system design that does not align with mental
-                models creates PEOU barriers. Users must expend effort learning system logic that is
-                unnecessarily complicated. The negative path from PEOU to Usefulness (path = -.49 in
-                Study 1, -.51 in Study 2, indicating that more complex systems are perceived as less
-                useful) suggests that complex systems undermine both adoption paths. •Inadequate
-                Training and Support: Without accessible training and technical support, users face
-                high barriers to developing competence. The model’s findings about PEOU suggest that
-                barriers to learning will significantly constrain adoption. •System Instability or
-                Technical Problems: If systems are unstable, unreliable, or frequently unavailable,
-                users perceive low ease of use despite objectively straightforward interfaces.
-                Technical issues compound learning burdens. •Insufficient Documentation and Help
-                Resources: When reference materials are unclear or help systems are unhelpful, users
-                perceive higher difficulty in system operation. 3. Social Influence Barriers
-                (Normative and Social Barriers) The model identifies negative subjective norms as
-                significant adoption barriers: •Peer Resistance or Skepticism: When respected
-                colleagues resist or question system adoption, social norms inhibit individual
-                adoption. The model shows subjective norm significantly predicts behavioral
-                intention (path = .13 in Study 1, .16 in Study 2), suggesting that peer opposition
-                constitutes a barrier. In contexts like academia, adoption barriers arise when
-                relevant professional communities (disciplinary colleagues, academic associations)
-                question system relevance or approach it skeptically.
-              </li>
-            </ul>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>
-                4. Perceived Behavioral Control Barriers (Resource and Capability Barriers)
-              </strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The model identifies barriers to perceived capacity and control:
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Insufficient Technical Support and Resources:</strong> When help desk
-                support is unavailable, response times are slow, or technical assistance is
-                inadequate, users perceive low behavioral control. The model shows PBC significantly
-                predicts intention (path = .21 in Study 1, .18 in Study 2), indicating that resource
-                barriers substantially limit adoption.
-              </li>
-              <li>
-                <strong>Lack of Training and Development Opportunities:</strong> Without adequate
-                training programs, users doubt their capability to use systems effectively. Training
-                barriers directly reduce perceived behavioral control.
-              </li>
-              <li>
-                <strong>Poor System Access:</strong> If users lack convenient access to systems,
-                cannot obtain necessary equipment, or face administrative obstacles to obtaining
-                credentials, behavioral control is low.
-              </li>
-              <li>
-                <strong>Competing Demands and Time Constraints:</strong> Users facing heavy
-                workloads may perceive insufficient time and cognitive capacity to learn new
-                systems. Time scarcity creates a behavioral control barrier by making adoption seem
-                infeasible.
-              </li>
-              <li>
-                <strong>Knowledge and Skills Gaps:</strong> Users lacking prerequisite knowledge
-                (e.g., computer literacy, specific domain knowledge) perceive low behavioral
-                control. Age, prior technology experience, and educational background influence this
-                barrier.
-              </li>
-              <li>
-                <strong>Organizational Infrastructure Deficiencies:</strong> Systems requiring
-                reliable infrastructure (network connectivity, power, equipment maintenance) create
-                barriers when infrastructure is inadequate.
-              </li>
-            </ul>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>5. Attitude Barriers (Affective Resistance)</strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The model reveals that negative attitudes form significant barriers:
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Dislike of Technology:</strong> Even with perceived usefulness and ease of
-                use, if systems generate negative affective responses (frustration, anxiety,
-                unease), attitudes remain negative. Attitude significantly predicts intention (path
-                = .53 in Study 1, .49 in Study 2).
-              </li>
-              <li>
-                <strong>Computer Anxiety and Technophobia:</strong> Users with general anxiety about
-                technology develop negative attitudes even toward relatively simple systems.
-              </li>
-              <li>
-                <strong>Loss of Autonomy or Professional Judgment:</strong> If systems reduce
-                perceived professional autonomy or require conformity to rigid procedures, negative
-                attitudes develop despite objective usefulness.
-              </li>
-              <li>
-                <strong>Change Anxiety:</strong> Systems representing organizational change create
-                anxiety about competence, job security, or professional relevance that translates to
-                negative attitudes.
-              </li>
-            </ul>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>6. Intention-Behavior Barriers (Volitional Barriers)</strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              While the model predicts intention well, barriers to intention-behavior translation
-              include:
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Insufficient Commitment:</strong> Users may develop moderate intention to
-                use but lack strong commitment, causing usage to be sporadic or superficial.
-              </li>
-              <li>
-                <strong>Competing Priorities:</strong> Even with adoption intention, competing
-                demands and competing technologies may displace system usage.
-              </li>
-              <li>
-                <strong>Habit and Path Dependency:</strong> Existing work processes and systems
-                create inertia. Stated intention may not translate to usage if established habits
-                are easier than adopting new systems.
-              </li>
-              <li>
-                <strong>Organizational Obstacles to Implementation:</strong> Organizational systems,
-                policies, and processes may not support stated intentions to use new technology.
-              </li>
-            </ul>
-            <p className={PARAGRAPH_CLASSES}>
-              The model reveals that adoption barriers operate through multiple channels. Purely
-              technical barriers (ease of use, system quality) create obstacles, but equally
-              important are perceptual barriers (perceived usefulness despite actual benefits),
-              social barriers (peer resistance and organizational norms), and behavioral control
-              barriers (inadequate support and resources). Addressing adoption requires multi-level
-              intervention across these barrier categories.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>
-              What does the model instruct leaders to do in order to reduce these barriers?
-            </h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Taylor and Todd provide explicit guidance for leadership actions to reduce adoption
-              barriers:
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>For Perceived Usefulness Barriers:</strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The model&rsquo;s strong emphasis on Perceived Usefulness (with path coefficients of
-              .40-.42 to intention being the strongest direct effect) indicates that this is the
-              primary lever for adoption. The authors recommend:
-            </p>
-            <ol className={BODY_OL_CLASSES}>
-              <li>
-                <strong>Clear Communication of Value Proposition:</strong> Leaders should explicitly
-                articulate how systems improve job performance, increase efficiency, or reduce
-                burdensome tasks. The research shows that &ldquo;usefulness is the primary
-                determinant of intentions to use IT,&rdquo; suggesting that &ldquo;communication
-                should focus on functional benefits.&rdquo;
-              </li>
-              <li>
-                <strong>Job-Relevant Application Definition:</strong> Rather than generic training,
-                application examples should map directly to individuals&rsquo; job functions.
-                Leaders should work with department heads to identify specific ways systems enhance
-                particular roles.
-              </li>
-              <li>
-                <strong>Pilot Programs and Case Demonstrations:</strong> Early adopter successes
-                should be publicized. When users see peers in similar roles achieving documented
-                improvements from system use, perceived usefulness increases. The authors recommend
-                that &ldquo;visible success stories of early adopters demonstrating improved job
-                performance&rdquo; strengthen usefulness perceptions.
-              </li>
-              <li>
-                <strong>Realistic Expectations Management:</strong> Leaders must ensure that
-                promised benefits are achievable and realistic. The model&rsquo;s strong effect
-                suggests that if usefulness promises are not fulfilled, subsequent adoption suffers.
-                Over-promising creates barriers when implementation reveals limited benefits.
-              </li>
-              <li>
-                <strong>Iterative Refinement:</strong> Rather than static implementation, leaders
-                should gather usage data and refine systems to enhance actual usefulness. As
-                objective usefulness increases, perceptions follow.
-              </li>
-              <li>
-                <strong>Integration with Organizational Priorities:</strong> Leaders should
-                explicitly connect system adoption to organizational strategy and individual
-                performance metrics. When performance evaluations reward system usage and
-                demonstrate performance improvements, perceived usefulness increases.
-              </li>
-            </ol>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>For Perceived Ease of Use Barriers:</strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              With path coefficients of .40-.45 to Attitude and substantial indirect effects through
-              Perceived Usefulness, PEOU represents the second critical barrier reduction lever:
-            </p>
-            <ol className={BODY_OL_CLASSES}>
-              <li>
-                <strong>Systematic User Interface Design:</strong> Leaders should allocate resources
-                to user-centered interface design. The model&rsquo;s strong negative relationship
-                between PEOU and Perceived Usefulness (path = -.49 to -.51, indicating that complex
-                systems are perceived as less useful) reveals that improving ease of use enhances
-                usefulness perceptions simultaneously.
-              </li>
-              <li>
-                <strong>Comprehensive Training Program Design:</strong> Training should be carefully
-                structured to build competence progressively. The authors suggest that
-                &ldquo;training focused on building perceived ease of use through hands-on
-                experience in low-pressure environments&rdquo; reduces PEOU barriers.
-              </li>
-              <li>
-                <strong>Accessible, Responsive Technical Support:</strong> Help desk availability
-                and responsiveness directly influence PEOU. Leaders should ensure that
-                &ldquo;technical support is immediately available when users encounter
-                difficulties,&rdquo; recognizing that unresolved support requests perpetuate
-                perceptions of difficulty.
-              </li>
-              <li>
-                <strong>Development of Accessible Documentation:</strong> Written materials, video
-                tutorials, and help systems should be professionally developed to guide users.
-                &ldquo;Easily accessible reference materials increase perceived ease of use.&rdquo;
-              </li>
-              <li>
-                <strong>Iterative System Simplification:</strong> Post-implementation, leaders
-                should collect usage data identifying where users struggle and simplify those
-                functions. Continuous improvement of interface design over time reduces PEOU
-                barriers.
-              </li>
-              <li>
-                <strong>Peer Support and Mentoring:</strong> Rather than relying solely on formal
-                support, leaders should facilitate peer learning where experienced users help
-                newcomers. Peer-to-peer training often improves perceived ease of use because peers
-                understand contextual challenges.
-              </li>
-              <li>
-                <strong>Expectations About Learning Curves:</strong> Leaders should transparently
-                communicate that learning takes time but becomes easier with experience. Tempering
-                expectations about immediate mastery reduces anxiety and helps users persist through
-                initial difficulty periods.
-              </li>
-            </ol>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>For Social Influence Barriers:</strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              With path coefficients of .13-.16 from subjective norms to intention, the model
-              indicates that social factors, while smaller than usefulness factors, significantly
-              influence adoption:
-            </p>
-            <ol className={BODY_OL_CLASSES}>
-              <li>
-                <strong>Leadership Visibly Supports Adoption:</strong> Executives and department
-                heads should actively use systems and publicly acknowledge their own usage. The
-                authors note that &ldquo;visible leadership endorsement of technology adoption
-                signals organizational norm supporting usage.&rdquo;
-              </li>
-              <li>
-                <strong>Identify and Empower Champions:</strong> Organizations should identify
-                enthusiastic early adopters and formalize their championing role. Champions should
-                be visible - giving presentations, providing one-on-one coaching, and being publicly
-                recognized as system experts.
-              </li>
-              <li>
-                <strong>Peer Learning Communities:</strong> Establish communities of practice around
-                new systems. &ldquo;Communities of practice where users support one another increase
-                subjective norms supporting adoption&rdquo; through normalization of usage.
-              </li>
-              <li>
-                <strong>Public Recognition of Adopters:</strong> Celebrate users who achieve success
-                with systems through awards, recognition programs, and publicity. Public recognition
-                signals that adoption is organizationally valued.
-              </li>
-              <li>
-                <strong>Integration of System Use into Workflow Norms:</strong> Make system usage
-                part of standard operating procedures and daily expectations. When systems become
-                part of &ldquo;how we do things here,&rdquo; subjective norms naturally support
-                adoption.
-              </li>
-              <li>
-                <strong>Cross-Functional Advocacy:</strong> Identify respected opinion leaders
-                across departments and involve them in championing adoption. Diverse advocates
-                demonstrate broad organizational support beyond IT departments.
-              </li>
-              <li>
-                <strong>Address Opinion Leader Resistance:</strong> Critically, the model implies
-                that influential voices opposing adoption create substantial barriers. Leaders
-                should engage skeptical opinion leaders directly, addressing their concerns and
-                potentially converting them to champions.
-              </li>
-            </ol>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>For Perceived Behavioral Control Barriers:</strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              With path coefficients of .18-.21 from PBC to intention, resource and capability
-              barriers represent a significant but secondary leverage point:
-            </p>
-            <ol className={BODY_OL_CLASSES}>
-              <li>
-                <strong>Proactive Resource Provisioning:</strong> Organizations should ensure that
-                systems are accessible, equipment is available, and technical infrastructure is
-                reliable. &ldquo;Removing objective barriers to use increases perceived behavioral
-                control.&rdquo;
-              </li>
-              <li>
-                <strong>Comprehensive Training and Development:</strong> Beyond single training
-                sessions, leaders should offer ongoing skill development, advanced training, and
-                refresher programs. Progressive training builds competence and sustains perceived
-                behavioral control.
-              </li>
-              <li>
-                <strong>Flexible Support Options:</strong> Different users have different support
-                needs. Leaders should offer multiple support channels (help desk, peer support,
-                online resources, formal training) allowing users to select approaches matching
-                their learning styles.
-              </li>
-              <li>
-                <strong>Workspace and Infrastructure Optimization:</strong> Ensure that workspaces
-                support system usage. Adequate computers, reliable networks, and ergonomic
-                environments remove physical barriers to control.
-              </li>
-              <li>
-                <strong>Time Allocation for Learning:</strong> Leaders should communicate that
-                investment in learning is valued and provide time within work schedules for training
-                and skill development. When people feel pressured to adopt systems without allocated
-                time, perceived control decreases.
-              </li>
-              <li>
-                <strong>Administrative Streamlining:</strong> Remove bureaucratic obstacles to
-                system access, such as complicated credential acquisition or lengthy approval
-                processes.
-              </li>
-              <li>
-                <strong>Accountability Structures:</strong> When organizational accountability
-                systems reward system usage, perceived behavioral control increases. Clear
-                expectations and reinforcement mechanisms communicate that the organization expects
-                usage and will support it.
-              </li>
-            </ol>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>For Attitude Barriers:</strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Attitude shows substantial effects on intention (path = .49-.53), making attitude
-              improvement important:
-            </p>
-            <ol className={BODY_OL_CLASSES}>
-              <li>
-                <strong>Emphasize Positive Aspects and Benefits:</strong> Marketing and
-                communication should emphasize positive elements - efficiency gains, reduced tedious
-                work, new capabilities. &ldquo;Framing systems positively and highlighting benefits
-                that appeal to user values&rdquo; improves attitudes.
-              </li>
-              <li>
-                <strong>Address Anxiety and Concerns:</strong> For users with technology anxiety,
-                leaders should create safe learning environments, recognize anxiety legitimacy, and
-                provide reassurance about capability. &ldquo;Acknowledging technology anxiety and
-                providing low-pressure learning environments&rdquo; reduces negative affect.
-              </li>
-              <li>
-                <strong>Autonomy and Professional Respect:</strong> System design and implementation
-                should preserve professional autonomy and acknowledge user expertise. Systems that
-                reduce judgment or impose rigid procedures create negative attitudes. &ldquo;Systems
-                should be designed to augment, not replace, professional judgment.&rdquo;
-              </li>
-              <li>
-                <strong>Change Communication and Framing:</strong> When systems represent
-                organizational change, leaders should frame change as enhancement rather than
-                replacement or threat. &ldquo;Communication emphasizing continuity and positive
-                change outcomes&rdquo; improves attitudes toward change-inducing systems.
-              </li>
-              <li>
-                <strong>Quick Wins and Immediate Benefits:</strong> Highlight early benefits users
-                experience. Quick wins improve attitudes and motivate persistence through learning
-                curves.
-              </li>
-            </ol>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>Integrated Multi-Barrier Approach:</strong>
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The research indicates that &ldquo;no single factor dominates adoption; rather,
-              multiple factors combine to shape intentions and behavior.&rdquo; Therefore,
-              comprehensive adoption strategies must address all barrier categories:
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                Address the strongest barrier (Perceived Usefulness) through clear communication and
-                visible benefits
-              </li>
-              <li>
-                Simultaneously reduce Perceived Ease of Use barriers through design and training
-              </li>
-              <li>Cultivate social support through championing and norms management</li>
-              <li>Provide resources enabling Behavioral Control</li>
-              <li>Build positive attitudes through framing and anxiety management</li>
-            </ul>
-            <p className={PARAGRAPH_CLASSES}>
-              The model further suggests that barriers interact. For example, &ldquo;complex systems
-              (high PEOU barrier) are perceived as less useful (reducing usefulness perceptions),
-              which reduces intention independent of improving ease of use alone.&rdquo; Leaders
-              should therefore tackle multiple barriers simultaneously rather than sequentially.
-            </p>
-          </section>
-
-          {/* 7. Following Models or Theories */}
-          <section className={SECTION_CLASSES}>
-            <h2 className={H2_CLASSES}>7. Following Models or Theories</h2>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>Following Models:</strong> Subsequent extensions of TAM incorporating
-              additional moderators and mediators; models examining extended technology acceptance
-              frameworks; investigations of technology adoption across diverse populations and
-              contexts
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>Following Theories:</strong> Venkatesh and Davis (2000) - Technology
-              Acceptance Model 2; refinements incorporating trust, social influences, and
-              organizational factors; unified models of technology acceptance and use
-            </p>
-          </section>
-
-          {/* Series Navigation */}
-          <section className={SECTION_CLASSES}>
-            <h2 className={H2_CLASSES}>Series Navigation</h2>
-            <p className={PARAGRAPH_CLASSES}>
-              This article is part of a Technology Adoption Models Literature Review series:
-            </p>
-            <ol className={BODY_OL_CLASSES}>
-              <li>Ram (1987) - A Model of Innovation Resistance</li>
-              <li>
-                Thompson et al. (1991) - Toward a Conceptual Model of Personal Computing Utilization
-              </li>
-              <li>
-                Taylor and Todd (1995) - Understanding Information Technology Usage: A Test of
-                Competing Models
-              </li>
-              <li>Goodhue and Thompson (1995) - Task-Technology Fit and Individual Performance</li>
-            </ol>
-          </section>
-
-          {/* References */}
-          <section className={SECTION_CLASSES}>
-            <h2 className={H2_CLASSES}>References</h2>
-            <ol className={REFERENCES_OL_CLASSES}>
-              <li>
-                Taylor, S., and Todd, P. A. (1995). Understanding information technology usage: A
-                test of competing models. <em>Information Systems Research</em>, 6(2), 144-176.
-              </li>
-              <li>
-                Davis, F. D. (1989). Perceived usefulness, ease of use, and user acceptance of
-                information technology. <em>MIS Quarterly</em>, 13(3), 319-340.
-              </li>
-            </ol>
-          </section>
-
-          <p className="mt-8 text-sm italic text-gray-600">
-            Note: This article provides an overview based on the comprehensive literature review.
-            Readers are encouraged to consult the original publication for complete details.
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Taylor and Todd developed the Decomposed Theory of Planned Behavior to advance beyond
+            the original Theory of Planned Behavior (TPB) in predicting IT adoption and usage. While
+            Ajzen&rsquo;s TPB was a robust general theory of human behavior, it operated at a
+            relatively high level of abstraction with broad categories of beliefs (attitudes,
+            subjective norms, and perceived control). Taylor and Todd recognized that IT adoption
+            required more technology-specific theorizing with decomposed belief constructs that
+            captured the unique facets influencing information systems decisions.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            The authors observed that prior IT adoption models like TAM offered narrower constructs
+            (usefulness and ease of use) but lacked the behavioral intention framework of TPB. They
+            conceptualized DTPB as decomposing the three TPB belief categories into multiple
+            technology-specific dimensions. Attitudinal beliefs decompose into usefulness and
+            compatibility; normative beliefs decompose into subjective norm, social influence
+            factors, and organizational support; control beliefs decompose into facilitating
+            conditions and technology complexity.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            The empirical research compared three models (TAM, TPB, DTPB) using 786 university
+            students at a business school computing facility. This large-scale study enabled
+            comprehensive model comparison revealing that DTPB provided superior fit and explained
+            more variance in IT usage intentions than both TAM and the original TPB. The research
+            demonstrated that decomposing general behavioral constructs into technology-specific
+            dimensions substantially improved prediction of IT adoption behavior.
           </p>
         </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Decomposed Theory of Planned Behavior operationalizes nine primary constructs
+            organized within the three TPB belief categories:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Perceived Usefulness (Attitude component):</strong> The degree to which users
+              believe the IT system enhances job performance and productivity. Captures instrumental
+              benefits and outcome value.
+            </li>
+            <li>
+              <strong>Perceived Compatibility (Attitude component):</strong> The extent to which
+              users perceive the system aligns with their existing work practices, values, and
+              needs. Reflects adoption of innovations theory compatibility construct.
+            </li>
+            <li>
+              <strong>Subjective Norm (Normative belief component):</strong> Perceived social
+              pressure from important others regarding IT system adoption. Reflects primary
+              normative influence pathway.
+            </li>
+            <li>
+              <strong>Social Influence (Normative belief component):</strong> Influence of peers,
+              managers, and organizational leadership on adoption decisions. Captures network
+              effects and referent power.
+            </li>
+            <li>
+              <strong>Organizational Support (Normative belief component):</strong> Perceived
+              organizational encouragement, training, and resource allocation supporting system
+              adoption. Reflects institutional normative influences.
+            </li>
+            <li>
+              <strong>Facilitating Conditions (Control belief component):</strong> Objective
+              availability of resources supporting IT use including training, equipment, and
+              technical support. Reflects environmental control factors.
+            </li>
+            <li>
+              <strong>Technology Complexity (Control belief component):</strong> Perceived
+              difficulty and learning requirements of the IT system. Reflects effort and cognitive
+              burden in system use.
+            </li>
+            <li>
+              <strong>Attitude Toward Use:</strong> Overall favorable or unfavorable evaluation of
+              the system predicted by usefulness, compatibility, and other beliefs.
+            </li>
+            <li>
+              <strong>Behavioral Intention to Use:</strong> User likelihood of adopting and using
+              the system, predicted by attitudes, normative pressures, and control beliefs.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The DTPB synthesized multiple prior theoretical traditions:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Theory of Planned Behavior (
+                <a
+                  id="cite-ref-ajzen-1991-1"
+                  href="#ref-ajzen-1991"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Ajzen, 1991
+                </a>
+                ):
+              </strong>{' '}
+              Foundational framework establishing attitude, subjective norm, and perceived
+              behavioral control as intention predictors.
+            </li>
+            <li>
+              <strong>
+                Technology Acceptance Model (
+                <a
+                  id="cite-ref-davis-1989-1"
+                  href="#ref-davis-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis, 1989
+                </a>
+                ):
+              </strong>{' '}
+              IS-specific model demonstrating perceived usefulness and ease of use effectiveness in
+              predicting IT adoption.
+            </li>
+            <li>
+              <strong>
+                Diffusion of Innovations (
+                <a
+                  id="cite-ref-rogers-1983-1"
+                  href="#ref-rogers-1983"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Rogers, 1983
+                </a>
+                ):
+              </strong>{' '}
+              Provided compatibility construct and concepts of relative advantage relevant to
+              technology adoption.
+            </li>
+            <li>
+              <strong>
+                Social influence theory (Kelman, 1961;{' '}
+                <a
+                  id="cite-ref-french-1959-1"
+                  href="#ref-french-1959"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  French &amp; Raven, 1959
+                </a>
+                ):
+              </strong>{' '}
+              Grounded normative belief decomposition into subjective norm, social influence, and
+              organizational support.
+            </li>
+            <li>
+              <strong>Resource commitment theory:</strong> Provided foundations for understanding
+              facilitating conditions and organizational support as control belief components.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            DTPB specifies that behavioral intentions to use IT are determined by attitudes,
+            subjective norms, and perceived behavioral control. Critically, each of these three
+            intention predictors is decomposed into multiple specific belief dimensions. Attitudes
+            toward IT use are predicted by perceived usefulness and compatibility beliefs.
+            Subjective norms are predicted by subjective norm, social influence, and organizational
+            support beliefs. Perceived behavioral control is predicted by facilitating conditions
+            and technology complexity beliefs. The model explained 71% of variance in intention to
+            use IT systems, substantially outperforming both TAM and original TPB in predictive
+            power.
+          </p>
+
+          <h3 className={H3_CLASSES}>What does the model measure?</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Attitudinal beliefs:</strong> Usefulness and compatibility perceptions
+              capturing instrumental and value-alignment motivations for adoption.
+            </li>
+            <li>
+              <strong>Normative beliefs:</strong> Subjective norms, social influence, and
+              organizational support capturing multiple social influence pathways.
+            </li>
+            <li>
+              <strong>Control beliefs:</strong> Facilitating conditions and technology complexity
+              capturing resource availability and learning barriers.
+            </li>
+            <li>
+              <strong>Behavioral intentions:</strong> Likelihood of system adoption and usage
+              predicted through multiple belief pathways.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Theoretical comprehensiveness:</strong> Integrates three distinct theoretical
+              traditions (TPB, TAM, diffusion theory) creating more complete framework than any
+              single theory.
+            </li>
+            <li>
+              <strong>Technology-specific decomposition:</strong> Decomposes general TPB constructs
+              into IT-relevant dimensions (usefulness, compatibility, organizational support)
+              improving precision.
+            </li>
+            <li>
+              <strong>Superior predictive power:</strong> Explains 71% of intention variance,
+              substantially outperforming TAM (54%) and original TPB (58%) in this sample.
+            </li>
+            <li>
+              <strong>Multi-pathway modeling:</strong> Recognizes attitudes, norms, and control
+              operate through separate pathways, none fully mediating others.
+            </li>
+            <li>
+              <strong>Large-scale validation:</strong> Tested with 786 university users across
+              multiple IT systems providing adequate statistical power for complex model estimation.
+            </li>
+            <li>
+              <strong>Comparative design:</strong> Direct comparison with competing theories (TAM
+              and TPB) in same sample strengthens conclusions about relative model performance.
+            </li>
+            <li>
+              <strong>Organizational relevance:</strong> Includes organizational support and social
+              influence dimensions reflecting real organizational adoption contexts.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>University laboratory context:</strong> Study conducted in university
+              computing facility with voluntary student users, limiting generalization to mandatory
+              workplace contexts.
+            </li>
+            <li>
+              <strong>Single-time measurement:</strong> Cross-sectional design at single time point
+              prevents understanding of actual adoption trajectories or sustained usage patterns.
+            </li>
+            <li>
+              <strong>Intention-behavior gap:</strong> Measures behavioral intentions rather than
+              actual system usage, which may diverge due to implementation factors and context
+              constraints.
+            </li>
+            <li>
+              <strong>Model complexity:</strong> Nine-construct model with multiple paths is more
+              complex than simpler alternatives (TAM), potentially overfitting the specific sample.
+            </li>
+            <li>
+              <strong>Limited moderator exploration:</strong> Does not examine whether
+              belief-intention relationships differ by user experience, task type, or system
+              characteristics.
+            </li>
+            <li>
+              <strong>Self-report limitations:</strong> All measures relied on self-reported beliefs
+              rather than behavioral observation or system usage logs.
+            </li>
+            <li>
+              <strong>Sample homogeneity:</strong> Student sample may not represent diverse
+              organizational roles, skill levels, and adoption motivations of heterogeneous
+              workforces.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Theoretical integration model:</strong> Demonstrated how to combine
+              TPB&rsquo;s behavioral intention framework with TAM&rsquo;s IT-specific constructs
+              into unified model.
+            </li>
+            <li>
+              <strong>Decomposition methodology:</strong> Established approach for making general
+              behavioral theories technology-specific through construct decomposition.
+            </li>
+            <li>
+              <strong>Superior predictive framework:</strong> Provided empirical evidence that
+              decomposed, technology-specific theories outperform both TAM and original TPB.
+            </li>
+            <li>
+              <strong>Multi-belief-pathway recognition:</strong> Articulated how attitudes,
+              normative pressures, and control beliefs operate as independent intention predictors.
+            </li>
+            <li>
+              <strong>Organizational constructs emphasis:</strong> Elevated organizational support
+              and social influence from peripheral to central in adoption models.
+            </li>
+            <li>
+              <strong>IT adoption theory advancement:</strong> Created framework synthesizing
+              behavioral intention theory with information systems adoption insights.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The researchers established internal validity through comprehensive measurement and
+            structural equation modeling:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Multi-item measurement scales:</strong> Operationalized all constructs with
+              multiple survey items enabling measurement error and reliability estimation.
+            </li>
+            <li>
+              <strong>Reliability assessment:</strong> Reported Cronbach&rsquo;s alpha coefficients
+              for all scales demonstrating internal consistency of multi-item constructs.
+            </li>
+            <li>
+              <strong>Discriminant validity:</strong> Provided evidence that model constructs are
+              empirically distinct through correlation analysis and variance extracted comparisons.
+            </li>
+            <li>
+              <strong>Structural equation modeling:</strong> Used SEM for simultaneous estimation of
+              measurement and structural models with appropriate goodness-of-fit assessment.
+            </li>
+            <li>
+              <strong>Model fit comparison:</strong> Systematically compared three competing models
+              (TAM, TPB, DTPB) using chi-square and fit indices enabling model selection.
+            </li>
+            <li>
+              <strong>Variance explained:</strong> Reported R-squared values showing 71% of
+              intention variance explained by DTPB model.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations require acknowledging both strengths and limitations:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>University sample composition:</strong> Students may be younger, more
+              educated, and more computer-proficient than typical organizational IT users.
+            </li>
+            <li>
+              <strong>Voluntary adoption context:</strong> University lab context with optional
+              system use differs from mandatory workplace IT implementations.
+            </li>
+            <li>
+              <strong>Single-system limitation:</strong> While tested on multiple systems, all
+              systems remained relatively simple university-focused applications.
+            </li>
+            <li>
+              <strong>Structural generalization:</strong> Three-component belief structure of TPB is
+              theoretically robust and generalizable across populations and technologies.
+            </li>
+            <li>
+              <strong>Cross-national applicability:</strong> While specific belief dimensions may
+              vary, the decomposition approach transfers to different cultural contexts.
+            </li>
+            <li>
+              <strong>Temporal generalizability:</strong> Cross-sectional design limits
+              understanding of whether belief-intention relationships persist over time or change as
+              use experience accumulates.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            DTPB is directly relevant to technology adoption because it identifies multiple specific
+            barriers and levers operating through distinct belief pathways. The model suggests that
+            adoption strategies must address not only instrumental utility but also social
+            influences and organizational support simultaneously.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Low perceived usefulness:</strong> When users believe systems do not enhance
+              job performance or outcomes, attitude-based resistance emerges.
+            </li>
+            <li>
+              <strong>Poor perceived compatibility:</strong> Systems perceived as misaligned with
+              existing work practices and values face adoption friction despite potential utility.
+            </li>
+            <li>
+              <strong>Weak social support:</strong> Absence of peer adoption, manager endorsement,
+              or opinion leader influence undermines normative adoption motivation.
+            </li>
+            <li>
+              <strong>Absent organizational support:</strong> Insufficient training, inadequate
+              technical help, and lack of management enforcement reduce adoption likelihood.
+            </li>
+            <li>
+              <strong>Perceived high complexity:</strong> Systems requiring substantial learning
+              effort create control barriers reducing adoption intentions.
+            </li>
+            <li>
+              <strong>Insufficient facilitating conditions:</strong> Lack of resources, equipment
+              access, and technical support undermine behavioral control perceptions.
+            </li>
+            <li>
+              <strong>Negative social influence:</strong> Peer skepticism, visible non-adoption by
+              respected users, and management indifference create normative barriers.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Model Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Establish clear usefulness narrative:</strong> Communicate specific
+              productivity gains, time savings, or capability enhancements building usefulness
+              beliefs.
+            </li>
+            <li>
+              <strong>Demonstrate compatibility fit:</strong> Show how systems integrate with
+              existing workflows, tools, and job tasks reducing friction and workflow disruption.
+            </li>
+            <li>
+              <strong>Mobilize social influence:</strong> Identify opinion leaders, early adopters,
+              and respected figures to publicly endorse and visibly use systems.
+            </li>
+            <li>
+              <strong>Secure visible management commitment:</strong> Ensure managers and executives
+              visibly adopt and use systems, creating strong normative pressure.
+            </li>
+            <li>
+              <strong>Provide comprehensive facilitating conditions:</strong> Ensure training
+              programs, help desk support, documentation, and easy access to required resources.
+            </li>
+            <li>
+              <strong>Reduce perceived complexity:</strong> Design intuitive interfaces, provide
+              hands-on practice, and create clear learning pathways reducing cognitive burden.
+            </li>
+            <li>
+              <strong>Implement multi-level strategies:</strong> Address attitudinal barriers
+              (usefulness, compatibility), normative barriers (social influence, organizational
+              support), and control barriers (complexity, facilitating conditions) simultaneously.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Taylor and Todd&rsquo;s decomposed approach influenced subsequent IT adoption research
+            directions:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>TAM 2 and TAM 3 (Venkatesh &amp; Bala):</strong> Extended TAM with moderators
+              and social influence variables mirroring DTPB&rsquo;s decomposition approach.
+            </li>
+            <li>
+              <strong>Unified Theory of Acceptance and Use of Technology (UTAUT):</strong>{' '}
+              Integrated multiple theories including TPB, TAM, and DTPB insights into comprehensive
+              model.
+            </li>
+            <li>
+              <strong>Technology Readiness Index expansions:</strong> Applied decomposition
+              methodology to user predispositions and technology readiness dimensions.
+            </li>
+            <li>
+              <strong>Implementation science frameworks:</strong> Adopted decomposed multi-pathway
+              approach examining fidelity, adoption, and sustainability determinants.
+            </li>
+            <li>
+              <strong>Organizational change models:</strong> Incorporated multi-level decomposition
+              acknowledging individual beliefs, group norms, and organizational structures.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-taylor-1995">
+              Taylor, S., &amp; Todd, P. A. (1995). Understanding information technology usage: A
+              test of competing models. <em>Information Systems Research</em>, 6(2), 144-176.
+              https://doi.org/10.1287/isre.6.2.144
+            </li>
+            <li id="ref-ajzen-1991">
+              Ajzen, I. (1991). The theory of planned behavior.{' '}
+              <em>Organizational Behavior and Human Decision Processes</em>, 50(2), 179-211.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-ajzen-1991-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>{' '}
+              https://doi.org/10.1016/0749-5978(91)90020-T
+            </li>
+            <li id="ref-davis-1989">
+              Davis, F. D. (1989). Perceived usefulness, perceived ease of use, and user acceptance
+              of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-davis-1989-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>{' '}
+              https://doi.org/10.2307/249008
+            </li>
+            <li id="ref-rogers-1983">
+              Rogers, E. M. (1983). Diffusion of innovations (3rd ed.). Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-rogers-1983-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-french-1959">
+              French, J. R. P., &amp; Raven, B. (1959). The bases of social power. In D. Cartwright
+              (Ed.), <em>Studies in social power</em>. University of Michigan Press.
+            </li>
+          </ol>
+        </section>
+
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-fishbein-1975">
+              Fishbein, M., &amp; Ajzen, I. (1975). Belief, attitude, intention, and behavior: An
+              introduction to theory and research. Addison-Wesley.
+            </li>
+            <li id="ref-venkatesh-2003">
+              Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
+              of information technology: Toward a unified view. <em>MIS Quarterly</em>, 27(3),
+              425-478. https://doi.org/10.2307/30036540
+            </li>
+            <li id="ref-davis-1992">
+              Davis, F. D., Bagozzi, R. P., &amp; Warshaw, P. R. (1992). Extrinsic and intrinsic
+              motivation to use computers in the workplace.{' '}
+              <em>Journal of Applied Social Psychology</em>, 22(14), 1111-1132.
+              https://doi.org/10.1111/j.1559-1816.1992.tb00945.x
+            </li>
+            <li id="ref-venkatesh-2000">
+              Venkatesh, V., &amp; Davis, F. D. (2000). A theoretical extension of the technology
+              acceptance model: Four longitudinal field studies. <em>Management Science</em>, 46(2),
+              186-204.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Extrinsic &amp; Intrinsic Motivation (Davis et al.)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-11-task-technology-fit-ttf-goodhue-thompson-1995"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Task-Technology Fit (Goodhue &amp; Thompson) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>

--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Decomposed Theory of Planned Behavior - Taylor & Todd (1995)',
+  title: 'Bibliography: Decomposed TPB - Taylor & Todd (1995)',
   description:
     'Comprehensive analysis of the Decomposed Theory of Planned Behavior (DTPB), which decomposes attitudinal, normative, and control beliefs into technology-specific multidimensional constructs for predicting IT adoption.',
 }
@@ -21,9 +21,7 @@ const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>
-          Decomposed Theory of Planned Behavior - Taylor &amp; Todd (1995)
-        </h1>
+        <h1 className={H1_CLASSES}>Decomposed TPB - Taylor &amp; Todd (1995)</h1>
 
         {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>

--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -67,6 +67,17 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 144-176
             </p>
+            <p>
+              <strong>DOI:</strong>{' '}
+              <a
+                href="https://doi.org/10.1287/isre.6.2.144"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.1287/isre.6.2.144
+              </a>
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -572,9 +572,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-ajzen-1991-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>{' '}
               https://doi.org/10.1016/0749-5978(91)90020-T
             </li>
@@ -586,9 +584,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-davis-1989-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>{' '}
               https://doi.org/10.2307/249008
             </li>
@@ -599,9 +595,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-rogers-1983-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
           </ol>

--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -237,25 +237,6 @@ const BibliographyArticlePage = () => {
               Provided compatibility construct and concepts of relative advantage relevant to
               technology adoption.
             </li>
-            <li>
-              <strong>
-                Social influence theory (Kelman, 1961;{' '}
-                <a
-                  id="cite-ref-french-1959-1"
-                  href="#ref-french-1959"
-                  className="text-tabs-teal-deep hover:underline"
-                >
-                  French &amp; Raven, 1959
-                </a>
-                ):
-              </strong>{' '}
-              Grounded normative belief decomposition into subjective norm, social influence, and
-              organizational support.
-            </li>
-            <li>
-              <strong>Resource commitment theory:</strong> Provided foundations for understanding
-              facilitating conditions and organizational support as control belief components.
-            </li>
           </ul>
         </section>
 
@@ -624,10 +605,6 @@ const BibliographyArticlePage = () => {
                   ↩
                 </a>
               </span>
-            </li>
-            <li id="ref-french-1959">
-              French, J. R. P., &amp; Raven, B. (1959). The bases of social power. In D. Cartwright
-              (Ed.), <em>Studies in social power</em>. University of Michigan Press.
             </li>
           </ol>
         </section>


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 1-10 Decomposed TPB (Taylor & Todd, 1995) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1562
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)