### PR TITLE
docs: standardize bibliography 1-19 TAM3 (Venkatesh & Bala, 2008)

### DIFF
--- a/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
+++ b/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
@@ -132,32 +132,111 @@ const BibliographyArticlePage = () => {
             <a href="#ref-venkatesh-2000b" className="text-tabs-teal-deep hover:underline">
               2000
             </a>
-            ) had published research identifying four specific determinants of perceived ease of
-            use: computer anxiety, computer playfulness, perceived enjoyment, and objective
-            usability. However, this research existed separately from TAM2, creating fragmentation
-            where perceived usefulness had comprehensive theoretical coverage while perceived ease
-            of use remained incompletely integrated. Venkatesh and Bala recognized that technology
-            acceptance required comprehensive integration of both usefulness and ease of use
-            determinants, combined with recognition that experience moderates these relationships.
-            Users&rsquo; perceptions change dramatically as they gain experience with technology:
-            initial ease of use concerns diminish through learning, enjoyment may transition from
-            intrinsic to instrumental motivation, and usefulness assessments become more informed
-            through actual usage.
+            ) had published research identifying six determinants of perceived ease of use organized
+            as an anchoring-and-adjustment framework: four anchors (computer self-efficacy,
+            perceptions of external control, computer anxiety, and computer playfulness) that drive
+            initial judgments, and two adjustments (perceived enjoyment and objective usability)
+            that refine judgments once users gain hands-on experience. However, this research
+            existed separately from TAM2, creating fragmentation where perceived usefulness had
+            comprehensive theoretical coverage while perceived ease of use remained incompletely
+            integrated. Venkatesh and Bala recognized that technology acceptance required
+            comprehensive integration of both usefulness and ease of use determinants with explicit
+            modeling of how experience moderates specific relationships.
           </p>
           <p className={PARAGRAPH_CLASSES}>
             TAM3 was created to provide a comprehensive model integrating TAM2&rsquo;s usefulness
-            determinants with Venkatesh&rsquo;s ease of use determinants, while explicitly modeling
-            how experience moderates these relationships. The authors also emphasized a research
-            agenda for interventions, arguing that understanding what predicts adoption was
-            insufficient without guidance on practical interventions to enhance acceptance.
-            Empirical testing occurred longitudinally at four organizations across three measurement
-            points with N=156 users, examining actual information system implementations where
-            different technologies showed varying adoption trajectories across pre-implementation,
-            implementation, and post-implementation phases.
+            determinants with Venkatesh&rsquo;s (2000) ease of use determinants, plus three new
+            experience-moderated relationships not previously tested: perceived ease of use to
+            perceived usefulness (stronger with experience), computer anxiety to perceived ease of
+            use (weaker with experience), and perceived ease of use to behavioral intention (weaker
+            with experience). TAM3 also posits no crossover effects (determinants of PU do not
+            influence PEOU and vice versa). The authors paired the model with a research agenda on
+            interventions, arguing that understanding what predicts adoption was insufficient
+            without guidance on practical interventions to enhance acceptance. Empirical testing
+            occurred via four longitudinal field studies at four organizations (N=156 total: 38+39
+            at two voluntary-use sites, 43+36 at two mandatory-use sites) over a 5-month period with
+            four measurement points (T1 post-training, T2 at 1 month, T3 at 3 months, T4 at 5 months
+            with only use measured).
           </p>
         </section>
 
-        {/* 5. Core Concepts and Definitions */}
+        {/* 5. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            TAM3 measures a nomological network of 14+ constructs (plus interaction terms)
+            operationalized with validated multi-item scales from prior research. Items use 7-point
+            agree-disagree scales adapted from Davis (1989), Venkatesh &amp; Davis (2000), Venkatesh
+            (2000), Moore &amp; Benbasat (1991), Compeau &amp; Higgins (1995), and Taylor &amp; Todd
+            (1995). Data was analyzed with Partial Least Squares (PLS-Graph v3) and bootstrapping
+            (500 resamples). Internal consistency reliability exceeded 0.70 for all constructs at
+            every measurement point; factor loadings exceeded 0.70 and no cross-loadings exceeded
+            0.30 (Tables 3-4, p.286-288).
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Perceived Usefulness (PU):</strong> 4 items adapted from Davis et al. (1989).
+            </li>
+            <li>
+              <strong>Perceived Ease of Use (PEOU):</strong> 4 items adapted from Davis et al.
+              (1989).
+            </li>
+            <li>
+              <strong>Behavioral Intention (BI):</strong> Items from Davis (1989).
+            </li>
+            <li>
+              <strong>Use (USE):</strong> Self-reported hours and minutes per day on the system;
+              measured separated from survey items by at least 1 month.
+            </li>
+            <li>
+              <strong>Subjective Norm (SN):</strong> 4 items adapted from Taylor &amp; Todd (1995).
+            </li>
+            <li>
+              <strong>Image (IMG):</strong> 3 items from Moore &amp; Benbasat (1991).
+            </li>
+            <li>
+              <strong>Result Demonstrability (RES):</strong> 4 items from Moore &amp; Benbasat
+              (1991).
+            </li>
+            <li>
+              <strong>Job Relevance (REL), Output Quality (OUT):</strong> 3 items each, adapted from
+              Davis et al. (1992).
+            </li>
+            <li>
+              <strong>Computer Self-Efficacy (CSE):</strong> 4 items from Compeau &amp; Higgins
+              (1995).
+            </li>
+            <li>
+              <strong>Perceptions of External Control (PEC):</strong> 4 items from Mathieson (1991)
+              and Taylor &amp; Todd (1995).
+            </li>
+            <li>
+              <strong>Computer Playfulness (CPLAY):</strong> 4 items from Webster &amp; Martocchio
+              (1992).
+            </li>
+            <li>
+              <strong>Computer Anxiety (CANX):</strong> 4 items from Venkatesh (2000).
+            </li>
+            <li>
+              <strong>Perceived Enjoyment (ENJ):</strong> 4 items from Davis, Bagozzi, &amp; Warshaw
+              (1992).
+            </li>
+            <li>
+              <strong>Objective Usability (OU):</strong> Novice-to-expert task completion time ratio
+              (not self-report); each participant performed training tasks that the system timed.
+            </li>
+            <li>
+              <strong>Voluntariness (VOL):</strong> 3 items from Moore &amp; Benbasat (1991);
+              measured as perceived voluntariness even though sites were selected to include both
+              voluntary and mandatory use.
+            </li>
+            <li>
+              <strong>Experience:</strong> Coded as ordinal across measurement periods (T1, T2, T3).
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -206,30 +285,53 @@ const BibliographyArticlePage = () => {
               that technology will deliver promised benefits.
             </li>
             <li>
-              <strong>Computer Anxiety:</strong> Individual feelings of apprehension and discomfort
-              when interacting with computers. Anxiety directly increases perceived ease of use
-              barriers by heightening concern about learning difficulty.
+              <strong>Computer Self-Efficacy (Anchor):</strong> Individual control beliefs about
+              personal ability to use a computer or system to accomplish a task/job (Compeau &amp;
+              Higgins, 1995). A PEOU anchor whose effect on PEOU persists even with increasing
+              experience (Venkatesh, 2000).
             </li>
             <li>
-              <strong>Computer Playfulness:</strong> Individual tendency to interact with computers
-              creatively and spontaneously, viewing technology engagement as intrinsically
-              enjoyable. Playfulness reduces perceived ease of use concerns by reframing technology
-              interaction as exploration.
+              <strong>Perceptions of External Control (Anchor):</strong> Individual beliefs about
+              whether organizational and technical resources exist to support use of the system
+              (facilitating conditions; Venkatesh et al., 2003). A PEOU anchor whose effect persists
+              with experience.
             </li>
             <li>
-              <strong>Perceived Enjoyment:</strong> Individual perception that technology
-              interaction provides inherent satisfaction beyond instrumental benefits. Enjoyment
-              reduces ease of use concerns and increases motivation for technology exploration.
+              <strong>Computer Anxiety (Anchor):</strong> Individual apprehension or fear when faced
+              with the possibility of using computers (Venkatesh, 2000). A PEOU anchor whose effect
+              is theorized to diminish with experience (one of the three new TAM3 moderation
+              relationships).
             </li>
             <li>
-              <strong>Objective Usability:</strong> Actual measured system characteristics
-              determining learning requirements and operational complexity. Objective usability
-              serves as anchor for users&rsquo; subjective ease of use perceptions.
+              <strong>Computer Playfulness (Anchor):</strong> The degree of cognitive spontaneity in
+              microcomputer interactions (Webster &amp; Martocchio, 1992). A PEOU anchor whose
+              effect diminishes with experience as users gain accurate perceptions of the specific
+              system.
             </li>
             <li>
-              <strong>Experience:</strong> User history with technology, reflecting cumulative
-              learning and familiarity. Experience moderates effects of all determinants on
-              perceived ease of use through reduced learning concerns and improved capability.
+              <strong>Perceived Enjoyment (Adjustment):</strong> The extent to which using a system
+              is perceived as enjoyable in its own right, apart from any performance consequences
+              (Venkatesh, 2000). A PEOU adjustment whose effect strengthens with experience once
+              users have hands-on interaction.
+            </li>
+            <li>
+              <strong>Objective Usability (Adjustment):</strong> A comparison of systems based on
+              the actual level of effort required to complete specific tasks, measured via a
+              novice-to-expert time ratio (Venkatesh, 2000). A PEOU adjustment whose effect
+              strengthens with experience.
+            </li>
+            <li>
+              <strong>Experience (Moderator):</strong> User&rsquo;s history with the specific
+              system. Moderates three new TAM3 relationships: PEOU to PU (stronger over time),
+              computer anxiety to PEOU (weaker), and PEOU to BI (weaker). Also moderates the
+              anchoring-adjustment dynamic: anchor effects diminish and adjustment effects
+              strengthen with experience.
+            </li>
+            <li>
+              <strong>Voluntariness (Moderator):</strong> The degree to which potential adopters
+              perceive the adoption decision to be non-mandatory. Carried forward from TAM2;
+              moderates the effect of subjective norm on behavioral intention (stronger when use is
+              mandatory).
             </li>
             <li>
               <strong>Adoption Intention:</strong> Degree to which user intends to adopt and use
@@ -239,7 +341,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -289,9 +391,11 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Identified computer anxiety, computer playfulness, perceived enjoyment, and objective
-              usability as direct predictors of perceived ease of use. TAM3 integrates these ease of
-              use antecedents into comprehensive model framework.
+              Identified six determinants of perceived ease of use organized as an
+              anchoring-and-adjustment framework: four anchors (computer self-efficacy, perceptions
+              of external control, computer anxiety, computer playfulness) that drive initial PEOU
+              judgments, and two adjustments (perceived enjoyment, objective usability) that refine
+              judgments with experience. TAM3 integrates all six.
             </li>
             <li>
               <strong>
@@ -342,26 +446,50 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
-            TAM3 proposes comprehensive determinants of perceived usefulness and perceived ease of
-            use, with experience moderating ease of use relationships. Perceived usefulness is
-            directly determined by subjective norm, image, job relevance, output quality, and result
-            demonstrability, consistent with TAM2. Perceived ease of use is directly determined by
-            computer anxiety (negative), computer playfulness, perceived enjoyment, and objective
-            usability. Experience moderates how computer anxiety, computer playfulness, perceived
-            enjoyment, and objective usability influence perceived ease of use: as users gain
-            experience, anxiety effects diminish as learning progresses, playfulness effects
-            diminish as technology becomes routine, enjoyment effects diminish as intrinsic
-            motivation transitions to instrumental use, and objective usability effects diminish as
-            system knowledge reduces reliance on measurable characteristics. Perceived usefulness
-            and perceived ease of use remain direct predictors of adoption intention regardless of
-            experience, but ease of use effects are strongest for inexperienced users and diminish
-            with experience. TAM3 recognizes adoption as dynamic process where determinants vary
-            across pre-implementation, implementation, and post-implementation phases, requiring
-            interventions matched to current adoption phase and user experience level.
+            TAM3 specifies a complete nomological network of the determinants of individual IT
+            adoption and use (Figure 2, p.280). Perceived usefulness is determined by five
+            antecedents from TAM2: subjective norm, image (both social-influence processes), job
+            relevance, output quality, and result demonstrability (cognitive-instrumental
+            processes), plus perceived ease of use. Job relevance and output quality have an
+            interactive effect on PU such that higher output quality strengthens the job-relevance
+            to PU link. Perceived ease of use is determined by six antecedents from Venkatesh
+            (2000): four anchors (computer self-efficacy, perceptions of external control, computer
+            anxiety, computer playfulness) and two adjustments (perceived enjoyment, objective
+            usability). Both PU and PEOU predict behavioral intention, which predicts use behavior.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            TAM3 explicitly proposes <strong>no crossover effects</strong> (determinants of PU do
+            not influence PEOU and vice versa). Two moderators operate: <strong>Experience</strong>{' '}
+            and <strong>Voluntariness</strong> (carried over from TAM2). Voluntariness moderates
+            subjective norm&rsquo;s effect on BI.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            TAM3 proposes <strong>three new experience-moderated relationships</strong> not
+            empirically tested in Venkatesh (2000) or Venkatesh &amp; Davis (2000):
+          </p>
+          <ol className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>PEOU to PU</strong> becomes <em>stronger</em> with experience, as users gain
+              low-level action information that informs high-level performance judgments.
+            </li>
+            <li>
+              <strong>Computer anxiety to PEOU</strong> becomes <em>weaker</em> with experience, as
+              anchor-based general computer beliefs give way to system-specific experience.
+            </li>
+            <li>
+              <strong>PEOU to BI</strong> becomes <em>weaker</em> with experience, as initial
+              complexity concerns recede once procedural knowledge develops.
+            </li>
+          </ol>
+          <p className={PARAGRAPH_CLASSES}>
+            The broader anchoring-adjustment dynamic from Venkatesh (2000) also applies: anchor
+            effects (CSE, PEC, CANX, CPLAY) diminish with experience while adjustment effects (ENJ,
+            OU) strengthen. CSE and PEC remain strong predictors of PEOU even with experience, while
+            CANX and CPLAY fade.
           </p>
 
           <h3 className={H3_CLASSES}>TAM3 Determinant Mechanisms</h3>
@@ -416,21 +544,39 @@ const BibliographyArticlePage = () => {
               judgments.
             </li>
             <li>
-              <strong>Experience Moderates All Ease Determinants:</strong> As users gain experience,
-              initial concerns about anxiety diminish through mastery, playfulness effects diminish
-              as technology becomes routine, enjoyment transitions from intrinsic to instrumental,
-              and objective usability becomes less critical as tacit knowledge develops. Experience
-              weakens all four ease of use antecedents.
+              <strong>Experience moderation (anchoring-adjustment):</strong> Anchor effects
+              (computer self-efficacy, perceptions of external control, computer anxiety, computer
+              playfulness) diminish with experience, except CSE and PEC which remain strong.
+              Adjustment effects (perceived enjoyment, objective usability) strengthen with
+              experience as users gain system-specific information. The TAM3 new moderation of
+              computer anxiety to PEOU (weaker over time) is one specific consequence.
             </li>
             <li>
-              <strong>Perceived Usefulness &rarr; Adoption Intention:</strong> Strongest direct
-              effect on adoption intention remains constant across experience levels. Performance
-              benefits always motivate adoption regardless of learning history.
+              <strong>Perceived Usefulness &rarr; Behavioral Intention:</strong> Strongest direct
+              effect on intention. Performance benefits remain the primary adoption driver across
+              experience levels.
             </li>
             <li>
-              <strong>Perceived Ease of Use &rarr; Adoption Intention:</strong> Effect strongest for
-              inexperienced users and diminishes with experience. Initial users emphasize complexity
-              concerns more heavily than experienced users who focus on instrumental benefits.
+              <strong>
+                Perceived Ease of Use &rarr; Behavioral Intention (moderated by Experience):
+              </strong>{' '}
+              TAM3 new relationship: effect is strongest for inexperienced users and weakens with
+              experience as procedural knowledge reduces reliance on ease-of-use judgments in
+              forming intention.
+            </li>
+            <li>
+              <strong>
+                Perceived Ease of Use &rarr; Perceived Usefulness (moderated by Experience):
+              </strong>{' '}
+              TAM3 new relationship: effect strengthens with experience as low-level action
+              information (PEOU) informs high-level goal judgments (PU).
+            </li>
+            <li>
+              <strong>
+                Subjective Norm &rarr; BI (moderated by Voluntariness and Experience):
+              </strong>{' '}
+              Carried from TAM2: subjective norm has a direct effect on behavioral intention only in
+              mandatory-use settings, and this effect attenuates with experience.
             </li>
           </ul>
 
@@ -442,9 +588,10 @@ const BibliographyArticlePage = () => {
               substantially expanding explanatory breadth compared to prior TAM versions.
             </li>
             <li>
-              <strong>Longitudinal design with multiple measurement points:</strong> Data collection
-              at baseline, post-implementation, 3-month, and 6-month intervals allowed assessment of
-              how relationships change across adoption lifecycle phases.
+              <strong>Longitudinal design with four measurement points:</strong> Data collected at
+              T1 (immediately post-training), T2 (1 month after implementation), T3 (3 months after
+              implementation), and T4 (5 months, use only), spanning 5 months total. Allowed testing
+              of experience-moderated relationships across adoption phases.
             </li>
             <li>
               <strong>Experience-moderation hypothesis testing:</strong> Explicit empirical testing
@@ -462,11 +609,12 @@ const BibliographyArticlePage = () => {
               acceptance, shifting focus from prediction to practical change mechanisms.
             </li>
             <li>
-              <strong>
-                Pre-implementation, implementation, and post-implementation framework:
-              </strong>{' '}
-              Recognition that adoption is three-phase process requiring different interventions at
-              different stages provided actionable guidance for technology deployment.
+              <strong>Research agenda for pre- and post-implementation interventions:</strong>{' '}
+              Venkatesh and Bala pair the TAM3 model with a companion research agenda proposing
+              specific interventions (design characteristics, user participation, management
+              support, training, organizational support, peer support) for pre- and
+              post-implementation stages, providing a bridge from predictive modeling to actionable
+              managerial guidance.
             </li>
             <li>
               <strong>Real organizational contexts:</strong> Studies examined actual technology
@@ -483,9 +631,11 @@ const BibliographyArticlePage = () => {
           <h3 className={H3_CLASSES}>Main Weaknesses</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Model complexity and practical measurement burden:</strong> Measuring 11
-              constructs plus experience moderation substantially exceeds practical capacity in many
-              organizational settings. Practitioners may find streamlined models more implementable.
+              <strong>Model complexity and practical measurement burden:</strong> TAM3 includes PU,
+              PEOU, BI, Use, five PU antecedents, six PEOU antecedents (four anchors plus two
+              adjustments), and two moderators (Experience, Voluntariness) - at least 14 constructs
+              plus interaction terms. This substantially exceeds practical capacity in many
+              organizational settings.
             </li>
             <li>
               <strong>Intervention research incomplete:</strong> While Venkatesh and Bala
@@ -532,7 +682,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -557,9 +707,11 @@ const BibliographyArticlePage = () => {
               acceptance research toward actionable guidance.
             </li>
             <li>
-              <strong>Lifecycle adoption framework:</strong> Recognition of pre-implementation,
-              implementation, and post-implementation phases provided foundation for understanding
-              how adoption determinants and required interventions vary across deployment stages.
+              <strong>Pre- and post-implementation intervention typology:</strong> Companion
+              research agenda (paper Section 6) maps specific interventions - design
+              characteristics, user participation, management support, incentive alignment,
+              training, organizational and peer support - to pre- and post-implementation stages,
+              providing a bridge from predictive modeling to managerial guidance.
             </li>
             <li>
               <strong>Explanatory power improvement:</strong> TAM3 substantially improved prediction
@@ -579,7 +731,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -587,10 +739,10 @@ const BibliographyArticlePage = () => {
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Longitudinal design with multiple measurement occasions:</strong> Data
-              collection at baseline, immediately post-implementation, 3 months, and 6 months
-              allowed assessment of how relationships change across adoption phases and experience
-              accumulation.
+              <strong>Longitudinal design with four measurement occasions:</strong> Data collected
+              at T1 (immediately post-training), T2 (1 month post-implementation), T3 (3 months
+              post-implementation), and T4 (5 months, use only), separating survey measurement from
+              use measurement by at least 1 month to mitigate common-method bias.
             </li>
             <li>
               <strong>Real system implementations:</strong> Study examined actual enterprise system
@@ -612,9 +764,11 @@ const BibliographyArticlePage = () => {
               previously validated scales established in prior technology acceptance research.
             </li>
             <li>
-              <strong>Structural equation modeling:</strong> SEM approach tested complete model
-              specification simultaneously with multiple direct effects, indirect pathways, and
-              moderating relationships.
+              <strong>Partial Least Squares (PLS) estimation:</strong> Analyzed with PLS-Graph
+              version 3 (Chin et al., 2003), a component-based SEM method suited to complex
+              moderated models and smaller samples. Mean-centered indicators were used prior to
+              creating interaction terms to limit multicollinearity (VIFs remained low).
+              Bootstrapping (500 resamples) produced path significance estimates.
             </li>
             <li>
               <strong>Experience moderation specification:</strong> Moderation effects tested using
@@ -629,7 +783,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -672,9 +826,10 @@ const BibliographyArticlePage = () => {
               technology adoption contexts where choice mechanisms operate differently.
             </li>
             <li>
-              <strong>Measurement period constraints:</strong> Studies measured adoption over six
-              months. Long-term use patterns beyond initial adoption period, discontinuance
-              decisions, or technology replacement scenarios remain unexplored.
+              <strong>Measurement period constraints:</strong> Studies measured adoption over 5
+              months with four measurement points. Long-term use patterns beyond initial adoption
+              period, discontinuance decisions, or technology replacement scenarios remain
+              unexplored.
             </li>
             <li>
               <strong>System stability assumptions:</strong> Studies examined relatively stable
@@ -684,7 +839,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -694,14 +849,14 @@ const BibliographyArticlePage = () => {
             (performance expectancy barrier), worry about learning difficulty (complexity barrier),
             experience anxiety about technology interaction (emotional barrier), receive negative
             social messages about adoption (social barrier), or perceive inadequate output quality
-            (reliability barrier). Critically, TAM3 shows these barriers operate differently across
-            adoption lifecycle: early-stage users emphasize complexity and anxiety concerns while
-            experienced users focus predominantly on perceived usefulness. Organizations must
-            therefore tailor adoption strategies to deployment phase, providing extensive support
-            and addressing complexity barriers during initial implementation, then emphasizing
-            instrumental benefits and performance value as users gain experience. The model
+            (reliability barrier). Critically, TAM3 proposes specific experience-moderated dynamics:
+            early users emphasize ease-of-use concerns (which weaken over time), while the
+            PEOU-to-PU link strengthens over time as users translate low-level usability experience
+            into high-level performance judgments. Organizations can therefore target ease-of-use
+            and anxiety interventions during early adoption, then shift to usefulness-reinforcement
+            and performance-demonstration interventions once users have direct experience. The model
             prescribes different intervention strategies for different barriers rather than assuming
-            identical change strategies would address all adoption resistance.
+            identical change strategies address all adoption resistance.
           </p>
 
           <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
@@ -802,7 +957,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -867,7 +1022,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -923,6 +1078,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -956,7 +1112,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
+++ b/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
@@ -4,14 +4,17 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
+  BODY_LIST_CLASSES,
+  REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Technology Acceptance Model 3 (TAM3) - Venkatesh & Bala (2008)',
   description:
-    'Deep dive into the Technology Acceptance Model 3 (TAM3) by Viswanath Venkatesh and Hillol Bala (2008), providing a complete nomological network of TAM with determinants of perceived usefulness and perceived ease of use plus a research agenda on interventions.',
+    'Comprehensive overview of the Technology Acceptance Model 3 (TAM3), synthesizing TAM2 antecedents of perceived usefulness with determinants of perceived ease of use, including experience and usage moderators.',
 }
 
 const BibliographyArticlePage = () => {
@@ -22,448 +25,961 @@ const BibliographyArticlePage = () => {
           Technology Acceptance Model 3 (TAM3) - Venkatesh &amp; Bala (2008)
         </h1>
 
-        {/* Model Identification */}
+        {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Model Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Model Name:</strong> Technology Acceptance Model 3 (TAM3)
+              <strong>Model Name:</strong> Technology Acceptance Model 3
             </p>
+            <p>
+              <strong>Model Abbreviation:</strong> TAM3
+            </p>
+            <p>
+              <strong>Target of Model:</strong> Integration of TAM2 determinants of perceived
+              usefulness with comprehensive determinants of perceived ease of use, including
+              moderating effects of experience and usage context
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Information Systems, Technology Adoption,
+              Human-Computer Interaction
+            </p>
+          </div>
+        </section>
+
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
             <p>
               <strong>Authors:</strong> Viswanath Venkatesh and Hillol Bala
             </p>
             <p>
-              <strong>Publication Date:</strong> 2008
+              <strong>Formal Publication Date:</strong> 2008
+            </p>
+            <p>
+              <strong>Official Title:</strong> Technology acceptance model 3 and a research agenda
+              on interventions
+            </p>
+            <p>
+              <strong>Journal:</strong> Decision Sciences
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 39, No. 2
+            </p>
+            <p>
+              <strong>Pages:</strong> 273-315
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Venkatesh, V., &amp; Bala, H. (2008). Technology acceptance model 3 and a research
-              agenda on interventions. <em>Decision Sciences</em>, 39(2), 273-315.{' '}
-              <a
-                href="https://doi.org/10.1111/j.1540-5915.2008.00192.x"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1111/j.1540-5915.2008.00192.x
-              </a>
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Venkatesh, V., &amp; Bala, H. (
+                <a href="#ref-venkatesh-2008" className="text-tabs-teal-deep hover:underline">
+                  2008
+                </a>
+                ). Technology acceptance model 3 and a research agenda on interventions.{' '}
+                <em>Decision Sciences</em>, 39(2), 273-315.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Venkatesh, Viswanath, and Hillol Bala. 2008. &ldquo;Technology Acceptance Model 3
+                and a Research Agenda on Interventions.&rdquo; <em>Decision Sciences</em> 39, no. 2:
+                273-315.
+              </p>
+            </div>
           </div>
         </section>
 
-        {/* Why TAM3 Was Created */}
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Why TAM3 Was Created</h2>
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            By 2008, the Technology Acceptance Model lineage had produced two important but
-            incomplete extensions. TAM2 (Venkatesh &amp; Davis, 2000) had successfully identified
-            the social influence and cognitive instrumental determinants of perceived usefulness,
-            explaining why users find systems useful or not useful. Separately, Venkatesh (2000) had
-            identified anchor and adjustment determinants of perceived ease of use, explaining the
-            factors that shape how easy or difficult users believe a system is to use. However, no
-            single model had integrated both sets of determinants into a comprehensive theoretical
-            framework. The Technology Acceptance Model lacked a complete nomological network-a full
-            specification of all the constructs, their antecedents, and their interrelationships.
+            Venkatesh and Bala developed Technology Acceptance Model 3 to consolidate and extend two
+            decades of technology acceptance research. The original Technology Acceptance Model had
+            established that perceived usefulness and perceived ease of use predicted adoption
+            intention, but offered limited theoretical explanation for what shaped these core
+            perceptions. Subsequent research had addressed this gap through TAM2, which identified
+            specific antecedents of perceived usefulness including subjective norm, image, job
+            relevance, output quality, and result demonstrability. However, while TAM2
+            comprehensively addressed usefulness determinants, perceived ease of use remained
+            theoretically underdeveloped with limited understanding of what factors shaped
+            users&rsquo; complexity perceptions.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Venkatesh and Bala sought to address this gap by developing TAM3, which combined the
-            determinants of perceived usefulness from TAM2 with the determinants of perceived ease
-            of use from Venkatesh (2000) into a single integrated model. This integration was not
-            merely a mechanical combination of two prior models. TAM3 also examined whether
-            cross-over effects existed between the determinants-specifically, whether the
-            determinants of perceived usefulness also influenced perceived ease of use, or vice
-            versa. The researchers hypothesized and tested that no such cross-over effects exist,
-            meaning that the antecedents of perceived usefulness and the antecedents of perceived
-            ease of use operate through independent theoretical mechanisms.
+            Additionally, Venkatesh (
+            <a href="#ref-venkatesh-2000b" className="text-tabs-teal-deep hover:underline">
+              2000
+            </a>
+            ) had published research identifying four specific determinants of perceived ease of
+            use: computer anxiety, computer playfulness, perceived enjoyment, and objective
+            usability. However, this research existed separately from TAM2, creating fragmentation
+            where perceived usefulness had comprehensive theoretical coverage while perceived ease
+            of use remained incompletely integrated. Venkatesh and Bala recognized that technology
+            acceptance required comprehensive integration of both usefulness and ease of use
+            determinants, combined with recognition that experience moderates these relationships.
+            Users&rsquo; perceptions change dramatically as they gain experience with technology:
+            initial ease of use concerns diminish through learning, enjoyment may transition from
+            intrinsic to instrumental motivation, and usefulness assessments become more informed
+            through actual usage.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Beyond theoretical completeness, TAM3 was motivated by a desire to develop a practical
-            research agenda on interventions. Venkatesh and Bala argued that while the TAM research
-            stream had made substantial theoretical progress, it had not sufficiently addressed the
-            question of what organizations can actually do to improve technology adoption. By
-            providing a complete nomological network, TAM3 enabled systematic identification of
-            specific intervention points: organizational leaders could identify which antecedents of
-            perceived usefulness or perceived ease of use were most problematic for a specific
-            technology implementation and design targeted interventions to address those specific
-            barriers.
+            TAM3 was created to provide a comprehensive model integrating TAM2&rsquo;s usefulness
+            determinants with Venkatesh&rsquo;s ease of use determinants, while explicitly modeling
+            how experience moderates these relationships. The authors also emphasized a research
+            agenda for interventions, arguing that understanding what predicts adoption was
+            insufficient without guidance on practical interventions to enhance acceptance.
+            Empirical testing occurred longitudinally at four organizations across three measurement
+            points with N=156 users, examining actual information system implementations where
+            different technologies showed varying adoption trajectories across pre-implementation,
+            implementation, and post-implementation phases.
           </p>
         </section>
 
-        {/* Determinants of Perceived Usefulness */}
+        {/* 5. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Determinants of Perceived Usefulness</h2>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
-            TAM3 retained the determinants of perceived usefulness established in TAM2 without
-            modification. These determinants comprise both social influence processes and cognitive
-            instrumental processes that shape users&rsquo; beliefs about how useful a system will be
-            for their work.
+            TAM3 integrates and expands prior technology acceptance components:
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The social influence determinants include subjective norm (perceptions about whether
-            important others believe one should use the system), voluntariness (the degree to which
-            use is perceived as non-mandatory), and image (the extent to which technology use
-            enhances one&rsquo;s social status). Subjective norm influences perceived usefulness
-            through internalization and influences behavioral intention through compliance in
-            mandatory settings. Image mediates part of the relationship between subjective norm and
-            perceived usefulness.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The cognitive instrumental determinants include job relevance (the degree to which the
-            system applies to one&rsquo;s job), output quality (the quality of the system&rsquo;s
-            task performance), and result demonstrability (the tangibility and communicability of
-            usage results). An important feature of these constructs is the interaction between job
-            relevance and output quality: users evaluate output quality primarily for tasks they
-            consider relevant to their work, so high job relevance amplifies the positive effect of
-            high output quality on perceived usefulness.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Perceived ease of use also serves as a determinant of perceived usefulness, reflecting
-            the principle that easier-to-use systems free up cognitive resources that can be
-            redirected toward productive work, thereby enhancing the system&rsquo;s net contribution
-            to user performance. This relationship links the two halves of the TAM3 nomological
-            network.
-          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Perceived Usefulness:</strong> Individual beliefs that using technology will
+              improve job performance and achieve valued outcomes. TAM3 maintains usefulness as
+              primary adoption driver while identifying specific antecedents from TAM2 and Venkatesh
+              (
+              <a href="#ref-venkatesh-2000b" className="text-tabs-teal-deep hover:underline">
+                2000
+              </a>
+              ).
+            </li>
+            <li>
+              <strong>Perceived Ease of Use:</strong> Individual beliefs about the degree of
+              learning effort required to use technology and psychological effort during operation.
+              TAM3 positions ease of use as jointly determined by both initial factors shaping
+              perceived complexity and experience-dependent moderation effects.
+            </li>
+            <li>
+              <strong>Subjective Norm:</strong> Individual perception that people important to them
+              believe they should use technology. Subjective norm predicts perceived usefulness, as
+              endorsement from valued reference groups signals technology value.
+            </li>
+            <li>
+              <strong>Image:</strong> Individual beliefs that technology use will enhance
+              professional status and public visibility. Technologies positioned as status symbols
+              or capability markers enhance perceived usefulness through image enhancement motives.
+            </li>
+            <li>
+              <strong>Job Relevance:</strong> Individual beliefs that technology relates directly to
+              job responsibilities and performance outcomes. Strong job relevance increases
+              perceived usefulness regardless of actual technology functionality.
+            </li>
+            <li>
+              <strong>Output Quality:</strong> Individual beliefs that technology produces reliable,
+              accurate, and comprehensive work outputs. Higher output quality perceptions enhance
+              perceived usefulness.
+            </li>
+            <li>
+              <strong>Result Demonstrability:</strong> Individual beliefs that technology benefits
+              are observable and communicable to others. Demonstrable results increase confidence
+              that technology will deliver promised benefits.
+            </li>
+            <li>
+              <strong>Computer Anxiety:</strong> Individual feelings of apprehension and discomfort
+              when interacting with computers. Anxiety directly increases perceived ease of use
+              barriers by heightening concern about learning difficulty.
+            </li>
+            <li>
+              <strong>Computer Playfulness:</strong> Individual tendency to interact with computers
+              creatively and spontaneously, viewing technology engagement as intrinsically
+              enjoyable. Playfulness reduces perceived ease of use concerns by reframing technology
+              interaction as exploration.
+            </li>
+            <li>
+              <strong>Perceived Enjoyment:</strong> Individual perception that technology
+              interaction provides inherent satisfaction beyond instrumental benefits. Enjoyment
+              reduces ease of use concerns and increases motivation for technology exploration.
+            </li>
+            <li>
+              <strong>Objective Usability:</strong> Actual measured system characteristics
+              determining learning requirements and operational complexity. Objective usability
+              serves as anchor for users&rsquo; subjective ease of use perceptions.
+            </li>
+            <li>
+              <strong>Experience:</strong> User history with technology, reflecting cumulative
+              learning and familiarity. Experience moderates effects of all determinants on
+              perceived ease of use through reduced learning concerns and improved capability.
+            </li>
+            <li>
+              <strong>Adoption Intention:</strong> Degree to which user intends to adopt and use
+              technology, determined by perceived usefulness and perceived ease of use as shaped by
+              multiple antecedents and moderated by experience.
+            </li>
+          </ul>
         </section>
 
-        {/* Determinants of Perceived Ease of Use */}
+        {/* 6. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Determinants of Perceived Ease of Use</h2>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The determinants of perceived ease of use in TAM3 are organized around an anchoring and
-            adjustment framework derived from cognitive psychology. According to this framework,
-            individuals form initial perceptions of ease of use based on general beliefs (anchors)
-            that exist prior to direct experience with a specific system. As they gain hands-on
-            experience, they adjust these initial perceptions based on system-specific information.
+            TAM3 explicitly synthesizes and integrates prior frameworks:
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            TAM3 identifies four anchoring determinants. <strong>Computer Self-Efficacy</strong>,
-            drawn from Bandura&rsquo;s social cognitive theory and operationalized by Compeau and
-            Higgins (1995), refers to an individual&rsquo;s judgment of their capability to use
-            computers across different situations. Individuals with high computer self-efficacy
-            approach new systems with greater confidence.{' '}
-            <strong>Perceptions of External Control</strong> captures the degree to which an
-            individual believes that organizational and technical resources are available to support
-            their use of the system. When users believe that help desk support, training, and
-            specialized assistance are readily available, they perceive the system as easier to use.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Computer Anxiety</strong> reflects the degree of apprehension or fear that an
-            individual experiences when using or contemplating the use of computers. Users with high
-            computer anxiety develop more negative perceptions of system ease of use, regardless of
-            the actual complexity of the system. <strong>Computer Playfulness</strong> captures an
-            individual&rsquo;s tendency toward spontaneity, inventiveness, and creativity in
-            computer interactions. Individuals high in computer playfulness approach new systems
-            with greater curiosity and openness, leading to more favorable initial ease perceptions.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            TAM3 identifies two adjustment determinants that become influential as users accumulate
-            direct experience with a system. <strong>Perceived Enjoyment</strong>
-            captures the extent to which using a specific system is perceived as enjoyable in its
-            own right, apart from any performance consequences. Users who find a system pleasant to
-            interact with develop more favorable ease perceptions over time.
-            <strong> Objective Usability</strong> represents the actual (rather than perceived)
-            level of effort required to complete specific tasks using the system, measured through
-            comparison of expert and novice performance. Unlike the other determinants, objective
-            usability captures system-side characteristics rather than user-side beliefs.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Experience plays a critical moderating role in the anchoring and adjustment framework.
-            Anchor effects (computer self-efficacy, perceptions of external control, computer
-            anxiety, and computer playfulness) are strongest before users have direct experience and
-            weaken as experience accumulates because users develop system-specific assessments that
-            supersede general beliefs. Adjustment effects (perceived enjoyment and objective
-            usability), in contrast, strengthen with experience because users need direct
-            interaction with the system to form these system-specific evaluations.
-          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Technology Acceptance Model (
+                <a
+                  id="cite-ref-davis-1989-1"
+                  href="#ref-davis-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis, 1989
+                </a>
+                ):
+              </strong>{' '}
+              Foundational model establishing perceived usefulness and perceived ease of use as
+              technology adoption predictors. TAM3 retains these core constructs while extensively
+              developing their antecedents and moderators.
+            </li>
+            <li>
+              <strong>
+                TAM2 (Venkatesh &amp;{' '}
+                <Link
+                  href="/bibliography-1-13-technology-acceptance-model-2-tam2-venkatesh-davis-2000"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis, 2000
+                </Link>
+                ):
+              </strong>{' '}
+              Extended TAM by identifying antecedents of perceived usefulness including subjective
+              norm, image, job relevance, output quality, and result demonstrability. TAM3
+              incorporates all TAM2 determinants while adding ease of use antecedent framework.
+            </li>
+            <li>
+              <strong>
+                Ease of Use Determinants (
+                <a
+                  id="cite-ref-venkatesh-2000b-1"
+                  href="#ref-venkatesh-2000b"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Venkatesh, 2000
+                </a>
+                ):
+              </strong>{' '}
+              Identified computer anxiety, computer playfulness, perceived enjoyment, and objective
+              usability as direct predictors of perceived ease of use. TAM3 integrates these ease of
+              use antecedents into comprehensive model framework.
+            </li>
+            <li>
+              <strong>
+                Theory of Reasoned Action (Fishbein &amp;{' '}
+                <Link
+                  href="/bibliography-1-1-theory-of-reasoned-action-tra-fishbein-ajzen-1975"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Ajzen, 1975
+                </Link>
+                ):
+              </strong>{' '}
+              Foundational framework establishing that behavioral intention determined by attitudes
+              and subjective norms predicts behavior. TAM3 incorporates TRA&rsquo;s subjective norm
+              construct as usefulness antecedent.
+            </li>
+            <li>
+              <strong>
+                Self-Efficacy Theory (
+                <a
+                  id="cite-ref-bandura-1997-1"
+                  href="#ref-bandura-1997"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Bandura, 1997
+                </a>
+                ):
+              </strong>{' '}
+              Established that perceived capability to perform behaviors influences motivation and
+              actual performance. TAM3&rsquo;s ease of use construct reflects self-efficacy
+              regarding technology operation.
+            </li>
+            <li>
+              <strong>
+                Intrinsic Motivation Research (
+                <a
+                  id="cite-ref-deci-1985-1"
+                  href="#ref-deci-1985"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Deci &amp; Ryan, 1985
+                </a>
+                ):
+              </strong>{' '}
+              Distinguished intrinsic motivation from extrinsic motivation. TAM3&rsquo;s perceived
+              enjoyment reflects intrinsic motivation, which moderates ease of use perceptions.
+            </li>
+          </ul>
         </section>
 
-        {/* No Cross-Over Effects */}
+        {/* 7. Describe The Model */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Independence of Determinants: No Cross-Over Effects</h2>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
-            A theoretically important hypothesis in TAM3 was that the determinants of perceived
-            usefulness do not influence perceived ease of use, and the determinants of perceived
-            ease of use do not influence perceived usefulness. Venkatesh and Bala argued that these
-            two sets of determinants operate through distinct theoretical mechanisms: the perceived
-            usefulness determinants reflect social and cognitive assessments of what a system can do
-            and its relevance to one&rsquo;s work, while the perceived ease of use determinants
-            reflect individual differences and system-specific experiences related to how much
-            effort the system requires.
+            TAM3 proposes comprehensive determinants of perceived usefulness and perceived ease of
+            use, with experience moderating ease of use relationships. Perceived usefulness is
+            directly determined by subjective norm, image, job relevance, output quality, and result
+            demonstrability, consistent with TAM2. Perceived ease of use is directly determined by
+            computer anxiety (negative), computer playfulness, perceived enjoyment, and objective
+            usability. Experience moderates how computer anxiety, computer playfulness, perceived
+            enjoyment, and objective usability influence perceived ease of use: as users gain
+            experience, anxiety effects diminish as learning progresses, playfulness effects
+            diminish as technology becomes routine, enjoyment effects diminish as intrinsic
+            motivation transitions to instrumental use, and objective usability effects diminish as
+            system knowledge reduces reliance on measurable characteristics. Perceived usefulness
+            and perceived ease of use remain direct predictors of adoption intention regardless of
+            experience, but ease of use effects are strongest for inexperienced users and diminish
+            with experience. TAM3 recognizes adoption as dynamic process where determinants vary
+            across pre-implementation, implementation, and post-implementation phases, requiring
+            interventions matched to current adoption phase and user experience level.
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            This no-cross-over hypothesis was confirmed empirically. The determinants of perceived
-            usefulness (subjective norm, image, job relevance, output quality, result
-            demonstrability) did not significantly predict perceived ease of use. Likewise, the
-            determinants of perceived ease of use (computer self-efficacy, perceptions of external
-            control, computer anxiety, computer playfulness, perceived enjoyment, objective
-            usability) did not significantly predict perceived usefulness directly. The only link
-            between the two sides of the nomological network remained the established path from
-            perceived ease of use to perceived usefulness. This finding provided important
-            theoretical clarity by demonstrating that the mechanisms driving usefulness perceptions
-            and ease perceptions are fundamentally different processes.
-          </p>
+
+          <h3 className={H3_CLASSES}>TAM3 Determinant Mechanisms</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Subjective Norm &rarr; Perceived Usefulness:</strong> When important reference
+              groups endorse technology adoption, individuals infer that technology delivers valued
+              benefits. Social approval signals usefulness and supports belief that adoption is
+              instrumentally beneficial.
+            </li>
+            <li>
+              <strong>Image &rarr; Perceived Usefulness:</strong> Technologies associated with
+              enhanced status and professional visibility increase perceived usefulness through
+              image enhancement motives alongside instrumental performance benefits.
+            </li>
+            <li>
+              <strong>Job Relevance &rarr; Perceived Usefulness:</strong> Technologies directly
+              relevant to core job responsibilities are perceived as more useful than tangentially
+              related systems. Relevance anchors usefulness to performance impact.
+            </li>
+            <li>
+              <strong>Output Quality &rarr; Perceived Usefulness:</strong> Systems producing
+              reliable, accurate outputs are perceived as more useful than systems producing
+              questionable results. Quality provides concrete evidence of technology benefit.
+            </li>
+            <li>
+              <strong>Result Demonstrability &rarr; Perceived Usefulness:</strong> Technologies
+              whose benefits are observable and communicable are perceived as more useful than
+              systems with opaque or difficult-to-articulate benefits. Demonstrability reduces
+              uncertainty about usefulness.
+            </li>
+            <li>
+              <strong>Computer Anxiety &rarr; Perceived Ease of Use (Negative):</strong> Users
+              experiencing technology anxiety perceive greater complexity and learning requirements.
+              Anxiety heightens concern about capability to operate systems effectively.
+            </li>
+            <li>
+              <strong>Computer Playfulness &rarr; Perceived Ease of Use:</strong> Users viewing
+              technology interaction as enjoyable exploration perceive lower complexity by reframing
+              learning as intrinsically engaging activity. Playfulness reduces threat perception.
+            </li>
+            <li>
+              <strong>Perceived Enjoyment &rarr; Perceived Ease of Use:</strong> Users perceiving
+              technology interaction as inherently satisfying experience perceive lower effort
+              requirements by balancing effort with satisfaction benefits. Enjoyment reduces effort
+              concerns.
+            </li>
+            <li>
+              <strong>Objective Usability &rarr; Perceived Ease of Use:</strong> Systems with
+              objectively lower complexity (fewer steps, clearer navigation, consistent design) are
+              perceived as easier to use. Actual usability provides anchor for subjective complexity
+              judgments.
+            </li>
+            <li>
+              <strong>Experience Moderates All Ease Determinants:</strong> As users gain experience,
+              initial concerns about anxiety diminish through mastery, playfulness effects diminish
+              as technology becomes routine, enjoyment transitions from intrinsic to instrumental,
+              and objective usability becomes less critical as tacit knowledge develops. Experience
+              weakens all four ease of use antecedents.
+            </li>
+            <li>
+              <strong>Perceived Usefulness &rarr; Adoption Intention:</strong> Strongest direct
+              effect on adoption intention remains constant across experience levels. Performance
+              benefits always motivate adoption regardless of learning history.
+            </li>
+            <li>
+              <strong>Perceived Ease of Use &rarr; Adoption Intention:</strong> Effect strongest for
+              inexperienced users and diminishes with experience. Initial users emphasize complexity
+              concerns more heavily than experienced users who focus on instrumental benefits.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Comprehensive determinant integration:</strong> TAM3 provides complete
+              framework for understanding what shapes usefulness and ease of use perceptions,
+              substantially expanding explanatory breadth compared to prior TAM versions.
+            </li>
+            <li>
+              <strong>Longitudinal design with multiple measurement points:</strong> Data collection
+              at baseline, post-implementation, 3-month, and 6-month intervals allowed assessment of
+              how relationships change across adoption lifecycle phases.
+            </li>
+            <li>
+              <strong>Experience-moderation hypothesis testing:</strong> Explicit empirical testing
+              of whether experience moderates ease of use determinants&apos; effects provided
+              evidence that adoption is dynamic process, not static state.
+            </li>
+            <li>
+              <strong>Multiple technology implementations:</strong> Testing across different
+              technologies within organizational contexts demonstrated generalizability across
+              diverse information systems.
+            </li>
+            <li>
+              <strong>Intervention research agenda:</strong> Beyond predictive modeling, Venkatesh
+              and Bala articulated research agenda for testing specific interventions to enhance
+              acceptance, shifting focus from prediction to practical change mechanisms.
+            </li>
+            <li>
+              <strong>
+                Pre-implementation, implementation, and post-implementation framework:
+              </strong>{' '}
+              Recognition that adoption is three-phase process requiring different interventions at
+              different stages provided actionable guidance for technology deployment.
+            </li>
+            <li>
+              <strong>Real organizational contexts:</strong> Studies examined actual technology
+              implementations in organizational settings with natural adoption pressures and outcome
+              measurement.
+            </li>
+            <li>
+              <strong>Model complexity justification:</strong> Despite added complexity relative to
+              original TAM, substantially higher explanatory power provided empirical justification
+              for expanded model.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Model complexity and practical measurement burden:</strong> Measuring 11
+              constructs plus experience moderation substantially exceeds practical capacity in many
+              organizational settings. Practitioners may find streamlined models more implementable.
+            </li>
+            <li>
+              <strong>Intervention research incomplete:</strong> While Venkatesh and Bala
+              articulated intervention research agenda, they did not comprehensively test specific
+              interventions. Guidance on what interventions actually change adoption rates remains
+              limited.
+            </li>
+            <li>
+              <strong>Moderating effect specificity:</strong> Model proposes experience moderates
+              all ease of use determinants, but does not specify whether moderation is uniform
+              across all four factors or whether some show stronger temporal dynamics.
+            </li>
+            <li>
+              <strong>Organizational context limitations:</strong> Four organizations studied were
+              established enterprises with formal IT infrastructure. Generalization to small
+              businesses, startups, or non-traditional organizations requires investigation.
+            </li>
+            <li>
+              <strong>Technology-specific limitations:</strong> Enterprise systems and information
+              systems studied differ substantially from contemporary consumer mobile applications or
+              cloud services where adoption mechanisms may differ.
+            </li>
+            <li>
+              <strong>Cross-cultural generalizability uncertain:</strong> Developed and tested in
+              U.S. organizational contexts. Antecedent effects may differ in non-Western
+              organizations with different status hierarchies, social norms, or technology
+              relationships.
+            </li>
+            <li>
+              <strong>Long-term sustained use unmeasured:</strong> Studies measured adoption over
+              six months. Long-term use patterns, discontinuance decisions, or evolution beyond
+              initial adoption period remain unexplored.
+            </li>
+            <li>
+              <strong>Affective and emotional factors underdeveloped:</strong> Model focuses on
+              cognitive determinants and enjoyment but does not comprehensively address technology
+              anxiety mechanisms or emotional resistance factors beyond anxiety construct.
+            </li>
+            <li>
+              <strong>Organizational implementation variability:</strong> Different organizations
+              likely provided varying implementation quality, training, and support, which could
+              moderate effectiveness of usefulness and ease of use determinants.
+            </li>
+          </ul>
         </section>
 
-        {/* Empirical Validation */}
+        {/* 8. Key Contributions */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Empirical Validation</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            TAM3 was validated using longitudinal data from four organizations, following the same
-            rigorous multi-organization design established in TAM2. A total of 416 participants were
-            surveyed at three time points: immediately after initial training on a new system, one
-            month after implementation, and three months after implementation. The four
-            organizations represented diverse industry contexts, and the systems under study
-            differed in nature and complexity.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The results supported the complete TAM3 model. All hypothesized antecedent effects on
-            perceived usefulness and perceived ease of use were statistically significant. The
-            experience-based moderation effects were confirmed: anchor effects on perceived ease of
-            use weakened over time while adjustment effects strengthened. The no-cross-over
-            hypothesis was supported, confirming the independence of the two sets of determinants.
-            The model demonstrated strong explanatory power for both perceived usefulness and
-            perceived ease of use, and the established TAM relationships (perceived usefulness and
-            perceived ease of use predicting behavioral intention) remained robust.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The temporal dynamics revealed important practical insights. Computer anxiety, for
-            example, had its strongest negative effect on perceived ease of use at the earliest
-            measurement point, suggesting that anxiety-reduction interventions are most critical
-            during initial system introduction. Perceived enjoyment, by contrast, emerged as a
-            significant predictor only after users had gained some experience with the system,
-            suggesting that interface design choices affecting enjoyment become important for
-            sustained adoption rather than initial adoption.
-          </p>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Comprehensive antecedent integration:</strong> Consolidated diverse prior
+              research into single framework with complete specification of what determines
+              perceived usefulness and perceived ease of use.
+            </li>
+            <li>
+              <strong>Experience-moderation hypothesis:</strong> Provided empirical evidence that
+              adoption mechanisms change over time, establishing adoption as dynamic process with
+              shifting determinants across experience levels.
+            </li>
+            <li>
+              <strong>Ease of use theoretical development:</strong> Comprehensive treatment of ease
+              of use determinants addressed prior theoretical underdevelopment and showed ease of
+              use was not monolithic but shaped by multiple distinct factors.
+            </li>
+            <li>
+              <strong>Intervention research agenda:</strong> Articulated specific research agenda
+              for testing practical interventions to enhance adoption, shifting technology
+              acceptance research toward actionable guidance.
+            </li>
+            <li>
+              <strong>Lifecycle adoption framework:</strong> Recognition of pre-implementation,
+              implementation, and post-implementation phases provided foundation for understanding
+              how adoption determinants and required interventions vary across deployment stages.
+            </li>
+            <li>
+              <strong>Explanatory power improvement:</strong> TAM3 substantially improved prediction
+              of adoption intentions compared to prior models, providing empirical justification for
+              comprehensive framework.
+            </li>
+            <li>
+              <strong>Practical guidance for technology deployment:</strong> Model provided
+              organizations with specific understanding of which factors influenced technology
+              acceptance and where interventions could most effectively enhance adoption.
+            </li>
+            <li>
+              <strong>Bridge between academic research and practice:</strong> Venkatesh and
+              Bala&rsquo;s emphasis on interventions and practical deployment translated academic
+              models into actionable guidance for technology leaders.
+            </li>
+          </ul>
         </section>
 
-        {/* Research Agenda on Interventions */}
+        {/* 9. Internal Validity */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Research Agenda on Interventions</h2>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            A distinctive contribution of TAM3 was its explicit formulation of a research agenda
-            focused on organizational interventions to improve technology adoption. By specifying
-            the complete set of antecedents for both perceived usefulness and perceived ease of use,
-            TAM3 enabled systematic mapping of intervention strategies to specific adoption
-            barriers.
+            TAM3 employed rigorous methodology to establish relationships among constructs:
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Venkatesh and Bala proposed two broad categories of interventions. Design-focused
-            interventions address system characteristics that influence adoption perceptions. These
-            include user interface redesign to improve objective usability, feature customization to
-            enhance job relevance, output formatting improvements to increase output quality, and
-            gamification or aesthetic enhancements to boost perceived enjoyment. Training-focused
-            interventions target user beliefs and concerns. These include self-efficacy building
-            programs to increase computer self-efficacy, organizational support communication to
-            strengthen perceptions of external control, anxiety reduction workshops to mitigate
-            computer anxiety, and exploratory learning sessions to foster computer playfulness.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The intervention research agenda emphasized the importance of timing. Pre-implementation
-            interventions should target anchor-related barriers (self-efficacy, external control,
-            anxiety, playfulness) because these dominate ease perceptions before users have direct
-            experience. Post-implementation interventions should focus on adjustment-related factors
-            (enjoyment, objective usability) and cognitive instrumental factors (job relevance,
-            output quality, result demonstrability) that become more important as users develop
-            system-specific knowledge. This temporal framework for intervention design was a
-            significant practical contribution.
-          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Longitudinal design with multiple measurement occasions:</strong> Data
+              collection at baseline, immediately post-implementation, 3 months, and 6 months
+              allowed assessment of how relationships change across adoption phases and experience
+              accumulation.
+            </li>
+            <li>
+              <strong>Real system implementations:</strong> Study examined actual enterprise system
+              deployments rather than hypothetical or lab-based technology scenarios, ensuring
+              adoption context realism and genuine outcome measurement.
+            </li>
+            <li>
+              <strong>Multiple technologies across organizations:</strong> Testing different systems
+              across four distinct organizations controlled for organizational factors while varying
+              technology characteristics, enhancing generalizability.
+            </li>
+            <li>
+              <strong>Adequate sample size:</strong> N=156 users across organizations provided
+              statistical power for testing main effects and experience moderation at multiple
+              measurement points.
+            </li>
+            <li>
+              <strong>Validated measurement instruments:</strong> All constructs measured using
+              previously validated scales established in prior technology acceptance research.
+            </li>
+            <li>
+              <strong>Structural equation modeling:</strong> SEM approach tested complete model
+              specification simultaneously with multiple direct effects, indirect pathways, and
+              moderating relationships.
+            </li>
+            <li>
+              <strong>Experience moderation specification:</strong> Moderation effects tested using
+              appropriate statistical methods examining whether relationships change across
+              experience levels.
+            </li>
+            <li>
+              <strong>Competitor model testing:</strong> Study tested alternative model
+              specifications to establish that proposed relationships provided better fit than
+              competing arrangements.
+            </li>
+          </ul>
         </section>
 
-        {/* Strengths and Limitations */}
+        {/* 10. External Validity */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Strengths and Limitations</h2>
+          <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            TAM3&rsquo;s primary strength is its completeness. As the most comprehensive model in
-            the TAM lineage, it provides a full nomological network specifying the antecedents of
-            both core TAM constructs and their interrelationships. This completeness enables
-            practitioners to conduct systematic diagnostic assessments of technology adoption
-            challenges, identifying precisely which antecedent factors are problematic for a given
-            implementation and designing appropriately targeted interventions.
+            External validity considerations require nuanced interpretation of generalizability:
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The anchoring and adjustment framework for perceived ease of use determinants provides a
-            theoretically elegant explanation for how ease perceptions form and evolve over time.
-            The confirmation that anchor effects weaken while adjustment effects strengthen with
-            experience offers practical guidance for timing interventions. The explicit research
-            agenda on interventions bridges the gap between theoretical understanding and practical
-            action, which had been a persistent criticism of the TAM research tradition.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            However, TAM3&rsquo;s comprehensiveness is also a limitation. The model includes
-            thirteen distinct constructs plus experience as a moderator, creating a complex
-            theoretical structure that is challenging to operationalize in full in any single study
-            or practical assessment. The model was validated exclusively in organizational settings
-            in the United States, limiting its generalizability to consumer contexts, non-Western
-            cultures, and emerging technology categories such as mobile applications or social media
-            platforms. The proposed intervention framework, while conceptually valuable, was not
-            empirically tested in TAM3 itself, leaving the actual effectiveness of specific
-            intervention strategies as an open research question. Additionally, like other
-            TAM-lineage models, TAM3 focuses on individual-level adoption decisions and does not
-            address organizational-level or institutional-level adoption dynamics.
-          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Organizational context limitations:</strong> Four organizations studied were
+              established enterprises with mature IT infrastructure. Generalization to small
+              businesses, startups, non-profit organizations, or government agencies requires
+              investigation.
+            </li>
+            <li>
+              <strong>Technology type specificity:</strong> Enterprise information systems studied
+              represent formal, complex organizational technologies. Results may not generalize to
+              consumer-oriented technologies, mobile applications, or cloud-based SaaS platforms
+              with different adoption dynamics.
+            </li>
+            <li>
+              <strong>Geographic and cultural scope:</strong> U.S.-based organizations studied with
+              predominantly Western samples. Antecedent effects may differ substantially in
+              non-Western contexts with different social norms, status systems, or technology
+              relationships.
+            </li>
+            <li>
+              <strong>User population characteristics:</strong> Organizational knowledge workers and
+              professionals with baseline technology experience participated in studies.
+              Generalization to non-technical users, older workers with limited technology
+              experience, or diverse skill populations requires verification.
+            </li>
+            <li>
+              <strong>Implementation quality variation:</strong> Participating organizations likely
+              provided different levels of training, support, and change management. Results assume
+              adequate implementation; underfunded implementations might show different determinant
+              patterns.
+            </li>
+            <li>
+              <strong>Mandatory versus voluntary adoption:</strong> Organizational implementations
+              examined were largely mandatory. Results may not generalize to purely voluntary
+              technology adoption contexts where choice mechanisms operate differently.
+            </li>
+            <li>
+              <strong>Measurement period constraints:</strong> Studies measured adoption over six
+              months. Long-term use patterns beyond initial adoption period, discontinuance
+              decisions, or technology replacement scenarios remain unexplored.
+            </li>
+            <li>
+              <strong>System stability assumptions:</strong> Studies examined relatively stable
+              technology implementations. Rapidly evolving systems or frequent technology updates
+              might create different moderation patterns around experience.
+            </li>
+          </ul>
         </section>
 
-        {/* Relevance to Technology Adoption Barriers */}
+        {/* 11. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Relevance to Technology Adoption Barriers</h2>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
-            TAM3 offers the most granular barrier taxonomy in the TAM lineage, enabling
-            organizations to diagnose specific adoption barriers at a fine-grained level. On the
-            perceived usefulness side, barriers can be traced to social influence deficits (lack of
-            endorsement from important referents), cognitive instrumental gaps (poor job relevance,
-            low output quality, or invisible results), or both. On the perceived ease of use side,
-            barriers can be traced to individual deficits (low self-efficacy, high anxiety), system
-            deficits (poor objective usability), organizational deficits (inadequate support
-            resources), or experiential factors (insufficient time to adjust initial perceptions
-            through hands-on use).
+            TAM3 directly addresses technology adoption barriers by comprehensively identifying
+            mechanisms inhibiting acceptance. The model demonstrates that adoption barriers operate
+            through multiple distinct pathways: users may doubt technology&rsquo;s job relevance
+            (performance expectancy barrier), worry about learning difficulty (complexity barrier),
+            experience anxiety about technology interaction (emotional barrier), receive negative
+            social messages about adoption (social barrier), or perceive inadequate output quality
+            (reliability barrier). Critically, TAM3 shows these barriers operate differently across
+            adoption lifecycle: early-stage users emphasize complexity and anxiety concerns while
+            experienced users focus predominantly on perceived usefulness. Organizations must
+            therefore tailor adoption strategies to deployment phase, providing extensive support
+            and addressing complexity barriers during initial implementation, then emphasizing
+            instrumental benefits and performance value as users gain experience. The model
+            prescribes different intervention strategies for different barriers rather than assuming
+            identical change strategies would address all adoption resistance.
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Self-efficacy barriers represent one of the most common and consequential adoption
-            obstacles. Individuals who doubt their ability to learn and use new technologies may
-            avoid adoption entirely or adopt with such reluctance that they fail to develop
-            proficiency. These barriers disproportionately affect populations with less prior
-            computing experience, including older workers, individuals in non-technical roles, and
-            communities with limited technology access. TAM3 suggests that self-efficacy barriers
-            can be addressed through mastery experiences (graduated exposure to system features),
-            vicarious learning (observation of similar others successfully using the system), and
-            verbal persuasion (encouragement from credible sources).
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Computer anxiety barriers create a particularly pernicious cycle. Anxious users approach
-            systems with negative expectations, engage less deeply with system features, and
-            consequently develop less proficiency, which reinforces their anxiety. TAM3&rsquo;s
-            finding that anxiety effects attenuate with experience suggests that providing
-            supported, low-stakes opportunities for hands-on exploration can break this cycle.
-            External control barriers are especially relevant in resource-constrained environments
-            where technical support, training, and infrastructure may be insufficient. These
-            barriers highlight the organizational responsibility to provide the enabling conditions
-            for technology adoption rather than placing the burden entirely on individual users.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The temporal dimension of TAM3&rsquo;s barrier framework is particularly valuable.
-            Different barriers dominate at different stages of the adoption process. Early barriers
-            are anchored in general beliefs and can be addressed through pre-implementation
-            preparation. Later barriers reflect system-specific experience and require ongoing
-            attention to system design, usability, and support. Organizations that treat technology
-            adoption as a one-time implementation event rather than an ongoing process will fail to
-            address the full range of barriers that users encounter across the adoption lifecycle.
-          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Low perceived job relevance:</strong> Technologies not directly connected to
+              core job responsibilities face adoption resistance regardless of actual capability or
+              ease of use.
+            </li>
+            <li>
+              <strong>Low output quality:</strong> Systems producing unreliable, incomplete, or
+              inaccurate results create perception of worthlessness and obstruct adoption despite
+              marketing claims.
+            </li>
+            <li>
+              <strong>Result indemonstability:</strong> Technologies with opaque or
+              difficult-to-communicate benefits face skepticism and adoption resistance compared to
+              systems with visible, concrete results.
+            </li>
+            <li>
+              <strong>Negative social influence:</strong> Colleagues, supervisors, or organizational
+              culture communicating skepticism or resistance to technology create normative barriers
+              to acceptance.
+            </li>
+            <li>
+              <strong>Status threat perception:</strong> Technologies perceived as threatening
+              professional status or visibility face adoption resistance despite instrumental
+              benefits.
+            </li>
+            <li>
+              <strong>Computer anxiety:</strong> Technology-anxious users perceive greater
+              complexity and face psychological barriers to adoption even with user-friendly
+              interfaces.
+            </li>
+            <li>
+              <strong>Objective complexity:</strong> Systems with inherent operational complexity
+              create genuine barriers to learning and proficient use.
+            </li>
+            <li>
+              <strong>Low enjoyment potential:</strong> Systems perceived as tedious or boring face
+              adoption resistance from users emphasizing intrinsic satisfaction alongside
+              instrumental benefits.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Model Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Establish clear job relevance:</strong> Demonstrate and communicate how
+              technology directly addresses core job responsibilities and performance requirements.
+              Relevance is foundational to overcoming usefulness skepticism.
+            </li>
+            <li>
+              <strong>Ensure high output quality:</strong> Invest in implementation quality and
+              system configuration to guarantee that technology produces reliable, accurate, and
+              comprehensive outputs that validate usefulness claims.
+            </li>
+            <li>
+              <strong>Make results demonstrable:</strong> Create mechanisms for users to visually
+              observe technology benefits through dashboards, reports, or comparative metrics that
+              make advantages concrete and communicable.
+            </li>
+            <li>
+              <strong>Mobilize positive social influence:</strong> Secure explicit support from
+              leadership, supervisors, and opinion leaders who can communicate endorsement and model
+              adoption to organizational peers.
+            </li>
+            <li>
+              <strong>Position technology as status-enhancing:</strong> Frame adoption as
+              strengthening professional capability and enhancing organizational visibility,
+              addressing status concerns rather than treating them as irrelevant.
+            </li>
+            <li>
+              <strong>Address technology anxiety directly:</strong> Provide comprehensive training,
+              readily available support, and reassurance that anxiety is normal and addressable
+              through skill development.
+            </li>
+            <li>
+              <strong>Reduce objective complexity:</strong> Invest in user interface design,
+              workflow optimization, and system customization to minimize actual operational
+              complexity.
+            </li>
+            <li>
+              <strong>Create engaging user experiences:</strong> Design technology interaction to
+              include elements of exploration, discovery, or gamification that enhance intrinsic
+              enjoyment alongside instrumental utility.
+            </li>
+            <li>
+              <strong>Phase interventions across adoption lifecycle:</strong> Emphasize complexity
+              reduction and anxiety management during implementation phase, then shift to usefulness
+              reinforcement and performance benefits communication as users gain experience.
+            </li>
+            <li>
+              <strong>Sustain engagement through post-implementation:</strong> Continue support and
+              messaging beyond initial adoption as user experience influences long-term technology
+              commitment.
+            </li>
+          </ul>
         </section>
 
-        {/* References */}
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            TAM3 fundamentally shaped subsequent technology adoption research:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                UTAUT2 (
+                <a
+                  id="cite-ref-venkatesh-2012-1"
+                  href="#ref-venkatesh-2012"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Venkatesh et al., 2012
+                </a>
+                ):
+              </strong>{' '}
+              Extended acceptance models to consumer contexts by adding hedonic motivation and price
+              value, building on TAM3&rsquo;s foundation of experience-moderated adoption dynamics.
+            </li>
+            <li>
+              <strong>Intervention research programs:</strong> Researchers implemented Venkatesh and
+              Bala&rsquo;s intervention research agenda by testing specific change strategies and
+              their effectiveness in enhancing adoption across diverse organizations.
+            </li>
+            <li>
+              <strong>Experience-moderation expansion:</strong> Subsequent research examined whether
+              other moderators beyond experience (organizational support, change management quality,
+              user training) influenced determinant effects on adoption.
+            </li>
+            <li>
+              <strong>Lifecycle adoption models:</strong> Research adopted TAM3&rsquo;s
+              pre-implementation, implementation, post-implementation framework to understand
+              different adoption dynamics across deployment phases.
+            </li>
+            <li>
+              <strong>Emotion and anxiety integration:</strong> Researchers built on TAM3&rsquo;s
+              computer anxiety work to comprehensively integrate emotional factors alongside
+              cognitive determinants of adoption.
+            </li>
+            <li>
+              <strong>Organizational change management integration:</strong> Technology adoption
+              research incorporated change management theories alongside TAM3 framework, recognizing
+              adoption as organizational change phenomenon.
+            </li>
+            <li>
+              <strong>Context-specific adoption models:</strong> Healthcare technology, educational
+              technology, and public sector adoption research adopted TAM3 framework while adding
+              domain-specific barriers and facilitators.
+            </li>
+            <li>
+              <strong>Technology-specific extensions:</strong> Researchers adapted TAM3 to emerging
+              technologies including cloud computing, mobile applications, artificial intelligence,
+              and extended reality systems.
+            </li>
+            <li>
+              <strong>Continued-use and discontinuance research:</strong> Studies extended TAM3
+              logic to post-adoption contexts examining sustained use, habitual behavior, and
+              technology discontinuance patterns.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
-          <ol className="list-decimal list-inside space-y-3 text-sm">
-            <li>
-              Compeau, D. R., &amp; Higgins, C. A. (1995). Computer self-efficacy: Development of a
-              measure and initial test. <em>MIS Quarterly</em>, 19(2), 189-211.{' '}
-              <a
-                href="https://doi.org/10.2307/249688"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/249688
-              </a>
-            </li>
-            <li>
-              Davis, F. D. (1989). Perceived usefulness, perceived ease of use, and user acceptance
-              of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.{' '}
-              <a
-                href="https://doi.org/10.2307/249008"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/249008
-              </a>
-            </li>
-            <li>
-              Venkatesh, V. (2000). Determinants of perceived ease of use: Integrating control,
-              intrinsic motivation, and emotion into the technology acceptance model.{' '}
-              <em>Information Systems Research</em>, 11(4), 342-365.{' '}
-              <a
-                href="https://doi.org/10.1287/isre.11.4.342.11872"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1287/isre.11.4.342.11872
-              </a>
-            </li>
-            <li>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-venkatesh-2008">
               Venkatesh, V., &amp; Bala, H. (2008). Technology acceptance model 3 and a research
-              agenda on interventions. <em>Decision Sciences</em>, 39(2), 273-315.{' '}
-              <a
-                href="https://doi.org/10.1111/j.1540-5915.2008.00192.x"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1111/j.1540-5915.2008.00192.x
-              </a>
+              agenda on interventions. <em>Decision Sciences</em>, 39(2), 273-315.
+              https://doi.org/10.1111/j.1540-5915.2008.00192.x
             </li>
-            <li>
+            <li id="ref-davis-1989">
+              Davis, F. D. (1989). Perceived usefulness, perceived ease of use, and user acceptance
+              of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-davis-1989-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>{' '}
+              https://doi.org/10.2307/249008
+            </li>
+            <li id="ref-venkatesh-2000a">
               Venkatesh, V., &amp; Davis, F. D. (2000). A theoretical extension of the technology
               acceptance model: Four longitudinal field studies. <em>Management Science</em>, 46(2),
-              186-204.{' '}
-              <a
-                href="https://doi.org/10.1287/mnsc.46.2.186.11926"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1287/mnsc.46.2.186.11926
-              </a>
+              186-204.
             </li>
-            <li>
-              Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
-              of information technology: Toward a unified view. <em>MIS Quarterly</em>, 27(3),
-              425-478.{' '}
-              <a
-                href="https://doi.org/10.2307/30036540"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/30036540
-              </a>
+            <li id="ref-bandura-1997">
+              Bandura, A. (1997). Self-efficacy: The exercise of control. W.H. Freeman.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-bandura-1997-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
+            <li id="ref-venkatesh-2012">
               Venkatesh, V., Thong, J. Y. L., &amp; Xu, X. (2012). Consumer acceptance and use of
               information technology: Extending the unified theory of acceptance and use of
-              technology. <em>MIS Quarterly</em>, 36(1), 157-178.{' '}
-              <a
-                href="https://doi.org/10.2307/41410412"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/41410412
-              </a>
+              technology. <em>MIS Quarterly</em>, 36(1), 157-178.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-venkatesh-2012-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>{' '}
+              https://doi.org/10.2307/41410412
+            </li>
+            <li id="ref-deci-1985">
+              Deci, E. L., &amp; Ryan, R. M. (1985). Intrinsic motivation and self-determination in
+              human behavior. Plenum Press.
             </li>
           </ol>
         </section>
 
-        <p className="mt-8 text-sm italic text-gray-600">
-          Note: This article provides an overview based on the comprehensive literature review.
-          Readers are encouraged to consult the original publication for complete details.
-        </p>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-venkatesh-2000b">
+              Venkatesh, V. (2000). Determinants of perceived ease of use: Integrating control,
+              intrinsic motivation, and emotion into the technology acceptance model.
+              <em>Information Systems Research</em>, 11(4), 342-365.
+            </li>
+            <li id="ref-fishbein-1975">
+              Fishbein, M., &amp; Ajzen, I. (1975). Belief, attitude, intention, and behavior: An
+              introduction to theory and research. Addison-Wesley.
+            </li>
+            <li id="ref-ajzen-1991">
+              Ajzen, I. (1991). The theory of planned behavior.{' '}
+              <em>Organizational Behavior and Human Decision Processes</em>, 50(2), 179-211.
+              https://doi.org/10.1016/0749-5978(91)90020-T
+            </li>
+            <li id="ref-compeau-1995">
+              Compeau, D. R., &amp; Higgins, C. A. (1995). Computer self-efficacy: Development of a
+              measure and initial test. <em>MIS Quarterly</em>, 19(2), 189-211.
+              https://doi.org/10.2307/249688
+            </li>
+            <li id="ref-taylor-1995">
+              Taylor, S., &amp; Todd, P. A. (1995). Understanding information technology usage: A
+              test of competing models. <em>Information Systems Research</em>, 6(2), 144-176.
+              https://doi.org/10.1287/isre.6.2.144
+            </li>
+            <li id="ref-rogers-1995">
+              Rogers, E. M. (1995). Diffusion of innovations (4th ed.). Free Press.
+            </li>
+          </ol>
+        </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-18-tram-lin-2007"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Technology Readiness and Acceptance Model (Lin, Shih, &amp; Sher)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-20-utaut2-venkatesh-2012"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: UTAUT2 (Venkatesh, Thong, &amp; Xu) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>

--- a/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
+++ b/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
@@ -437,7 +437,7 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Experience-moderation hypothesis testing:</strong> Explicit empirical testing
-              of whether experience moderates ease of use determinants&apos; effects provided
+              of whether experience moderates ease of use determinants&rsquo; effects provided
               evidence that adoption is dynamic process, not static state.
             </li>
             <li>
@@ -873,9 +873,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-davis-1989-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>{' '}
               https://doi.org/10.2307/249008
             </li>
@@ -891,9 +889,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-bandura-1997-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-venkatesh-2012">
@@ -905,9 +901,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-venkatesh-2012-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>{' '}
               https://doi.org/10.2307/41410412
             </li>

--- a/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
+++ b/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
@@ -492,6 +492,31 @@ const BibliographyArticlePage = () => {
             CANX and CPLAY fade.
           </p>
 
+          <h3 className={H3_CLASSES}>Explanatory Power (R², Tables 5-8)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Across the four field studies and three PLS measurement models (T1, T2, T3), TAM3
+            explained:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Perceived Usefulness: 52% to 67%</strong> of variance (Table 5, p.289).
+            </li>
+            <li>
+              <strong>Perceived Ease of Use: 43% to 52%</strong> of variance (Table 6, p.293).
+            </li>
+            <li>
+              <strong>Behavioral Intention: up to 53%</strong> of variance (Table 7, p.295).
+            </li>
+            <li>
+              <strong>Use: 31% to 36%</strong> of variance (Table 8, p.296).
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            The paper also confirmed the &ldquo;no crossover effects&rdquo; hypothesis: none of the
+            six PEOU determinants had a significant effect on PU at any measurement point, and none
+            of the five PU determinants had a significant effect on PEOU.
+          </p>
+
           <h3 className={H3_CLASSES}>TAM3 Determinant Mechanisms</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>

--- a/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
+++ b/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
@@ -927,6 +927,57 @@ const BibliographyArticlePage = () => {
             </li>
           </ul>
 
+          <h3 className={H3_CLASSES}>TAM3 Intervention Framework (Table 9, p.293)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Venkatesh and Bala&rsquo;s core managerial contribution is a typology of seven
+            interventions mapped to specific PU and PEOU determinants, drawing on Cooper &amp;
+            Zmud&rsquo;s (1990) IT implementation stage model (initiation, adoption, adaptation,
+            acceptance, routinization, infusion):
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            <strong>Preimplementation interventions</strong> (during system development and
+            deployment):
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Design Characteristics:</strong> Information-related design improves PU
+              determinants (job relevance, output quality, result demonstrability); system-related
+              design improves PEOU determinants (anxiety, enjoyment, objective usability).
+            </li>
+            <li>
+              <strong>User Participation:</strong> Overall responsibility, user-IS relationship, and
+              hands-on activity during development (Barki &amp; Hartwick, 1994) influence most
+              determinants of both PU and PEOU.
+            </li>
+            <li>
+              <strong>Management Support:</strong> Visible championship influences subjective norm,
+              image, and perceptions of external control.
+            </li>
+            <li>
+              <strong>Incentive Alignment:</strong> Aligning rewards with system use influences job
+              relevance, output quality, and result demonstrability.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            <strong>Postimplementation interventions</strong> (during and after deployment):
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Training:</strong> Improves all PEOU determinants (self-efficacy, external
+              control, anxiety, playfulness, enjoyment, objective usability) plus several PU
+              determinants.
+            </li>
+            <li>
+              <strong>Organizational Support:</strong> Help desks, user manuals, and hotline support
+              improve external control perceptions and anxiety; also influence subjective norm and
+              image.
+            </li>
+            <li>
+              <strong>Peer Support:</strong> Informal peer networks and support channels influence
+              subjective norm, image, external control, and enjoyment.
+            </li>
+          </ul>
+
           <h3 className={H3_CLASSES}>Leadership Actions the Model Prescribes</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>

--- a/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
+++ b/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
@@ -70,6 +70,17 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 273-315
             </p>
+            <p>
+              <strong>DOI:</strong>{' '}
+              <a
+                href="https://doi.org/10.1111/j.1540-5915.2008.00192.x"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.1111/j.1540-5915.2008.00192.x
+              </a>
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
+++ b/src/app/bibliography-1-19-technology-acceptance-model-3-tam3-venkatesh-bala-2008/page.tsx
@@ -897,7 +897,7 @@ const BibliographyArticlePage = () => {
               marketing claims.
             </li>
             <li>
-              <strong>Result indemonstability:</strong> Technologies with opaque or
+              <strong>Lack of result demonstrability:</strong> Technologies with opaque or
               difficult-to-communicate benefits face skepticism and adoption resistance compared to
               systems with visible, concrete results.
             </li>


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 1-19 TAM3 (Venkatesh & Bala, 2008) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1572
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)