### PR TITLE
docs: standardize bibliography 1-15 UTAUT (Venkatesh et al., 2003)

### DIFF
--- a/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
+++ b/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
@@ -410,8 +410,8 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Facilitating Conditions - Infrastructure and Support:</strong> Available
-              technical infrastructure, training, and support directly influence adoption intentions
-              by reducing adoption barriers and enhancing self-efficacy. Facilitating conditions
+              technical infrastructure, training, and support directly influence usage behavior by
+              reducing practical barriers and enhancing self-efficacy. Facilitating conditions
               effects are stronger for women and older users who may have lower technology
               confidence.
             </li>

--- a/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
+++ b/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
@@ -4,15 +4,18 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
+  BODY_LIST_CLASSES,
+  REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
   title:
     'Bibliography: Unified Theory of Acceptance and Use of Technology (UTAUT) - Venkatesh et al. (2003)',
   description:
-    'Deep dive into the Unified Theory of Acceptance and Use of Technology (UTAUT) by Venkatesh, Morris, Davis, and Davis (2003), a landmark synthesis of eight competing technology adoption models into a single unified framework.',
+    'Comprehensive overview of the Unified Theory of Acceptance and Use of Technology (UTAUT), synthesizing eight prior models to predict technology acceptance with performance expectancy, effort expectancy, social influence, and facilitating conditions across user demographics.',
 }
 
 const BibliographyArticlePage = () => {
@@ -23,474 +26,1000 @@ const BibliographyArticlePage = () => {
           Unified Theory of Acceptance and Use of Technology (UTAUT) - Venkatesh et al. (2003)
         </h1>
 
-        {/* Model Identification */}
+        {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Model Identification</h2>
           <div className="space-y-2">
             <p>
               <strong>Model Name:</strong> Unified Theory of Acceptance and Use of Technology
-              (UTAUT)
             </p>
+            <p>
+              <strong>Model Abbreviation:</strong> UTAUT
+            </p>
+            <p>
+              <strong>Target of Model:</strong> Determinants of technology acceptance intention and
+              usage behavior integrating constructs from eight prior adoption theories with
+              moderating effects of demographic and contextual factors
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Information Systems, Technology Adoption,
+              Organizational Behavior, Consumer Research
+            </p>
+          </div>
+        </section>
+
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
             <p>
               <strong>Authors:</strong> Viswanath Venkatesh, Michael G. Morris, Gordon B. Davis, and
               Fred D. Davis
             </p>
             <p>
-              <strong>Publication Date:</strong> 2003
+              <strong>Formal Publication Date:</strong> 2003
+            </p>
+            <p>
+              <strong>Official Title:</strong> User acceptance of information technology: Toward a
+              unified view
+            </p>
+            <p>
+              <strong>Journal:</strong> MIS Quarterly
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 27, No. 3
+            </p>
+            <p>
+              <strong>Pages:</strong> 425-478
+            </p>
+            <p>
+              <strong>DOI:</strong>
+              {chr(39) + ' ' + chr(39)}
+              <a
+                href="https://doi.org/10.2307/30036540"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.2307/30036540
+              </a>
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
-              of information technology: Toward a unified view. <em>MIS Quarterly</em>, 27(3),
-              425-478.{' '}
-              <a
-                href="https://doi.org/10.2307/30036540"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/30036540
-              </a>
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (
+                <a href="#ref-venkatesh-2003" className="text-tabs-teal-deep hover:underline">
+                  2003
+                </a>
+                ). User acceptance of information technology: Toward a unified view.{' '}
+                <em>MIS Quarterly</em>, 27(3), 425-478.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Venkatesh, Viswanath, Michael G. Morris, Gordon B. Davis, and Fred D. Davis. 2003.
+                &ldquo;User Acceptance of Information Technology: Toward a Unified View.&rdquo;
+                <em>MIS Quarterly</em> 27, no. 3: 425-478.
+              </p>
+            </div>
           </div>
         </section>
 
-        {/* Why UTAUT Was Created */}
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Why UTAUT Was Created</h2>
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            By the early 2000s, technology adoption research had produced a proliferation of
-            competing theoretical models. At least eight distinct frameworks-each with its own
-            constructs, relationships, and empirical support-vied to explain why individuals accept
-            or reject information technologies. This theoretical fragmentation created significant
-            challenges for both researchers and practitioners. Researchers faced difficult choices
-            about which model to employ, often selecting models based on familiarity rather than
-            empirical superiority. Practitioners seeking evidence-based guidance for technology
-            implementation found conflicting recommendations depending on which theoretical
-            perspective they consulted.
+            Venkatesh and colleagues developed UTAUT to address a critical fragmentation in
+            technology adoption research. By 2003, prior decades of adoption research had produced
+            eight distinct theoretical models, each with different core constructs and empirical
+            validation. The Technology Acceptance Model focused on perceived usefulness and ease of
+            use, while the Theory of Reasoned Action emphasized attitudes and subjective norms. The
+            Theory of Planned Behavior added perceived behavioral control, Diffusion of Innovations
+            highlighted relative advantage and complexity, the Model of Adoption of Technology in
+            Households examined household-specific adoption drivers, and Social Cognitive Theory
+            emphasized self-efficacy. This theoretical proliferation created confusion:
+            practitioners and researchers lacked a unified framework for understanding technology
+            adoption, different studies used different models without clear guidance on which was
+            most appropriate, and the relative importance of different constructs across models
+            remained unclear.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The fragmentation also impeded cumulative knowledge building. Because different research
-            teams used different models with different constructs, findings across studies were
-            difficult to compare, integrate, or synthesize. The field lacked a common theoretical
-            language for discussing technology acceptance determinants. Studies using TAM emphasized
-            perceived usefulness and ease of use; studies using the Theory of Planned Behavior
-            emphasized attitudes, subjective norms, and perceived behavioral control; studies using
-            Innovation Diffusion Theory emphasized relative advantage, complexity, and
-            compatibility. These overlapping but non-identical constructs created conceptual
-            confusion about which factors truly drive technology acceptance.
+            The authors recognized that technology adoption research needed theoretical
+            consolidation rather than continued model multiplication. They conducted a comprehensive
+            meta-analysis of prior adoption research, systematically comparing the eight existing
+            models to identify commonalities, construct overlaps, and distinctive contributions.
+            From this analysis, Venkatesh and colleagues identified four core constructs that
+            consistently predicted adoption intention and behavior across prior research:
+            performance expectancy (perceived usefulness and relative advantage), effort expectancy
+            (ease of use and complexity), social influence (subjective norms), and facilitating
+            conditions (perceived behavioral control). They hypothesized that these four constructs
+            directly predict acceptance, and that demographic factors including gender, age,
+            experience, and voluntariness moderate these relationships.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Venkatesh, Morris, Davis, and Davis undertook a comprehensive review and empirical
-            comparison of eight prominent technology acceptance models. Their objective was to
-            formulate a unified model that would retain the explanatory strengths of each individual
-            model while achieving greater parsimony and predictive power than any single model could
-            provide. The result was the Unified Theory of Acceptance and Use of Technology (UTAUT),
-            which synthesized the eight source models into a single integrated framework with four
-            core determinants of behavioral intention and usage behavior, moderated by four key
-            individual difference variables.
+            UTAUT was created through empirical testing in organizational settings where multiple
+            technologies were implemented, allowing researchers to validate whether a unified model
+            could explain adoption across different technology types, user populations, and
+            organizational contexts. The authors tested UTAUT against each of the eight prior models
+            separately and against a combined model, demonstrating that UTAUT explained
+            approximately 70 percent of variance in adoption intention, substantially improving
+            explanatory power. This theoretical integration provided researchers and practitioners
+            with a parsimonious, validated framework for understanding technology adoption without
+            the need to navigate eight competing theoretical traditions.
           </p>
         </section>
 
-        {/* The Eight Source Models */}
+        {/* 5. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>The Eight Source Models</h2>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
-            UTAUT was derived from a systematic review and empirical comparison of eight established
-            theoretical models: (1) the Theory of Reasoned Action (TRA; Fishbein &amp; Ajzen, 1975),
-            which posited that behavioral intention is determined by attitudes and subjective norms;
-            (2) the Technology Acceptance Model (TAM; Davis, 1989), which identified perceived
-            usefulness and perceived ease of use as key determinants;(3) the Motivational Model (MM;
-            Davis, Bagozzi, &amp; Warshaw, 1992), which distinguished extrinsic and intrinsic
-            motivation; (4) the Theory of Planned Behavior (TPB; Ajzen, 1991), which added perceived
-            behavioral control to TRA; (5) the Combined TAM-TPB model (C-TAM-TPB; Taylor &amp; Todd,
-            1995), which integrated TAM&rsquo;s usefulness construct with TPB&rsquo;s subjective
-            norm and perceived behavioral control; (6) the Model of PC Utilization (MPCU; Thompson,
-            Higgins, &amp; Howell, 1991), which drew on Triandis&rsquo; theory of human behavior;
-            (7) Innovation Diffusion Theory (IDT; Rogers, 1995; Moore &amp; Benbasat, 1991), which
-            emphasized innovation characteristics such as relative advantage, complexity, and
-            compatibility; and (8) Social Cognitive Theory (SCT; Bandura, 1986; Compeau &amp;
-            Higgins, 1995), which emphasized self-efficacy and outcome expectations.
+            UTAUT is built on four core constructs plus moderating factors:
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Each of these models had demonstrated varying degrees of predictive success in
-            explaining technology acceptance, typically accounting for between 17 percent and 53
-            percent of the variance in behavioral intention. Venkatesh and colleagues tested all
-            eight models using the same longitudinal dataset across four organizations, enabling the
-            first direct head-to-head empirical comparison. This comparison revealed substantial
-            overlap among the models&rsquo; constructs and motivated the development of a unified
-            framework that captured the common explanatory mechanisms while eliminating redundancy.
-          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Performance Expectancy:</strong> The degree to which an individual believes
+              that using the technology will help him or her attain gains in job performance.
+              Performance expectancy is the strongest direct predictor of technology acceptance
+              intention and encompasses concepts from prior models including perceived usefulness,
+              relative advantage, extrinsic motivation, and job-fit.
+            </li>
+            <li>
+              <strong>Effort Expectancy:</strong> The degree of ease associated with the use of the
+              technology. Effort expectancy encompasses perceived ease of use, complexity, and ease
+              of use, recognizing that users adopt technologies requiring less learning effort and
+              mental exertion. Effort expectancy directly influences adoption intention and
+              indirectly influences intention through perceived usefulness as less effortful systems
+              are perceived as more useful.
+            </li>
+            <li>
+              <strong>Social Influence:</strong> The degree to which an individual perceives that
+              important others (colleagues, supervisors, family members) believe he or she should
+              use the new technology. Social influence encompasses subjective norms, social factors,
+              and normative pressures from reference groups. Social influence effects are
+              particularly strong in mandatory adoption contexts where organizational authority and
+              peer expectations create adoption pressure.
+            </li>
+            <li>
+              <strong>Facilitating Conditions:</strong> The degree to which an individual believes
+              that organizational and technical infrastructure exists to support use of the
+              technology. Facilitating conditions reflect perceived behavioral control,
+              self-efficacy, and compatibility, recognizing that adoption depends on whether
+              individuals have access to training, technical support, compatible systems, and
+              sufficient knowledge to use technology effectively.
+            </li>
+            <li>
+              <strong>Gender as Moderator:</strong> Male and female users weight adoption
+              determinants differently. Women tend to place greater weight on effort expectancy and
+              social influence, while men emphasize performance expectancy. These gender-based
+              differences may reflect socialization patterns affecting technology interest and
+              confidence.
+            </li>
+            <li>
+              <strong>Age as Moderator:</strong> Older users show stronger effects of effort
+              expectancy and facilitating conditions, placing greater weight on whether systems are
+              easy to use and whether adequate support is available. Younger users emphasize
+              performance expectancy more heavily. Age-based differences may reflect cognitive
+              processing differences and differential technological socialization.
+            </li>
+            <li>
+              <strong>Experience as Moderator:</strong> As users gain experience with technology,
+              the influence of performance expectancy strengthens while effort expectancy and social
+              influence effects weaken. Experienced users develop more informed usefulness
+              assessments and reduced reliance on social cues and ease of use concerns.
+            </li>
+            <li>
+              <strong>Voluntariness of Use as Moderator:</strong> In mandatory adoption contexts
+              where organizations require technology use, social influence effects are substantially
+              stronger. In voluntary contexts where users choose whether to adopt, performance
+              expectancy dominates while social pressure has minimal effect.
+            </li>
+          </ul>
         </section>
 
-        {/* Core Constructs */}
+        {/* 6. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Core Constructs</h2>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            UTAUT distilled the numerous constructs from the eight source models into four core
-            determinants of technology acceptance and use. Each UTAUT construct represents a
-            synthesis of conceptually similar constructs from multiple source models.
+            UTAUT synthesized and integrated eight prior adoption theories:
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Performance Expectancy</strong> is defined as the degree to which an individual
-            believes that using the system will help them attain gains in job performance. This
-            construct captures the essence of perceived usefulness (TAM/TAM2), extrinsic motivation
-            (MM), job-fit (MPCU), relative advantage (IDT), and outcome expectations (SCT).
-            Performance expectancy was the strongest predictor of behavioral intention across all
-            four organizational contexts studied, reflecting a consistent finding across decades of
-            technology adoption research: users are most likely to adopt technologies they believe
-            will improve their work performance.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Effort Expectancy</strong> is defined as the degree of ease associated with the
-            use of the system. This construct synthesizes perceived ease of use (TAM), complexity
-            (MPCU), and ease of use (IDT). Effort expectancy captures the fundamental assessment of
-            whether a technology requires excessive cognitive or physical effort to operate. High
-            effort expectancy (meaning the system is perceived as easy to use) promotes adoption by
-            reducing anticipated costs of technology acquisition.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Social Influence</strong> is defined as the degree to which an individual
-            perceives that important others believe they should use the new system. This construct
-            maps to subjective norm (TRA, TPB, TAM2, C-TAM-TPB), social factors (MPCU), and image
-            (IDT). Social influence accounts for the interpersonal and organizational pressures that
-            shape technology adoption decisions, recognizing that adoption occurs within social
-            contexts where the opinions and behaviors of peers, supervisors, and other referents
-            matter.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Facilitating Conditions</strong> is defined as the degree to which an individual
-            believes that an organizational and technical infrastructure exists to support use of
-            the system. This construct draws on perceived behavioral control (TPB, C-TAM-TPB),
-            facilitating conditions (MPCU), and compatibility (IDT). Uniquely in UTAUT, facilitating
-            conditions were hypothesized to influence use behavior directly rather than through
-            behavioral intention, reflecting the insight that resource availability and
-            infrastructure support become most relevant at the point of actual system use rather
-            than at the earlier intention-formation stage.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The structural model established that performance expectancy, effort expectancy, and
-            social influence are direct determinants of behavioral intention, which in turn predicts
-            use behavior. Facilitating conditions bypass behavioral intention and directly predict
-            use behavior. This distinction between intention-mediated and direct pathways to usage
-            was an important theoretical contribution, recognizing that some adoption factors
-            operate at the motivational level (shaping the desire to use technology) while others
-            operate at the enablement level (removing or providing practical barriers to usage).
-          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Theory of Reasoned Action (Fishbein &amp;{' '}
+                <Link
+                  href="/bibliography-1-1-theory-of-reasoned-action-tra-fishbein-ajzen-1975"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Ajzen, 1975
+                </Link>
+                ):
+              </strong>{' '}
+              Foundational model establishing that behavioral intention is the primary predictor of
+              actual behavior, determined by attitudes toward the behavior and subjective norms.
+              UTAUT retains TRA&rsquo;s intention-behavior logic while operationalizing constructs
+              for technology adoption contexts.
+            </li>
+            <li>
+              <strong>
+                Technology Acceptance Model (
+                <a
+                  id="cite-ref-davis-1989-1"
+                  href="#ref-davis-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis, 1989
+                </a>
+                ):
+              </strong>{' '}
+              Identified perceived usefulness and perceived ease of use as technology-specific
+              beliefs predicting adoption. UTAUT integrates TAM&rsquo;s performance expectancy and
+              effort expectancy while adding social influence and facilitating conditions.
+            </li>
+            <li>
+              <strong>
+                Motivation Model (
+                <Link
+                  href="/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis et al., 1992
+                </Link>
+                ):
+              </strong>{' '}
+              Distinguished extrinsic motivation (performing activities to attain external goals
+              like improved job performance) from intrinsic motivation (inherent satisfaction from
+              technology use). UTAUT incorporates extrinsic motivation through performance
+              expectancy.
+            </li>
+            <li>
+              <strong>
+                Theory of Planned Behavior (
+                <a
+                  id="cite-ref-ajzen-1991-1"
+                  href="#ref-ajzen-1991"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Ajzen, 1991
+                </a>
+                ):
+              </strong>{' '}
+              Extended TRA by adding perceived behavioral control as a direct predictor of both
+              intention and behavior. UTAUT operationalizes behavioral control as facilitating
+              conditions reflecting available resources and support.
+            </li>
+            <li>
+              <strong>
+                Combined TAM-TPB Model (Taylor &amp;{' '}
+                <Link
+                  href="/bibliography-1-10-decomposed-tpb-taylor-todd-1995"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Todd, 1995
+                </Link>
+                ):
+              </strong>{' '}
+              Merged TAM and TPB by combining perceived usefulness and ease of use with perceived
+              behavioral control. UTAUT builds on this combination by adding social influence as
+              explicit moderator.
+            </li>
+            <li>
+              <strong>
+                Model of PC Utilization (
+                <a
+                  id="cite-ref-thompson-1991-1"
+                  href="#ref-thompson-1991"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Thompson et al., 1991
+                </a>
+                ):
+              </strong>{' '}
+              Identified job-fit, complexity, long-term consequences, and affect as PC adoption
+              predictors in organizational contexts. UTAUT incorporates job-fit through performance
+              expectancy and complexity through effort expectancy.
+            </li>
+            <li>
+              <strong>
+                Diffusion of Innovation (
+                <a
+                  id="cite-ref-rogers-1995-1"
+                  href="#ref-rogers-1995"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Rogers, 1995
+                </a>
+                ):
+              </strong>{' '}
+              Identified relative advantage, complexity, trialability, and observability as
+              innovation characteristics predicting adoption rates across populations. UTAUT&rsquo;s
+              performance expectancy parallels relative advantage and complexity parallels effort
+              expectancy.
+            </li>
+            <li>
+              <strong>
+                Social Cognitive Theory (
+                <a
+                  id="cite-ref-bandura-1986-1"
+                  href="#ref-bandura-1986"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Bandura, 1986
+                </a>
+                ):
+              </strong>{' '}
+              Emphasized self-efficacy and outcome expectations as predictors of behavior, with
+              social influences shaping efficacy perceptions. UTAUT incorporates self-efficacy
+              through facilitating conditions and outcome expectations through performance
+              expectancy.
+            </li>
+          </ul>
         </section>
 
-        {/* Moderating Variables */}
+        {/* 7. Describe The Model */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Moderating Variables</h2>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
-            A distinctive feature of UTAUT is its systematic incorporation of four key moderating
-            variables: gender, age, experience, and voluntariness of use. These moderators recognize
-            that the influence of each core construct on behavioral intention and use behavior
-            varies across different demographic groups and organizational contexts.
+            UTAUT proposes that acceptance intention is directly determined by performance
+            expectancy, effort expectancy, social influence, and facilitating conditions.
+            Performance expectancy is the strongest direct predictor of adoption intention. Effort
+            expectancy influences intention both directly and indirectly through performance
+            expectancy, as systems perceived as easy to use are more likely to be viewed as useful.
+            Social influence directly predicts adoption intention and indirectly influences the
+            effect of performance expectancy. Facilitating conditions influence adoption intention
+            directly and also influence perceived usefulness by removing performance barriers. Four
+            key demographic and contextual moderators strengthen or weaken these relationships:
+            gender moderates the effects of effort expectancy, social influence, and facilitating
+            conditions; age moderates effort expectancy, facilitating conditions, and social
+            influence; experience moderates all four construct relationships with intention; and
+            voluntariness moderates the social influence-to-intention relationship, with mandatory
+            contexts showing substantially stronger norm effects.
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Gender moderates multiple relationships within UTAUT. Performance expectancy was found
-            to have a stronger influence on behavioral intention for men, while effort expectancy
-            and social influence were found to have stronger effects for women. These findings
-            reflect established gender differences in technology-related cognitions documented in
-            social psychology and information systems research. Age moderates all four core
-            relationships. Performance expectancy effects are stronger for younger workers, while
-            effort expectancy, social influence, and facilitating conditions effects are stronger
-            for older workers, reflecting differences in processing capacity, social sensitivity,
-            and resource needs across the lifespan.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Experience moderates the effects of effort expectancy, social influence, and
-            facilitating conditions. As users gain experience with a technology, the effect of
-            effort expectancy on behavioral intention diminishes (because the system becomes more
-            familiar), the effect of social influence on behavioral intention weakens (because users
-            develop personal evaluations), and the effect of facilitating conditions on use behavior
-            increases (because experienced users better leverage available support resources).
-            Voluntariness of use moderates the effect of social influence: in mandatory usage
-            contexts, social influence exerts a stronger direct effect on behavioral intention
-            through compliance mechanisms.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The inclusion of moderating variables was not merely a statistical refinement but a
-            substantive theoretical contribution. By specifying when and for whom each construct is
-            most influential, UTAUT moved beyond one-size-fits-all predictions to more nuanced
-            understanding of how technology adoption determinants operate differently across diverse
-            user populations. This moderator-based approach provided practitioners with the ability
-            to tailor interventions to specific demographic segments within their organizations.
-          </p>
+
+          <h3 className={H3_CLASSES}>UTAUT Determinant Mechanisms</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Performance Expectancy - Strongest Direct Effect:</strong> The degree to which
+              users believe technology will improve job performance is the primary adoption driver.
+              Performance expectancy reflects instrumental outcomes, job relevance, and
+              expectancy-value judgments. Stronger in voluntary contexts and with high experience as
+              users develop informed performance beliefs.
+            </li>
+            <li>
+              <strong>Effort Expectancy - Gender and Age Moderated:</strong> Perceived ease of use
+              directly influences adoption intention and indirectly influences intention through
+              perceived usefulness. Effort expectancy effects are particularly strong for women and
+              older users, suggesting these groups prioritize usability and ease of learning more
+              heavily.
+            </li>
+            <li>
+              <strong>Social Influence - Context and Experience Dependent:</strong> Subjective norms
+              and social pressures directly influence adoption intention, with effects substantially
+              stronger in mandatory adoption contexts. Social influence effects weaken with
+              increased user experience as independent usefulness assessments replace reliance on
+              social cues.
+            </li>
+            <li>
+              <strong>Facilitating Conditions - Infrastructure and Support:</strong> Available
+              technical infrastructure, training, and support directly influence adoption intentions
+              by reducing adoption barriers and enhancing self-efficacy. Facilitating conditions
+              effects are stronger for women and older users who may have lower technology
+              confidence.
+            </li>
+            <li>
+              <strong>Moderation by Gender:</strong> Women show stronger effort expectancy and
+              facilitating conditions effects, suggesting gender-based differences in technology
+              confidence, learning preferences, or occupational contexts. Men show stronger
+              performance expectancy effects.
+            </li>
+            <li>
+              <strong>Moderation by Age:</strong> Older users emphasize effort expectancy and
+              facilitating conditions more heavily, reflecting greater learning concerns and support
+              needs. Younger users rely more on performance expectancy. Age may proxy for technology
+              generation, occupational stage, or cognitive processing differences.
+            </li>
+            <li>
+              <strong>Moderation by Experience:</strong> As users gain experience, performance
+              expectancy effects strengthen while effort expectancy and social influence effects
+              weaken. Experienced users develop informed usefulness assessments independent of
+              initial ease perceptions or peer influence.
+            </li>
+            <li>
+              <strong>Moderation by Voluntariness:</strong> Social influence effects are
+              dramatically stronger in mandatory adoption contexts. In voluntary adoption, users can
+              refuse technology, so performance expectancy dominates while social pressure is
+              largely irrelevant.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Parsimonious unified framework:</strong> UTAUT synthesized eight competing
+              models into four core constructs, providing a simplified yet comprehensive framework
+              more accessible than navigating multiple theories.
+            </li>
+            <li>
+              <strong>High explanatory power:</strong> UTAUT explained approximately 70 percent of
+              variance in adoption intention, substantially higher than any single predecessor model
+              and demonstrating superior predictive validity.
+            </li>
+            <li>
+              <strong>Validated across multiple technologies:</strong> Testing occurred across four
+              different technologies (e-mail, spreadsheet software, web browsers, presentation
+              software), demonstrating generalizability beyond single-technology studies.
+            </li>
+            <li>
+              <strong>Demographic moderator testing:</strong> Explicit empirical testing of gender,
+              age, experience, and voluntariness as moderators provided evidence that adoption
+              mechanisms vary by user characteristics and contexts.
+            </li>
+            <li>
+              <strong>Longitudinal design with system-logged usage:</strong> Studies measured actual
+              system usage through system logs rather than relying on self-reported intentions or
+              behaviors, improving validity of behavioral outcomes.
+            </li>
+            <li>
+              <strong>Multiple measurement occasions:</strong> Longitudinal data collection at
+              baseline and multiple subsequent time points allowed assessment of how adoption
+              determinants change over experience.
+            </li>
+            <li>
+              <strong>Large sample sizes:</strong> Testing involved N=215 individual users across
+              organizations, providing adequate statistical power to detect moderating effects.
+            </li>
+            <li>
+              <strong>Direct comparisons to predecessor models:</strong> UTAUT was tested against
+              each of the eight prior models separately and combined, directly demonstrating its
+              superior explanatory power.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Model complexity increases practical application difficulty:</strong> While
+              simpler than eight separate models, UTAUT requires measuring four core constructs plus
+              multiple moderators, potentially exceeding practical measurement capacity in some
+              applied settings.
+            </li>
+            <li>
+              <strong>Limited theoretical explanation of underlying mechanisms:</strong> UTAUT
+              identifies what predicts adoption without deeply explaining why these mechanisms
+              operate or what psychological processes they reflect. Theoretical depth is sacrificed
+              for parsimony.
+            </li>
+            <li>
+              <strong>Voluntariness moderator definition challenges:</strong> Measuring whether
+              adoption is truly voluntary versus mandatory is complex in organizational contexts
+              where employees face subtle pressures to adopt despite nominal voluntariness.
+            </li>
+            <li>
+              <strong>Cross-cultural generalizability uncertain:</strong> Developed and tested in
+              U.S. and other Western organizational contexts. Gender, age, and experience moderating
+              effects may differ substantially in non-Western cultures with different gender roles,
+              age hierarchies, and technology relationships.
+            </li>
+            <li>
+              <strong>Technology-specific limitations:</strong> 2003-era organizational technologies
+              (enterprise systems, productivity software) differ substantially from contemporary
+              mobile, cloud, and consumer-oriented technologies where adoption mechanisms may vary.
+            </li>
+            <li>
+              <strong>Measurement challenges in practice:</strong> Self-reported perceptions of
+              usefulness, ease of use, and facilitating conditions may suffer from common method
+              variance, response bias, or social desirability effects.
+            </li>
+            <li>
+              <strong>Moderator interaction effects unexplored:</strong> UTAUT tests single
+              moderating effects but does not examine how multiple moderators interact (e.g., young
+              female users versus older male users) to shape adoption differently.
+            </li>
+            <li>
+              <strong>Equifinality not addressed:</strong> UTAUT does not address whether different
+              combinations of low constructs (e.g., low performance expectancy but high social
+              influence) might produce different adoption outcomes than currently modeled.
+            </li>
+            <li>
+              <strong>Emotional and attitudinal factors underdeveloped:</strong> Model focuses on
+              expectancy-value judgments and largely ignores affect, enthusiasm, or emotional
+              responses to technology that might independently predict adoption.
+            </li>
+          </ul>
         </section>
 
-        {/* Empirical Validation */}
+        {/* 8. Key Contributions */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Empirical Validation</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            UTAUT was validated through a rigorous empirical process involving longitudinal data
-            from four organizations over a six-month period. The researchers first tested each of
-            the eight source models individually using the same dataset, establishing baseline
-            performance for each model. They then tested UTAUT against the same data and
-            subsequently cross-validated the model using new data from two additional organizations.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The results were striking. UTAUT explained approximately 70 percent of the variance in
-            behavioral intention to use technology-a substantial improvement over every individual
-            source model. The best-performing individual model (TAM2) explained approximately 53
-            percent of the variance, while other models ranged between 17 and 42 percent.
-            UTAUT&rsquo;s 70 percent explained variance represented a significant advance in
-            predictive capability and demonstrated that the unified approach captured explanatory
-            power that no single model could achieve alone.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The four core constructs all demonstrated significant effects in the hypothesized
-            directions. Performance expectancy was the strongest predictor of behavioral intention,
-            confirming its central importance. The moderating effects of gender, age, experience,
-            and voluntariness were largely supported, demonstrating that these individual difference
-            variables meaningfully influence the strength of adoption determinants across different
-            user groups. The cross-validation with two additional organizations confirmed the
-            robustness and generalizability of the model.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The explained variance for actual use behavior, while lower than for behavioral
-            intention (as is typical in behavioral research due to the intention-behavior gap), also
-            exceeded that of individual source models. Facilitating conditions demonstrated a
-            significant direct effect on use behavior as hypothesized, confirming that
-            infrastructure and support factors operate at the point of actual usage rather than at
-            the motivational stage.
-          </p>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Theoretical synthesis and consolidation:</strong> Successfully integrated
+              eight competing adoption models into unified framework, resolving decades of
+              theoretical fragmentation and establishing common ground across adoption research
+              traditions.
+            </li>
+            <li>
+              <strong>Four-construct adoption model validated:</strong> Demonstrated that
+              performance expectancy, effort expectancy, social influence, and facilitating
+              conditions comprehensively explain technology adoption intention across different
+              technologies and organizational contexts.
+            </li>
+            <li>
+              <strong>Predictive power benchmark:</strong> Achieved 70 percent variance explained in
+              adoption intention, establishing a high-performance baseline for adoption prediction
+              that challenged successor models to exceed this standard.
+            </li>
+            <li>
+              <strong>Demographic moderators empirically demonstrated:</strong> Provided empirical
+              evidence that gender, age, experience, and voluntariness systematically moderate
+              adoption relationships, establishing demographic heterogeneity in adoption mechanisms.
+            </li>
+            <li>
+              <strong>Technology-independent generalizability:</strong> Validation across four
+              different technologies demonstrated that UTAUT constructs apply beyond
+              single-technology contexts, establishing broad applicability.
+            </li>
+            <li>
+              <strong>Voluntariness-mandatory distinction validated:</strong> Empirically
+              demonstrated that mandatory adoption contexts show substantially different social
+              influence effects than voluntary adoption, addressing critical context-dependent
+              adoption dynamics.
+            </li>
+            <li>
+              <strong>Experience-based adoption dynamics:</strong> Showed that adoption determinants
+              change over experience, establishing adoption as dynamic process where mechanisms vary
+              across user learning curve.
+            </li>
+            <li>
+              <strong>Practical guidance for adoption management:</strong> Provided organizations
+              with actionable framework for understanding which levers (demonstrating performance
+              benefits, ensuring ease of use, mobilizing social support, providing facilitating
+              conditions) would most effectively drive technology acceptance.
+            </li>
+          </ul>
         </section>
 
-        {/* Strengths and Limitations */}
+        {/* 9. Internal Validity */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Strengths and Limitations</h2>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            UTAUT&rsquo;s principal strength lies in its successful unification of a fragmented
-            theoretical landscape. By demonstrating that the essential explanatory power of eight
-            competing models could be captured in four core constructs with four moderators, UTAUT
-            provided the field with a common theoretical framework and vocabulary. This unification
-            facilitated cross-study comparison, cumulative knowledge building, and more coherent
-            practical guidance.
+            UTAUT employed rigorous methodology to establish internal validity:
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The model&rsquo;s explanatory power (70 percent of variance in behavioral intention) set
-            a new benchmark for technology adoption models. The systematic inclusion of moderating
-            variables provided nuanced predictions across demographic and organizational contexts.
-            The direct path from facilitating conditions to use behavior was a novel contribution
-            that recognized the distinct roles of motivational and enabling factors. The
-            comprehensive empirical validation across multiple organizations and the
-            cross-validation with new data strengthened confidence in the model&rsquo;s robustness.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            However, UTAUT had notable limitations. The model was developed and tested exclusively
-            in organizational workplace contexts, limiting its applicability to consumer technology
-            adoption where different dynamics (such as hedonic motivation and price sensitivity)
-            operate. The model did not account for habit, which subsequent research identified as a
-            powerful predictor of continued technology use. The complexity of the full model with
-            four constructs, four moderators, and numerous moderated relationships made it
-            challenging for practitioners to apply in its complete form. Cultural factors were not
-            addressed, despite evidence that technology acceptance processes vary across national
-            and organizational cultures. These limitations motivated subsequent extensions,
-            particularly UTAUT2 (Venkatesh, Thong, &amp; Xu, 2012), which expanded the model to
-            consumer contexts.
-          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Longitudinal design with multiple measurement occasions:</strong> Data
+              collection occurred at baseline (Week 1), after 1 month of use, after 3 months, and
+              after 6 months, allowing assessment of how relationships change over extended usage
+              experience.
+            </li>
+            <li>
+              <strong>System-logged usage as dependent variable:</strong> Rather than relying on
+              self-reported usage intentions, actual system usage was captured through automated
+              system logs, reducing common method variance and providing objective behavioral
+              outcome measures.
+            </li>
+            <li>
+              <strong>Large sample with adequate power:</strong> N=215 individual users across four
+              organizations provided statistical power to detect main effects and moderating effects
+              with adequate precision.
+            </li>
+            <li>
+              <strong>Real-world implementation contexts:</strong> Studies examined actual
+              organizational technology implementations rather than artificial laboratory scenarios,
+              ensuring adoption pressures and outcomes reflect genuine organizational technology
+              deployment.
+            </li>
+            <li>
+              <strong>Multiple technology types:</strong> Testing across four different technologies
+              (e-mail, spreadsheet software, web browsers, presentation software) within the same
+              organizations controlled for organizational and user factors while varying technology
+              characteristics.
+            </li>
+            <li>
+              <strong>Explicit moderator hypothesis testing:</strong> Tests of gender, age,
+              experience, and voluntariness moderating effects used appropriate statistical
+              procedures with a priori hypotheses specified before analysis.
+            </li>
+            <li>
+              <strong>Competitor model comparisons:</strong> Tested UTAUT against each of the eight
+              individual predecessor models and a combined model, directly demonstrating superior
+              explanatory power through comparative model fit.
+            </li>
+            <li>
+              <strong>Psychometric validation:</strong> Reported reliability coefficients
+              (Cronbach&rsquo;s alpha), convergent validity, and discriminant validity evidence for
+              multi-item constructs.
+            </li>
+            <li>
+              <strong>Structural equation modeling:</strong> Used appropriate path analysis and SEM
+              techniques to test proposed theoretical relationships among constructs and moderating
+              effects.
+            </li>
+          </ul>
         </section>
 
-        {/* Relevance to Technology Adoption Barriers */}
+        {/* 10. External Validity */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Relevance to Technology Adoption Barriers</h2>
+          <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            UTAUT provides a comprehensive taxonomy of technology adoption barriers organized around
-            its four core constructs. Performance expectancy barriers arise when users do not
-            believe the technology will improve their work performance-either because the system
-            genuinely fails to deliver meaningful productivity gains or because the benefits are
-            unclear, poorly communicated, or not aligned with the user&rsquo;s specific job
-            responsibilities. Effort expectancy barriers emerge when the technology is perceived as
-            too difficult to learn and use, requiring excessive cognitive effort, training time, or
-            technical skill that exceeds the user&rsquo;s capacity or willingness.
+            External validity considerations require nuanced interpretation of generalizability:
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Social influence barriers manifest when the user&rsquo;s social environment does not
-            support technology adoption. If supervisors, peers, or other important referents express
-            skepticism about a technology, fail to use it themselves, or actively discourage its
-            use, social influence works against adoption. These barriers are particularly strong in
-            mandatory contexts where compliance pressure may generate surface-level adoption without
-            genuine acceptance. Facilitating conditions barriers arise from inadequate
-            infrastructure, insufficient training resources, lack of technical support, or
-            incompatibility between the new technology and existing systems and workflows.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The moderating variables in UTAUT have important implications for understanding
-            differential barriers across populations. Older workers may face stronger effort
-            expectancy barriers due to less familiarity with new interface paradigms. Women may be
-            more susceptible to negative social influence barriers due to stronger sensitivity to
-            social cues. Less experienced users face barriers across multiple dimensions
-            simultaneously. Organizations seeking to reduce technology adoption barriers must
-            therefore consider not only which barriers are present but which user populations are
-            most affected by each type of barrier, designing targeted interventions rather than
-            one-size-fits-all approaches.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            UTAUT&rsquo;s distinction between intention-level barriers (performance expectancy,
-            effort expectancy, social influence) and behavior-level barriers (facilitating
-            conditions) is analytically valuable. Some users may form positive intentions to adopt a
-            technology but fail to translate those intentions into actual use due to practical
-            obstacles. Organizations that address only motivational barriers while neglecting
-            facilitating conditions barriers may find high stated willingness to adopt but low
-            actual usage rates.
-          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Technology-specific limitations:</strong> While tested across four
+              technologies, all were productivity software (e-mail, spreadsheets, web browsers,
+              presentations) used in office contexts. Generalization to consumer technologies,
+              mobile applications, or enterprise software like customer relationship management
+              systems requires investigation.
+            </li>
+            <li>
+              <strong>Organizational context limitations:</strong> Four organizations studied were
+              all relatively large, formally structured organizations in Western countries with
+              established IT infrastructure. Generalization to small businesses, informal
+              organizations, or non-Western organizational structures is unclear.
+            </li>
+            <li>
+              <strong>Mandatory-voluntary distinction:</strong> Organizations in studies showed
+              variation in whether adoption was organizationally mandated or voluntary, but the
+              range may not represent the full spectrum of mandatory (required with enforcement)
+              versus voluntary (purely optional) adoption contexts.
+            </li>
+            <li>
+              <strong>User population characteristics:</strong> Participants were predominantly
+              office workers, professionals, and knowledge workers with baseline technology
+              exposure. Generalization to non-technical users, older workers with low technology
+              experience, or non-Western user populations requires verification.
+            </li>
+            <li>
+              <strong>Cultural generalizability:</strong> U.S. and Western-dominant samples limit
+              generalization to non-Western contexts where cultural values regarding social
+              hierarchy, conformity, uncertainty avoidance, and individualism may modify moderating
+              effects.
+            </li>
+            <li>
+              <strong>Time period considerations:</strong> Year 2003 organizational technology
+              context differs from contemporary technology adoption where cloud services, mobile
+              platforms, and artificial intelligence represent different adoption dynamics than
+              legacy enterprise systems.
+            </li>
+            <li>
+              <strong>Implementation support variation:</strong> Organizational support quality,
+              training provided, and change management approaches varied across organizations but
+              are not modeled as moderators, potentially limiting generalization to different
+              implementation contexts.
+            </li>
+            <li>
+              <strong>Long-term sustainability:</strong> Studies measured adoption over six months.
+              Long-term technology continuation, discontinuance patterns, or evolving usage beyond
+              initial implementation period remain unexplored.
+            </li>
+          </ul>
         </section>
 
-        {/* References */}
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            UTAUT directly addresses technology adoption barriers by identifying four critical
+            mechanisms that inhibit or facilitate acceptance. The model recognizes that users face
+            multiple distinct barriers: perceived uselessness of technology for job performance
+            (performance expectancy), difficulty learning and using systems (effort expectancy),
+            negative social pressures and norms (social influence), and lack of supporting
+            infrastructure and training (facilitating conditions). Critically, UTAUT demonstrates
+            that different user populations encounter different barriers, with women and older
+            workers particularly hindered by complexity and lack of support, while men emphasize
+            performance relevance. Organizations implementing technology must address all four
+            barrier dimensions simultaneously, recognizing that improving one dimension cannot
+            compensate for severe barriers in others.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Low performance expectancy:</strong> When users doubt that technology will
+              meaningfully improve job performance or outcomes, adoption intention remains low
+              regardless of ease of use or social support.
+            </li>
+            <li>
+              <strong>High complexity perception:</strong> Technologies perceived as difficult,
+              complicated, or requiring extensive learning face adoption resistance, especially from
+              women and older workers.
+            </li>
+            <li>
+              <strong>Negative social influence:</strong> In mandatory adoption contexts, when
+              colleagues, supervisors, and organizational leadership communicate skepticism or
+              resistance, strong normative pressures inhibit adoption intentions.
+            </li>
+            <li>
+              <strong>Inadequate facilitating conditions:</strong> Lack of training, insufficient
+              technical support, incompatible systems, or unreliable infrastructure prevent adoption
+              despite positive performance and ease beliefs.
+            </li>
+            <li>
+              <strong>Status threat from technology:</strong> Users perceiving technology adoption
+              as threatening job security, deskilling, or reducing professional status face
+              psychological barriers overcoming positive performance expectations.
+            </li>
+            <li>
+              <strong>Demographic-specific barriers:</strong> Women may face particular complexity
+              barriers, older workers may lack technology confidence despite capability,
+              inexperienced users may be overly influenced by negative peer commentary.
+            </li>
+            <li>
+              <strong>Mandatory context fatigue:</strong> Organizations with repeated mandatory
+              technology implementations may condition users to resist each new adoption despite
+              potential benefits.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Model Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Demonstrate clear performance benefits:</strong> Use pilot programs, business
+              case analysis, and performance metrics to establish credible evidence that technology
+              will improve job outcomes. Performance expectancy is the strongest adoption driver.
+            </li>
+            <li>
+              <strong>Reduce complexity and ease of learning:</strong> Invest in user interface
+              design, comprehensive training, and accessible documentation that minimize perceived
+              effort. Allocate additional resources for women and older workers who emphasize ease
+              of use more heavily.
+            </li>
+            <li>
+              <strong>Mobilize positive social influence:</strong> In mandatory contexts, ensure
+              supervisors, opinion leaders, and peer champions actively communicate support and
+              positive expectations. In voluntary contexts, focus on performance benefits rather
+              than social pressure.
+            </li>
+            <li>
+              <strong>Provide robust facilitating conditions:</strong> Ensure technical support is
+              readily available, training is comprehensive, compatible systems are deployed, and
+              infrastructure is reliable. Allocate additional support resources for women and older
+              users.
+            </li>
+            <li>
+              <strong>Tailor approaches by demographics:</strong> Recognize that women may need more
+              emphasis on ease and support, older workers may benefit from more intensive training,
+              and inexperienced users may be disproportionately influenced by social context.
+            </li>
+            <li>
+              <strong>Address voluntariness differences:</strong> In mandatory adoption, leverage
+              social influence and organizational authority; in voluntary adoption, emphasize
+              performance benefits to overcome adoption resistance.
+            </li>
+            <li>
+              <strong>Build support infrastructure early:</strong> Facilitating conditions exert
+              direct effects on adoption and become more critical as users with low confidence
+              encounter difficulties.
+            </li>
+            <li>
+              <strong>Sustain engagement over experience:</strong> As users gain experience,
+              leverage their developing competence to reinforce performance expectancy; recognize
+              that social influence effects naturally diminish as experience increases.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            UTAUT fundamentally reshaped technology adoption research following its publication:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                UTAUT2 (
+                <a
+                  id="cite-ref-venkatesh-2012-1"
+                  href="#ref-venkatesh-2012"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Venkatesh et al., 2012
+                </a>
+                ):
+              </strong>{' '}
+              Extended UTAUT to consumer contexts by adding hedonic motivation (intrinsic
+              enjoyment), price value, and habit as additional determinants, recognizing adoption
+              differences between organizational and consumer technologies.
+            </li>
+            <li>
+              <strong>Mobile and consumer technology adoption research:</strong> Researchers adapted
+              UTAUT framework to understand adoption of smartphones, tablets, mobile applications,
+              and consumer cloud services, validating mechanisms across consumer domains.
+            </li>
+            <li>
+              <strong>Emerging technology adoption studies:</strong> UTAUT became the dominant
+              framework for studying adoption of new technologies including cloud computing,
+              artificial intelligence, blockchain, extended reality, and Internet of Things
+              applications.
+            </li>
+            <li>
+              <strong>Cross-cultural adoption research:</strong> Researchers tested UTAUT across
+              diverse cultural contexts (Asia, Europe, Africa, Latin America), examining whether
+              moderating effects and construct relationships vary by cultural dimensions.
+            </li>
+            <li>
+              <strong>Technology-in-education adoption:</strong> Educational technology adoption
+              research widely adopted UTAUT to understand student and faculty technology acceptance
+              in learning management systems, virtual classrooms, and educational applications.
+            </li>
+            <li>
+              <strong>Healthcare technology adoption:</strong> UTAUT became standard framework for
+              understanding clinician and patient adoption of electronic health records,
+              telemedicine platforms, and clinical decision support systems.
+            </li>
+            <li>
+              <strong>Government and public sector adoption:</strong> Government agencies used UTAUT
+              to understand citizen adoption of e-government services, digital identity systems, and
+              online public services.
+            </li>
+            <li>
+              <strong>Moderator extension research:</strong> Researchers added additional moderators
+              beyond gender, age, experience, and voluntariness, including technology anxiety,
+              self-efficacy, organizational culture, and situational factors.
+            </li>
+            <li>
+              <strong>Acceptance-to-continued use transitions:</strong> Researchers extended UTAUT
+              logic to post-adoption contexts, examining how initial acceptance leads to sustained
+              use, discontinuance, or abandonment.
+            </li>
+            <li>
+              <strong>Integration with related theories:</strong> Researchers combined UTAUT with
+              organizational culture, change management theory, and innovation diffusion theory to
+              enhance explanatory scope.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
-          <ol className="list-decimal list-inside space-y-3 text-sm">
-            <li>
-              Ajzen, I. (1991). The theory of planned behavior.{' '}
-              <em>Organizational Behavior and Human Decision Processes</em>, 50(2), 179-211.{' '}
-              <a
-                href="https://doi.org/10.1016/0749-5978(91)90020-T"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1016/0749-5978(91)90020-T
-              </a>
-            </li>
-            <li>
-              Bandura, A. (1986).{' '}
-              <em>Social Foundations of Thought and Action: A Social Cognitive Theory</em>.
-              Prentice-Hall.
-            </li>
-            <li>
-              Compeau, D. R., &amp; Higgins, C. A. (1995). Computer self-efficacy: Development of a
-              measure and initial test. <em>MIS Quarterly</em>, 19(2), 189-211.{' '}
-              <a
-                href="https://doi.org/10.2307/249688"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/249688
-              </a>
-            </li>
-            <li>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-davis-1989">
               Davis, F. D. (1989). Perceived usefulness, perceived ease of use, and user acceptance
-              of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.{' '}
-              <a
-                href="https://doi.org/10.2307/249008"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/249008
-              </a>
+              of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-davis-1989-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>{' '}
+              https://doi.org/10.2307/249008
             </li>
-            <li>
-              Davis, F. D., Bagozzi, R. P., &amp; Warshaw, P. R. (1992). Extrinsic and intrinsic
-              motivation to use computers in the workplace.{' '}
-              <em>Journal of Applied Social Psychology</em>, 22(14), 1111-1132.{' '}
-              <a
-                href="https://doi.org/10.1111/j.1559-1816.1992.tb00945.x"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1111/j.1559-1816.1992.tb00945.x
-              </a>
+            <li id="ref-ajzen-1991">
+              Ajzen, I. (1991). The theory of planned behavior.{' '}
+              <em>Organizational Behavior and Human Decision Processes</em>, 50(2), 179-211.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-ajzen-1991-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>{' '}
+              https://doi.org/10.1016/0749-5978(91)90020-T
             </li>
-            <li>
-              Fishbein, M., &amp; Ajzen, I. (1975).{' '}
-              <em>
-                Belief, Attitude, Intention, and Behavior: An Introduction to Theory and Research
-              </em>
-              . Addison-Wesley.
+            <li id="ref-rogers-1995">
+              Rogers, E. M. (1995). Diffusion of innovations (4th ed.). Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-rogers-1995-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
             </li>
-            <li>
-              Moore, G. C., &amp; Benbasat, I. (1991). Development of an instrument to measure the
-              perceptions of adopting an information technology innovation.{' '}
-              <em>Information Systems Research</em>, 2(3), 192-222.{' '}
-              <a
-                href="https://doi.org/10.1287/isre.2.3.192"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1287/isre.2.3.192
-              </a>
+            <li id="ref-bandura-1986">
+              Bandura, A. (1986). Social foundations of thought and action: A social cognitive
+              theory. Prentice Hall.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-bandura-1986-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
             </li>
-            <li>
-              Rogers, E. M. (1995). <em>Diffusion of Innovations</em> (4th ed.). Free Press.
-            </li>
-            <li>
-              Taylor, S., &amp; Todd, P. A. (1995). Understanding information technology usage: A
-              test of competing models. <em>Information Systems Research</em>, 6(2), 144-176.{' '}
-              <a
-                href="https://doi.org/10.1287/isre.6.2.144"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1287/isre.6.2.144
-              </a>
-            </li>
-            <li>
+            <li id="ref-thompson-1991">
               Thompson, R. L., Higgins, C. A., &amp; Howell, J. M. (1991). Personal computing:
-              Toward a conceptual model of utilization. <em>MIS Quarterly</em>, 15(1), 125-143.{' '}
-              <a
-                href="https://doi.org/10.2307/249443"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/249443
-              </a>
+              Toward a conceptual model of utilization. <em>MIS Quarterly</em>, 15(1), 125-143.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-thompson-1991-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
             </li>
-            <li>
-              Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
-              of information technology: Toward a unified view. <em>MIS Quarterly</em>, 27(3),
-              425-478.{' '}
-              <a
-                href="https://doi.org/10.2307/30036540"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/30036540
-              </a>
-            </li>
-            <li>
+            <li id="ref-venkatesh-2012">
               Venkatesh, V., Thong, J. Y. L., &amp; Xu, X. (2012). Consumer acceptance and use of
               information technology: Extending the unified theory of acceptance and use of
-              technology. <em>MIS Quarterly</em>, 36(1), 157-178.{' '}
-              <a
-                href="https://doi.org/10.2307/41410412"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/41410412
-              </a>
+              technology. <em>MIS Quarterly</em>, 36(1), 157-178. https://doi.org/10.2307/41410412{' '}
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-venkatesh-2012-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-venkatesh-2003">
+              Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
+              of information technology: Toward a unified view. <em>MIS Quarterly</em>, 27(3),
+              425-478. https://doi.org/10.2307/30036540
             </li>
           </ol>
         </section>
 
-        <p className="mt-8 text-sm italic text-gray-600">
-          Note: This article provides an overview based on the comprehensive literature review.
-          Readers are encouraged to consult the original publication for complete details.
-        </p>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-fishbein-1975">
+              Fishbein, M., &amp; Ajzen, I. (1975). Belief, attitude, intention, and behavior: An
+              introduction to theory and research. Addison-Wesley.
+            </li>
+            <li id="ref-taylor-1995">
+              Taylor, S., &amp; Todd, P. A. (1995). Understanding information technology usage: A
+              test of competing models. <em>Information Systems Research</em>, 6(2), 144-176.
+              https://doi.org/10.1287/isre.6.2.144
+            </li>
+            <li id="ref-compeau-1995">
+              Compeau, D. R., &amp; Higgins, C. A. (1995). Computer self-efficacy: Development of a
+              measure and initial test. <em>MIS Quarterly</em>, 19(2), 189-211.
+              https://doi.org/10.2307/249688
+            </li>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+            <li id="ref-goodhue-1995">
+              Goodhue, D. L., &amp; Thompson, R. L. (1995). Task-technology fit and individual
+              performance. <em>MIS Quarterly</em>, 19(2), 213-236. https://doi.org/10.2307/249689
+            </li>
+            <li id="ref-venkatesh-2000">
+              Venkatesh, V., &amp; Davis, F. D. (2000). A theoretical extension of the technology
+              acceptance model: Four longitudinal field studies. <em>Management Science</em>, 46(2),
+              186-204.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-14-expectation-confirmation-model-ecm-bhattacherjee-2001"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Expectation-Confirmation Model (Bhattacherjee)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-16-math-venkatesh-brown-2001"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Model of Adoption of Technology in Households (Venkatesh &amp; Brown) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>

--- a/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
+++ b/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
@@ -174,11 +174,11 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Effort Expectancy:</strong> The degree of ease associated with the use of the
-              technology. Effort expectancy encompasses perceived ease of use, complexity, and ease
-              of use, recognizing that users adopt technologies requiring less learning effort and
-              mental exertion. Effort expectancy directly influences adoption intention and
-              indirectly influences intention through perceived usefulness as less effortful systems
-              are perceived as more useful.
+              technology. Effort expectancy encompasses perceived ease of use and complexity,
+              recognizing that users adopt technologies requiring less learning effort and mental
+              exertion. Effort expectancy directly influences adoption intention and indirectly
+              influences intention through perceived usefulness as less effortful systems are
+              perceived as more useful.
             </li>
             <li>
               <strong>Social Influence:</strong> The degree to which an individual perceives that
@@ -368,20 +368,21 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
-            UTAUT proposes that acceptance intention is directly determined by performance
-            expectancy, effort expectancy, social influence, and facilitating conditions.
+            UTAUT proposes that acceptance intention is directly determined by three constructs:
+            performance expectancy, effort expectancy, and social influence. A fourth construct,
+            facilitating conditions, directly predicts actual use behavior rather than intention.
             Performance expectancy is the strongest direct predictor of adoption intention. Effort
             expectancy influences intention both directly and indirectly through performance
             expectancy, as systems perceived as easy to use are more likely to be viewed as useful.
-            Social influence directly predicts adoption intention and indirectly influences the
-            effect of performance expectancy. Facilitating conditions influence adoption intention
-            directly and also influence perceived usefulness by removing performance barriers. Four
-            key demographic and contextual moderators strengthen or weaken these relationships:
-            gender moderates the effects of effort expectancy, social influence, and facilitating
-            conditions; age moderates effort expectancy, facilitating conditions, and social
-            influence; experience moderates all four construct relationships with intention; and
-            voluntariness moderates the social influence-to-intention relationship, with mandatory
-            contexts showing substantially stronger norm effects.
+            Social influence directly predicts adoption intention, with effects strongest in
+            mandatory contexts. Facilitating conditions directly influence usage behavior by
+            removing practical barriers to technology use. Four key demographic and contextual
+            moderators strengthen or weaken these relationships: gender moderates the effects of
+            effort expectancy, social influence, and facilitating conditions; age moderates effort
+            expectancy, facilitating conditions, and social influence; experience moderates all four
+            construct relationships with intention; and voluntariness moderates the social
+            influence-to-intention relationship, with mandatory contexts showing substantially
+            stronger norm effects.
           </p>
 
           <h3 className={H3_CLASSES}>UTAUT Determinant Mechanisms</h3>

--- a/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
+++ b/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
@@ -73,8 +73,7 @@ const BibliographyArticlePage = () => {
               <strong>Pages:</strong> 425-478
             </p>
             <p>
-              <strong>DOI:</strong>
-              {chr(39) + ' ' + chr(39)}
+              <strong>DOI:</strong>{' '}
               <a
                 href="https://doi.org/10.2307/30036540"
                 target="_blank"
@@ -455,8 +454,9 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Validated across multiple technologies:</strong> Testing occurred across four
-              different technologies (e-mail, spreadsheet software, web browsers, presentation
-              software), demonstrating generalizability beyond single-technology studies.
+              organizations with different technologies (an online meeting manager, a database
+              application, a portfolio analyzer, and an accounting system), demonstrating
+              generalizability beyond single-technology studies.
             </li>
             <li>
               <strong>Demographic moderator testing:</strong> Explicit empirical testing of gender,
@@ -469,13 +469,15 @@ const BibliographyArticlePage = () => {
               behaviors, improving validity of behavioral outcomes.
             </li>
             <li>
-              <strong>Multiple measurement occasions:</strong> Longitudinal data collection at
-              baseline and multiple subsequent time points allowed assessment of how adoption
-              determinants change over experience.
+              <strong>Multiple measurement occasions:</strong> Longitudinal data collection at four
+              time points (1 week post-training, 1 month, 3 months, and 6 months
+              post-implementation) allowed assessment of how adoption determinants change over
+              experience.
             </li>
             <li>
-              <strong>Large sample sizes:</strong> Testing involved N=215 individual users across
-              organizations, providing adequate statistical power to detect moderating effects.
+              <strong>Large sample sizes:</strong> Testing involved N=645 individual users pooled
+              across four organizations (with N=119 in voluntary settings and N=96 in mandatory
+              settings), providing adequate statistical power to detect moderating effects.
             </li>
             <li>
               <strong>Direct comparisons to predecessor models:</strong> UTAUT was tested against
@@ -608,9 +610,9 @@ const BibliographyArticlePage = () => {
               outcome measures.
             </li>
             <li>
-              <strong>Large sample with adequate power:</strong> N=215 individual users across four
-              organizations provided statistical power to detect main effects and moderating effects
-              with adequate precision.
+              <strong>Large sample with adequate power:</strong> N=645 individual users pooled
+              across four organizations provided statistical power to detect main effects and
+              moderating effects with adequate precision.
             </li>
             <li>
               <strong>Real-world implementation contexts:</strong> Studies examined actual
@@ -620,9 +622,8 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Multiple technology types:</strong> Testing across four different technologies
-              (e-mail, spreadsheet software, web browsers, presentation software) within the same
-              organizations controlled for organizational and user factors while varying technology
-              characteristics.
+              in four distinct organizations (entertainment, telecommunications, banking, and public
+              administration) controlled for technology type while varying organizational context.
             </li>
             <li>
               <strong>Explicit moderator hypothesis testing:</strong> Tests of gender, age,
@@ -656,10 +657,10 @@ const BibliographyArticlePage = () => {
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>Technology-specific limitations:</strong> While tested across four
-              technologies, all were productivity software (e-mail, spreadsheets, web browsers,
-              presentations) used in office contexts. Generalization to consumer technologies,
-              mobile applications, or enterprise software like customer relationship management
-              systems requires investigation.
+              organizations with different technologies (meeting manager, database application,
+              portfolio analyzer, accounting system), all were workplace systems in formal
+              organizational contexts. Generalization to consumer technologies, mobile applications,
+              or informal adoption contexts requires investigation.
             </li>
             <li>
               <strong>Organizational context limitations:</strong> Four organizations studied were
@@ -1005,7 +1006,7 @@ const BibliographyArticlePage = () => {
             </p>
             <p className={PARAGRAPH_CLASSES}>
               <Link
-                href="/bibliography-1-16-math-venkatesh-brown-2001"
+                href="/bibliography-1-16-math-brown-venkatesh-2005"
                 className="text-blue-600 hover:text-blue-800 underline"
               >
                 Next: Model of Adoption of Technology in Households (Venkatesh &amp; Brown) &rarr;

--- a/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
+++ b/src/app/bibliography-1-15-unified-theory-utaut-venkatesh-2003/page.tsx
@@ -475,9 +475,10 @@ const BibliographyArticlePage = () => {
               experience.
             </li>
             <li>
-              <strong>Large sample sizes:</strong> Testing involved N=645 individual users pooled
-              across four organizations (with N=119 in voluntary settings and N=96 in mandatory
-              settings), providing adequate statistical power to detect moderating effects.
+              <strong>Large sample sizes:</strong> Testing involved 215 individual users across four
+              organizations (119 in voluntary settings, 96 in mandatory settings), measured at three
+              time points yielding 645 pooled observations, providing adequate statistical power to
+              detect moderating effects.
             </li>
             <li>
               <strong>Direct comparisons to predecessor models:</strong> UTAUT was tested against
@@ -610,9 +611,10 @@ const BibliographyArticlePage = () => {
               outcome measures.
             </li>
             <li>
-              <strong>Large sample with adequate power:</strong> N=645 individual users pooled
-              across four organizations provided statistical power to detect main effects and
-              moderating effects with adequate precision.
+              <strong>Large sample with adequate power:</strong> 215 individual users across four
+              organizations (119 voluntary, 96 mandatory), measured at three time points (645 pooled
+              observations), provided statistical power to detect main effects and moderating
+              effects with adequate precision.
             </li>
             <li>
               <strong>Real-world implementation contexts:</strong> Studies examined actual


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 1-15 UTAUT (Venkatesh et al., 2003) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1567
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)