### PR TITLE
docs: standardize bibliography 1-17 Value-Based Adoption (Kim et al., 2007)

### DIFF
--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -561,7 +561,8 @@ const BibliographyArticlePage = () => {
             <li>
               <strong>Multiple regression analysis:</strong> Used Pearson correlation followed by
               multiple regression (not SEM) to test hypothesized paths among constructs. Mediation
-              was tested using Baron &amp; Kenny's method (Table 5, p.120). Multicollinearity was
+              was tested using Baron &amp; Kenny&rsquo;s method (Table 5, p.120). Multicollinearity
+              was
               examined via VIF (1.20-1.60, below the 10 threshold).
             </li>
             <li>

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -562,8 +562,7 @@ const BibliographyArticlePage = () => {
               <strong>Multiple regression analysis:</strong> Used Pearson correlation followed by
               multiple regression (not SEM) to test hypothesized paths among constructs. Mediation
               was tested using Baron &amp; Kenny&rsquo;s method (Table 5, p.120). Multicollinearity
-              was
-              examined via VIF (1.20-1.60, below the 10 threshold).
+              was examined via VIF (1.20-1.60, below the 10 threshold).
             </li>
             <li>
               <strong>Psychometric validation:</strong> Reported reliability coefficients,

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -759,9 +759,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-davis-1989-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>{' '}
               https://doi.org/10.2307/249008
             </li>
@@ -773,9 +771,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-zeithaml-1988-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-rogers-1995">
@@ -785,9 +781,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-rogers-1995-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-kim-2007">

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -8,738 +8,870 @@ import {
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
+  REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Value-Based Adoption Model - Kim et al. (2007)',
+  title: 'Bibliography: Value-Based Adoption Model (VAM) - Kim, Chan, & Gupta (2007)',
   description:
-    'Deep dive into the Value-Based Adoption of Mobile Internet (VAM) model by Kim et al. (2007), exploring its foundational contributions to technology adoption research.',
+    'Comprehensive examination of the Value-Based Adoption Model (VAM), which posits that technology adoption is driven by perceived value as trade-off between perceived benefits and perceived sacrifices in consumer technology adoption.',
 }
 
 const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Value-Based Adoption Model - Kim et al. (2007)</h1>
+        <h1 className={H1_CLASSES}>
+          Value-Based Adoption Model (VAM) - Kim, Chan, &amp; Gupta (2007)
+        </h1>
 
-        {/* Model Identification */}
+        {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Model Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Model Name:</strong> Value-Based Adoption of Mobile Internet (VAM)
+              <strong>Model Name:</strong> Value-Based Adoption Model
             </p>
             <p>
-              <strong>Authors:</strong> Kim et al.
+              <strong>Model Abbreviation:</strong> VAM
             </p>
             <p>
-              <strong>Publication Date:</strong> 2007
+              <strong>Target of Model:</strong> Determinants of consumer technology adoption
+              intention based on perceived value as trade-off between perceived benefits (usefulness
+              and enjoyment) and perceived sacrifices (fee and technicality)
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Consumer Behavior, Marketing, Technology
+              Adoption, Value Theory
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Authors:</strong> Hee-Woong Kim, Hock Chuan Chan, and Sumeet Gupta
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 2007
+            </p>
+            <p>
+              <strong>Official Title:</strong> Value-based adoption of mobile internet: An empirical
+              investigation
+            </p>
+            <p>
+              <strong>Journal:</strong> Decision Support Systems
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 43, No. 1
+            </p>
+            <p>
+              <strong>Pages:</strong> 111-126
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Kim, H.-W., Chan, H. C., &amp; Gupta, S. (2007). Value-based adoption of mobile
-              internet: An empirical investigation. <em>Decision Support Systems</em>, 43(1),
-              111-126.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Kim, H.-W., Chan, H. C., &amp; Gupta, S. (
+                <a href="#ref-kim-2007" className="text-tabs-teal-deep hover:underline">
+                  2007
+                </a>
+                ). Value-based adoption of mobile internet: An empirical investigation.{' '}
+                <em>Decision Support Systems</em>, 43(1), 111-126.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Kim, Hee-Woong, Hock Chuan Chan, and Sumeet Gupta. 2007. &ldquo;Value-Based Adoption
+                of Mobile Internet: An Empirical Investigation.&rdquo;{' '}
+                <em>Decision Support Systems</em> 43, no. 1: 111-126.
+              </p>
+            </div>
           </div>
         </section>
 
-        {/* Main Content */}
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>Why was the model made?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Value-Based Adoption of Mobile Internet (VAM) model was developed to address a
-              fundamental gap in existing technology adoption theories. The authors recognized that
-              previous adoption models, particularly the Technology Acceptance Model, inadequately
-              captured the complexity of how consumers evaluate technology through the lens of
-              personal values. While TAM effectively modeled perceived usefulness and ease of use as
-              predictors of adoption, it did not explicitly address how consumers’ personal values,
-              goals, and desired life outcomes influence technology adoption decisions. The
-              development of VAM was motivated by the observation that consumer technology adoption
-              involves value judgments beyond narrow instrumental assessments of utility and
-              usability. When consumers evaluate whether to adopt mobile internet services, they are
-              not just asking “Is this useful?” and “Is it easy to use?” They are also asking deeper
-              questions about what they value in life: “Will this help me achieve what I care
-              about?” “Does this align with my priorities and goals?” “What kind of person will I
-              become if I use this?” These value-based questions drive adoption decisions in ways
-              that existing TAM-based models do not capture.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The authors recognized that mobile internet adoption presented a particularly
-              compelling context for investigating value-based adoption. Unlike computer adoption in
-              organizational settings where utility is relatively clear, mobile internet adoption in
-              consumer contexts involves substantial uncertainty about how the technology will fit
-              into daily life and what value it will deliver. Consumers evaluating mobile internet
-              must make judgments about whether having internet access in mobile contexts aligns
-              with their values and priorities. The theoretical foundation drew from
-              expectancy-value theory, which proposes that individuals’ attitudes toward objects are
-              determined by their beliefs about the object’s attributes and the value or importance
-              they assign to those attributes. The authors applied this theoretical framework
-              specifically to technology adoption, proposing that technology adoption depends not
-              just on perceived attributes (usefulness, ease of use) but on the values that
-              individuals hold and how the technology relates to those values.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The model was also motivated by gaps in existing technology adoption literature
-              regarding how personal values influence adoption. The authors noted that while
-              consumer behavior research had extensively documented the importance of personal
-              values in consumer decision-making, technology adoption literature had largely
-              neglected this dimension. The VAM model sought to integrate personal values theory
-              with technology adoption research. Additionally, the authors recognized that different
-              market segments adopt technologies for fundamentally different reasons reflecting
-              different value systems. Some consumers might adopt mobile internet to increase
-              efficiency and productivity (utilitarian values). Others might adopt to maintain
-              social connection and relationships (social values). Still others might adopt for
-              entertainment and enjoyment (hedonic values). Existing adoption models did not
-              adequately account for these different value-based motivations.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The practical motivation for developing VAM centered on improving market segmentation
-              and marketing strategy for mobile internet services. Understanding which consumers
-              adopted based on utilitarian values, which based on social values, and which based on
-              hedonic values would enable providers to develop more targeted marketing strategies
-              and service offerings that appealed to different value-driven segments. The model was
-              also developed to advance theoretical understanding of how consumers construct value
-              assessments in technology adoption. Rather than treating value as a single
-              unidimensional construct, the authors proposed that consumers evaluate technologies
-              across multiple value dimensions reflecting different aspects of what they value in
-              life.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How was the model’s internal validity tested?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The internal validity of the VAM model was tested through structural equation modeling
-              analysis using data from 210 mobile internet users in Canada. The research design
-              involved developing and validating a measurement model that captured personal values,
-              value-based benefits, and adoption intention. The measurement model was developed
-              using established value measurement scales. Personal values were measured using value
-              scales from Schwartz’s Theory of Values, which distinguishes between multiple
-              dimensions of human values including self-direction (autonomy and independence),
-              security (safety and stability), tradition (cultural and family commitment),
-              conformity (social order and obligation), benevolence (welfare of others),
-              universalism (understanding and appreciation), achievement (success and ambition),
-              hedonism (pleasure and satisfaction), power (status and influence), and stimulation
-              (excitement and novelty). These value dimensions were operationalized through items
-              measuring the importance individuals assign to each value.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The measurement of value-based benefits involved developing items that reflected
-              specific benefits the technology could deliver to individuals. These benefits were
-              conceptually linked to personal values. For example, time- saving benefits
-              (efficiency) were linked to achievement values; mobility and location independence
-              benefits were linked to self-direction values; connectivity and relationship
-              maintenance benefits were linked to benevolence values; and entertainment and
-              enjoyment benefits were linked to hedonism values. Adoption intention was measured
-              through items assessing stated willingness to use and continue using mobile internet
-              services. Multiple items captured different aspects of adoption intention (likelihood
-              of use, frequency of intended use, amount of money willing to spend). Confirmatory
-              factor analysis examined the dimensional structure of the measurement model.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>The analysis tested whether:</strong> (1) personal value items loaded
-                appropriately on their respective value dimensions, (2) benefit items loaded
-                appropriately on their respective benefit dimensions, and (3) adoption intention
-                items loaded appropriately on a single adoption intention construct. Model fit
-                indices indicated that the measurement model provided reasonable representation of
-                the data structure. Convergent validity was demonstrated through examination of
-                standardized factor loadings and average variance extracted (AVE) for each
-                construct. Items designed to measure each construct loaded appropriately on their
-                intended factors, with standardized loadings generally exceeding .50. AVE values
-                exceeded the .50 threshold for most constructs, indicating that measured items
-                explained more than half the variance in their respective constructs. Discriminant
-                validity was examined by comparing inter-construct correlations with the square root
-                of AVE for each construct. Results demonstrated adequate discriminant validity,
-                indicating that each measured construct captured a distinct aspect of the adoption
-                decision. The structural model tested the hypothesized relationships between
-                personal values, value-based benefits, and adoption intention. Path analysis
-                examined whether personal values influenced adoption intention both directly and
-                through value-based benefits. The analysis tested whether value-based benefits
-                mediated effects of personal values on adoption intention. Standardized path
-                coefficients and their significance levels indicated the strength and significance
-                of proposed relationships. Multiple model specifications were tested to identify the
-                optimal structural configuration
-              </li>
-              <li>
-                <strong>Alternative models tested included:</strong> (1) direct effects only
-                (personal values directly influencing adoption), (2) indirect effects only (personal
-                values influencing adoption only through value-based benefits), and (3) both direct
-                and indirect effects (the proposed model). Comparison of model fit indices indicated
-                which specification provided superior fit. The model examined whether different
-                personal values showed different effects on adoption. The research tested whether
-                some values more strongly influenced adoption than others, revealing a hierarchy of
-                value importance in adoption decisions. Values with stronger effects on adoption
-                intention were identified as more salient in mobile internet adoption decisions.
-                Internal validity was further supported through examination of the mediation
-                pathways. The analysis examined whether specific value dimensions influenced
-                adoption primarily through corresponding benefit dimensions or through broader
-                value-benefit relationships. For example, achievement values might influence
-                adoption primarily through efficiency benefits, while benevolence values might
-                influence adoption through relationship-maintenance benefits
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How was the model’s external validity tested?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              External validity of the VAM model was demonstrated through multiple validation
-              approaches examining whether the model’s relationships held across diverse conditions
-              and whether findings aligned with expectations from value theory. The model
-              demonstrated predictive validity through its ability to explain variance in adoption
-              intention. The value-based model explained approximately 47% of variance in adoption
-              intention (R² = .47). While this was somewhat less than the TAM-only models (which
-              typically explain 30- 50%), the value-based approach captured different variance than
-              TAM, suggesting the two approaches are complementary rather than competitive.
-              Cross-validation examined whether the factor structure and path relationships remained
-              consistent across subsamples. The dataset was randomly split, with the structural
-              model estimated separately on each subsample. Comparison of standardized path
-              coefficients between the two subsamples demonstrated that relationships were
-              consistent across subsamples, supporting generalizability.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Convergence with value theory provided validity evidence. The pattern of which values
-              most strongly influenced adoption intention aligned with expectations from consumer
-              behavior theory. Achievement and self- direction values showed stronger effects on
-              adoption than tradition or conformity values, which is consistent with theory
-              suggesting that adoption of innovative technologies is driven by achievement and
-              autonomy values rather than tradition-focused or conformity-focused values.
-              Segmentation analysis examined whether different consumer segments adopting for
-              different value-based reasons showed different demographic and behavioral
-              characteristics. Cluster analysis of personal values revealed distinct segments: (1)
-              achievement-motivated consumers valuing success and efficiency, (2) socially-motivated
-              consumers valuing relationships and benevolence, and (3) pleasure-motivated consumers
-              valuing enjoyment and stimulation. These segments differed on adoption behaviors and
-              service usage patterns in expected ways, providing external validity evidence.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The model demonstrated discriminant validity through its distinction from purely
-              utilitarian adoption models. The value-based approach predicted adoption for consumers
-              whose values emphasized social connection and pleasure even when perceived usefulness
-              and ease of use were not primary motivations. This demonstrated that the value-based
-              approach captured adoption variance not explained by functional benefit perspectives.
-              The research examined whether value-based and TAM-based models predicted adoption for
-              different consumer segments. For consumers with utilitarian values (achievement,
-              self-direction), the TAM-based approach predicted adoption well. For consumers with
-              social values (benevolence, community) or hedonic values (hedonism, stimulation), the
-              value-based approach provided better prediction. This differential predictive power
-              for different segments supported the external validity of the value-based approach.
-              Behavioral validation examined actual service usage patterns.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Users whose adoption was predicted by value-based models showed usage patterns
-              consistent with their underlying values. Achievement-motivated users showed usage
-              patterns focused on productivity applications; socially- motivated users showed usage
-              patterns focused on communication and relationship maintenance; pleasure-motivated
-              users showed usage patterns focused on entertainment and games. The model also
-              demonstrated validity through its ability to explain adoption heterogeneity.
-              Traditional TAM-based research had noted that some consumers adopted despite low
-              perceived usefulness/ease of use perceptions, and some did not adopt despite high
-              perceived usefulness/ease of use perceptions. The value-based model provided
-              explanations for this heterogeneity by showing that consumers with different value
-              systems made adoption decisions through different decision-making processes.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How is the model intended to be used in practice?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The VAM model was designed for practical application in marketing strategy, product
-              development, and customer segmentation for technology providers. The primary
-              application is value-based market segmentation that recognizes different consumer
-              segments adopt technologies for fundamentally different reasons reflecting different
-              personal values. Organizations should use VAM to identify which personal values are
-              most salient drivers of adoption for their target market. Rather than assuming all
-              consumers evaluate technologies the same way, organizations should understand whether
-              their market emphasizes achievement values (efficiency, productivity), social values
-              (connection, relationships), or hedonic values (pleasure, enjoyment). This
-              understanding informs what benefits to emphasize in marketing and what features to
-              prioritize in product development. The model instructs organizations to develop
-              differentiated marketing strategies for different value-based segments.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              For achievement-motivated consumers, marketing should emphasize efficiency gains,
-              productivity improvements, and success-enabling features. For socially-motivated
-              consumers, marketing should emphasize connection capabilities, relationship
-              maintenance, and community features. For pleasure-motivated consumers, marketing
-              should emphasize entertainment value, enjoyment, and fun features. Organizations
-              should use VAM to identify gaps between what values their product delivers and what
-              values potential customers hold. If a market segment holds strong hedonic values but
-              the technology provides primarily utilitarian benefits, marketing and product
-              development adjustments are needed to bridge this gap. Alternatively, organizations
-              might choose to focus on customer segments whose values align with the benefits the
-              technology naturally provides. The model suggests that organizations should assess
-              personal values of different market segments to understand adoption barriers. For some
-              segments, low adoption may reflect value-benefit misalignment rather than genuinely
-              low usefulness or ease of use.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The solution then is not improving functionality but repositioning how the technology
-              delivers value to customers’ personal values. Organizations should use VAM to inform
-              product design decisions. If a significant market segment holds strong social values,
-              product development should include strong social and communication features even if
-              these increase system complexity. If achievement-oriented segments are important,
-              efficiency and productivity features should be prioritized. The model instructs
-              organizations to consider what values they want their brand and product to represent.
-              Mobile internet services positioned around efficiency, productivity, and achievement
-              appeal to achievement-oriented consumers. Services positioned around friendship,
-              connection, and community appeal to socially-oriented consumers. Services positioned
-              around entertainment and enjoyment appeal to pleasure-oriented consumers.
-              Organizations should consciously choose which values to emphasize based on strategic
-              positioning decisions.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              For pricing and service tier strategy, VAM suggests organizations might develop
-              differentiated service levels for different value segments. Achievement-oriented
-              customers might be willing to pay premium prices for professional features and
-              efficiency enhancements. Social-oriented customers might value affordable family
-              plans. Pleasure-oriented customers might be attracted to entertainment packages.
-              Value-based positioning allows organizations to develop service tiers that resonate
-              with different segments. The model suggests organizations should use value positioning
-              in all customer communications. Rather than generic claims about the technology,
-              organizations should highlight specifically how the technology serves the values their
-              target customers hold. For value-oriented messaging to be effective, it must be
-              authentic-the technology genuinely must deliver the value-based benefits promised.
-              Organizations should use VAM to inform corporate social responsibility and
-              sustainability messaging.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Consumers with universal values (concern for nature and all humanity) are motivated by
-              environmental and social responsibility. Positioning technology as environmentally
-              sustainable or socially beneficial appeals to this value segment. The model instructs
-              organizations that value-based adoption requires understanding customer motivation.
-              Customer research should investigate not just functional needs but personal values and
-              goals. In-depth interviews, ethnographic research, and values assessment tools help
-              organizations understand what drives different customer segments. For employee sales
-              and support teams, the model suggests training employees to understand which customers
-              are motivated by which values. Salespeople should be able to tailor their value
-              propositions to customer values rather than using one-size-fits-all messaging. An
-              achievement- oriented customer needs different messaging than a socially-oriented
-              customer, and this differentiation requires salespeople who understand value
-              motivation.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Organizations should use VAM to develop customer personas that go beyond demographics
-              to include personal values. Rather than just “women aged 25-35,” personas might
-              describe “achievement-oriented professionals seeking efficiency and success” or
-              “socially-connected individuals prioritizing relationships and community.” Value-based
-              personas better inform product and marketing decisions. The model instructs
-              organizations that understanding value-based adoption is particularly important during
-              market growth phases. Early adopters often have different values than mainstream or
-              late adopters. To expand market penetration beyond early adopters, organizations must
-              understand what values drive different customer segments and develop strategies
-              appealing to broader value diversity. Organizations implementing the model should
-              recognize that personal values are relatively stable characteristics. Unlike
-              satisfaction or perceived usefulness which can fluctuate, personal values remain
-              relatively constant.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              This suggests that value-based segmentation provides stable target markets for
-              long-term strategy rather than fluctuating based on short-term satisfaction or
-              perception changes.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What does the model measure?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Value-Based Adoption of Mobile Internet model measures how personal values
-              influence adoption of mobile internet services through value-based benefits.
-              Specifically, the model measures: Personal Values : The importance individuals assign
-              to different life objectives and priorities. The research operationalized personal
-              values using Schwartz’s value dimensions including: - Achievement values (success,
-              ambition) - Self-direction values (autonomy, independence) - Benevolence values
-              (helping others, community welfare) - Hedonic values (pleasure, enjoyment) -
-              Stimulation values (excitement, novelty) - Security values (safety, stability) -
-              Conformity values (social order, obligation) - Tradition values (cultural
-              preservation) - Universalism values (understanding, environmental protection) - Power
-              values (status, influence) Value-Based Benefits : Specific benefits the technology
-              provides that relate to personal values. Value-based benefits measured included: -
-              Efficiency and productivity benefits (achievement-related) - Autonomy and independence
-              benefits (self-direction-related) - Social connection and relationship benefits
-              (benevolence-related) - Enjoyment and entertainment benefits (hedonism-related) -
-              Excitement and novelty benefits (stimulation- related) - Security and privacy benefits
-              (security-related) Adoption Intention : Stated intention to adopt and use mobile
-              internet services, including likelihood and frequency of use.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The model measures these constructs and their relationships, showing how personal
-              values influence adoption both directly and through value-based benefits.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What are the main strengths of the model?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The VAM model contributes several significant strengths to technology adoption
-              literature. First, it successfully incorporates personal values theory into the
-              technology adoption framework, addressing a gap in existing literature. By explicitly
-              measuring personal values and value-based benefits, VAM captures adoption motivations
-              not represented in traditional utilitarian models. Second, the model explains adoption
-              heterogeneity that traditional models struggle to address. VAM provides explanations
-              for why some consumers adopt despite low perceived usefulness/ease of use, and why
-              some do not adopt despite high perceived usefulness/ease of use. Different value
-              systems lead to different adoption decisions. Third, the model provides practical
-              guidance for market segmentation based on values rather than just demographics.
-              Value-based segmentation identifies fundamental differences in what consumers seek
-              from technology, enabling more targeted marketing and product development strategies.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Fourth, the value-based approach validates consumer behavior research showing that
-              personal values drive consumption decisions across product categories. Extending this
-              well-established consumer behavior principle to technology adoption strengthens
-              theoretical grounding. Fifth, the model maintains compatibility with existing adoption
-              models while extending them. The VAM approach does not replace TAM but complements it
-              by identifying additional adoption drivers. The model shows that utilitarian-focused
-              and value-based approaches are compatible, not mutually exclusive. Sixth, the
-              empirical validation through structural equation modeling demonstrates the model’s
-              statistical viability. The identification of mediation pathways through value-based
-              benefits shows the mechanism through which values influence adoption. Seventh, the
-              model has practical applicability for marketers and product managers. Understanding
-              which values drive different customer segments enables development of segment-specific
-              strategies that increase adoption effectiveness compared to one-size-fits-all
-              approaches.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What are the main weaknesses of the model?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Despite significant contributions, VAM has identifiable limitations. First, the
-              research was conducted specifically in the context of mobile internet services in
-              Canada. Generalizability to other technology types, geographic markets, and cultural
-              contexts requires validation in diverse settings. Mobile internet may have distinctive
-              characteristics affecting value-based adoption differently than other technologies.
-              Second, the model explains approximately 47% of adoption intention variance, leaving
-              substantial variance unexplained. While this is comparable to some technology adoption
-              models, it indicates other factors beyond personal values and value-based benefits
-              influence adoption decisions. Third, the study employed cross-sectional design
-              measuring personal values and adoption intention at a single point in time. This
-              design does not establish causal direction definitively. While the theory proposes
-              that personal values influence value-based benefits perception, which influences
-              adoption, longitudinal data would provide stronger evidence of causal order.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Fourth, the measurement of personal values relies on established value scales that may
-              not capture all value dimensions relevant to technology adoption. Schwartz’s value
-              theory is comprehensive, but some technology- specific values (e.g., control, privacy
-              as a value distinct from security) might be more salient for technology adoption than
-              for consumer behavior generally. Fifth, the model does not explicitly address how
-              technology-related factors (actual usefulness, ease of use, cost) interact with values
-              to influence adoption. While VAM proposes values matter, the research does not compare
-              relative importance of values versus technology attributes. In reality, both influence
-              adoption, and their relative importance might vary. Sixth, the research does not
-              explore how values change or are influenced by adoption itself. The model assumes
-              values are stable inputs to adoption decisions, but adoption experiences might shift
-              values or reveal value hierarchies previously unknown to consumers.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Seventh, the model does not address peer influence, social norms, or organizational
-              factors that influence adoption. While personal values are individual characteristics,
-              adoption decisions are influenced by social context. The model would be strengthened
-              by incorporating social influence alongside individual values. Eighth, the
-              segmentation analysis that revealed achievement, social, and pleasure-motivated
-              segments was exploratory. More rigorous segmentation validation would strengthen
-              understanding of how value-based segments translate into distinct customer groups.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How does this model differ from older models?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              VAM differs from the Technology Acceptance Model by explicitly incorporating personal
-              values as adoption drivers. While TAM focuses on instrumental beliefs (usefulness,
-              ease of use), VAM recognizes that adoption also reflects personal values and goals.
-              TAM asks “Is this useful and easy to use?” while VAM asks “Does this support what I
-              value in life?” VAM differs from the Technology Readiness Index by focusing on values
-              as adoption drivers rather than general technology propensity. TRI measures
-              dispositional tendencies toward technology generally, while VAM measures specific
-              values that drive adoption of particular technologies. A person with low technology
-              readiness might still adopt a technology that strongly aligns with their personal
-              values. VAM differs from UTAUT by focusing specifically on values rather than social
-              influence, facilitating conditions, and effort expectancy.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              While UTAUT incorporates more adoption variables than TAM, it does not explicitly
-              address personal values as adoption drivers. VAM represents a distinctly different
-              theoretical perspective from existing adoption models by grounding adoption in deeper
-              psychological constructs (personal values) rather than narrow technology perceptions.
-              This represents a shift from “Does this technology appear useful?” to “Does this
-              technology help me achieve what I value?” The contribution of VAM lies in showing that
-              technology adoption cannot be fully understood through a purely utilitarian lens.
-              Different individuals adopt the same technology for fundamentally different reasons
-              reflecting different value systems. This recognition of value-driven adoption
-              diversity is VAM’s primary theoretical innovation. 6. Barriers Identification Section:
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>
-              What Barriers to Technology Adoption does the model identify?
-            </h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Value-Based Adoption of Mobile Internet model identifies barriers to technology
-              adoption through the lens of value-benefit misalignment, recognizing that barriers
-              often reflect mismatch between what a technology offers and what consumers value.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>The primary barrier identified is Value-Benefit Misalignment :</strong>{' '}
-                where the benefits a technology delivers do not align with or support the personal
-                values individuals hold
-              </li>
-              <li>
-                <strong>This barrier operates differently across different value segments:</strong>{' '}
-                For Achievement-Oriented Consumers (valuing success, efficiency, productivity), the
-                barrier is technology that does not deliver efficiency gains, productivity
-                improvements, or success-enabling benefits. Even if a technology is easy to use and
-                useful for some purposes, if it does not deliver achievement-related benefits,
-                achievement-oriented consumers will not adopt. The barrier manifests as perception
-                that the technology is a time- waster rather than a productivity tool, or that it
-                does not meaningfully contribute to success or accomplishment. For
-                Self-Direction-Oriented Consumers (valuing autonomy, independence, control), the
-                barrier is technology that constrains freedom or requires dependence on others.
-                Mobile internet services that require reliance on service providers, that limit user
-                customization, or that restrict autonomy may be rejected despite offering other
-                benefits. The barrier is loss of autonomy or increased dependence. For
-                Socially-Motivated Consumers (valuing connection, community, relationships), the
-                barrier is technology that fails to facilitate or enhance social connection. A
-                mobile internet service positioned purely on productivity may fail to appeal to
-                socially-motivated consumers if it doesn’t emphasize relationship maintenance or
-                community features. The barrier is perceived inability to fulfill social needs. For
-                Pleasure-Motivated Consumers (valuing enjoyment, entertainment, fun), the barrier is
-                technology perceived as utilitarian drudgery without enjoyment value. Services
-                positioned as “serious” tools for work may not appeal to pleasure-motivated
-                consumers. The barrier is perceived lack of fun or entertainment value. For
-                Security-Focused Consumers (valuing safety, stability, protection), the barrier is
-                technology that creates perceived security risks or instability. Privacy concerns,
-                financial risks, or system unreliability create barriers regardless of benefits
-                offered. The barrier is fundamentally the perceived threat posed by the technology.
-                The research identified that Lack of Value-Benefit Recognition represents a
-                significant barrier. Some consumers might benefit from mobile internet in ways
-                aligned with their values but do not recognize these benefits. For example, an
-                achievement-oriented individual might not recognize how mobile internet enables
-                productivity in their particular work context. The barrier here is not misalignment
-                but failure to perceive alignment that actually exists. This barrier is addressed
-                through education and demonstration rather than product changes. Competing Value
-                Priorities can create barriers. Some individuals hold multiple values that are not
-                simultaneously satisfiable through a single technology choice. For example, an
-                individual valuing both security and autonomy might see mobile internet as requiring
-                a trade-off between these values. The barrier is the perceived conflict between
-                values. Value Conflicts with Broader Life Values represent another barrier. Some
-                individuals might value family time and tradition strongly, and perceive mobile
-                internet as undermining these values by creating constant connectivity and
-                distraction from family. The barrier reflects conflict between technology adoption
-                and broader value systems. The research also identified Limited Awareness of
-                Value-Relevant Features as a barrier. Some mobile internet services offer benefits
-                aligned with consumer values but do not prominently highlight these benefits. For
-                example, a service might have excellent privacy protections (security benefit) but
-                not advertise these features, meaning security-conscious consumers don’t recognize
-                the value-benefit alignment. Social Barriers related to values emerged in the
-                research. Consumers whose values emphasize tradition or conformity might face social
-                barriers if their peer groups or families view mobile internet adoption as
-                threatening traditional values or social bonds. Social pressure to maintain
-                tradition creates barriers independent of personal value-benefit assessment.
-                Economic Barriers interact with personal values. Consumers who strongly value
-                security might demand premium services with guaranteed security features, creating
-                cost barriers. Consumers valuing self-direction might resist subscription models
-                that constrain autonomy. Consumers valuing community might seek affordable options
-                accessible to all, creating price- sensitivity barriers
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>
-              What does the model instruct leaders to do in order to reduce these barriers?
-            </h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The VAM model provides specific guidance for organizations seeking to reduce barriers
-              by addressing value-benefit alignment and communicating value-relevant benefits to
-              different customer segments. Assess Customer Values Organizations should conduct
-              research to understand personal values of target customers. This research should go
-              beyond demographic and needs assessment to understand what customers fundamentally
-              value in life. Value assessment might use established value measurement scales,
-              qualitative interviews exploring what customers care about, or observational research
-              examining customer life priorities. Segment Markets by Values Organizations should
-              develop value-based customer segmentation that groups customers by shared values.
-              Rather than assuming all mobile internet consumers value the same things,
-              organizations should identify distinct value-driven segments: achievement-oriented,
-              socially-motivated, pleasure-seeking, security-focused, and autonomy-valuing
-              customers. Align Product Features with Customer Values For organizations seeking to
-              appeal to multiple value segments, the model instructs developing product features
-              addressing diverse values.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Achievement-oriented features (productivity tools, efficiency enhancements) appeal to
-              achievement-focused segments. Social features (communication, community) appeal to
-              socially-motivated segments. Entertainment features appeal to pleasure-motivated
-              segments. Security features appeal to security-focused segments.
-            </p>
-            <h3 className={H3_CLASSES}>Develop Segment-Specific Value Positioning</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The model instructs organizations to develop differentiated marketing positioning for
-              different value segments. Rather than generic claims that mobile internet is
-              &ldquo;useful and easy,&rdquo; organizations should develop specific value
-              propositions for each segment:
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                To achievement-oriented customers: &ldquo;Mobile internet makes you more productive
-                and successful&rdquo;
-              </li>
-              <li>
-                To autonomy-oriented customers: &ldquo;Mobile internet gives you freedom and
-                control&rdquo;
-              </li>
-              <li>
-                To socially-motivated customers: &ldquo;Mobile internet keeps you connected to
-                people you care about&rdquo;
-              </li>
-              <li>
-                To pleasure-motivated customers: &ldquo;Mobile internet brings entertainment and
-                enjoyment&rdquo;
-              </li>
-              <li>
-                To security-focused customers: &ldquo;Mobile internet with world-class security and
-                privacy protection&rdquo;
-              </li>
-            </ul>
-            <h3 className={H3_CLASSES}>Communicate Value-Relevant Benefits</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Organizations should explicitly communicate how mobile internet delivers benefits
-              aligned with customer values. Rather than assuming customers will recognize these
-              benefits, organizations should make the connection clear. For example, if a mobile
-              internet service enables field workers to be more efficient (achievement benefit),
-              marketing should emphasize this benefit to achievement-oriented professionals, not
-              just feature lists.
-            </p>
-            <h3 className={H3_CLASSES}>Address Value Conflicts</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              For barriers rooted in value conflicts, organizations should address the conflict
-              directly. For example, if some customers fear mobile internet undermines family time
-              (conflict between connectivity value and family time value), marketing might emphasize
-              features that support family connection (group plans, family communication features,
-              scheduled digital detox features) showing the technology can support both values.
-            </p>
-            <h3 className={H3_CLASSES}>Provide Value-Aligned Service Options</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The model instructs that organizations might develop different service tiers or
-              configurations for different value segments. Pleasure-motivated customers might prefer
-              entertainment-rich services; achievement-oriented customers might prefer
-              productivity-focused service configurations. Providing choice allows customers to
-              tailor the service to their values.
-            </p>
-            <h3 className={H3_CLASSES}>Build Trust for Security-Conscious Segments</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              For security-focused customers, organizations should transparently communicate
-              security and privacy practices. Third-party certifications, detailed explanations of
-              data protection, and privacy guarantees address barriers rooted in security values.
-            </p>
-            <h3 className={H3_CLASSES}>Emphasize Community for Socially-Motivated Segments</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              For socially-motivated customers, organizations should emphasize community features,
-              user networks, and relationship-building capabilities. Social proof through
-              testimonials about how the service strengthens relationships appeals to this segment.
-            </p>
-            <h3 className={H3_CLASSES}>Highlight Customization for Autonomy-Focused Segments</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              For autonomy-oriented customers, organizations should emphasize customization options,
-              user control, and freedom of choice. Services that allow users to configure features,
-              control data sharing, and maintain independence appeal to this segment.
-            </p>
-            <h3 className={H3_CLASSES}>Create Authentic Value Alignment</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The model emphasizes that value-based positioning must be authentic. If organizations
-              claim mobile internet enables achievement but the technology actually facilitates
-              procrastination, the misalignment becomes apparent and undermines trust. Value-aligned
-              positioning is only effective if the technology genuinely delivers promised
-              value-related benefits.
-            </p>
-            <h3 className={H3_CLASSES}>Use Value Language in Communications</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The model instructs that organizations should shift from technical feature language to
-              value-relevant language. Instead of &ldquo;Supports multimedia synchronization,&rdquo;
-              use &ldquo;Keeps you connected to what matters.&rdquo; Instead of &ldquo;Advanced
-              encryption protocols,&rdquo; use &ldquo;Your privacy is protected.&rdquo;
-              Value-relevant language resonates with customers&rsquo; deeper motivations.
-            </p>
-            <h3 className={H3_CLASSES}>Conduct Value Research in Target Markets</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Organizations should understand what values are most salient in their target
-              geographic and demographic markets. Cultural differences in values are significant;
-              value-based strategies that work in individualistic cultures might not work in
-              collectivist cultures. Market-specific value research ensures segment-relevant
-              positioning.
-            </p>
-            <h3 className={H3_CLASSES}>Train Sales and Support Teams on Value Motivation</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The model instructs that customer-facing employees should understand value-driven
-              motivation. Salespeople should be trained to understand customer values and match
-              value propositions accordingly. Support teams should be trained to recognize when
-              customer dissatisfaction reflects value misalignment versus technical problems,
-              allowing appropriate response.
-            </p>
-            <h3 className={H3_CLASSES}>Monitor Value Evolution</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The model suggests that organizations should periodically reassess market values. As
-              consumer values evolve (e.g., increasing environmental consciousness, changing family
-              values), organizations should adjust value positioning accordingly. Staying aligned
-              with evolving customer values maintains relevance over time.
-            </p>
-            <h3 className={H3_CLASSES}>Address Structural Value Barriers</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Some value barriers reflect institutional or structural factors beyond individual
-              control. For example, if security-conscious customers value privacy but business
-              models require data collection, organizations must either change business models or be
-              honest about this conflict. Authenticity in addressing value conflicts is essential
-              for trust.
-            </p>
-            <h3 className={H3_CLASSES}>Develop Messaging that Bridges Values</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The model suggests developing messaging showing how mobile internet can serve multiple
-              values simultaneously. For instance, messaging might show how mobile internet enables
-              achievement (success at work) while maintaining family connection (staying in touch
-              with family), bridging both achievement and social values.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              The overarching principle from VAM is that successful technology adoption requires
-              understanding that different customers adopt for fundamentally different value-based
-              reasons. Organizations that recognize this diversity and develop strategies addressing
-              multiple value segments will achieve higher adoption rates than those using
-              one-size-fits-all positioning focused only on narrow utilitarian benefits.
-            </p>
-          </section>
-
-          {/* 7. Following Models or Theories */}
-          <section className={SECTION_CLASSES}>
-            <h2 className={H2_CLASSES}>7. Following Models or Theories</h2>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>Following Models:</strong> Extensions of VAM to other technologies and
-              services; Studies examining how values moderate technology acceptance relationships;
-              Value-based adoption models in e-commerce and digital services
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              <strong>Following Theories:</strong> Research on value-technology fit; Cross-cultural
-              applications of value-based adoption frameworks; Longitudinal studies examining value
-              changes through adoption
-            </p>
-          </section>
-
-          <p className="mt-8 text-sm italic text-gray-600">
-            Note: This article provides an overview based on the comprehensive literature review.
-            Readers are encouraged to consult the original publication for complete details.
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Kim, Chan, and Gupta developed VAM to address a fundamental limitation in existing
+            technology adoption models. Prior adoption models including TAM, UTAUT, and Diffusion of
+            Innovations were grounded in organizational and information systems contexts where
+            technology users encountered established performance standards, organizational mandates,
+            and professional norms. Yet early 2000s mobile internet adoption represented emerging
+            consumer technology where individuals made purely voluntary adoption decisions based on
+            personal benefit evaluation rather than organizational requirements. These researchers
+            recognized that organizational adoption models overemphasized instrumental outcomes
+            (performance, usefulness, job relevance) while underspecifying the full spectrum of
+            benefits and sacrifices consumers evaluate when adopting new technologies.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            The authors drew on consumer behavior theory and value-based decision-making research to
+            develop an alternative framework. Consumer behavior theory emphasizes that purchase
+            decisions result from overall perceived value calculation where value equals the
+            trade-off between benefits (what consumers gain) and sacrifices (what consumers must
+            give up). In the mobile internet context, consumers weigh benefits including usefulness
+            (functional benefits) and enjoyment (hedonic benefits), against sacrifices including
+            monetary cost and difficulty (technical complexity, learning burden). Kim, Chan, and
+            Gupta hypothesized that adoption intention depends not on individual beliefs about
+            usefulness or ease of use in isolation, but rather on integrated value judgment
+            balancing all benefits against all sacrifices.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            VAM was developed and tested through empirical research with 161 Korean mobile internet
+            users, explicitly measuring perceived usefulness, perceived enjoyment (hedonic benefit
+            dimension often overlooked in organizational models), perceived fee (monetary
+            sacrifice), and perceived technicality (effort and learning sacrifice). The model
+            explained 67 percent of variance in adoption intention, demonstrating that consumer
+            technology adoption can be effectively explained through value-based frameworks that
+            integrate both instrumental and hedonic benefits against monetary and technical
+            sacrifices.
           </p>
         </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VAM operationalizes consumer technology adoption through benefits and sacrifices
+            components:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Perceived Usefulness (Instrumental Benefit):</strong> The degree to which
+              consumers believe mobile internet will provide practical utility through enhanced
+              communication, information access, productivity, or convenience. Usefulness reflects
+              functional benefits from technology use.
+            </li>
+            <li>
+              <strong>Perceived Enjoyment (Hedonic Benefit):</strong> The degree to which consumers
+              believe mobile internet use will be enjoyable, entertaining, or intrinsically
+              rewarding independent of any instrumental performance benefit. Enjoyment reflects
+              inherent pleasure from technology interaction.
+            </li>
+            <li>
+              <strong>Perceived Fee (Monetary Sacrifice):</strong> Consumer perception of the
+              monetary cost and financial burden associated with mobile internet service adoption
+              and usage. Fee includes subscription costs, device costs, and ongoing service charges
+              that consumers must sacrifice to adopt.
+            </li>
+            <li>
+              <strong>Perceived Technicality (Effort and Learning Sacrifice):</strong> Consumer
+              perception of technical complexity, learning difficulty, and effort required to
+              operate and maintain mobile internet effectively. Technicality represents the
+              sacrifice of time and cognitive effort required for competent technology use.
+            </li>
+            <li>
+              <strong>Perceived Value:</strong> The overall net benefit calculation where perceived
+              value equals the aggregate benefits (usefulness plus enjoyment) minus the aggregate
+              sacrifices (fee plus technicality). Consumers mentally integrate these dimensions into
+              holistic value judgment.
+            </li>
+            <li>
+              <strong>Consumer Technology Adoption:</strong> The decision by individual consumers to
+              adopt and use mobile internet or similar consumer technologies based on voluntary
+              choice driven by personal benefit-sacrifice calculation rather than organizational
+              mandate.
+            </li>
+            <li>
+              <strong>Functional and Hedonic Benefit Dimensions:</strong> Recognition that consumer
+              benefits encompass both instrumental outcomes (usefulness) and affective experiences
+              (enjoyment), reflecting the multidimensional nature of consumer motivation.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VAM integrated consumer behavior and technology adoption research:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Value Theory (
+                <a
+                  id="cite-ref-zeithaml-1988-1"
+                  href="#ref-zeithaml-1988"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Zeithaml, 1988
+                </a>
+                ):
+              </strong>{' '}
+              Foundational consumer behavior theory proposing that consumers evaluate purchase
+              decisions through value judgment where value equals benefits divided by price. VAM
+              extends value theory to technology adoption contexts.
+            </li>
+            <li>
+              <strong>
+                Technology Acceptance Model (
+                <a
+                  id="cite-ref-davis-1989-1"
+                  href="#ref-davis-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis, 1989
+                </a>
+                ):
+              </strong>{' '}
+              Identified perceived usefulness and ease of use as adoption drivers. VAM retains
+              usefulness from TAM but reframes ease of use as sacrifice component (technicality) and
+              adds hedonic enjoyment benefit dimension.
+            </li>
+            <li>
+              <strong>Consumer Behavior Theory:</strong> Emphasized that consumer decisions involve
+              comprehensive benefit-sacrifice calculation balancing multiple benefits against
+              multiple sacrifices. VAM operationalizes this framework in technology adoption
+              contexts.
+            </li>
+            <li>
+              <strong>
+                Diffusion of Innovation (
+                <a
+                  id="cite-ref-rogers-1995-1"
+                  href="#ref-rogers-1995"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Rogers, 1995
+                </a>
+                ):
+              </strong>{' '}
+              Identified relative advantage and complexity as adoption predictors. VAM incorporates
+              relative advantage through usefulness and complexity through technicality, but
+              emphasizes benefit-sacrifice integration.
+            </li>
+            <li>
+              <strong>
+                Intrinsic Motivation Theory (
+                <a
+                  id="cite-ref-ryan-2000-1"
+                  href="#ref-ryan-2000"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Ryan &amp; Deci, 2000
+                </a>
+                ):
+              </strong>{' '}
+              Distinguished intrinsic motivation (inherent enjoyment) from extrinsic motivation
+              (instrumental outcomes). VAM incorporates both through enjoyment and usefulness
+              dimensions.
+            </li>
+            <li>
+              <strong>Hedonic and Utilitarian Motivation Literature:</strong> Consumer research
+              distinguishing hedonic consumption (inherent enjoyment and pleasure) from utilitarian
+              consumption (functional utility). VAM integrates both motivation types in technology
+              adoption.
+            </li>
+            <li>
+              <strong>Mobile Technology Adoption Research:</strong> Emerging literature on mobile
+              and consumer device adoption recognizing unique characteristics distinct from
+              organizational technology adoption requiring consumer-behavior-based frameworks.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VAM proposes that consumer technology adoption intention is determined by perceived
+            value, which represents the integrated calculation of benefits minus sacrifices.
+            Perceived usefulness (instrumental benefit) and perceived enjoyment (hedonic benefit)
+            combine as positive determinants of value, while perceived fee (monetary sacrifice) and
+            perceived technicality (effort and learning sacrifice) combine as negative determinants
+            of value. Consumers do not evaluate these dimensions independently; instead, they
+            integrate them into holistic value judgment where strong benefits can offset moderate
+            sacrifices, and strong sacrifices can reduce positive impact of benefits. The model
+            emphasizes that consumer technology adoption is fundamentally different from
+            organizational adoption because consumers evaluate the complete value package rather
+            than narrow instrumental job performance outcomes.
+          </p>
+
+          <h3 className={H3_CLASSES}>VAM Determinant Mechanisms</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Integrated Benefit-Sacrifice Calculation:</strong> Consumers integrate
+              functional (usefulness) and hedonic (enjoyment) benefits against monetary (fee) and
+              effort (technicality) sacrifices into holistic value judgment. No single dimension
+              drives adoption in isolation.
+            </li>
+            <li>
+              <strong>Hedonic Benefit as Adoption Driver:</strong> Unlike organizational models
+              emphasizing purely instrumental outcomes, consumer technology adoption is
+              significantly driven by inherent enjoyment and intrinsic pleasure from technology
+              interaction.
+            </li>
+            <li>
+              <strong>Fee as Primary Sacrifice Dimension:</strong> Monetary cost directly reduces
+              perceived value and adoption intention in consumer contexts where individuals pay
+              directly from personal budgets rather than organizational expense budgets.
+            </li>
+            <li>
+              <strong>Technicality as Effort Sacrifice:</strong> Perceived technical complexity and
+              learning difficulty directly reduce perceived value by increasing effort and learning
+              sacrifices consumers must make.
+            </li>
+            <li>
+              <strong>Additive Benefits and Sacrifices:</strong> Multiple benefits reinforce each
+              other (usefulness enhances enjoyment benefit), and multiple sacrifices compound (high
+              fee plus high technicality creates larger combined sacrifice).
+            </li>
+            <li>
+              <strong>Consumer-Centric Value Framework:</strong> Treats consumers as
+              value-maximizing decision-makers balancing comprehensive benefit and sacrifice
+              portfolios, fundamentally different from organizational performance-maximization
+              logic.
+            </li>
+            <li>
+              <strong>Non-Mandatory Adoption Context:</strong> Without organizational mandate or
+              enforcement, consumer adoption depends entirely on perceived value. Low-value
+              propositions face rejection regardless of organizational encouragement.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Consumer behavior theory integration:</strong> VAM grounds technology adoption
+              in established consumer behavior frameworks emphasizing benefit-sacrifice value
+              calculation rather than technology-specific constructs.
+            </li>
+            <li>
+              <strong>Hedonic benefit inclusion:</strong> Explicitly incorporates enjoyment as
+              adoption driver, acknowledging that consumer technology adoption is motivated by
+              inherent pleasure not just instrumental utility.
+            </li>
+            <li>
+              <strong>Monetary cost explicitness:</strong> Fee explicitly measures financial
+              sacrifice, directly addressing consumer budget constraints in ways organizational
+              models overlook.
+            </li>
+            <li>
+              <strong>High explanatory power:</strong> Achieved 67 percent variance explained in
+              adoption intention, demonstrating strong predictive validity for consumer technology
+              adoption.
+            </li>
+            <li>
+              <strong>Parsimonious four-construct model:</strong> Simple framework integrating key
+              benefit and sacrifice dimensions without the complexity of organizational models like
+              UTAUT.
+            </li>
+            <li>
+              <strong>Mobile technology focus:</strong> Directly addresses emerging mobile and
+              consumer technology adoption rather than forcing organizational frameworks onto
+              consumer contexts.
+            </li>
+            <li>
+              <strong>Practical marketing applicability:</strong> Provides clear guidance for
+              technology companies: emphasize benefits (usefulness and enjoyment), manage sacrifices
+              (fee and complexity) to optimize perceived value.
+            </li>
+            <li>
+              <strong>Benefit-sacrifice balance insights:</strong> Demonstrates that adoption
+              depends on overall value balance; weak benefits can be overcome by low sacrifices, and
+              vice versa.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Limited theoretical explanation of integration process:</strong> While
+              proposing benefit-sacrifice integration, VAM provides limited detail on how consumers
+              weight and combine these dimensions or whether integration is truly linear additive.
+            </li>
+            <li>
+              <strong>Single technology and market context:</strong> Model tested exclusively on
+              Korean mobile internet users. Generalization to other consumer technologies, other
+              geographic markets, or other consumer segments requires verification.
+            </li>
+            <li>
+              <strong>Small sample size:</strong> Empirical testing involved only 161 mobile
+              internet users, limiting statistical power for detecting complex relationships or
+              moderating effects.
+            </li>
+            <li>
+              <strong>Limited moderator exploration:</strong> Model does not examine how consumer
+              characteristics (income level, technology experience, age, lifestyle preferences)
+              moderate value perception or adoption decisions.
+            </li>
+            <li>
+              <strong>Simplification of fee perception:</strong> Monetary cost perception may
+              involve complex calculations including bundled services, comparison with alternatives,
+              and value-for-money judgments not fully captured by single fee construct.
+            </li>
+            <li>
+              <strong>Technicality operationalization:</strong> Perceived technicality combines
+              complexity and learning difficulty; these may operate through different mechanisms and
+              warrant separate treatment.
+            </li>
+            <li>
+              <strong>Post-adoption outcomes not addressed:</strong> Model predicts adoption
+              intention without examining continued use, satisfaction, or sustained adoption beyond
+              initial acceptance.
+            </li>
+            <li>
+              <strong>Cultural context specificity:</strong> Korean mobile internet market in 2007
+              had unique characteristics (high mobile adoption rates, specific cultural attitudes
+              toward mobile technology) limiting generalization.
+            </li>
+            <li>
+              <strong>Reference point theory implications unexplored:</strong> Prospect theory
+              suggests consumers evaluate gains and losses relative to reference points; VAM does
+              not incorporate reference-dependent value assessment.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Consumer behavior framework for technology adoption:</strong> Demonstrated
+              that consumer technology adoption can be effectively explained through consumer
+              behavior theory emphasizing benefit-sacrifice value calculation rather than
+              technology-specific models.
+            </li>
+            <li>
+              <strong>Hedonic benefit legitimacy in adoption:</strong> Empirically demonstrated that
+              inherent enjoyment and intrinsic pleasure significantly predict technology adoption,
+              validating hedonic motivation as distinct from instrumental utility.
+            </li>
+            <li>
+              <strong>Fee as explicit sacrifice component:</strong> Brought monetary cost explicitly
+              into technology adoption models, recognizing direct consumer financial sacrifice
+              distinct from organizational cost-benefit calculations.
+            </li>
+            <li>
+              <strong>Integrated value judgment emphasis:</strong> Demonstrated that consumers
+              integrate benefits and sacrifices into holistic value judgments rather than evaluating
+              constructs independently as in TAM or UTAUT models.
+            </li>
+            <li>
+              <strong>Mobile technology adoption framework:</strong> Provided
+              consumer-behavior-based framework explicitly designed for mobile and consumer
+              technology adoption rather than adapting organizational frameworks.
+            </li>
+            <li>
+              <strong>Simplified yet comprehensive model:</strong> Achieved strong predictive
+              validity (67 percent variance) with parsimonious four-construct model, demonstrating
+              parsimony-accuracy trade-off optimization.
+            </li>
+            <li>
+              <strong>Practical marketing guidance:</strong> Provided clear actionable insights for
+              technology companies: optimize perceived value by emphasizing benefits while reducing
+              fee and complexity barriers.
+            </li>
+            <li>
+              <strong>Foundation for consumer technology adoption research:</strong> Established
+              value-based framework as viable alternative to technology-centric models for
+              understanding consumer adoption of technologies like mobile applications, streaming
+              services, and consumer IoT.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VAM employed appropriate methodology to establish internal validity:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Cross-sectional survey design:</strong> Administered comprehensive surveys to
+              mobile internet users measuring perceived usefulness, enjoyment, fee, technicality,
+              and adoption intention.
+            </li>
+            <li>
+              <strong>Real mobile internet users:</strong> Sampled consumers actively considering or
+              using mobile internet services rather than laboratory participants unfamiliar with
+              technology.
+            </li>
+            <li>
+              <strong>Consumer behavior theory grounding:</strong> Developed measures grounded in
+              established consumer behavior literature on value perception, utilitarian and hedonic
+              motivation, and cost perception.
+            </li>
+            <li>
+              <strong>Structural equation modeling analysis:</strong> Used appropriate SEM
+              methodology to test hypothesized relationships among latent constructs.
+            </li>
+            <li>
+              <strong>Psychometric validation:</strong> Reported reliability coefficients,
+              convergent validity, and discriminant validity for all measured constructs.
+            </li>
+            <li>
+              <strong>Alternative model testing:</strong> Tested VAM against alternative model
+              specifications to demonstrate superiority of proposed framework.
+            </li>
+            <li>
+              <strong>Adoption intention measurement:</strong> Measured adoption intentions rather
+              than actual behavior, appropriate for emerging technologies not yet universally
+              adopted.
+            </li>
+            <li>
+              <strong>Multi-item construct measurement:</strong> Used multiple survey items for each
+              construct to reduce measurement error and establish construct validity.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations require careful generalizability interpretation:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Technology-specific limitations:</strong> VAM tested on mobile internet
+              adoption. Generalization to other consumer technologies (streaming services, smart
+              devices, wearables) with different benefit-sacrifice profiles requires investigation.
+            </li>
+            <li>
+              <strong>Geographic and cultural context:</strong> Korean market sample limits
+              generalization to other geographic regions and cultures with different cost
+              structures, technology attitudes, and consumer preferences.
+            </li>
+            <li>
+              <strong>Time-period specificity:</strong> 2007 mobile internet landscape differs from
+              contemporary smartphone and mobile app ecosystems with different cost structures, user
+              interfaces, and perceived value components.
+            </li>
+            <li>
+              <strong>Sample size limitations:</strong> 161 participants provides limited
+              statistical power for detecting complex interactions or subtle moderating effects that
+              might emerge in larger samples.
+            </li>
+            <li>
+              <strong>Consumer segment representation:</strong> Sample characteristics (education
+              level, income, age, technology experience) not explicitly described. Generalization to
+              diverse consumer segments uncertain.
+            </li>
+            <li>
+              <strong>Market maturity considerations:</strong> Mobile internet adoption stage when
+              studied (emerging technology) differs from contemporary mature technology markets
+              where adoption has plateaued.
+            </li>
+            <li>
+              <strong>Reference group and social influence absence:</strong> Model does not
+              incorporate social influence or reference group effects that may independently
+              influence consumer adoption.
+            </li>
+            <li>
+              <strong>Behavioral outcome validation:</strong> Model predicts adoption intention
+              without confirming whether intentions translate to actual adoption behavior.
+            </li>
+            <li>
+              <strong>Competing technology alternatives:</strong> Model does not address choice
+              among competing technologies or substitutes for mobile internet services.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VAM directly addresses consumer and household technology adoption barriers by
+            identifying that adoption depends on overall perceived value balancing multiple benefits
+            against multiple sacrifices. Consumer technology adoption is fundamentally different
+            from organizational adoption because individuals must personally justify technology
+            investment through benefit-sacrifice calculation. VAM identifies four critical barriers
+            consumers face: low perceived usefulness of technology for practical goals, insufficient
+            enjoyment or entertainment value, high financial cost relative to perceived benefits,
+            and excessive technical complexity or learning burden. Critically, VAM demonstrates that
+            strong benefits cannot compensate for extreme sacrifices and vice versa; adoption
+            requires acceptable balance across all dimensions. Organizations marketing consumer
+            technologies must simultaneously address all four dimensions: demonstrating practical
+            usefulness, ensuring enjoyable user experiences, setting competitive pricing, and
+            minimizing technical complexity.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Low perceived usefulness:</strong> When consumers cannot identify practical
+              benefits (enhanced communication, information access, productivity) justifying
+              adoption, perceived value remains low.
+            </li>
+            <li>
+              <strong>Insufficient enjoyment or entertainment value:</strong> Technologies that lack
+              inherent appeal or enjoyable user experiences face adoption resistance from consumers
+              seeking hedonic benefits.
+            </li>
+            <li>
+              <strong>High financial cost:</strong> Consumers directly pay technology costs from
+              personal budgets. High fees relative to perceived benefits create adoption barriers
+              regardless of other advantages.
+            </li>
+            <li>
+              <strong>High technical complexity:</strong> Technologies requiring extensive learning
+              or difficult operation impose effort sacrifices deterring consumers from adoption.
+            </li>
+            <li>
+              <strong>Unfavorable benefit-sacrifice balance:</strong> Even strong benefits cannot
+              overcome extreme combined sacrifices, and vice versa. Overall value must be positive
+              for adoption.
+            </li>
+            <li>
+              <strong>Unclear value proposition:</strong> Consumers uncertain how technology
+              provides value compared to alternatives face adoption hesitation and risk perception.
+            </li>
+            <li>
+              <strong>Lack of usage trial opportunities:</strong> Without ability to experience
+              technology benefits directly, consumers struggle to assess usefulness and enjoyment.
+            </li>
+            <li>
+              <strong>Status and image concerns:</strong> Consumers perceiving technology adoption
+              as socially inappropriate, status-threatening, or inconsistent with identity face
+              adoption resistance.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Model Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Articulate clear practical usefulness:</strong> Demonstrate concrete benefits
+              (improved communication, information access, productivity, convenience) that directly
+              improve consumer life quality.
+            </li>
+            <li>
+              <strong>Emphasize enjoyment and entertainment value:</strong> Highlight inherent
+              pleasure, entertainment, and intrinsic appeal of technology use beyond instrumental
+              benefits.
+            </li>
+            <li>
+              <strong>Optimize pricing strategy:</strong> Set competitive prices aligned with
+              perceived value. Consider tiered pricing, freemium models, or subscription options
+              reducing upfront cost barriers.
+            </li>
+            <li>
+              <strong>Minimize technical complexity:</strong> Invest in user interface design,
+              intuitive workflows, and accessible documentation reducing learning burden and
+              complexity perception.
+            </li>
+            <li>
+              <strong>Offer trial and demonstration access:</strong> Enable consumers to experience
+              benefits and validate usefulness and enjoyment before commitment, reducing adoption
+              risk.
+            </li>
+            <li>
+              <strong>Highlight comprehensive value package:</strong> Market technology by
+              emphasizing complete value proposition balancing benefits and sacrifices rather than
+              single benefit dimension.
+            </li>
+            <li>
+              <strong>Provide early adopter incentives:</strong> Offer initial adopters reduced
+              fees, extended trials, or enhanced features accelerating value perception and
+              establishing social proof.
+            </li>
+            <li>
+              <strong>Build brand and image associations:</strong> Connect technology to positive
+              identity elements and lifestyle aspirations enhancing social appeal and enjoyment
+              value.
+            </li>
+            <li>
+              <strong>Develop support ecosystems:</strong> Create user communities, tutorials, and
+              support channels reducing perceived technicality and learning sacrifices.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VAM established value-based frameworks as viable alternative to technology-centric
+            adoption models:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Consumer technology adoption extensions:</strong> Researchers extended VAM
+              logic to understand adoption of streaming services, mobile applications, wearable
+              devices, and other consumer technologies using value-based frameworks.
+            </li>
+            <li>
+              <strong>Hedonic-utilitarian motivation integration:</strong> VAM influenced broader
+              adoption research integrating hedonic and utilitarian motivation dimensions in
+              consumer contexts.
+            </li>
+            <li>
+              <strong>Fee perception and pricing research:</strong> VAM emphasized monetary cost as
+              critical adoption barrier, motivating pricing optimization and freemium model research
+              in technology adoption.
+            </li>
+            <li>
+              <strong>Technology experience and enjoyment:</strong> VAM validated enjoyment as
+              significant adoption predictor, influencing research on user experience design and
+              hedonic technology use.
+            </li>
+            <li>
+              <strong>Mobile and smart device adoption:</strong> Researchers applied VAM framework
+              to understand smartphone adoption, smartwatch adoption, and smart home device adoption
+              across consumer populations.
+            </li>
+            <li>
+              <strong>Emerging technology consumer adoption:</strong> VAM provided framework for
+              understanding adoption of blockchain technologies, virtual reality, augmented reality,
+              and artificial intelligence in consumer contexts.
+            </li>
+            <li>
+              <strong>Cross-cultural value perception research:</strong> Motivated investigation of
+              how cultural dimensions shape benefit and sacrifice perception in technology adoption
+              across different markets.
+            </li>
+            <li>
+              <strong>Reference group and social influence in VAM:</strong> Researchers extended VAM
+              to incorporate social influence, status signaling, and reference group effects on
+              value perception.
+            </li>
+            <li>
+              <strong>Dynamic value perception research:</strong> Extended VAM to examine how
+              perceived value changes over technology experience and how satisfaction influences
+              continued use.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-davis-1989">
+              Davis, F. D. (1989). Perceived usefulness, perceived ease of use, and user acceptance
+              of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-davis-1989-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>{' '}
+              https://doi.org/10.2307/249008
+            </li>
+            <li id="ref-zeithaml-1988">
+              Zeithaml, V. A. (1988). Consumer perceptions of price, quality, and value: A means-end
+              model and synthesis of evidence. <em>Journal of Marketing</em>, 52(3), 2-22.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-zeithaml-1988-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-rogers-1995">
+              Rogers, E. M. (1995). Diffusion of innovations (4th ed.). Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-rogers-1995-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-kim-2007">
+              Kim, H.-W., Chan, H. C., &amp; Gupta, S. (2007). Value-based adoption of mobile
+              internet: An empirical investigation. <em>Decision Support Systems</em>, 43(1),
+              111-126. https://doi.org/10.1016/j.dss.2005.05.009
+            </li>
+            <li id="ref-ryan-2000">
+              Ryan, R. M., &amp; Deci, E. L. (2000). Intrinsic and extrinsic motivations: Classic
+              definitions and new directions. <em>Contemporary Educational Psychology</em>, 25(1),
+              54-67.
+            </li>
+          </ol>
+        </section>
+
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-veblen-1899">
+              Veblen, T. (1899). The theory of the leisure class: An economic study of institutions.
+              Macmillan.
+            </li>
+            <li id="ref-hirschman-1982">
+              Hirschman, E. C., &amp; Holbrook, M. B. (1982). Hedonic consumption: Emerging
+              concepts, methods and propositions. <em>Journal of Marketing</em>, 46(3), 92-101.
+            </li>
+            <li id="ref-babin-2000">
+              Babin, B. J., Boles, J. S., &amp; Robin, D. P. (2000). Representing the perceived
+              ethical work climate among marketing employees.{' '}
+              <em>Journal of the Academy of Marketing Science</em>, 28(3), 345-358.
+            </li>
+            <li id="ref-venkatesh-2001">
+              Venkatesh, V., &amp; Brown, S. C. (2001). A longitudinal investigation of personal
+              computers in homes: Adoption determinants and emerging challenges.{' '}
+              <em>MIS Quarterly</em>, 25(1), 71-102. https://doi.org/10.2307/3250959
+            </li>
+            <li id="ref-compeau-1995">
+              Compeau, D. R., &amp; Higgins, C. A. (1995). Computer self-efficacy: Development of a
+              measure and initial test. <em>MIS Quarterly</em>, 19(2), 189-211.
+              https://doi.org/10.2307/249688
+            </li>
+            <li id="ref-sweeney-2001">
+              Sweeney, J. C., &amp; Soutar, G. N. (2001). Consumer perceived value: The development
+              of a multiple item scale. <em>Journal of Retailing</em>, 77(2), 203-220.
+            </li>
+            <li id="ref-kotler-2006">
+              Kotler, P., &amp; Keller, K. L. (2006). Marketing management (12th ed.). Prentice
+              Hall.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-16-math-venkatesh-brown-2001"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Model of Adoption of Technology in Households (Venkatesh &amp;
+                Brown)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-18-tram-lin-2007"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Technology Readiness and Acceptance Model (TRAM - Lin) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -138,18 +138,60 @@ const BibliographyArticlePage = () => {
             balancing all benefits against all sacrifices.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            VAM was developed and tested through empirical research with 211 Singaporean mobile
-            internet users, explicitly measuring perceived usefulness, perceived enjoyment (hedonic
-            benefit dimension often overlooked in organizational models), perceived fee (monetary
-            sacrifice), and perceived technicality (effort and learning sacrifice). The model
-            explained 67 percent of variance in adoption intention, demonstrating that consumer
-            technology adoption can be effectively explained through value-based frameworks that
-            integrate both instrumental and hedonic benefits against monetary and technical
-            sacrifices.
+            VAM was developed and tested through empirical research with 161 Singaporean mobile
+            internet users (75.2% male, 88.2% aged 20-29; recruited via university email list and
+            public forums with a $5 incentive), explicitly measuring perceived usefulness, perceived
+            enjoyment (hedonic benefit dimension often overlooked in organizational models),
+            perceived fee (monetary sacrifice), and perceived technicality (a composite non-monetary
+            sacrifice covering ease of use, system reliability, connectivity, and efficiency). The
+            model explained 35.9% of the variance in adoption intention (Fig. 2, p.120),
+            outperforming TAM tested on the same sample (R²=0.131, Fig. 3, p.121) by nearly 3x,
+            demonstrating that consumer technology adoption can be effectively explained through
+            value-based frameworks that integrate both instrumental and hedonic benefits against
+            monetary and technical sacrifices.
           </p>
         </section>
 
-        {/* 5. Core Concepts and Definitions */}
+        {/* 5. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VAM measures six latent constructs using multi-item 7-point Likert scales (Table 3,
+            p.119). Cronbach&rsquo;s alpha reliabilities were all above the 0.70 threshold:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Adoption Intention</strong> (3 items, α=0.83): plan to use, intend to use, and
+              predict using M-Internet in the future.
+            </li>
+            <li>
+              <strong>Perceived Value</strong> (4 items, α=0.87): value for money vs. fee, benefit
+              vs. effort, worthwhile vs. time spent, and overall good value.
+            </li>
+            <li>
+              <strong>Usefulness</strong> (6 items, α=0.95): task speed, effectiveness, ease,
+              performance, time/effort savings, and overall usefulness.
+            </li>
+            <li>
+              <strong>Enjoyment</strong> (4 items, α=0.84): fun, enjoyment, pleasure, and
+              non-boredom (reverse-coded) interacting with M-Internet.
+            </li>
+            <li>
+              <strong>Technicality</strong> (3 items after TECH4 dropped for low factor loading,
+              α=0.76): connection instantaneity, response speed, and reliability of M-Internet.
+            </li>
+            <li>
+              <strong>Perceived Fee</strong> (3 items, α=0.89): perceptions of how high, reasonable,
+              and worthwhile the M-Internet usage fee is.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Principal component factor analysis with VARIMAX rotation extracted five factors with
+            eigenvalue &gt; 1.0 explaining 72.7% of total variance (Appendix B, p.119).
+          </p>
+        </section>
+
+        {/* 6. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -201,7 +243,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -292,7 +334,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -369,9 +411,9 @@ const BibliographyArticlePage = () => {
               models overlook.
             </li>
             <li>
-              <strong>High explanatory power:</strong> Achieved 67 percent variance explained in
-              adoption intention, demonstrating strong predictive validity for consumer technology
-              adoption.
+              <strong>Moderate explanatory power:</strong> Achieved 35.9% variance explained in
+              adoption intention (R²=0.359, Fig. 2), substantially outperforming TAM tested on the
+              same sample (R²=0.131).
             </li>
             <li>
               <strong>Parsimonious four-construct model:</strong> Simple framework integrating key
@@ -445,7 +487,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -476,9 +518,9 @@ const BibliographyArticlePage = () => {
               technology adoption rather than adapting organizational frameworks.
             </li>
             <li>
-              <strong>Simplified yet comprehensive model:</strong> Achieved strong predictive
-              validity (67 percent variance) with parsimonious four-construct model, demonstrating
-              parsimony-accuracy trade-off optimization.
+              <strong>Simplified yet comprehensive model:</strong> Achieved moderate predictive
+              validity (R²=0.359 for adoption intention) with a parsimonious four-construct model,
+              nearly 3x the explanatory power of TAM (R²=0.131) on the same sample.
             </li>
             <li>
               <strong>Practical marketing guidance:</strong> Provided clear actionable insights for
@@ -494,7 +536,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -517,8 +559,10 @@ const BibliographyArticlePage = () => {
               motivation, and cost perception.
             </li>
             <li>
-              <strong>Structural equation modeling analysis:</strong> Used appropriate SEM
-              methodology to test hypothesized relationships among latent constructs.
+              <strong>Multiple regression analysis:</strong> Used Pearson correlation followed by
+              multiple regression (not SEM) to test hypothesized paths among constructs. Mediation
+              was tested using Baron &amp; Kenny's method (Table 5, p.120). Multicollinearity was
+              examined via VIF (1.20-1.60, below the 10 threshold).
             </li>
             <li>
               <strong>Psychometric validation:</strong> Reported reliability coefficients,
@@ -540,7 +584,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -568,9 +612,9 @@ const BibliographyArticlePage = () => {
               might emerge in larger samples.
             </li>
             <li>
-              <strong>Consumer segment representation:</strong> Sample characteristics (education
-              level, income, age, technology experience) not explicitly described. Generalization to
-              diverse consumer segments uncertain.
+              <strong>Consumer segment skew:</strong> Sample was 75.2% male and 88.2% aged 20-29,
+              with 54% students and 38.5% professionals (Table 2, p.118). Generalization to older
+              adults, less technology-literate consumers, and non-student segments is uncertain.
             </li>
             <li>
               <strong>Market maturity considerations:</strong> Mobile internet adoption stage when
@@ -593,7 +637,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -702,7 +746,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -758,7 +802,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -808,6 +852,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -845,7 +890,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Value-Based Adoption Model (VAM) - Kim, Chan, & Gupta (2007)',
+  title: 'Bibliography: Value-Based Adoption Model (VAM) - Kim et al. (2007)',
   description:
     'Comprehensive examination of the Value-Based Adoption Model (VAM), which posits that technology adoption is driven by perceived value as trade-off between perceived benefits and perceived sacrifices in consumer technology adoption.',
 }
@@ -21,9 +21,7 @@ const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>
-          Value-Based Adoption Model (VAM) - Kim, Chan, &amp; Gupta (2007)
-        </h1>
+        <h1 className={H1_CLASSES}>Value-Based Adoption Model (VAM) - Kim et al. (2007)</h1>
 
         {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -129,9 +129,9 @@ const BibliographyArticlePage = () => {
             balancing all benefits against all sacrifices.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            VAM was developed and tested through empirical research with 161 Korean mobile internet
-            users, explicitly measuring perceived usefulness, perceived enjoyment (hedonic benefit
-            dimension often overlooked in organizational models), perceived fee (monetary
+            VAM was developed and tested through empirical research with 211 Singaporean mobile
+            internet users, explicitly measuring perceived usefulness, perceived enjoyment (hedonic
+            benefit dimension often overlooked in organizational models), perceived fee (monetary
             sacrifice), and perceived technicality (effort and learning sacrifice). The model
             explained 67 percent of variance in adoption intention, demonstrating that consumer
             technology adoption can be effectively explained through value-based frameworks that
@@ -395,8 +395,8 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Single technology and market context:</strong> Model tested exclusively on
-              Korean mobile internet users. Generalization to other consumer technologies, other
-              geographic markets, or other consumer segments requires verification.
+              Singaporean mobile internet users. Generalization to other consumer technologies,
+              other geographic markets, or other consumer segments requires verification.
             </li>
             <li>
               <strong>Small sample size:</strong> Empirical testing involved only 161 mobile
@@ -424,9 +424,9 @@ const BibliographyArticlePage = () => {
               initial acceptance.
             </li>
             <li>
-              <strong>Cultural context specificity:</strong> Korean mobile internet market in 2007
-              had unique characteristics (high mobile adoption rates, specific cultural attitudes
-              toward mobile technology) limiting generalization.
+              <strong>Cultural context specificity:</strong> Singaporean mobile internet market in
+              2007 had unique characteristics (high mobile adoption rates, specific cultural
+              attitudes toward mobile technology) limiting generalization.
             </li>
             <li>
               <strong>Reference point theory implications unexplored:</strong> Prospect theory

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -68,6 +68,17 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 111-126
             </p>
+            <p>
+              <strong>DOI:</strong>{' '}
+              <a
+                href="https://doi.org/10.1016/j.dss.2005.05.009"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.1016/j.dss.2005.05.009
+              </a>
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -544,7 +544,7 @@ const BibliographyArticlePage = () => {
               devices, wearables) with different benefit-sacrifice profiles requires investigation.
             </li>
             <li>
-              <strong>Geographic and cultural context:</strong> Korean market sample limits
+              <strong>Geographic and cultural context:</strong> Singaporean market sample limits
               generalization to other geographic regions and cultures with different cost
               structures, technology attitudes, and consumer preferences.
             </li>


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 1-17 Value-Based Adoption (Kim et al., 2007) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1570
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)