### PR TITLE
docs: standardize bibliography 2-1 RBV (Wernerfelt, 1984)

### DIFF
--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -4,481 +4,939 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
-  BODY_OL_CLASSES,
-  REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: A Resource-Based View (RBV) - Wernerfelt (1984)',
+  title: 'Bibliography: Resource-Based View (RBV) of the Firm - Wernerfelt (1984)',
   description:
-    "An exploration of Wernerfelt's Resource-Based View of the firm, a foundational framework for understanding how organizational resources and capabilities drive competitive advantage and strategic technology adoption.",
+    'Comprehensive overview of the Resource-Based View of the Firm, foundational strategic management theory arguing that competitive advantage originates from internal firm resources rather than industry structure, establishing resources as sustainable sources of performance differentiation.',
 }
 
-const ResourceBasedViewPage = () => {
+const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>
-          Bibliography: A Resource-Based View (RBV) - Wernerfelt (1984)
-        </h1>
+        <h1 className={H1_CLASSES}>Resource-Based View (RBV) of the Firm - Wernerfelt (1984)</h1>
 
-        {/* Framework Identification */}
+        {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Framework Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Framework Name:</strong> Resource-Based View (RBV)
+              <strong>Framework Name:</strong> Resource-Based View of the Firm
             </p>
             <p>
-              <strong>Authors:</strong> Birger Wernerfelt
+              <strong>Framework Abbreviation:</strong> RBV
             </p>
             <p>
-              <strong>Publication Date:</strong> 1984
+              <strong>Target of Framework:</strong> Explanation of how firms sustain competitive
+              advantage through control of unique, valuable, inimitable resources and capabilities
+              that create barriers to competitive imitation
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Strategic Management, Economics, Organization
+              Theory, Business Policy
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Author:</strong> Birger Wernerfelt
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 1984
+            </p>
+            <p>
+              <strong>Official Title:</strong> A resource-based view of the firm
+            </p>
+            <p>
+              <strong>Journal:</strong> Strategic Management Journal
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 5, No. 2
+            </p>
+            <p>
+              <strong>Pages:</strong> 171-180
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Wernerfelt, B. (1984). A resource-based view of the firm.{' '}
-              <em>Strategic Management Journal</em>, 5(2), 171-180.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Wernerfelt, B. (
+                <a href="#ref-wernerfelt-1984" className="text-tabs-teal-deep hover:underline">
+                  1984
+                </a>
+                ). A resource-based view of the firm. <em>Strategic Management Journal</em>, 5(2),
+                171-180.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Wernerfelt, Birger. 1984. &ldquo;A Resource-Based View of the Firm.&rdquo;
+                <em>Strategic Management Journal</em> 5, no. 2: 171-180.
+              </p>
+            </div>
           </div>
         </section>
 
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <p className={PARAGRAPH_CLASSES}>
-            In 1984, Birger Wernerfelt published &ldquo;A Resource-Based View of the Firm&rdquo; in
-            the Strategic Management Journal, introducing a revolutionary perspective that would
-            fundamentally reshape how organizations think about competitive advantage and strategic
-            decision-making. At a time when strategic analysis was dominated by product-market
-            positioning frameworks, Wernerfelt proposed a radical reorientation: rather than asking
-            &ldquo;What markets should we serve?&rdquo;, organizations should ask &ldquo;What
-            resources do we possess, and what unique competitive positions can these resources
-            create?&rdquo;
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The Resource-Based View (RBV) framework emerged from a recognition that firms possess
-            heterogeneous endowments of assets, skills, and capabilities that are often overlooked
-            when strategy is analyzed solely from a product perspective. By shifting the fundamental
-            unit of analysis from products to resources, Wernerfelt provided strategic insights that
-            explain why firms in the same industry achieve different levels of performance and why
-            some firms are better positioned to adopt new technologies and enter new markets than
-            others.
-          </p>
-
           <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Wernerfelt developed the Resource-Based View to address fundamental gaps in how strategy
-            scholars were conceptualizing competitive advantage. Traditional perspectives in
-            strategic management at that time were dominated by product-market analysis and external
-            market positioning, particularly Porter&rsquo;s Five Forces Model. While these
-            frameworks provided valuable insights into industry structure, they largely treated
-            firms within an industry as relatively homogeneous entities competing primarily through
-            market positioning.
+            Birger Wernerfelt developed the Resource-Based View as a direct counter to the dominant
+            Strategic Management paradigm of the early 1980s: industrial organization (IO)
+            economics. The dominant approach, exemplified by Michael Porter&rsquo;s Five Forces
+            framework, argued that firm profitability and competitive advantage were determined
+            primarily by industry structure -the competitive environment, supplier relationships,
+            customer bargaining power, and threat of substitutes and new entrants. According to this
+            perspective, firms succeeding in profitable industries succeeded because of favorable
+            industry structure, while firms in competitive industries struggled regardless of
+            internal quality. Strategic analysis focused on selecting attractive industries and
+            positioning within industry structures.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The author observed that most products require the services of several resources, and by
-            specifying the size of the firm&rsquo;s activity in different product markets, it is
-            possible to infer the minimum necessary resource consumption. However, this
-            product-centric approach missed a critical insight: resources themselves should be the
-            fundamental unit of analysis for understanding competitive advantage and strategic
-            direction.
+            Wernerfelt recognized a critical limitation in this IO economics perspective: it failed
+            to explain why some firms outperformed others within the same industry. If industry
+            structure determined performance, why did some companies far exceed competitors in
+            identical competitive environments? The IO view also suggested that firms were
+            essentially interchangeable within industries, differing only in positioning but not in
+            fundamental capabilities. This seemed inconsistent with observable reality where
+            firm-specific capabilities, histories, and assets clearly created performance
+            differences. Additionally, IO economics provided limited strategic guidance to
+            management beyond &ldquo;choose attractive industries,&rdquo; which overstated
+            management control (firms cannot simply select new industries) and understated the
+            importance of internal capabilities.
           </p>
-          <p className="mb-3 sm:mb-4">
-            The RBV framework was designed to answer key strategic questions for diversified firms:
-          </p>
-          <ol className={BODY_OL_CLASSES}>
-            <li>On which of the firm&rsquo;s current resources should diversification be based?</li>
-            <li>Which resources should be developed through diversification?</li>
-            <li>In what sequence and into what markets should diversification take place?</li>
-            <li>
-              What types of firms will be willing to bid for a particular firm at a given time to
-              acquire?
-            </li>
-          </ol>
           <p className={PARAGRAPH_CLASSES}>
-            By reorienting analysis toward resources rather than products, Wernerfelt provided a
-            complementary perspective that could explain persistent performance differences between
-            firms and illuminate why organizational capabilities matter for technology adoption and
-            strategic growth.
+            Wernerfelt proposed an alternative lens: instead of beginning strategic analysis by
+            examining external industry structure, begin by examining internal resources. Resources
+            are anything that could be considered a strength or weakness of the firm -physical
+            assets, intangible capabilities, brand reputation, knowledge, relationships. Resources
+            create strategic value to the extent they are valuable (able to address market
+            opportunities), rare (not widely available to competitors), difficult to imitate
+            (inimitable), and not easily substituted by alternative resources. Firms with unique
+            bundles of resources can sustain competitive advantages by creating barriers that
+            prevent competitors from imitation. Wernerfelt&rsquo;s conceptual framework provided a
+            complementary perspective to Porter&rsquo;s analysis, shifting strategic thinking from
+            external industry positioning to internal resource development as a source of
+            sustainable competitive advantage.
           </p>
+        </section>
 
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
-            At the heart of the Resource-Based View is a simple but powerful definition: resources
-            are anything that could be thought of as a strength or weakness of a given firm. More
-            formally, resources are stocks of available factors that are owned or controlled by the
-            firm. Wernerfelt categorized resources into two broad types:
+            The Resource-Based View is built on foundational concepts about how firms compete
+            through resources:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Tangible Assets:</strong> Physical and financial resources including plant and
-              equipment, geographic location, access to raw materials, and capital.
+              <strong>Resources:</strong> Tangible and intangible assets that a firm controls and
+              that it can use to conceive of and implement strategies. Resources include physical
+              assets (facilities, equipment, inventory), financial assets (capital, cash flow),
+              human capital (skills, knowledge), organizational resources (systems, processes,
+              culture), and intellectual property (patents, brand, reputation, relationships).
             </li>
             <li>
-              <strong>Intangible Assets:</strong> Non-physical resources including brand names,
-              technological know-how, skilled personnel, trade contacts, efficient procedures, and
-              organizational reputation.
+              <strong>Valuable Resources:</strong> Resources that enable firms to implement
+              strategies that reduce costs or increase revenues by addressing market opportunities
+              or mitigating threats. Resources generate value by creating solutions that customers
+              willingly pay for, reducing production costs, or protecting against competitive
+              threat.
+            </li>
+            <li>
+              <strong>Rare Resources:</strong> Resources that are not widely distributed among
+              competing firms, creating scarcity value. If all competing firms possess identical
+              resources, no firm can achieve competitive advantage. Rarity creates advantage by
+              restricting competitors&rsquo; ability to imitate strategies.
+            </li>
+            <li>
+              <strong>Inimitable Resources:</strong> Resources that competitors cannot easily
+              duplicate or replicate even after observing their value. Resources become inimitable
+              through causal ambiguity (competitors cannot determine what specific combination of
+              activities creates advantage), social complexity (resources embedded in organizational
+              relationships and culture that are difficult to transfer), or proprietary resources
+              with legal protections.
+            </li>
+            <li>
+              <strong>Sustainable Competitive Advantage:</strong> Performance superiority that a
+              firm maintains over extended periods by controlling resources that competitors cannot
+              replicate or substitute for. Sustainable advantage requires a resource combination
+              that is valuable, rare, and inimitable, protected by barriers to competitive
+              duplication.
+            </li>
+            <li>
+              <strong>Resource Position Barriers:</strong> Mechanisms that prevent competitors from
+              acquiring or imitating a firm&rsquo;s resources. Barriers include time compression
+              diseconomies (resources require years to build and cannot be quickly replicated),
+              interconnectedness (resources create value only through combinations of other
+              resources), causal ambiguity (unclear which resource combinations create value), and
+              social complexity (organizational culture and relationships cannot be transferred).
+            </li>
+            <li>
+              <strong>Resource-Product Matrix:</strong> A conceptual framework showing how firm
+              resources can address multiple product-market opportunities. A single resource (such
+              as brand reputation) can create value across diverse products and markets, while
+              product portfolios may share underlying resources.
             </li>
           </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            A fundamental insight of the RBV is that most resources can support multiple products
-            and markets. Rather than being tied to a single product line, resources such as
-            technological expertise, manufacturing capabilities, or distribution networks can be
-            leveraged across diverse business applications. This characteristic-resource
-            fungibility-creates opportunities for strategic diversification based on existing
-            organizational capabilities.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework introduces the concept of <strong>resource position barriers</strong>-
-            analogous to entry barriers in traditional product markets. A resource position barrier
-            exists when possession of a resource affects the costs or revenues of later acquirers,
-            making it expensive or difficult for competitors to replicate the firm&rsquo;s
-            competitive position. These barriers are self-reinforcing: a firm that achieves a strong
-            position in a resource at a given time can maintain its relative position because the
-            act of possessing the resource creates advantages that make it harder for competitors to
-            catch up.
-          </p>
-
-          <h2 className={H2_CLASSES}>The Resource-Product Matrix</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            One of Wernerfelt&rsquo;s most practical contributions is the resource-product matrix, a
-            visualization tool that maps the relationships between a firm&rsquo;s resources and the
-            products or markets they support. By creating this matrix, organizational leaders can
-            systematically identify:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>Which resources are deployed across multiple products and business units</li>
-            <li>Which products depend on particular resource strengths</li>
-            <li>Where resource gaps exist that constrain business opportunities</li>
-            <li>Logical pathways for diversification based on existing resource strengths</li>
-            <li>Opportunities for resource sharing and synergies across business units</li>
-          </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            This tool provides a systematic framework for understanding how organizational
-            capabilities relate to strategic opportunities, making resource-based thinking
-            accessible to practicing managers and executives.
-          </p>
-
-          <h2 className={H2_CLASSES}>Sequential Entry and Strategic Development</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The RBV framework introduces an important temporal dimension to strategy through the
-            concept of sequential entry. Rather than attempting to enter all target markets
-            simultaneously, firms can build competitive positions progressively by entering related
-            markets in sequence. This sequential approach offers several advantages:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              Firms can develop and refine resources through experience in initial markets before
-              expanding to more challenging applications
-            </li>
-            <li>
-              Early market entry creates resource position barriers that strengthen the firm&rsquo;s
-              competitive advantage in subsequent markets
-            </li>
-            <li>
-              Learning from initial deployments reduces uncertainty and improves success rates in
-              later expansions
-            </li>
-            <li>
-              Sequential investment reduces capital requirements and spreads risk over time compared
-              to simultaneous multi-market entry
-            </li>
-          </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            This concept of &ldquo;stepping stones&rdquo; in strategic development is particularly
-            relevant for technology adoption, where organizations can pilot new technologies in
-            limited contexts, develop expertise and supporting capabilities, and then progressively
-            expand deployment as organizational readiness increases.
-          </p>
-
-          <h2 className={H2_CLASSES}>Strengths of the Resource-Based View</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The RBV framework possesses several significant strengths that have contributed to its
-            enduring influence on strategic management and technology adoption research:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Reorientation of Strategic Thinking:</strong> The framework&rsquo;s most
-            fundamental strength is its shift from external market positioning toward internal
-            resource and capability development. This reorientation allows firms to recognize and
-            leverage their unique capabilities rather than pursuing generic strategies based solely
-            on industry structure. For many organizations, this opens new strategic possibilities
-            based on what they can do well rather than limiting strategy to what the market demands.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Explains Firm Heterogeneity:</strong> The RBV successfully explains why firms in
-            the same industry achieve different levels of performance. By recognizing that firms
-            possess heterogeneous resource endowments that are difficult to replicate, the model
-            explains why competitive advantages persist rather than being quickly eroded by
-            competition.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Practical Accessibility:</strong> The framework provides practical tools
-            (resource-product matrices, sequential entry diagrams) that executives can readily apply
-            to their strategic situations. Organizations can conduct resource audits, map their
-            resource-product portfolio, and identify diversification or acquisition opportunities
-            relatively straightforwardly.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Complementary to Existing Frameworks:</strong> Rather than completely replacing
-            product-market analysis, the RBV complements traditional strategic tools. Organizations
-            can use both industry analysis (to understand external opportunities and threats) and
-            resource analysis (to understand internal capabilities) together, providing more
-            complete strategic perspective than either approach alone.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Flexibility Across Contexts:</strong> The framework applies across different
-            types of firms, industries, and competitive environments. Whether applied to
-            manufacturing firms, service organizations, technology companies, or diversified
-            conglomerates, the fundamental logic of resource-based competition remains valid.
-          </p>
-
-          <h2 className={H2_CLASSES}>Limitations and Critiques</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Despite its considerable strengths, the Resource-Based View framework does exhibit
-            certain limitations that scholars and practitioners should understand:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Limited Guidance on Resource Identification:</strong> While the RBV emphasizes
-            the importance of resources, the framework provides limited practical guidance on
-            identifying which resources are strategically important versus which are merely
-            supportive. Firms can struggle with determining which specific capabilities should be
-            prioritized for development or investment.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Difficulty in Resource Valuation:</strong> The framework does not provide clear
-            mechanisms for valuing resources or predicting which resources will generate superior
-            returns in the future. Determining the actual magnitude of competitive advantage from
-            particular resources remains challenging, limiting practical application when firms must
-            make capital allocation decisions.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Tautological Tendencies:</strong> Critics have noted that the framework can
-            become somewhat circular-resources that lead to superior performance are explained as
-            being rare and inimitable, but the only evidence that resources are rare and inimitable
-            is that they lead to superior performance. This circularity makes the framework
-            difficult to falsify empirically and can reduce its predictive power.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Static versus Dynamic Concerns:</strong> The early RBV framework focuses
-            primarily on the value of existing resources and resource stocks rather than on the
-            processes and capabilities required to develop new resources or adapt existing resources
-            to changing environments. In rapidly changing markets, the ability to learn,
-            reconfigure, and develop new resources may be more important than the value of existing
-            resource endowments.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Limited Attention to Resource Integration:</strong> The framework emphasizes
-            individual resources and resource-product relationships but gives less attention to how
-            multiple resources must be integrated and coordinated to create competitive advantage.
-            In practice, competitive advantage typically emerges from how diverse resources are
-            orchestrated together, not from individual resources in isolation.
-          </p>
-
-          <h2 className={H2_CLASSES}>Barriers to Technology Adoption Identified</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Resource-Based View framework, while not explicitly focused on technology adoption,
-            implicitly identifies several critical barriers that organizations face when acquiring
-            new technological capabilities:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Resource Scarcity and Acquisition Barriers:</strong> When technologies embody
-            scarce resources demanded by many firms, organizations find it expensive to acquire
-            technological capability. The cost of acquiring the technology may exceed expected
-            returns, making adoption economically unviable for resource-constrained organizations.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Imitability and Tacit Knowledge Barriers:</strong> Some resources are inherently
-            difficult to imitate because knowledge is tacit, embedded in organizational routines and
-            personnel rather than codified in manuals or specifications. When new technologies
-            embody tacit knowledge requiring specific expertise and organizational learning, firms
-            cannot simply purchase the technology and immediately reap its benefits. The knowledge
-            integration challenge represents a significant adoption barrier.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Resource Heterogeneity and Deployment Barriers:</strong> Technology adoption
-            barriers reflect not just the technology itself but the fit between the new technology
-            and the firm&rsquo;s existing resource endowments. A technology that fits well with one
-            firm&rsquo;s existing capabilities may be disruptive and costly for another firm lacking
-            those complementary resources.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Position Barrier Defense and Entrenchment:</strong> When firms have invested
-            heavily in developing particular resource positions, new technologies that threaten or
-            undermine those positions face substantial internal resistance. Firms holding strong
-            resource positions in current technologies will face barriers to adopting disruptive new
-            technologies because the new technology threatens to make their existing resource
-            investments obsolete.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Complementary Resource Requirements:</strong> New technologies often require
-            complementary capabilities-personnel training, supporting systems, organizational
-            redesign. Firms lacking these complementary resources face barriers to realizing returns
-            from technology adoption, even after acquiring the core technology itself.
-          </p>
-
-          <h2 className={H2_CLASSES}>Strategic Guidance for Leaders</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Resource-Based View framework provides several strategic guidance principles that
-            organizational leaders can employ to reduce barriers to technology adoption and
-            capability development:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Conduct Systematic Resource Audits:</strong> Leaders should systematically
-            inventory and assess current resource endowments to understand what capabilities the
-            organization already possesses. This resource audit identifies which resources can be
-            leveraged as foundations for building new technological capabilities and reveals gaps
-            where new capabilities must be developed or acquired.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Identify Complementary Resources:</strong> Think about technology adoption not
-            as isolated technology implementation but as a problem of assembling complementary
-            resource bundles. Leaders should analyze what complementary resources (skilled
-            personnel, supporting systems, organizational redesign) are necessary to effectively
-            deploy new technology, then determine whether the organization possesses them, must
-            develop them, or must acquire them through hiring, training, or partnerships.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Develop Resources Through Sequential Adoption:</strong> Rather than attempting
-            to adopt complex technologies all at once across the entire organization, use a
-            sequential approach where firms build technological capability progressively. Identify
-            &ldquo;stepping stones&rdquo;-intermediate technological capabilities or market
-            applications where the organization can apply the new technology in limited contexts,
-            build expertise and experience, and gradually expand deployment as organizational
-            capabilities develop.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Build or Acquire Specific Expertise:</strong> Technology adoption requires human
-            expertise and knowledge embedded in skilled personnel. Leaders should focus on building
-            human capital through training existing personnel, hiring external experts, or creating
-            partnerships with external organizations that already possess needed expertise.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Manage Integration with Existing Resources:</strong> Recognize that technology
-            adoption is fundamentally a problem of integrating new capabilities with existing
-            organizational arrangements. Design integration approaches that leverage existing
-            strengths and minimize disruption to effective current practices, whether by modifying
-            how new technology is deployed to fit existing routines or redesigning organizational
-            processes to maximize the value of new technology.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Focus on Technology Fit Rather Than Generic Best Practices:</strong> Assess
-            whether specific technologies fit well with the organization&rsquo;s existing resource
-            endowments and strategic direction. A technology that works well for competitors may not
-            work well for your organization if it requires complementary capabilities you lack.
-            Technology adoption decisions should be grounded in assessment of fit with
-            organizational capabilities rather than simply following industry trends.
-          </p>
-
-          <h2 className={H2_CLASSES}>Influence and Legacy</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Wernerfelt&rsquo;s 1984 paper laid the foundation for an entire stream of strategic
-            management research. The Resource-Based View became one of the most influential
-            theoretical frameworks in strategic management, spawning decades of theoretical
-            development and empirical research. Key extensions and related frameworks include:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>VRIO Framework (Barney, 1991):</strong> Extended the RBV by specifying that
-              resources must be Valuable, Rare, Inimitable, and Organizationally exploited to
-              generate sustained competitive advantage.
-            </li>
-            <li>
-              <strong>Dynamic Capabilities Framework (Teece, Pisano, &amp; Shuen, 1997):</strong>{' '}
-              Addressed the dynamic limitations of the RBV by focusing on organizational processes
-              and capabilities for reconfiguring resources in response to changing environments.
-            </li>
-            <li>
-              <strong>Core Competencies Theory (Prahalad &amp; Hamel, 1990):</strong> Built on
-              resource-based thinking to identify competencies as the critical strategic resources
-              that should guide diversification and competitive positioning.
-            </li>
-          </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            For technology adoption research specifically, the RBV framework provided crucial
-            insights into why some organizations successfully adopt new technologies while others
-            struggle. It highlighted that technology adoption is not merely a matter of purchasing
-            systems or implementing tools, but rather requires building and integrating
-            complementary organizational capabilities. This perspective has informed subsequent
-            frameworks for understanding organizational technology readiness and adoption capacity.
-          </p>
         </section>
 
-        <section className="pt-8 border-t border-gray-200">
-          <h2 className={REFERENCES_H2_CLASSES}>References</h2>
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Resource-Based View emerged in opposition to and as complement to industrial
+            organization economics:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Industrial Organization Economics (
+                <a
+                  id="cite-ref-porter-1980-1"
+                  href="#ref-porter-1980"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Porter, 1980
+                </a>
+                ):
+              </strong>{' '}
+              Dominated strategic management thinking by arguing industry structure (competitive
+              intensity, supplier power, customer power, substitute availability) determines firm
+              profitability. Porter&rsquo;s Five Forces framework positioned strategy as industry
+              selection and positioning within industry structure. RBV complemented this by shifting
+              focus to internal resources as equally important to industry factors.
+            </li>
+            <li>
+              <strong>
+                Organizational Economics and Transaction Cost Theory (
+                <a
+                  id="cite-ref-coase-1937-1"
+                  href="#ref-coase-1937"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Coase, 1937
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-williamson-1975-1"
+                  href="#ref-williamson-1975"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Williamson, 1975
+                </a>
+                ):
+              </strong>{' '}
+              Examined why firms exist and how they organize activities differently than markets.
+              RBV incorporated these insights by treating firm-specific assets and capabilities as
+              reasons firms exist and compete differently.
+            </li>
+            <li>
+              <strong>
+                Penrose&rsquo;s Theory of the Growth of the Firm (
+                <a
+                  id="cite-ref-penrose-1959-1"
+                  href="#ref-penrose-1959"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Penrose, 1959
+                </a>
+                ):
+              </strong>{' '}
+              Pioneering work emphasizing that firms are bundles of resources and that growth is
+              constrained by management capacity to develop new resources. Wernerfelt explicitly
+              acknowledged Penrose as foundational to resource-based thinking, formalizing her
+              insights into strategic competitive advantage framework.
+            </li>
+            <li>
+              <strong>
+                Organizational Capabilities and Routines (
+                <a
+                  id="cite-ref-nelson-1982-1"
+                  href="#ref-nelson-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Nelson &amp; Winter, 1982
+                </a>
+                ):
+              </strong>{' '}
+              Evolutionary economics perspective emphasizing that firms develop distinctive
+              capabilities and routines that are path-dependent and difficult to imitate. RBV
+              incorporated these insights about organizational routines as inimitable resources.
+            </li>
+            <li>
+              <strong>
+                Strategic Business Unit (SBU) Portfolio Theory (Boston Consulting Group, 1970s):
+              </strong>{' '}
+              Models treating firms as portfolios of businesses with different growth-share
+              characteristics. RBV reframed portfolio thinking around shared resources and
+              capabilities rather than purely financial metrics.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Resource-Based View proposes that sustainable competitive advantage originates from
+            firm control of resources that are valuable, rare, inimitable, and non-substitutable.
+            Rather than analyzing strategy as response to industry structure, RBV analyzes strategy
+            as leveraging firm-specific resources to create competitive advantage. Resources can be
+            physical (factories, equipment, inventory), financial (capital availability), human
+            capital (employee skills, knowledge), organizational (systems, processes, culture,
+            structure), or intellectual property (patents, trademarks, knowledge, relationships).
+            Firms compete by accumulating, developing, and leveraging unique resource combinations
+            that competitors cannot easily replicate.
+          </p>
+
+          <h3 className={H3_CLASSES}>Resource Evaluation Framework</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Valuable Resources:</strong> Resources address market opportunities or
+              mitigate competitive threats by enabling cost reductions, revenue increases, or unique
+              value delivery. Resources create value to the extent they are sought by customers and
+              defended against competitive copying.
+            </li>
+            <li>
+              <strong>Rare Resources:</strong> Resources not widely available among competing firms.
+              Heterogeneity across firms in resource possession creates the potential for
+              competitive advantage. Resources that are common across firms cannot be sources of
+              competitive differentiation.
+            </li>
+            <li>
+              <strong>Inimitable Resources:</strong> Resources difficult for competitors to acquire
+              or develop through their own actions or through purchase in factor markets.
+              Inimitability arises from causal ambiguity (unclear connections between resources and
+              performance), social complexity (resources embedded in relationships and culture),
+              historical contingency (resources that required specific past conditions to develop),
+              or proprietary protection.
+            </li>
+            <li>
+              <strong>Non-Substitutable Resources:</strong> Resources that competitors cannot
+              replicate through alternative means. Substitutability risk occurs when different
+              resources or resource combinations can achieve similar strategic outcomes.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Mechanisms Creating Inimitability</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Causal Ambiguity:</strong> When the causal connections between firm resources,
+              actions, and performance outcomes are unclear or ambiguous, competitors cannot
+              determine which specific resource combinations or actions create competitive
+              advantage. Even observing the advantage, competitors cannot confidently identify which
+              changes to implement.
+            </li>
+            <li>
+              <strong>Social Complexity:</strong> Resources embodied in organizational
+              relationships, culture, values, and informal systems are extremely difficult to
+              transfer. These tacit, relationship-embedded resources are difficult for outsiders to
+              understand and impossible to acquire directly because they cannot be separated from
+              the organizational context that created them.
+            </li>
+            <li>
+              <strong>Time Compression Diseconomies:</strong> Resources that require extended
+              periods to develop cannot be quickly replicated through accelerated effort.
+              Experience, reputation, relationships, and organizational capabilities accumulate over
+              time; competitors cannot telescope this process.
+            </li>
+            <li>
+              <strong>Proprietary Legal Protection:</strong> Patents, trademarks, copyrights, trade
+              secrets, and contractual protections create legal barriers preventing imitation.
+              However, legal protection alone typically does not sustain advantage indefinitely as
+              protection eventually expires or technologies are designed around patent claims.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Explains within-industry performance variation:</strong> RBV accounts for why
+              firms in identical competitive environments achieve different performance levels
+              through internal resource differences, addressing a key limitation of
+              industry-structure-based analysis.
+            </li>
+            <li>
+              <strong>Shifts focus to sustainable advantage:</strong> Emphasizes sustainable
+              competitive advantage through difficult-to-imitate resources rather than temporary
+              advantages easily copied by competitors.
+            </li>
+            <li>
+              <strong>Integrates multiple strategic disciplines:</strong> Synthesizes insights from
+              organizational economics, behavioral theory, and economics of information into
+              coherent strategic framework.
+            </li>
+            <li>
+              <strong>Provides practical strategic guidance:</strong> Directs management attention
+              to identifying distinctive capabilities, protecting valuable resources, and developing
+              inimitable resource combinations rather than purely external positioning.
+            </li>
+            <li>
+              <strong>Addresses firm heterogeneity:</strong> Acknowledges and explains why firms
+              differ in capabilities, history, and strategic effectiveness rather than treating
+              firms as interchangeable units within industries.
+            </li>
+            <li>
+              <strong>Conceptually elegant framework:</strong> Relatively simple underlying logic
+              (value-rarity-inimitability) creates actionable framework that can be applied across
+              industries and competitive contexts.
+            </li>
+            <li>
+              <strong>Challenged orthodoxy productively:</strong> By directly opposing dominant IO
+              economics paradigm, RBV created productive dialogue and forced more nuanced
+              understanding of strategy including both industry and firm factors.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Limited practical guidance on resource identification:</strong> While the
+              value-rarity-inimitability framework is elegant, it provides limited guidance on how
+              managers should systematically identify which internal resources represent sustainable
+              advantages.
+            </li>
+            <li>
+              <strong>Tautological concerns:</strong> Critics argue RBV risks tautology: if a firm
+              has a competitive advantage, we infer it possesses valuable, rare, inimitable
+              resources; but the causal direction is unclear. Testing often amounts to observing
+              advantage and inferring resource characteristics.
+            </li>
+            <li>
+              <strong>Causality remains ambiguous:</strong> RBV emphasizes causal ambiguity as
+              source of advantage, but this creates challenges for validating the theory itself. If
+              causality cannot be determined, research validation becomes difficult.
+            </li>
+            <li>
+              <strong>Underestimates imitation through acquisition:</strong> RBV assumes firms must
+              build resources internally, but significant imitation occurs through acquisitions,
+              hiring of key personnel, and licensing. Acquisition-based imitation may be more common
+              than RBV acknowledges.
+            </li>
+            <li>
+              <strong>Insufficient guidance on change and adaptation:</strong> RBV provides strong
+              framework for understanding stable competitive advantage but less guidance for how
+              firms adapt when resource bases become obsolete or market conditions shift.
+            </li>
+            <li>
+              <strong>Limited attention to resource combination:</strong> RBV focuses on individual
+              resources but gives less attention to how resources combine, complement, and reinforce
+              each other to create advantage.
+            </li>
+            <li>
+              <strong>Difficulty measuring constructs:</strong> Operationalizing and measuring
+              valuable, rare, and inimitable resources is challenging in empirical research,
+              creating methodological implementation difficulties.
+            </li>
+            <li>
+              <strong>Incomplete treatment of external factors:</strong> While RBV critiques
+              exclusive focus on industry structure, it does not fully integrate how external
+              factors constrain, enable, or devalue internal resources.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Paradigm shift in strategic management:</strong> Successfully challenged
+              industrial organization economics as exclusive strategic lens by establishing internal
+              resources as equally important to external industry structure in determining
+              competitive performance.
+            </li>
+            <li>
+              <strong>Firm heterogeneity explanation:</strong> Provided theoretical explanation for
+              why firms in identical industries achieve dramatically different performance levels
+              through control of distinctive resources.
+            </li>
+            <li>
+              <strong>Sustainable competitive advantage framework:</strong> Established
+              value-rarity-inimitability as the criteria for sustainable advantage, moving strategy
+              beyond temporary advantages easily copied by competitors.
+            </li>
+            <li>
+              <strong>Resource barriers concept:</strong> Introduced concept of resource position
+              barriers explaining mechanisms through which firms protect advantages through time
+              compression diseconomies, causal ambiguity, social complexity, and proprietary
+              protection.
+            </li>
+            <li>
+              <strong>Management focus shift:</strong> Redirected management strategic thinking from
+              industry selection and positioning to internal capability development and distinctive
+              resource building.
+            </li>
+            <li>
+              <strong>Theoretical legitimacy for organizational studies:</strong> Established
+              organizational capabilities, culture, and human capital as legitimate strategic assets
+              worthy of analysis rather than dismissing them as soft factors.
+            </li>
+            <li>
+              <strong>Integration of multiple theoretical traditions:</strong> Successfully
+              synthesized organizational economics, behavioral theory, and strategic management into
+              coherent framework.
+            </li>
+            <li>
+              <strong>Foundation for further theory development:</strong> Provided foundation for
+              dynamic capabilities theory, knowledge-based view, and other resource-focused
+              strategic frameworks.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            As a conceptual framework paper rather than an empirical study, RBV&rsquo;s internal
+            validity derives from logical coherence, theoretical reasoning, and consistency with
+            existing organizational evidence:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Logical consistency:</strong> The core argument that valuable, rare, and
+              inimitable resources create sustainable competitive advantage is logically sound. If
+              resources were valuable but not rare, or rare but easily imitable, they would not
+              sustain advantage.
+            </li>
+            <li>
+              <strong>Grounding in established theory:</strong> RBV draws on well-established
+              economic theory (transaction costs, information economics) and organizational theory
+              (routines, capabilities), providing theoretical foundation for proposed mechanisms.
+            </li>
+            <li>
+              <strong>Consistency with observable patterns:</strong> RBV explains well-documented
+              organizational phenomena: why some firms persistently outperform competitors, why
+              resource accumulation takes time, why firm acquisitions often disappoint when trying
+              to purchase capabilities.
+            </li>
+            <li>
+              <strong>Theoretical integration:</strong> Successfully integrates previously separate
+              theoretical traditions (economics, organization theory, business policy) into coherent
+              framework without obvious logical contradictions.
+            </li>
+            <li>
+              <strong>Acknowledgment of foundational work:</strong> Explicit grounding in Penrose
+              and other precursor theorists establishes clear intellectual lineage rather than
+              claiming originality for integrated framework.
+            </li>
+            <li>
+              <strong>Balance of mechanism specificity:</strong> Framework is specific enough to
+              provide strategic direction yet flexible enough to apply across industries and
+              competitive contexts.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations concern generalizability of RBV across diverse
+            organizational and competitive contexts:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Empirical validation unresolved:</strong> As a conceptual framework, RBV
+              lacked empirical validation at time of publication. Subsequent empirical research has
+              produced mixed results, with some studies supporting RBV predictions while others find
+              limited support.
+            </li>
+            <li>
+              <strong>Industry variability:</strong> RBV applicability may vary by industry. In
+              industries where technology changes rapidly, today&rsquo;s inimitable resources become
+              obsolete quickly. In stable industries, resource-based advantages may persist longer.
+            </li>
+            <li>
+              <strong>Competitive context variation:</strong> RBV assumptions about resource
+              inimitability may not hold equally across competitive contexts. In international
+              competition where technology transfer is rapid, or where capital-rich competitors can
+              quickly purchase capabilities, resource advantages may erode faster.
+            </li>
+            <li>
+              <strong>Firm size and resource capabilities:</strong> RBV may better explain advantage
+              in large, established firms with mature resource bases. Applicability to startups,
+              small firms with limited resources, or newly formed organizations is less clear.
+            </li>
+            <li>
+              <strong>Organizational context differences:</strong> RBV was developed for
+              profit-oriented firms in competitive markets. Applicability to non-profit
+              organizations, government agencies, or heavily regulated industries may differ.
+            </li>
+            <li>
+              <strong>Dynamic environment generalizability:</strong> RBV assumes relatively stable
+              competitive environments where resources maintain value over extended periods. In
+              rapidly changing markets where resources quickly become obsolete, RBV may provide
+              limited guidance.
+            </li>
+            <li>
+              <strong>Substitution risk underestimated:</strong> In practice, competitors may find
+              substitutes for firm resources more readily than RBV suggests, potentially limiting
+              the sustainability of resource-based advantages.
+            </li>
+            <li>
+              <strong>International and cultural context:</strong> RBV was developed in Western
+              capitalist context. Applicability to different economic systems, cultural contexts, or
+              governance models requires investigation.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            RBV explains organizational capability to adopt technology through a resource lens.
+            Technology adoption requires organizations possess or develop resources enabling
+            adoption: capital for acquisition, technical expertise to implement, organizational
+            infrastructure to integrate systems, change management capabilities, and leadership
+            commitment. Organizations lacking these resource prerequisites struggle with adoption.
+            Conversely, organizations with strong resource bases can more successfully execute
+            technology implementations. RBV suggests that competitive advantage in technology
+            adoption comes from distinctive resources: superior technical talent, organizational
+            culture supporting change, technology infrastructure, and change management
+            capabilities. Organizations with these distinctive resources outpace competitors in
+            technology adoption, achieving performance benefits from technology investments faster
+            than resource-constrained competitors.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Insufficient capital resources:</strong> Technology acquisitions require
+              capital investment. Organizations lacking financial resources to fund technology
+              purchases and implementation face adoption barriers.
+            </li>
+            <li>
+              <strong>Lack of technical expertise:</strong> Technology implementation requires
+              technical skills organizations may lack. Absence of technical talent creates barriers
+              to successful deployment and maintenance.
+            </li>
+            <li>
+              <strong>Inadequate organizational infrastructure:</strong> Technology adoption
+              requires compatible systems, networks, databases, and operational processes.
+              Organizations with outdated or incompatible infrastructure face integration barriers.
+            </li>
+            <li>
+              <strong>Insufficient change management capability:</strong> Technology adoption
+              requires change management expertise, project management skills, and organizational
+              change competence. Organizations weak in these capabilities struggle with adoption
+              transitions.
+            </li>
+            <li>
+              <strong>Weak organizational culture for technology change:</strong> Organizations with
+              cultures resistant to change, risk-averse, or low in learning orientation face
+              adoption barriers despite technical capability.
+            </li>
+            <li>
+              <strong>Inadequate leadership commitment:</strong> Technology adoption requires
+              leadership sponsorship, resource commitment, and visible support. Organizations with
+              weak leadership commitment struggle with adoption implementation.
+            </li>
+            <li>
+              <strong>Limited knowledge and learning resources:</strong> Organizations lacking
+              training capacity, knowledge management systems, and learning infrastructure struggle
+              to transfer technology skills to users.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Framework Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Audit adoption resource base:</strong> Systematically assess organizational
+              resources relevant to technology adoption: capital availability, technical talent,
+              infrastructure capability, change management expertise, and leadership commitment.
+            </li>
+            <li>
+              <strong>Identify resource gaps:</strong> Determine which resources the organization
+              lacks or possesses weakly that are required for successful adoption. Gap
+              identification guides resource development or acquisition strategies.
+            </li>
+            <li>
+              <strong>Develop distinctive adoption capabilities:</strong> Build or acquire resources
+              that create competitive advantage in technology adoption speed and effectiveness.
+              Superior change management, technical talent, or organizational learning capability
+              create adoption advantage.
+            </li>
+            <li>
+              <strong>Invest in foundational infrastructure:</strong> Build organizational
+              infrastructure (networks, systems, integration platforms) that enables multiple future
+              technology adoptions rather than single-technology implementations.
+            </li>
+            <li>
+              <strong>Develop human capital:</strong> Invest in technical training, change
+              management expertise, and leadership capabilities required for technology adoption
+              success.
+            </li>
+            <li>
+              <strong>Build organizational culture:</strong> Develop culture characteristics
+              supporting technology adoption: learning orientation, change readiness, risk
+              tolerance, and innovation enthusiasm.
+            </li>
+            <li>
+              <strong>Secure sustained leadership commitment:</strong> Ensure leadership provides
+              visible sponsorship, allocates adequate resources, and maintains long-term commitment
+              to adoption initiatives.
+            </li>
+            <li>
+              <strong>Create path dependency in adoption advantage:</strong> Early successful
+              adoptions build experience, relationships, and expertise that create advantages in
+              subsequent adoptions, building compounding adoption capability.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            RBV has spawned significant theoretical developments and extensions in strategic
+            management:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Dynamic Capabilities (
+                <a
+                  id="cite-ref-teece-1997-1"
+                  href="#ref-teece-1997"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Teece, Pisano, &amp; Shuen, 1997
+                </a>
+                ):
+              </strong>{' '}
+              Extended RBV to dynamic environments by emphasizing not static resources but
+              organizational capabilities to sense market changes, seize opportunities, and
+              reconfigure resources rapidly. Dynamic capabilities address RBV limitations in
+              changing environments.
+            </li>
+            <li>
+              <strong>
+                Knowledge-Based View (
+                <a
+                  id="cite-ref-grant-1996-1"
+                  href="#ref-grant-1996"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Grant, 1996
+                </a>
+                ):
+              </strong>{' '}
+              Specialized RBV by treating knowledge as the most important strategic resource.
+              Knowledge-based view emphasizes knowledge creation, integration, and application as
+              sources of competitive advantage.
+            </li>
+            <li>
+              <strong>
+                Competence-Based Competition (
+                <a
+                  id="cite-ref-hamel-1994-1"
+                  href="#ref-hamel-1994"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Hamel &amp; Prahalad, 1994
+                </a>
+                ):
+              </strong>{' '}
+              Emphasized core competencies as bundles of skills and resources providing competitive
+              advantage. Articulated distinction between core competencies (strategic value-creating
+              resources) and non-core competencies.
+            </li>
+            <li>
+              <strong>Intellectual Capital Framework:</strong> Extended RBV to emphasize
+              intellectual resources including human capital, structural capital, and customer
+              capital as sources of competitive value.
+            </li>
+            <li>
+              <strong>Strategic Assets Theory:</strong> Refined resource conceptualization by
+              distinguishing between resources (inputs) and strategic assets (resources providing
+              defensible competitive advantages).
+            </li>
+            <li>
+              <strong>Organizational Learning Theory:</strong> Integration of RBV with learning
+              theory to understand how organizations develop, maintain, and leverage resources
+              through continuous learning and knowledge accumulation.
+            </li>
+            <li>
+              <strong>Strategic Human Capital:</strong> Application of RBV specifically to human
+              resources, emphasizing how distinctive workforce capabilities create competitive
+              advantage.
+            </li>
+            <li>
+              <strong>Relational View of the Firm:</strong> Extended RBV by emphasizing that
+              competitive advantage often emerges from inter-organizational relationships and
+              alliances rather than solely from internal resources.
+            </li>
+            <li>
+              <strong>Organizational Resilience:</strong> Applied RBV to organizational resilience
+              and adaptation, examining how resource diversity and slack create resilience in
+              disruption.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
-            <li>
-              Wernerfelt, B. (1984). A resource-based view of the firm. Strategic Management
-              Journal, 5(2), 171-180.{' '}
-              <a
-                href="https://doi.org/10.1002/smj.4250050207"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1002/smj.4250050207
-              </a>
+            <li id="ref-wernerfelt-1984">
+              Wernerfelt, B. (1984). A resource-based view of the firm.{' '}
+              <em>Strategic Management Journal</em>, 5(2), 171-180.
             </li>
-            <li>Porter, M. E. (1980). Competitive strategy. Free Press.</li>
-            <li>
-              Barney, J. (1991). Firm resources and sustained competitive advantage. Journal of
-              Management, 17(1), 99-120.{' '}
-              <a
-                href="https://doi.org/10.1177/014920639101700108"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1177/014920639101700108
-              </a>
+            <li id="ref-penrose-1959">
+              Penrose, E. T. (1959). The theory of the growth of the firm. Oxford University Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-penrose-1959-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
+            <li id="ref-porter-1980">
+              Porter, M. E. (1980). Competitive strategy: Techniques for analyzing industries and
+              competitors. Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-porter-1980-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-coase-1937">
+              Coase, R. H. (1937). The nature of the firm. <em>Economica</em>, 4(16), 386-405.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-coase-1937-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-williamson-1975">
+              Williamson, O. E. (1975). Markets and hierarchies: Analysis and antitrust
+              implications. Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-williamson-1975-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-grant-1996">
+              Grant, R. M. (1996). Toward a knowledge-based theory of the firm.
+              <em>Strategic Management Journal</em>, 17(S2), 109-122.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-grant-1996-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-nelson-1982">
+              Nelson, R. R., &amp; Winter, S. G. (1982). An evolutionary theory of economic change.
+              Harvard University Press.
+            </li>
+            <li id="ref-teece-1997">
               Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
-              management. Strategic Management Journal, 18(7), 509-533.{' '}
-              <a
-                href="https://doi.org/10.1002/smj.882"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1002/smj.882
-              </a>
+              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
+              https://doi.org/10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z
             </li>
-            <li>
-              Prahalad, C. K., &amp; Hamel, G. (1990). The core competence of the corporation.
-              Harvard Business Review, 68(3), 79-91.
-            </li>
-            <li>
-              Penrose, E. T. (1959). The theory of the growth of the firm. Oxford: Basil Blackwell.
+            <li id="ref-hamel-1994">
+              Hamel, G., &amp; Prahalad, C. K. (1994). Competing for the future. Harvard Business
+              School Press.
             </li>
           </ol>
         </section>
 
-        <p className="mt-8 text-sm italic text-gray-600">
-          Note: This article provides an overview based on the comprehensive literature review.
-          Readers are encouraged to consult the original publication for complete details.
-        </p>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-barney-1991">
+              Barney, J. B. (1991). Firm resources and sustained competitive advantage.
+              <em>Journal of Management</em>, 17(1), 99-120.
+              https://doi.org/10.1177/014920639101700108
+            </li>
+            <li id="ref-peteraf-1993">
+              Peteraf, M. A. (1993). The cornerstones of competitive advantage: A resource-based
+              view. <em>Strategic Management Journal</em>, 14(3), 179-191.
+            </li>
+            <li id="ref-rumelt-1991">
+              Rumelt, R. P. (1991). How much does industry matter?{' '}
+              <em>Strategic Management Journal</em>, 12(S1), 167-185.
+            </li>
+          </ol>
+        </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-21-technology-readiness-index-2-tri-2-parasuraman-colby-2015"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Technology Readiness Index 2.0 (Parasuraman &amp; Colby, 2015)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-2-vrio-framework-barney-1991"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: VRIO Framework (Barney, 1991) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>
   )
 }
 
-export default ResourceBasedViewPage
+export default BibliographyArticlePage

--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -479,87 +479,89 @@ const BibliographyArticlePage = () => {
           <h3 className={H3_CLASSES}>Main Strengths</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Explains within-industry performance variation:</strong> RBV accounts for why
-              firms in identical competitive environments achieve different performance levels
-              through internal resource differences, addressing a key limitation of
-              industry-structure-based analysis.
+              <strong>Resource-side symmetry with product-market analysis:</strong> By applying
+              Porter&rsquo;s (1980) competitive-forces framework at the resource level, Wernerfelt
+              provides a clean analytical extension rather than a rival paradigm - a design choice
+              that makes the framework easy to integrate with existing strategy teaching and
+              analysis (p.173).
             </li>
             <li>
-              <strong>Shifts focus to sustainable advantage:</strong> Emphasizes sustainable
-              competitive advantage through difficult-to-imitate resources rather than temporary
-              advantages easily copied by competitors.
+              <strong>Explicit duality:</strong> The &ldquo;two sides of the same coin&rdquo;
+              framing (p.171) and the resource-product matrix (Figure 1, p.175) force the analyst to
+              see both resources and products simultaneously, surfacing diversification
+              opportunities that a product-only analysis would miss.
             </li>
             <li>
-              <strong>Integrates multiple strategic disciplines:</strong> Synthesizes insights from
-              organizational economics, behavioral theory, and economics of information into
-              coherent strategic framework.
+              <strong>Concrete first-mover mechanisms:</strong> The four worked examples (machine
+              capacity, customer loyalty, production experience, technological leads) on pp.173-174
+              give readers ready-made templates rather than purely abstract concepts.
             </li>
             <li>
-              <strong>Provides practical strategic guidance:</strong> Directs management attention
-              to identifying distinctive capabilities, protecting valuable resources, and developing
-              inimitable resource combinations rather than purely external positioning.
+              <strong>Dynamic-strategy vocabulary:</strong> Figures 2-4 (sequential entry,
+              exploit-and-develop, stepping stones) provide a small but coherent set of multi-period
+              diversification patterns - a rarity in 1984 strategy literature that was otherwise
+              dominated by static positioning.
             </li>
             <li>
-              <strong>Addresses firm heterogeneity:</strong> Acknowledges and explains why firms
-              differ in capabilities, history, and strategic effectiveness rather than treating
-              firms as interchangeable units within industries.
+              <strong>Complementary, not oppositional, to Porter:</strong> Wernerfelt neither
+              dismisses industrial-organization strategy nor tries to replace it; he builds on
+              Porter&rsquo;s (1980) five forces to open an additional dimension of analysis. This
+              made the framework easier to adopt.
             </li>
             <li>
-              <strong>Conceptually elegant framework:</strong> Relatively simple underlying logic
-              (value-rarity-inimitability) creates actionable framework that can be applied across
-              industries and competitive contexts.
-            </li>
-            <li>
-              <strong>Challenged orthodoxy productively:</strong> By directly opposing dominant IO
-              economics paradigm, RBV created productive dialogue and forced more nuanced
-              understanding of strategy including both industry and firm factors.
+              <strong>Short, accessible, and generative:</strong> At ten pages the paper is
+              unusually compact for a foundational contribution, which helped it spawn a very large
+              follow-on literature (Barney 1991, Dierickx &amp; Cool 1989, Peteraf 1993, Teece et
+              al. 1997 - see Following Models).
             </li>
           </ul>
 
           <h3 className={H3_CLASSES}>Main Weaknesses</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Limited practical guidance on resource identification:</strong> While the
-              value-rarity-inimitability framework is elegant, it provides limited guidance on how
-              managers should systematically identify which internal resources represent sustainable
-              advantages.
+              <strong>First-cut nature, self-acknowledged:</strong> Wernerfelt himself calls the
+              paper &ldquo;a first cut at a huge can of worms&rdquo; (p.180). The framework names
+              concepts (resource position barrier, attractive resource) but does not formally
+              characterize when a resource qualifies - that work comes later with Barney (1991) and
+              Peteraf (1993).
             </li>
             <li>
-              <strong>Tautological concerns:</strong> Critics argue RBV risks tautology: if a firm
-              has a competitive advantage, we infer it possesses valuable, rare, inimitable
-              resources; but the causal direction is unclear. Testing often amounts to observing
-              advantage and inferring resource characteristics.
+              <strong>No inimitability mechanism:</strong> The paper describes first-mover
+              advantages through illustrative examples but does not provide a general theory of why
+              resources are hard to imitate. Causal ambiguity (Lippman &amp; Rumelt, 1982),
+              time-compression diseconomies (Dierickx &amp; Cool, 1989), and social complexity
+              (Barney, 1991) came later.
             </li>
             <li>
-              <strong>Causality remains ambiguous:</strong> RBV emphasizes causal ambiguity as
-              source of advantage, but this creates challenges for validating the theory itself. If
-              causality cannot be determined, research validation becomes difficult.
+              <strong>Limited implementability guidance:</strong> The closing paragraph explicitly
+              flags this: &ldquo;nothing is known, for example, about the practical difficulties
+              involved in identifying resources (products are easy to identify), nor about to what
+              extent one in practice can combine capabilities across operating divisions, or about
+              how one can set up a structure and systems which can help a firm execute these
+              strategies&rdquo; (p.180).
             </li>
             <li>
-              <strong>Underestimates imitation through acquisition:</strong> RBV assumes firms must
-              build resources internally, but significant imitation occurs through acquisitions,
-              hiring of key personnel, and licensing. Acquisition-based imitation may be more common
-              than RBV acknowledges.
+              <strong>No empirical test:</strong> The paper presents conceptual arguments and worked
+              examples but does not test its propositions empirically. Empirical support for the
+              resource perspective came through Rumelt (1991) and subsequent large-sample studies.
             </li>
             <li>
-              <strong>Insufficient guidance on change and adaptation:</strong> RBV provides strong
-              framework for understanding stable competitive advantage but less guidance for how
-              firms adapt when resource bases become obsolete or market conditions shift.
+              <strong>Mathematical appendix is minor:</strong> The paper includes a brief formal
+              model of sequential entry (pp.176-177) but it is illustrative rather than a general
+              formalization of resource position barriers.
             </li>
             <li>
-              <strong>Limited attention to resource combination:</strong> RBV focuses on individual
-              resources but gives less attention to how resources combine, complement, and reinforce
-              each other to create advantage.
+              <strong>Resource definition inherits Caves&rsquo;s looseness:</strong> Wernerfelt
+              adopts &ldquo;anything which could be thought of as a strength or weakness&rdquo;
+              (Caves, 1980; p.172), which is broad enough to invite the tautology critique that
+              later attached to RBV (&ldquo;if the firm is doing well, its resources must be
+              strong&rdquo;). Later work had to narrow the definition.
             </li>
             <li>
-              <strong>Difficulty measuring constructs:</strong> Operationalizing and measuring
-              valuable, rare, and inimitable resources is challenging in empirical research,
-              creating methodological implementation difficulties.
-            </li>
-            <li>
-              <strong>Incomplete treatment of external factors:</strong> While RBV critiques
-              exclusive focus on industry structure, it does not fully integrate how external
-              factors constrain, enable, or devalue internal resources.
+              <strong>Treatment of dynamics is schematic:</strong> The sequential-entry,
+              exploit-and-develop, and stepping-stone patterns are evocative diagrams rather than
+              predictive theories. Dynamic capabilities (Teece, Pisano &amp; Shuen, 1997) addresses
+              this gap with a more explicit mechanism.
             </li>
           </ul>
         </section>
@@ -629,38 +631,48 @@ const BibliographyArticlePage = () => {
             validity derives from logical coherence, theoretical reasoning, and consistency with
             existing organizational evidence:
           </p>
+          <p className={PARAGRAPH_CLASSES}>
+            Wernerfelt (1984) is a conceptual / theoretical paper, not an empirical study. Internal
+            validity here is assessed as logical coherence of the argument and fidelity to the cited
+            prior work:
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Logical consistency:</strong> The core argument that valuable, rare, and
-              inimitable resources create sustainable competitive advantage is logically sound. If
-              resources were valuable but not rare, or rare but easily imitable, they would not
-              sustain advantage.
+              <strong>Consistent analytical mapping:</strong> The paper&rsquo;s central move -
+              applying Porter&rsquo;s (1980) five competitive forces at the resource level - is
+              carried through systematically: monopoly at the resource level, substitute resources,
+              buyer/supplier power over resources, and resource-level entry. The symmetry with
+              product-market analysis holds throughout (pp.172-173).
             </li>
             <li>
-              <strong>Grounding in established theory:</strong> RBV draws on well-established
-              economic theory (transaction costs, information economics) and organizational theory
-              (routines, capabilities), providing theoretical foundation for proposed mechanisms.
+              <strong>Fidelity to cited sources:</strong> The resource definition is drawn directly
+              from Caves (1980, p.172). The experience-curve first-mover argument is drawn from BCG
+              (1972). Customer-loyalty first-mover advantages reference Ries &amp; Trout (1981).
+              Scale-economy first-mover advantages reference Spence (1979). Each example cites a
+              recognized source.
             </li>
             <li>
-              <strong>Consistency with observable patterns:</strong> RBV explains well-documented
-              organizational phenomena: why some firms persistently outperform competitors, why
-              resource accumulation takes time, why firm acquisitions often disappoint when trying
-              to purchase capabilities.
+              <strong>Transparent scope:</strong> The paper explicitly labels itself a &ldquo;first
+              cut&rdquo; (p.180) and names gaps (implementability, resource identification, no
+              empirical test). It does not over-claim.
             </li>
             <li>
-              <strong>Theoretical integration:</strong> Successfully integrates previously separate
-              theoretical traditions (economics, organization theory, business policy) into coherent
-              framework without obvious logical contradictions.
+              <strong>Mathematical appendix for sequential entry:</strong> The sequential-entry
+              illustration (pp.176-177) is backed by a small formal model of two-period optimal
+              entry conditions, providing limited but explicit mathematical grounding for that
+              specific pattern.
             </li>
             <li>
-              <strong>Acknowledgment of foundational work:</strong> Explicit grounding in Penrose
-              and other precursor theorists establishes clear intellectual lineage rather than
-              claiming originality for integrated framework.
+              <strong>Intellectual lineage stated:</strong> Penrose (1959), Rubin (1973), Caves
+              (1980) are credited as precursors of the resource perspective. The paper does not
+              claim originality for the resource concept itself, only for the symmetric analytical
+              framework.
             </li>
             <li>
-              <strong>Balance of mechanism specificity:</strong> Framework is specific enough to
-              provide strategic direction yet flexible enough to apply across industries and
-              competitive contexts.
+              <strong>Known limitations of internal validity:</strong> Three of the four first-mover
+              examples (customer loyalty, production experience, technological leads) are supported
+              by citation rather than worked proofs. The resource-product matrix and its dynamic
+              strategies are illustrated by one firm-example each and generalized informally.
             </li>
           </ul>
         </section>
@@ -669,52 +681,55 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            External validity considerations concern generalizability of RBV across diverse
-            organizational and competitive contexts:
+            Wernerfelt (1984) presents no empirical tests, so external validity is evaluated in
+            terms of how well the framework generalizes when applied in later work:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Empirical validation unresolved:</strong> As a conceptual framework, RBV
-              lacked empirical validation at time of publication. Subsequent empirical research has
-              produced mixed results, with some studies supporting RBV predictions while others find
-              limited support.
+              <strong>No original empirical test:</strong> The paper closes (p.180) by noting that
+              the strategies suggested need research on implementability and that identifying
+              resources in practice is an open problem. External validity was established by
+              subsequent work - notably Rumelt (1991) on firm vs. industry effects - not by
+              Wernerfelt 1984 itself.
             </li>
             <li>
-              <strong>Industry variability:</strong> RBV applicability may vary by industry. In
-              industries where technology changes rapidly, today&rsquo;s inimitable resources become
-              obsolete quickly. In stable industries, resource-based advantages may persist longer.
+              <strong>Worked examples are drawn from 1970s-1980s US/Western firms:</strong> The
+              illustrative firms (BIC Pen, razor and lighter markets, General Electric, Texas
+              Instruments) and the worked examples of international contacts, production skills, and
+              domestic contacts reflect the industrial-economy context of the paper&rsquo;s writing.
+              The framework as stated does not address service economies, platform businesses, or
+              digital resource types.
             </li>
             <li>
-              <strong>Competitive context variation:</strong> RBV assumptions about resource
-              inimitability may not hold equally across competitive contexts. In international
-              competition where technology transfer is rapid, or where capital-rich competitors can
-              quickly purchase capabilities, resource advantages may erode faster.
+              <strong>Industry scope is mostly manufacturing and diversified conglomerates:</strong>
+              The resource-product matrix (Figure 1) and the diversification-by-acquisition analysis
+              are most naturally applied to multi-business firms with tradeable physical and human
+              resources. Single-business firms and early-stage ventures fit less cleanly.
             </li>
             <li>
-              <strong>Firm size and resource capabilities:</strong> RBV may better explain advantage
-              in large, established firms with mature resource bases. Applicability to startups,
-              small firms with limited resources, or newly formed organizations is less clear.
+              <strong>Dynamic resource management is illustrative, not predictive:</strong>{' '}
+              Sequential entry, exploit-and-develop, and stepping stones are shown as possibilities
+              on a matrix; the paper offers no predictions about when each pattern dominates. That
+              work is taken up by later dynamic-capabilities research (Teece et al., 1997).
             </li>
             <li>
-              <strong>Organizational context differences:</strong> RBV was developed for
-              profit-oriented firms in competitive markets. Applicability to non-profit
-              organizations, government agencies, or heavily regulated industries may differ.
+              <strong>No treatment of intangible or knowledge-specific resources:</strong>{' '}
+              Wernerfelt names brand names, trade contacts, and in-house technology but does not
+              develop a theory of knowledge as a resource. The Knowledge-Based View (Grant, 1996)
+              addresses this later.
             </li>
             <li>
-              <strong>Dynamic environment generalizability:</strong> RBV assumes relatively stable
-              competitive environments where resources maintain value over extended periods. In
-              rapidly changing markets where resources quickly become obsolete, RBV may provide
-              limited guidance.
+              <strong>No treatment of non-profit or public organizations:</strong> The analysis
+              assumes profit-seeking firms in competitive markets. Applicability to nonprofits,
+              regulated industries, and public-sector organizations is outside the paper&rsquo;s
+              scope.
             </li>
             <li>
-              <strong>Substitution risk underestimated:</strong> In practice, competitors may find
-              substitutes for firm resources more readily than RBV suggests, potentially limiting
-              the sustainability of resource-based advantages.
-            </li>
-            <li>
-              <strong>International and cultural context:</strong> RBV was developed in Western
-              capitalist context. Applicability to different economic systems, cultural contexts, or
-              governance models requires investigation.
+              <strong>Reception and adoption:</strong> Wernerfelt (1984) is widely cited as a
+              foundational paper of RBV alongside Barney (1991). Wide citation reflects theoretical
+              generalizability, but the empirical defensibility of specific claims (e.g. that
+              resource position barriers translate into sustained returns) depends on follow-on work
+              rather than on the 1984 paper itself.
             </li>
           </ul>
         </section>

--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -411,17 +411,32 @@ const BibliographyArticlePage = () => {
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>Machine capacity:</strong> Scale economies in the use of a productive resource
-              are a prime example of product-entry barriers (Spence, 1979). From the resource
-              perspective, the product-entry barrier translates into a resource-position barrier:
-              where excess capacity would lead to cut-throat competition and low returns, the
-              resource position barrier operates through lower expected revenues for prospective
-              acquirers.
+              are a prime example of product-entry barriers (
+              <a
+                id="cite-ref-spence-1979-1"
+                href="#ref-spence-1979"
+                className="text-tabs-teal-deep hover:underline"
+              >
+                Spence, 1979
+              </a>
+              ). From the resource perspective, the product-entry barrier translates into a
+              resource-position barrier: where excess capacity would lead to cut-throat competition
+              and low returns, the resource position barrier operates through lower expected
+              revenues for prospective acquirers.
             </li>
             <li>
               <strong>Customer loyalty:</strong> The market for customers generates a resource
               position barrier - it is much easier to pioneer a position than to replace someone
-              else who already has it (Ries and Trout, 1981). Related examples are first-mover
-              advantages in government contracts and access to raw materials.
+              else who already has it (
+              <a
+                id="cite-ref-ries-trout-1981-1"
+                href="#ref-ries-trout-1981"
+                className="text-tabs-teal-deep hover:underline"
+              >
+                Ries and Trout, 1981
+              </a>
+              ). Related examples are first-mover advantages in government contracts and access to
+              raw materials.
             </li>
             <li>
               <strong>Production experience:</strong> If the leader executes the experience curve
@@ -472,7 +487,15 @@ const BibliographyArticlePage = () => {
             limit search to targets satisfying simple criteria: what resources a target has, which
             the firm can take advantage of, the cost of doing so, and what the firm could pay for
             them. Related-supplementary and related-complementary acquisition strategies are
-            distinguished (Salter &amp; Weinhold, 1979).
+            distinguished (
+            <a
+              id="cite-ref-salter-weinhold-1979-1"
+              href="#ref-salter-weinhold-1979"
+              className="text-tabs-teal-deep hover:underline"
+            >
+              Salter &amp; Weinhold, 1979
+            </a>
+            ).
           </p>
 
           <h3 className={H3_CLASSES}>Main Strengths</h3>

--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -175,9 +175,9 @@ const BibliographyArticlePage = () => {
             for dynamic strategy - <em>sequential entry</em> (Figure 2, p.176),
             <em>exploit-and-develop</em> (Figure 3, p.177), and <em>stepping stones</em> (Figure 4,
             p.178). The paper is presented by the author as &ldquo;a first cut at a huge can of
-            worms&rsquo;&rsquo; (p.180), explicitly calling for further research on
-            implementability. The later VRIN/VRIO apparatus commonly associated with RBV comes from
-            Barney (1991) and is NOT in Wernerfelt (1984).
+            worms&rdquo; (p.180), explicitly calling for further research on implementability. The
+            later VRIN/VRIO apparatus commonly associated with RBV comes from Barney (1991) and is
+            NOT in Wernerfelt (1984).
           </p>
         </section>
 
@@ -201,11 +201,10 @@ const BibliographyArticlePage = () => {
               <strong>Resource position barrier:</strong> A first-mover advantage tied to a specific
               resource that makes it more expensive or difficult for late-comers to acquire, build,
               or operate that resource. Wernerfelt positions resource position barriers as
-              &ldquo;partially analogous&rsquo;&rsquo; to entry barriers, but defined at the
-              resource level (p.173). A resource position barrier can exist without an entry barrier
-              (leaving the firm vulnerable to diversifying entrants), and an entry barrier can exist
-              without a resource position barrier (leaving the firm unable to exploit its position
-              further).
+              &ldquo;partially analogous&rdquo; to entry barriers, but defined at the resource level
+              (p.173). A resource position barrier can exist without an entry barrier (leaving the
+              firm vulnerable to diversifying entrants), and an entry barrier can exist without a
+              resource position barrier (leaving the firm unable to exploit its position further).
             </li>
             <li>
               <strong>Attractive resource:</strong> A resource around which a resource position
@@ -226,8 +225,8 @@ const BibliographyArticlePage = () => {
             <li>
               <strong>Mergers and acquisitions:</strong> Wernerfelt frames M&amp;A as an opportunity
               to trade otherwise non-marketable resources in bundles. Acquisitions allow firms to
-              buy or sell resources which have &ldquo;a high degree of transparency&rsquo;&rsquo;
-              only between specific pairs of firms, through an imperfect market with few buyers and
+              buy or sell resources which have &ldquo;a high degree of transparency&rdquo; only
+              between specific pairs of firms, through an imperfect market with few buyers and
               targets (pp.174-175).
             </li>
             <li>
@@ -1068,6 +1067,10 @@ const BibliographyArticlePage = () => {
                 ></a>
               </span>
             </li>
+            <li id="ref-ries-trout-1981">
+              Ries, A., &amp; Trout, J. (1981). <em>Positioning: The battle for your mind</em>.
+              McGraw-Hill.
+            </li>
             <li id="ref-rubin-1973">
               Rubin, P. H. (1973). The expansion of firms. <em>Journal of Political Economy</em>,
               81, 936-949.
@@ -1078,6 +1081,14 @@ const BibliographyArticlePage = () => {
                   aria-label="Back to citation 1"
                 ></a>
               </span>
+            </li>
+            <li id="ref-salter-weinhold-1979">
+              Salter, M. S., &amp; Weinhold, W. A. (1979). <em>Diversification by acquisition</em>.
+              Free Press.
+            </li>
+            <li id="ref-spence-1979">
+              Spence, A. M. (1979). Investment strategy and growth in a new market.{' '}
+              <em>Bell Journal of Economics</em>, 10, 1-19.
             </li>
           </ol>
         </section>

--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -813,9 +813,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-penrose-1959-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-porter-1980">
@@ -826,9 +824,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-porter-1980-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-coase-1937">
@@ -838,9 +834,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-coase-1937-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-williamson-1975">
@@ -851,9 +845,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-williamson-1975-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-grant-1996">
@@ -864,9 +856,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-grant-1996-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-nelson-1982">

--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Resource-Based View (RBV) of the Firm - Wernerfelt (1984)',
+  title: 'Bibliography: A Resource-Based View (RBV) - Wernerfelt (1984)',
   description:
     'Comprehensive overview of the Resource-Based View of the Firm, foundational strategic management theory arguing that competitive advantage originates from internal firm resources rather than industry structure, establishing resources as sustainable sources of performance differentiation.',
 }
@@ -21,7 +21,7 @@ const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Resource-Based View (RBV) of the Firm - Wernerfelt (1984)</h1>
+        <h1 className={H1_CLASSES}>A Resource-Based View (RBV) - Wernerfelt (1984)</h1>
 
         {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>

--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -67,6 +67,17 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 171-180
             </p>
+            <p>
+              <strong>URL:</strong>{' '}
+              <a
+                href="https://www.proquest.com/docview/230627518"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                https://www.proquest.com/docview/230627518
+              </a>
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
+++ b/src/app/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984/page.tsx
@@ -34,9 +34,11 @@ const BibliographyArticlePage = () => {
               <strong>Framework Abbreviation:</strong> RBV
             </p>
             <p>
-              <strong>Target of Framework:</strong> Explanation of how firms sustain competitive
-              advantage through control of unique, valuable, inimitable resources and capabilities
-              that create barriers to competitive imitation
+              <strong>Target of Framework:</strong> A resource-side counterpart to product-market
+              analysis. Introduces the notions of resource position barrier, resource-product
+              matrix, and dynamic-strategy patterns (sequential entry, exploit-and-develop, stepping
+              stones) as tools for analysing a firm&rsquo;s resource position. The later VRIN/VRIO
+              formalization is Barney (1991/1995), not Wernerfelt (1984).
             </p>
             <p>
               <strong>Disciplinary Origin:</strong> Strategic Management, Economics, Organization
@@ -112,156 +114,151 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Birger Wernerfelt developed the Resource-Based View as a direct counter to the dominant
-            Strategic Management paradigm of the early 1980s: industrial organization (IO)
-            economics. The dominant approach, exemplified by Michael Porter&rsquo;s Five Forces
-            framework, argued that firm profitability and competitive advantage were determined
-            primarily by industry structure -the competitive environment, supplier relationships,
-            customer bargaining power, and threat of substitutes and new entrants. According to this
-            perspective, firms succeeding in profitable industries succeeded because of favorable
-            industry structure, while firms in competitive industries struggled regardless of
-            internal quality. Strategic analysis focused on selecting attractive industries and
-            positioning within industry structures.
+            Wernerfelt (1984) opens with a symmetry argument: &ldquo;For the firm, resources and
+            products are two sides of the same coin&rdquo; (p.171). Most products require the
+            services of several resources and most resources can be used in several products; by
+            specifying a firm&rsquo;s resource profile it is possible to find the optimal
+            product-market activities. The strategic management literature of the early 1980s -
+            particularly Porter&rsquo;s (1980) industrial-organization-based competitive-strategy
+            framework - analysed firms almost exclusively from the product-market side.
+            Wernerfelt&rsquo;s aim was not to displace that analysis, but to develop the resource
+            side of the coin with the same rigour.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Wernerfelt recognized a critical limitation in this IO economics perspective: it failed
-            to explain why some firms outperformed others within the same industry. If industry
-            structure determined performance, why did some companies far exceed competitors in
-            identical competitive environments? The IO view also suggested that firms were
-            essentially interchangeable within industries, differing only in positioning but not in
-            fundamental capabilities. This seemed inconsistent with observable reality where
-            firm-specific capabilities, histories, and assets clearly created performance
-            differences. Additionally, IO economics provided limited strategic guidance to
-            management beyond &ldquo;choose attractive industries,&rdquo; which overstated
-            management control (firms cannot simply select new industries) and understated the
-            importance of internal capabilities.
+            The paper identifies two categories of precedent for a resource perspective: a
+            long-standing tradition in economics (Penrose, 1959; Rubin, 1973; Caves, 1980) that
+            analyses firms in terms of their resource endowments, and portfolio / growth-share work
+            from strategic management (BCG, 1972; Henderson, 1979) that implicitly trades on
+            resource shareability. Wernerfelt argues that a general economic theory of resources has
+            received relatively little formal attention, mainly because resources have unpleasant
+            properties for modelling purposes - declining returns, difficulty defining them
+            precisely, and the problem of identifying them as technological &ldquo;skills&rdquo;
+            (p.171).
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Wernerfelt proposed an alternative lens: instead of beginning strategic analysis by
-            examining external industry structure, begin by examining internal resources. Resources
-            are anything that could be considered a strength or weakness of the firm -physical
-            assets, intangible capabilities, brand reputation, knowledge, relationships. Resources
-            create strategic value to the extent they are valuable (able to address market
-            opportunities), rare (not widely available to competitors), difficult to imitate
-            (inimitable), and not easily substituted by alternative resources. Firms with unique
-            bundles of resources can sustain competitive advantages by creating barriers that
-            prevent competitors from imitation. Wernerfelt&rsquo;s conceptual framework provided a
-            complementary perspective to Porter&rsquo;s analysis, shifting strategic thinking from
-            external industry positioning to internal resource development as a source of
-            sustainable competitive advantage.
+            The purpose of the paper, stated explicitly in the introduction, is to &ldquo;develop
+            some simple economic tools for analysing a firm&rsquo;s resource position and to look at
+            some strategic options suggested by this analysis&rdquo; (p.171). Specifically, the
+            paper uses Porter&rsquo;s (1980) five competitive forces as the analytical tool but
+            applies them at the resource level (p.173), producing the notion of a resource position
+            barrier, the resource-product matrix, and the dynamic-strategy illustrations (sequential
+            entry, exploit-and-develop, stepping stones). Wernerfelt closes the paper by calling it
+            &ldquo;a first cut at a huge can of worms&rdquo; (p.180), with much research still
+            needed on the implementability of the strategies suggested.
           </p>
         </section>
 
-        {/* 5. Core Concepts and Definitions */}
+        {/* 5. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Wernerfelt (1984) is a conceptual framework paper, not a measurement model. It does not
+            propose scales, latent constructs, or empirical operationalizations. Instead, it
+            proposes a re-orientation of strategic analysis: examining the firm from the resource
+            side rather than from the product side (p.171). The paper is structured around four
+            diversification questions the resource perspective is meant to answer (p.172):
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              (a) On which of the firm&rsquo;s current resources should diversification be based?
+            </li>
+            <li>(b) Which resources should be developed through diversification?</li>
+            <li>(c) In what sequence and into what markets should diversification take place?</li>
+            <li>(d) What types of firms will be desirable for this particular firm to acquire?</li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            The paper&rsquo;s analytical tools are conceptual rather than statistical: (i) the
+            notion of a <em>resource position barrier</em> (analogous to an entry barrier, for
+            resources rather than product-markets); (ii) the <em>resource-product matrix</em>
+            (Figure 1, p.175) showing how a given resource can support multiple products and a given
+            product can draw on multiple resources; and (iii) a small set of illustrative diagrams
+            for dynamic strategy - <em>sequential entry</em> (Figure 2, p.176),
+            <em>exploit-and-develop</em> (Figure 3, p.177), and <em>stepping stones</em> (Figure 4,
+            p.178). The paper is presented by the author as &ldquo;a first cut at a huge can of
+            worms&rsquo;&rsquo; (p.180), explicitly calling for further research on
+            implementability. The later VRIN/VRIO apparatus commonly associated with RBV comes from
+            Barney (1991) and is NOT in Wernerfelt (1984).
+          </p>
+        </section>
+
+        {/* 6. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The Resource-Based View is built on foundational concepts about how firms compete
-            through resources:
+            Wernerfelt&rsquo;s (1984) framework rests on a compact set of concepts introduced over
+            the ten pages of the paper:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Resources:</strong> Tangible and intangible assets that a firm controls and
-              that it can use to conceive of and implement strategies. Resources include physical
-              assets (facilities, equipment, inventory), financial assets (capital, cash flow),
-              human capital (skills, knowledge), organizational resources (systems, processes,
-              culture), and intellectual property (patents, brand, reputation, relationships).
+              <strong>Resource:</strong> Anything which could be thought of as a strength or
+              weakness of a given firm; formally, tangible and intangible assets which are tied
+              semipermanently to the firm (Wernerfelt, 1984, p.172, adopting the definition of
+              Caves, 1980). Examples Wernerfelt gives: brand names, in-house knowledge of
+              technology, employment of skilled personnel, trade contacts, machinery, efficient
+              procedures, and capital.
             </li>
             <li>
-              <strong>Valuable Resources:</strong> Resources that enable firms to implement
-              strategies that reduce costs or increase revenues by addressing market opportunities
-              or mitigating threats. Resources generate value by creating solutions that customers
-              willingly pay for, reducing production costs, or protecting against competitive
-              threat.
+              <strong>Resource position barrier:</strong> A first-mover advantage tied to a specific
+              resource that makes it more expensive or difficult for late-comers to acquire, build,
+              or operate that resource. Wernerfelt positions resource position barriers as
+              &ldquo;partially analogous&rsquo;&rsquo; to entry barriers, but defined at the
+              resource level (p.173). A resource position barrier can exist without an entry barrier
+              (leaving the firm vulnerable to diversifying entrants), and an entry barrier can exist
+              without a resource position barrier (leaving the firm unable to exploit its position
+              further).
             </li>
             <li>
-              <strong>Rare Resources:</strong> Resources that are not widely distributed among
-              competing firms, creating scarcity value. If all competing firms possess identical
-              resources, no firm can achieve competitive advantage. Rarity creates advantage by
-              restricting competitors&rsquo; ability to imitate strategies.
+              <strong>Attractive resource:</strong> A resource around which a resource position
+              barrier can be built - one that is self-reproducing or for which a firm which at a
+              given time finds itself in some sense ahead of others may use these barriers to cement
+              that lead (p.173). Wernerfelt gives four illustrative mechanisms for first-mover
+              resource advantages: <em>machine capacity</em>, <em>customer loyalty</em>,
+              <em>production experience</em>, and <em>technological leads</em> (pp.173-174).
             </li>
             <li>
-              <strong>Inimitable Resources:</strong> Resources that competitors cannot easily
-              duplicate or replicate even after observing their value. Resources become inimitable
-              through causal ambiguity (competitors cannot determine what specific combination of
-              activities creates advantage), social complexity (resources embedded in organizational
-              relationships and culture that are difficult to transfer), or proprietary resources
-              with legal protections.
+              <strong>Resource-product matrix:</strong> The central analytical device of the paper
+              (Figure 1, p.175). Rows represent resources, columns represent product-markets; X
+              entries mark a resource&rsquo;s role in a product-market. The matrix makes explicit
+              that diversification can be analysed from the resource side (reading across a row) as
+              well as from the product side (reading down a column), and that products share
+              resources just as resource portfolios share products.
             </li>
             <li>
-              <strong>Sustainable Competitive Advantage:</strong> Performance superiority that a
-              firm maintains over extended periods by controlling resources that competitors cannot
-              replicate or substitute for. Sustainable advantage requires a resource combination
-              that is valuable, rare, and inimitable, protected by barriers to competitive
-              duplication.
+              <strong>Mergers and acquisitions:</strong> Wernerfelt frames M&amp;A as an opportunity
+              to trade otherwise non-marketable resources in bundles. Acquisitions allow firms to
+              buy or sell resources which have &ldquo;a high degree of transparency&rsquo;&rsquo;
+              only between specific pairs of firms, through an imperfect market with few buyers and
+              targets (pp.174-175).
             </li>
             <li>
-              <strong>Resource Position Barriers:</strong> Mechanisms that prevent competitors from
-              acquiring or imitating a firm&rsquo;s resources. Barriers include time compression
-              diseconomies (resources require years to build and cannot be quickly replicated),
-              interconnectedness (resources create value only through combinations of other
-              resources), causal ambiguity (unclear which resource combinations create value), and
-              social complexity (organizational culture and relationships cannot be transferred).
-            </li>
-            <li>
-              <strong>Resource-Product Matrix:</strong> A conceptual framework showing how firm
-              resources can address multiple product-market opportunities. A single resource (such
-              as brand reputation) can create value across diverse products and markets, while
-              product portfolios may share underlying resources.
+              <strong>Sequential entry, exploit-and-develop, stepping stones:</strong> Three
+              dynamic-strategy patterns illustrated using the resource-product matrix (Figures 2-4,
+              pp.176-178). Sequential entry uses a single resource in successive markets;
+              exploit-and-develop uses profits from an established resource to build a new one;
+              stepping stones enter adjacent product-markets to build up resource positions for a
+              longer-term target market.
             </li>
           </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Concepts frequently associated with RBV in the <em>later</em> literature - including
+            &ldquo;valuable, rare, inimitable, non-substitutable&rdquo; (Barney, 1991), causal
+            ambiguity (Lippman &amp; Rumelt, 1982; Reed &amp; DeFillippi, 1990), social complexity
+            (Barney, 1991), and time-compression diseconomies (Dierickx &amp; Cool, 1989) - are
+            <em>not</em> in Wernerfelt (1984). They are treated in the Following Models section with
+            their correct attribution.
+          </p>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The Resource-Based View emerged in opposition to and as complement to industrial
-            organization economics:
+            Wernerfelt (1984) positions the resource perspective as a <em>complement</em> to - not a
+            rejection of - the dominant product-market analyses of the early 1980s (p.171:
+            &ldquo;resources and products are two sides of the same coin&rdquo;). The paper draws
+            explicitly on the following traditions:
           </p>
           <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>
-                Industrial Organization Economics (
-                <a
-                  id="cite-ref-porter-1980-1"
-                  href="#ref-porter-1980"
-                  className="text-tabs-teal-deep hover:underline"
-                >
-                  Porter, 1980
-                </a>
-                ):
-              </strong>{' '}
-              Dominated strategic management thinking by arguing industry structure (competitive
-              intensity, supplier power, customer power, substitute availability) determines firm
-              profitability. Porter&rsquo;s Five Forces framework positioned strategy as industry
-              selection and positioning within industry structure. RBV complemented this by shifting
-              focus to internal resources as equally important to industry factors.
-            </li>
-            <li>
-              <strong>
-                Organizational Economics and Transaction Cost Theory (
-                <a
-                  id="cite-ref-coase-1937-1"
-                  href="#ref-coase-1937"
-                  className="text-tabs-teal-deep hover:underline"
-                >
-                  Coase, 1937
-                </a>
-                ;{' '}
-                <a
-                  id="cite-ref-williamson-1975-1"
-                  href="#ref-williamson-1975"
-                  className="text-tabs-teal-deep hover:underline"
-                >
-                  Williamson, 1975
-                </a>
-                ):
-              </strong>{' '}
-              Examined why firms exist and how they organize activities differently than markets.
-              RBV incorporated these insights by treating firm-specific assets and capabilities as
-              reasons firms exist and compete differently.
-            </li>
             <li>
               <strong>
                 Penrose&rsquo;s Theory of the Growth of the Firm (
@@ -274,111 +271,210 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Pioneering work emphasizing that firms are bundles of resources and that growth is
-              constrained by management capacity to develop new resources. Wernerfelt explicitly
-              acknowledged Penrose as foundational to resource-based thinking, formalizing her
-              insights into strategic competitive advantage framework.
+              Wernerfelt cites Penrose as having &ldquo;relatively little formal attention&rdquo; in
+              strategy at the time (p.171) and as the direct source of the resource-bundle
+              conception of the firm. Penrose framed firms as bundles of productive resources whose
+              use is constrained by managerial capacity.
             </li>
             <li>
               <strong>
-                Organizational Capabilities and Routines (
+                Caves on industrial organization (
                 <a
-                  id="cite-ref-nelson-1982-1"
-                  href="#ref-nelson-1982"
+                  id="cite-ref-caves-1980-1"
+                  href="#ref-caves-1980"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Nelson &amp; Winter, 1982
+                  Caves, 1980
                 </a>
                 ):
               </strong>{' '}
-              Evolutionary economics perspective emphasizing that firms develop distinctive
-              capabilities and routines that are path-dependent and difficult to imitate. RBV
-              incorporated these insights about organizational routines as inimitable resources.
+              Wernerfelt adopts the resource definition of Caves (1980, p.172): &ldquo;tangible and
+              intangible assets which are tied semipermanently to the firm&rdquo;. Caves supplies
+              both the definitional vocabulary and the link to industrial organization that the
+              paper extends to the resource side.
             </li>
             <li>
               <strong>
-                Strategic Business Unit (SBU) Portfolio Theory (Boston Consulting Group, 1970s):
+                Porter&rsquo;s Competitive Strategy (
+                <a
+                  id="cite-ref-porter-1980-1"
+                  href="#ref-porter-1980"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Porter, 1980
+                </a>
+                ):
               </strong>{' '}
-              Models treating firms as portfolios of businesses with different growth-share
-              characteristics. RBV reframed portfolio thinking around shared resources and
-              capabilities rather than purely financial metrics.
+              Wernerfelt explicitly <em>uses</em> Porter&rsquo;s five competitive forces as the
+              analytical tool, noting (p.173) that while Porter&rsquo;s forces were originally
+              intended for product-market analysis, they apply by analogy at the resource level. The
+              paper positions the resource perspective as complementary to Porter&rsquo;s
+              product-perspective, not as its opposition.
+            </li>
+            <li>
+              <strong>
+                Strategy literature (
+                <a
+                  id="cite-ref-andrews-1971-1"
+                  href="#ref-andrews-1971"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Andrews, 1971
+                </a>
+                ):
+              </strong>{' '}
+              Wernerfelt opens by observing that traditional strategy (Andrews, 1971) is phrased in
+              terms of the resource position (strengths and weaknesses) of the firm, and that formal
+              economic tools operate on the product-market side. The paper aims to bring the two
+              perspectives together.
+            </li>
+            <li>
+              <strong>
+                Growth-share and experience-curve work (
+                <a
+                  id="cite-ref-bcg-1972-1"
+                  href="#ref-bcg-1972"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  BCG, 1972
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-henderson-1979-1"
+                  href="#ref-henderson-1979"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Henderson, 1979
+                </a>
+                ):
+              </strong>{' '}
+              BCG&rsquo;s experience-curve and growth-share matrix directly inspired the
+              resource-product matrix. Wernerfelt notes that the product portfolio theory
+              (Henderson, 1979) &ldquo;underscores the duality between the product and resource
+              perspectives on the firm&rdquo; (p.177).
+            </li>
+            <li>
+              <strong>
+                Economics of scope and growth (
+                <a
+                  id="cite-ref-panzar-1981-1"
+                  href="#ref-panzar-1981"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Panzar &amp; Willig, 1981
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-rubin-1973-1"
+                  href="#ref-rubin-1973"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Rubin, 1973
+                </a>
+                ):
+              </strong>{' '}
+              Cited as formal-economic precedents for how multiproduct linkages benefit from
+              non-financial (resource) linkages. Panzar &amp; Willig supply the formalization of the
+              economics of scope; Rubin supplies an earlier formal treatment of multiproduct firm
+              growth.
             </li>
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The Resource-Based View proposes that sustainable competitive advantage originates from
-            firm control of resources that are valuable, rare, inimitable, and non-substitutable.
-            Rather than analyzing strategy as response to industry structure, RBV analyzes strategy
-            as leveraging firm-specific resources to create competitive advantage. Resources can be
-            physical (factories, equipment, inventory), financial (capital availability), human
-            capital (employee skills, knowledge), organizational (systems, processes, culture,
-            structure), or intellectual property (patents, trademarks, knowledge, relationships).
-            Firms compete by accumulating, developing, and leveraging unique resource combinations
-            that competitors cannot easily replicate.
+            Wernerfelt (1984) develops the framework in four steps: (1) reframe strategic analysis
+            from the product side to the resource side; (2) identify classes of resources for which
+            resource position barriers can be built; (3) illustrate dynamic strategy with the
+            resource-product matrix; (4) extend the analysis to mergers and acquisitions as a means
+            of trading otherwise non-marketable resources. The paper uses Porter&rsquo;s (1980) five
+            competitive forces as the tool of analysis but applies them at the resource level
+            (p.173), positioning RBV as complement to - not replacement of - industrial-organization
+            strategy analysis.
           </p>
 
-          <h3 className={H3_CLASSES}>Resource Evaluation Framework</h3>
+          <h3 className={H3_CLASSES}>Resource position barriers (pp.172-173)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Wernerfelt argues that resources, like product-markets, admit analogues of
+            Porter&rsquo;s competitive forces: monopoly power in the production of a resource,
+            ceteris paribus, diminishes the returns available to its users; the availability of
+            substitute resources depresses returns; buyer and supplier power at the resource level
+            shape the payoffs of resource ownership (pp.172-173). A{' '}
+            <em>resource position barrier</em> is the first-mover analogue at the resource level - a
+            mechanism which makes an advantage over another resource holder defensible.
+          </p>
+
+          <h3 className={H3_CLASSES}>
+            Four illustrative first-mover resource advantages (pp.173-174)
+          </h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Valuable Resources:</strong> Resources address market opportunities or
-              mitigate competitive threats by enabling cost reductions, revenue increases, or unique
-              value delivery. Resources create value to the extent they are sought by customers and
-              defended against competitive copying.
+              <strong>Machine capacity:</strong> Scale economies in the use of a productive resource
+              are a prime example of product-entry barriers (Spence, 1979). From the resource
+              perspective, the product-entry barrier translates into a resource-position barrier:
+              where excess capacity would lead to cut-throat competition and low returns, the
+              resource position barrier operates through lower expected revenues for prospective
+              acquirers.
             </li>
             <li>
-              <strong>Rare Resources:</strong> Resources not widely available among competing firms.
-              Heterogeneity across firms in resource possession creates the potential for
-              competitive advantage. Resources that are common across firms cannot be sources of
-              competitive differentiation.
+              <strong>Customer loyalty:</strong> The market for customers generates a resource
+              position barrier - it is much easier to pioneer a position than to replace someone
+              else who already has it (Ries and Trout, 1981). Related examples are first-mover
+              advantages in government contracts and access to raw materials.
             </li>
             <li>
-              <strong>Inimitable Resources:</strong> Resources difficult for competitors to acquire
-              or develop through their own actions or through purchase in factor markets.
-              Inimitability arises from causal ambiguity (unclear connections between resources and
-              performance), social complexity (resources embedded in relationships and culture),
-              historical contingency (resources that required specific past conditions to develop),
-              or proprietary protection.
+              <strong>Production experience:</strong> If the leader executes the experience curve
+              strategy correctly, later resource producers have to pay their experience in an uphill
+              battle with earlier producers who have lower costs (BCG, 1972). Ideally, later
+              acquirers should pay more for the experience and expect lower returns from it.
             </li>
             <li>
-              <strong>Non-Substitutable Resources:</strong> Resources that competitors cannot
-              replicate through alternative means. Substitutability risk occurs when different
-              resources or resource combinations can achieve similar strategic outcomes.
+              <strong>Technological leads:</strong> A technological lead allows the firm higher
+              returns and enables it to keep better people in a more stimulating setting, so that
+              the organization can develop and calibrate more advanced ideas than followers - who
+              must often face the reinvention of your ideas easier than you found the original
+              invention. The advantage is fragile and must be kept protected.
             </li>
           </ul>
 
-          <h3 className={H3_CLASSES}>Mechanisms Creating Inimitability</h3>
+          <h3 className={H3_CLASSES}>Resource-product matrix and dynamic strategy (pp.175-178)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            The resource-product matrix (Figure 1) is a grid with resources as rows and
+            product-markets as columns, with X entries marking a resource&rsquo;s use in a given
+            product-market. Three dynamic strategy patterns are then illustrated on top of this
+            device:
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Causal Ambiguity:</strong> When the causal connections between firm resources,
-              actions, and performance outcomes are unclear or ambiguous, competitors cannot
-              determine which specific resource combinations or actions create competitive
-              advantage. Even observing the advantage, competitors cannot confidently identify which
-              changes to implement.
+              <strong>Sequential entry (Figure 2, p.176):</strong> A single resource is used in
+              successive product-markets over time. Wernerfelt gives the example of a firm using
+              production skills to enter pen, lighters, and razors sequentially.
             </li>
             <li>
-              <strong>Social Complexity:</strong> Resources embodied in organizational
-              relationships, culture, values, and informal systems are extremely difficult to
-              transfer. These tacit, relationship-embedded resources are difficult for outsiders to
-              understand and impossible to acquire directly because they cannot be separated from
-              the organizational context that created them.
+              <strong>Exploit-and-develop (Figure 3, p.177):</strong> Profits from an established
+              resource (e.g. &ldquo;domestic contacts&rdquo;) are used to build a new resource (e.g.
+              &ldquo;international contacts&rdquo;) through joint cost effects. This balances
+              exploitation of existing resources against development of new ones.
             </li>
             <li>
-              <strong>Time Compression Diseconomies:</strong> Resources that require extended
-              periods to develop cannot be quickly replicated through accelerated effort.
-              Experience, reputation, relationships, and organizational capabilities accumulate over
-              time; competitors cannot telescope this process.
-            </li>
-            <li>
-              <strong>Proprietary Legal Protection:</strong> Patents, trademarks, copyrights, trade
-              secrets, and contractual protections create legal barriers preventing imitation.
-              However, legal protection alone typically does not sustain advantage indefinitely as
-              protection eventually expires or technologies are designed around patent claims.
+              <strong>Stepping stones (Figure 4, p.178):</strong> A firm enters related
+              product-markets not for their own sake but because each market short-term balance
+              effects (joint positioning, shared learning) that build resource positions for a
+              longer-term target product-market.
             </li>
           </ul>
+
+          <h3 className={H3_CLASSES}>Mergers and acquisitions (pp.174-175)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Wernerfelt treats M&amp;A as the primary vehicle for trading non-marketable resources in
+            bundles - brand, technology, skills - under thin-market conditions. Prospective buyers
+            limit search to targets satisfying simple criteria: what resources a target has, which
+            the firm can take advantage of, the cost of doing so, and what the firm could pay for
+            them. Related-supplementary and related-complementary acquisition strategies are
+            distinguished (Salter &amp; Weinhold, 1979).
+          </p>
 
           <h3 className={H3_CLASSES}>Main Strengths</h3>
           <ul className={BODY_LIST_CLASSES}>
@@ -468,56 +564,64 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The contributions of Wernerfelt (1984) as originally stated are narrower than later
+            reviews often suggest. The paper&rsquo;s specific contributions are:
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Paradigm shift in strategic management:</strong> Successfully challenged
-              industrial organization economics as exclusive strategic lens by establishing internal
-              resources as equally important to external industry structure in determining
-              competitive performance.
+              <strong>Resource-perspective analogue to product-market analysis:</strong> Established
+              that the tools of industrial-organization strategy (entry barriers, Porter&rsquo;s
+              five forces) can be applied symmetrically at the resource level rather than only at
+              the product-market level (pp.172-173).
             </li>
             <li>
-              <strong>Firm heterogeneity explanation:</strong> Provided theoretical explanation for
-              why firms in identical industries achieve dramatically different performance levels
-              through control of distinctive resources.
+              <strong>Concept of a resource position barrier:</strong> Introduced resource position
+              barriers as the resource-level analogue of entry barriers - a first-mover advantage in
+              a specific resource that makes an advantage over another resource holder defensible
+              (p.173). Wernerfelt does <em>not</em> supply the mechanisms later attributed to RBV
+              (causal ambiguity, social complexity, time-compression diseconomies); those came
+              later.
             </li>
             <li>
-              <strong>Sustainable competitive advantage framework:</strong> Established
-              value-rarity-inimitability as the criteria for sustainable advantage, moving strategy
-              beyond temporary advantages easily copied by competitors.
+              <strong>Resource-product matrix:</strong> Introduced the resource-product matrix
+              (Figure 1, p.175) as a working analytical tool, explicitly connected to
+              growth-share-style portfolio thinking (Henderson, 1979) and to the duality between
+              product and resource perspectives.
             </li>
             <li>
-              <strong>Resource barriers concept:</strong> Introduced concept of resource position
-              barriers explaining mechanisms through which firms protect advantages through time
-              compression diseconomies, causal ambiguity, social complexity, and proprietary
-              protection.
+              <strong>Four illustrative first-mover resource advantages:</strong> Spelled out
+              machine capacity, customer loyalty, production experience, and technological leads as
+              concrete mechanisms for resource-level first-mover advantages, with named references
+              to Spence (1979), Ries &amp; Trout (1981), and BCG (1972).
             </li>
             <li>
-              <strong>Management focus shift:</strong> Redirected management strategic thinking from
-              industry selection and positioning to internal capability development and distinctive
-              resource building.
+              <strong>Dynamic strategy patterns:</strong> Provided three schematic dynamic-strategy
+              patterns on the resource-product matrix - sequential entry, exploit-and-develop,
+              stepping stones (Figures 2-4, pp.176-178) - offering a vocabulary for multi-period
+              resource development.
             </li>
             <li>
-              <strong>Theoretical legitimacy for organizational studies:</strong> Established
-              organizational capabilities, culture, and human capital as legitimate strategic assets
-              worthy of analysis rather than dismissing them as soft factors.
+              <strong>M&amp;A as resource-trading mechanism:</strong> Framed mergers and
+              acquisitions as an opportunity to trade otherwise non-marketable resources in bundles
+              - a framing that pre-dates and informs the later RBV and dynamic-capabilities
+              treatments of acquisitions.
             </li>
             <li>
-              <strong>Integration of multiple theoretical traditions:</strong> Successfully
-              synthesized organizational economics, behavioral theory, and strategic management into
-              coherent framework.
-            </li>
-            <li>
-              <strong>Foundation for further theory development:</strong> Provided foundation for
-              dynamic capabilities theory, knowledge-based view, and other resource-focused
-              strategic frameworks.
+              <strong>Foundation for later RBV work:</strong> Provided the conceptual ground from
+              which Barney (1991) later built the VRIN framework; Dierickx &amp; Cool (1989) built
+              the asset-stock-accumulation / time-compression-diseconomies treatment; Peteraf (1993)
+              built the four cornerstones formalization; and Teece, Pisano &amp; Shuen (1997) built
+              dynamic capabilities. These follow-on works are addressed in Following Models and
+              Further Reading.
             </li>
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -561,7 +665,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -615,7 +719,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -719,14 +823,103 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            RBV has spawned significant theoretical developments and extensions in strategic
-            management:
+            Wernerfelt (1984) was followed by a substantial RBV literature that filled in the
+            mechanisms the original paper left open. The most important extensions, in rough
+            chronological order, are:
           </p>
           <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Uncertain imitability (
+                <a
+                  id="cite-ref-lippman-1982-1"
+                  href="#ref-lippman-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Lippman &amp; Rumelt, 1982
+                </a>
+                ):
+              </strong>{' '}
+              Published two years <em>before</em> Wernerfelt (1984) but developed the
+              <em>causal-ambiguity</em> concept independently. Argues that interfirm efficiency
+              differences can persist when imitation requires replicating unclear causal chains.
+              Often grouped with Wernerfelt (1984) as a joint foundation of RBV, though Wernerfelt
+              does not cite it.
+            </li>
+            <li>
+              <strong>
+                Asset stock accumulation (
+                <a
+                  id="cite-ref-dierickx-1989-1"
+                  href="#ref-dierickx-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Dierickx &amp; Cool, 1989
+                </a>
+                ):
+              </strong>{' '}
+              Introduced <em>time-compression diseconomies</em>, <em>asset-mass efficiencies</em>,
+              <em>interconnectedness of asset stocks</em>, <em>asset erosion</em>, and{' '}
+              <em>causal ambiguity</em> as specific mechanisms that make resource positions
+              defensible. These are the mechanisms often (incorrectly) attributed to Wernerfelt
+              1984.
+            </li>
+            <li>
+              <strong>
+                VRIN framework (
+                <a
+                  id="cite-ref-barney-1991-1"
+                  href="#ref-barney-1991"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Barney, 1991
+                </a>
+                ):
+              </strong>{' '}
+              The canonical formalization of RBV. Barney argues sustained competitive advantage
+              requires resources that are <em>valuable</em>, <em>rare</em>, <em>inimitable</em>, and{' '}
+              <em>non-substitutable</em>. Barney (1995) later restated this as VRIO (substituting{' '}
+              <em>organization</em> for non-substitutability). VRIN/VRIO is Barney, not Wernerfelt;
+              the two papers are usually read together but say different things.
+            </li>
+            <li>
+              <strong>
+                Cornerstones of competitive advantage (
+                <a
+                  id="cite-ref-peteraf-1993-1"
+                  href="#ref-peteraf-1993"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Peteraf, 1993
+                </a>
+                ):
+              </strong>{' '}
+              Integrated the Wernerfelt, Barney, and Dierickx &amp; Cool strands into four
+              conditions: <em>heterogeneity</em>, <em>ex post limits to competition</em>,
+              <em>imperfect mobility</em>, and <em>ex ante limits to competition</em>. Widely
+              adopted as the canonical statement of the RBV logic.
+            </li>
+            <li>
+              <strong>
+                Industry vs. firm effects (
+                <a
+                  id="cite-ref-rumelt-1991-1"
+                  href="#ref-rumelt-1991"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Rumelt, 1991
+                </a>
+                ):
+              </strong>{' '}
+              Empirical work showing firm-level effects dominate industry effects in explaining
+              business-unit profitability variance - providing the empirical backing for the RBV
+              proposition that firm-specific resources, not industry structure, drive differential
+              performance.
+            </li>
             <li>
               <strong>
                 Dynamic Capabilities (
@@ -739,10 +932,10 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Extended RBV to dynamic environments by emphasizing not static resources but
-              organizational capabilities to sense market changes, seize opportunities, and
-              reconfigure resources rapidly. Dynamic capabilities address RBV limitations in
-              changing environments.
+              Extended RBV to dynamic environments by shifting the focus from static resources to
+              organizational capabilities for sensing market changes, seizing opportunities, and
+              reconfiguring resources. Addresses Wernerfelt&rsquo;s original concern that the
+              framework needed a dynamic treatment.
             </li>
             <li>
               <strong>
@@ -756,13 +949,13 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Specialized RBV by treating knowledge as the most important strategic resource.
-              Knowledge-based view emphasizes knowledge creation, integration, and application as
-              sources of competitive advantage.
+              Specialized RBV by treating knowledge as the strategically dominant resource class,
+              emphasizing knowledge creation, integration, and application as sources of competitive
+              advantage.
             </li>
             <li>
               <strong>
-                Competence-Based Competition (
+                Core competencies (
                 <a
                   id="cite-ref-hamel-1994-1"
                   href="#ref-hamel-1994"
@@ -772,44 +965,14 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Emphasized core competencies as bundles of skills and resources providing competitive
-              advantage. Articulated distinction between core competencies (strategic value-creating
-              resources) and non-core competencies.
-            </li>
-            <li>
-              <strong>Intellectual Capital Framework:</strong> Extended RBV to emphasize
-              intellectual resources including human capital, structural capital, and customer
-              capital as sources of competitive value.
-            </li>
-            <li>
-              <strong>Strategic Assets Theory:</strong> Refined resource conceptualization by
-              distinguishing between resources (inputs) and strategic assets (resources providing
-              defensible competitive advantages).
-            </li>
-            <li>
-              <strong>Organizational Learning Theory:</strong> Integration of RBV with learning
-              theory to understand how organizations develop, maintain, and leverage resources
-              through continuous learning and knowledge accumulation.
-            </li>
-            <li>
-              <strong>Strategic Human Capital:</strong> Application of RBV specifically to human
-              resources, emphasizing how distinctive workforce capabilities create competitive
-              advantage.
-            </li>
-            <li>
-              <strong>Relational View of the Firm:</strong> Extended RBV by emphasizing that
-              competitive advantage often emerges from inter-organizational relationships and
-              alliances rather than solely from internal resources.
-            </li>
-            <li>
-              <strong>Organizational Resilience:</strong> Applied RBV to organizational resilience
-              and adaptation, examining how resource diversity and slack create resilience in
-              disruption.
+              Popularized the view of firms as bundles of core competencies - collective
+              organizational learning - that enable entry into multiple markets, extending the
+              resource-product matrix logic to a managerial audience.
             </li>
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -817,8 +980,61 @@ const BibliographyArticlePage = () => {
               Wernerfelt, B. (1984). A resource-based view of the firm.{' '}
               <em>Strategic Management Journal</em>, 5(2), 171-180.
             </li>
+            <li id="ref-andrews-1971">
+              Andrews, K. (1971). <em>The concept of corporate strategy</em>. Dow Jones-Irwin.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-andrews-1971-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-bcg-1972">
+              Boston Consulting Group. (1972). <em>Perspectives on experience</em>. Boston
+              Consulting Group.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-bcg-1972-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-caves-1980">
+              Caves, R. E. (1980). Industrial organization, corporate strategy and structure.{' '}
+              <em>Journal of Economic Literature</em>, 58, 64-92.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-caves-1980-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-henderson-1979">
+              Henderson, B. D. (1979). <em>Henderson on corporate strategy</em>. Abt Books.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-henderson-1979-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-panzar-1981">
+              Panzar, J. C., &amp; Willig, R. D. (1981). Economies of scope.{' '}
+              <em>American Economic Review</em>, 71(2), 268-272.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-panzar-1981-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
             <li id="ref-penrose-1959">
-              Penrose, E. T. (1959). The theory of the growth of the firm. Oxford University Press.
+              Penrose, E. G. (1959). <em>The theory of the growth of the firm</em>. Wiley.
               <span className="text-xs ml-1">
                 <a
                   href="#cite-ref-penrose-1959-1"
@@ -828,8 +1044,7 @@ const BibliographyArticlePage = () => {
               </span>
             </li>
             <li id="ref-porter-1980">
-              Porter, M. E. (1980). Competitive strategy: Techniques for analyzing industries and
-              competitors. Free Press.
+              Porter, M. E. (1980). <em>Competitive strategy</em>. Free Press.
               <span className="text-xs ml-1">
                 <a
                   href="#cite-ref-porter-1980-1"
@@ -838,61 +1053,42 @@ const BibliographyArticlePage = () => {
                 ></a>
               </span>
             </li>
-            <li id="ref-coase-1937">
-              Coase, R. H. (1937). The nature of the firm. <em>Economica</em>, 4(16), 386-405.
+            <li id="ref-rubin-1973">
+              Rubin, P. H. (1973). The expansion of firms. <em>Journal of Political Economy</em>,
+              81, 936-949.
               <span className="text-xs ml-1">
                 <a
-                  href="#cite-ref-coase-1937-1"
+                  href="#cite-ref-rubin-1973-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
                 ></a>
               </span>
-            </li>
-            <li id="ref-williamson-1975">
-              Williamson, O. E. (1975). Markets and hierarchies: Analysis and antitrust
-              implications. Free Press.
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-williamson-1975-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>
-              </span>
-            </li>
-            <li id="ref-grant-1996">
-              Grant, R. M. (1996). Toward a knowledge-based theory of the firm.
-              <em>Strategic Management Journal</em>, 17(S2), 109-122.
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-grant-1996-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>
-              </span>
-            </li>
-            <li id="ref-nelson-1982">
-              Nelson, R. R., &amp; Winter, S. G. (1982). An evolutionary theory of economic change.
-              Harvard University Press.
-            </li>
-            <li id="ref-teece-1997">
-              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
-              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
-              https://doi.org/10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z
-            </li>
-            <li id="ref-hamel-1994">
-              Hamel, G., &amp; Prahalad, C. K. (1994). Competing for the future. Harvard Business
-              School Press.
             </li>
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The following works are <em>not</em> cited by Wernerfelt (1984). They represent the
+            later RBV tradition and are listed here for readers tracing the development of the
+            framework:
+          </p>
           <ol className={REFERENCES_OL_CLASSES}>
             <li id="ref-barney-1991">
-              Barney, J. B. (1991). Firm resources and sustained competitive advantage.
+              Barney, J. B. (1991). Firm resources and sustained competitive advantage.{' '}
               <em>Journal of Management</em>, 17(1), 99-120.
               https://doi.org/10.1177/014920639101700108
+            </li>
+            <li id="ref-dierickx-1989">
+              Dierickx, I., &amp; Cool, K. (1989). Asset stock accumulation and sustainability of
+              competitive advantage. <em>Management Science</em>, 35(12), 1504-1511.
+            </li>
+            <li id="ref-lippman-1982">
+              Lippman, S. A., &amp; Rumelt, R. P. (1982). Uncertain imitability: An analysis of
+              interfirm differences in efficiency under competition.{' '}
+              <em>Bell Journal of Economics</em>, 13(2), 418-438.
             </li>
             <li id="ref-peteraf-1993">
               Peteraf, M. A. (1993). The cornerstones of competitive advantage: A resource-based
@@ -902,10 +1098,22 @@ const BibliographyArticlePage = () => {
               Rumelt, R. P. (1991). How much does industry matter?{' '}
               <em>Strategic Management Journal</em>, 12(S1), 167-185.
             </li>
+            <li id="ref-teece-1997">
+              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
+              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
+            </li>
+            <li id="ref-grant-1996">
+              Grant, R. M. (1996). Toward a knowledge-based theory of the firm.{' '}
+              <em>Strategic Management Journal</em>, 17(S2), 109-122.
+            </li>
+            <li id="ref-hamel-1994">
+              Hamel, G., &amp; Prahalad, C. K. (1994). <em>Competing for the future</em>. Harvard
+              Business School Press.
+            </li>
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 2-1 RBV (Wernerfelt, 1984) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1575
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)