### PR TITLE
docs: standardize bibliography 2-2 VRIO Framework (Barney, 1991)

### DIFF
--- a/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
+++ b/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
@@ -800,9 +800,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-wernerfelt-1984-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-penrose-1959">
@@ -812,9 +810,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-penrose-1959-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-teece-1997">
@@ -826,9 +822,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-teece-1997-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-porter-1980">
@@ -839,9 +833,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-porter-1980-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-coase-1937">
@@ -851,9 +843,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-coase-1937-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-williamson-1975">
@@ -864,9 +854,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-williamson-1975-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-nelson-1982">

--- a/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
+++ b/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
@@ -727,9 +727,9 @@ const BibliographyArticlePage = () => {
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>Empirical validation mixed:</strong> Subsequent research has produced mixed
-              support for VRIO predictions. Some studies confirm that VRIO-predicted advantages
-              persist while others find limited relationship between VRIO criteria and actual
-              performance.
+              support for the framework&rsquo;s predictions. Some studies confirm that
+              VRIO-predicted advantages persist while others find limited relationship between VRIO
+              criteria and actual performance.
             </li>
             <li>
               <strong>Industry differences in applicability:</strong> VRIO may better predict
@@ -849,9 +849,13 @@ const BibliographyArticlePage = () => {
               negates resource value.
             </li>
             <li>
-              <strong>Invest in causal ambiguity:</strong> Build adoption advantage through
-              organizational culture, subtle processes, and interconnected routines that competitors
-              will find difficult to understand and imitate.
+              <strong>
+                Emphasize resources with naturally high causal ambiguity or social complexity:
+              </strong>{' '}
+              The framework suggests that adoption advantages rooted in interconnected culture,
+              routines, and tacit know-how are structurally harder for competitors to imitate than
+              those rooted in purchased technology alone (Barney, 1991, p.110). This is a
+              descriptive implication, not a recommendation to obscure processes deliberately.
             </li>
             <li>
               <strong>Develop social capital and relationships:</strong> Build adoption advantages
@@ -1026,6 +1030,26 @@ const BibliographyArticlePage = () => {
                   aria-label="Back to citation 1"
                 ></a>
               </span>
+            </li>
+            <li id="ref-baumol-1982">
+              Baumol, W. J., Panzar, J. C., &amp; Willig, R. D. (1982).{' '}
+              <em>Contestable markets and the theory of industry structure</em>. Harcourt Brace
+              Jovanovich.
+            </li>
+            <li id="ref-becker-1964">
+              Becker, G. S. (1964). <em>Human capital</em>. Columbia University Press.
+            </li>
+            <li id="ref-nelson-1982">
+              Nelson, R. R., &amp; Winter, S. G. (1982).{' '}
+              <em>An evolutionary theory of economic change</em>. Harvard University Press.
+            </li>
+            <li id="ref-tomer-1987">
+              Tomer, J. F. (1987).{' '}
+              <em>Organizational capital: The path to higher productivity and well-being</em>.
+              Praeger.
+            </li>
+            <li id="ref-williamson-1975">
+              Williamson, O. E. (1975). <em>Markets and hierarchies</em>. Free Press.
             </li>
             <li id="ref-barney-1986">
               Barney, J. B. (1986). Strategic factor markets: Expectations, luck, and business

--- a/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
+++ b/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
@@ -608,46 +608,56 @@ const BibliographyArticlePage = () => {
         {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Barney (1991) is a specific conceptual contribution within a larger RBV tradition. Its
+            contributions, as stated by the paper and subsequent literature, are:
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>RBV operationalization:</strong> Successfully translated Wernerfelt&rsquo;s
-              abstract RBV concepts into practical, applicable analytical framework usable by
-              practitioners and researchers.
+              <strong>Four-attribute framework (VRIN):</strong> Introduced a parsimonious set of
+              empirical indicators - value, rareness, imperfect imitability, non-substitutability -
+              that collectively distinguish resources generating sustained competitive advantage
+              from those that do not (p.105-112). This was the first explicit and systematic list of
+              such criteria in the RBV literature.
             </li>
             <li>
-              <strong>Added organization dimension:</strong> Extended RBV by recognizing that
-              resource possession alone is insufficient; organizational structures and systems must
-              be aligned to exploit resources.
+              <strong>Equilibrium definition of sustained competitive advantage:</strong> Redefined
+              &ldquo;sustained&rdquo; not as calendar duration but as robustness to duplication
+              efforts (p.102-103), adapting the Lippman &amp; Rumelt (1982) and Hirshleifer (1982)
+              equilibrium framing. This avoids both the trivial reading (&ldquo;sustained means
+              lasts forever&rdquo;) and the imprecise reading (&ldquo;sustained means has lasted N
+              years&rdquo;).
             </li>
             <li>
-              <strong>Predictive framework:</strong> Provided decision-tree logic predicting
-              competitive implications of different resource combinations, moving beyond descriptive
-              framework to prescriptive guidance.
+              <strong>Resource heterogeneity and immobility as prerequisites:</strong> Made explicit
+              the two assumptions (p.101, 103-105) that must hold for any resource-based explanation
+              of sustained advantage to be coherent. This clarified what RBV commits to and what it
+              rules out.
             </li>
             <li>
-              <strong>Research validation foundation:</strong> Enabled empirical research testing
-              VRIO predictions by providing operationalizable criteria, advancing from theoretical
-              discussion to empirical science.
+              <strong>Typology of imperfect imitability sources:</strong> Organized the earlier
+              literature on why resources are hard to imitate into three named mechanisms - unique
+              historical conditions, causal ambiguity, social complexity (p.107-112) - attributing
+              the underlying concepts to Lippman &amp; Rumelt (1982) and Dierickx &amp; Cool (1989).
             </li>
             <li>
-              <strong>Strategic management pedagogy transformation:</strong> Made resource-based
-              strategy teaching practical and case-study compatible, enabling strategy education
-              based on framework application.
+              <strong>Three illustrative applications:</strong> Demonstrated the framework&rsquo;s
+              use on strategic planning, information processing systems, and positive reputations
+              (p.112-117), showing how to reason from resource description to
+              competitive-implication conclusion.
             </li>
             <li>
-              <strong>Comprehensive resource evaluation:</strong> Established systematic approach
-              evaluating all resource types (physical, financial, human, organizational,
-              intellectual) through unified analytical framework.
+              <strong>Positioning RBV as complement to industry analysis:</strong> Figure 1 (p.100)
+              explicitly locates the resource-based model and environmental models of competitive
+              impact as addressing different aspects of the same strengths-weaknesses-
+              opportunities-threats frame, rather than competing paradigms.
             </li>
             <li>
-              <strong>Advantage sustainability articulation:</strong> Clearly distinguished between
-              temporary and sustained competitive advantage, explaining what determines advantage
-              persistence.
-            </li>
-            <li>
-              <strong>Foundation for extended research:</strong> Provided foundation for subsequent
-              theory development including dynamic capabilities, organizational ambidexterity, and
-              capability development research.
+              <strong>Foundation for VRIO (Barney, 1995, 1997):</strong> The four-attribute
+              structure of Barney (1991) became the substrate for the later VRIO refinement, where
+              Non-substitutability is replaced with Organization (folding substitution into the
+              Imitability criterion). VRIO is the teaching-focused successor to Barney 1991, not a
+              distinct theoretical proposal.
             </li>
           </ul>
         </section>
@@ -656,41 +666,53 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            As a framework paper extending Wernerfelt&rsquo;s RBV, VRIO&rsquo;s internal validity
-            derives from logical coherence and consistency with established organizational evidence:
+            Barney (1991) is a conceptual paper, not an empirical study. Internal validity is
+            therefore assessed as logical coherence of the argument and fidelity to cited sources:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Logical consistency:</strong> The framework&rsquo;s core logic is sound:
-              resources creating value become competitive advantages only if they are rare,
-              inimitable, and organized for exploitation. The decision-tree implications follow
-              logically from criteria combinations.
+              <strong>Deductive chain is clean:</strong> The paper begins with two assumptions
+              (resource heterogeneity and immobility), derives that competition with homogeneous and
+              perfectly mobile resources cannot sustain advantage (p.103-105), and then derives the
+              four attributes as necessary conditions for sustained advantage given heterogeneity
+              and immobility. The four-attribute framework is a conclusion of the argument, not an
+              assumed input.
             </li>
             <li>
-              <strong>Grounding in RBV foundation:</strong> VRIO directly operationalizes RBV,
-              maintaining theoretical consistency with Wernerfelt&rsquo;s foundational concepts
-              while extending them with the organization dimension.
+              <strong>Equilibrium definition is well-formed:</strong> The sustained-CA definition
+              (p.102) follows Lippman &amp; Rumelt (1982) and is consistent with standard
+              equilibrium reasoning (Hirshleifer, 1982). &ldquo;Sustained&rdquo; is defined in terms
+              of counterfactual duplication attempts, not calendar time.
             </li>
             <li>
-              <strong>Integration with organizational evidence:</strong> VRIO explains
-              well-documented organizational phenomena: why some firms sustain advantage while
-              others erode competitive positions, why organizational structure matters for advantage
-              realization.
+              <strong>Imitability mechanisms are explicitly attributed:</strong> Causal ambiguity is
+              attributed to Lippman &amp; Rumelt (1982) and Alchian (1950), unique historical
+              conditions to path-dependency economics (Arthur, 1983; David, 1985), social complexity
+              to Dierickx &amp; Cool (1989) and Barney (1986b). The paper does not claim these
+              mechanisms as original.
             </li>
             <li>
-              <strong>Theoretical completeness:</strong> By addressing value, rarity, inimitability,
-              and organization, the framework addresses multiple dimensions of resource advantage
-              rather than treating advantage unidimensionally.
+              <strong>Explicit scope of SCA:</strong> The paper explicitly states that SCA does not
+              mean &ldquo;lasts forever&rdquo; and can be disrupted by Schumpeterian shocks or
+              structural revolutions in an industry (p.103, citing Schumpeter 1934, 1950; Rumelt
+              &amp; Wensley 1981). The construct is defined carefully enough to survive trivial
+              counterexamples.
             </li>
             <li>
-              <strong>Clear definitional consistency:</strong> Definitions of each VRIO criterion
-              are clearly articulated and internally consistent, reducing ambiguity in framework
-              interpretation.
+              <strong>Three applied examples test the framework internally:</strong> The paper
+              itself applies the VRIN criteria to three candidate sources (strategic planning,
+              information processing systems, positive reputation) and shows the framework generates
+              non-trivial conclusions - some versions of each resource qualify for SCA, others do
+              not. This demonstrates the framework discriminates rather than rubber-stamping.
             </li>
             <li>
-              <strong>Comprehensive advantage prediction:</strong> The framework provides
-              predictions for all possible resource combinations, covering competitive parity,
-              temporary advantage, and sustained advantage.
+              <strong>Known internal-validity limitations:</strong> (i) The framework&rsquo;s four
+              attributes are yes/no questions without a formal metric, so operationalization is left
+              to subsequent work; (ii) the causal ambiguity criterion is self-referentially
+              problematic - if managers cannot understand their own resource-performance link, the
+              test requires external observers to judge what the firm itself does not know (Barney
+              acknowledges this tension on p.109); (iii) the paper is susceptible to the tautology
+              critique that attaches to RBV more broadly (Priem &amp; Butler, 2001, later response).
             </li>
           </ul>
         </section>

--- a/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
+++ b/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
@@ -69,6 +69,17 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 99-120
             </p>
+            <p>
+              <strong>DOI:</strong>{' '}
+              <a
+                href="https://doi.org/10.1177/014920639101700108"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.1177/014920639101700108
+              </a>
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
+++ b/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
@@ -4,627 +4,943 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
-  REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
   title: 'Bibliography: VRIO Framework - Barney (1991)',
   description:
-    "An exploration of Jay Barney's VRIO Framework for analyzing firm resources and sustained competitive advantage, providing practical criteria for evaluating which organizational capabilities drive technology adoption success.",
+    'Comprehensive overview of the VRIO (Valuable, Rare, Inimitable, Organized) framework, operationalizing the Resource-Based View of the firm with analytical criteria for identifying sustainable sources of competitive advantage.',
 }
 
-const VRIOFrameworkPage = () => {
+const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Bibliography: VRIO Framework - Barney (1991)</h1>
+        <h1 className={H1_CLASSES}>VRIO Framework - Barney (1991)</h1>
 
-        {/* Framework Identification */}
+        {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Framework Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Framework Name:</strong> VRIO Framework
+              <strong>Framework Name:</strong> VRIO Framework (Valuable, Rare, Inimitable,
+              Organized)
             </p>
             <p>
-              <strong>Authors:</strong> Jay B. Barney
+              <strong>Framework Abbreviation:</strong> VRIO (also known as VRIN - Valuable, Rare,
+              Inimitable, Non-substitutable)
             </p>
             <p>
-              <strong>Publication Date:</strong> 1991
+              <strong>Target of Framework:</strong> Systematic analysis of firm resources to
+              identify sources of sustained competitive advantage and predict competitive
+              implications of resource possession
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Strategic Management, Business Policy,
+              Organization Theory
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Author:</strong> Jay B. Barney
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 1991
+            </p>
+            <p>
+              <strong>Official Title:</strong> Firm resources and sustained competitive advantage
+            </p>
+            <p>
+              <strong>Journal:</strong> Journal of Management
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 17, No. 1
+            </p>
+            <p>
+              <strong>Pages:</strong> 99-120
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Barney, J. B. (1991). Firm resources and sustained competitive advantage.{' '}
-              <em>Journal of Management</em>, 17(1), 99-120.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Barney, J. B. (
+                <a href="#ref-barney-1991" className="text-tabs-teal-deep hover:underline">
+                  1991
+                </a>
+                ). Firm resources and sustained competitive advantage.
+                <em>Journal of Management</em>, 17(1), 99-120.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Barney, Jay B. 1991. &ldquo;Firm Resources and Sustained Competitive
+                Advantage.&rdquo;
+                <em>Journal of Management</em> 17, no. 1: 99-120.
+              </p>
+            </div>
           </div>
         </section>
 
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <p className={PARAGRAPH_CLASSES}>
-            In 1991, Jay B. Barney published &ldquo;Firm Resources and Sustained Competitive
-            Advantage&rdquo; in the Journal of Management, creating what would become one of the
-            most widely applied frameworks in strategic management: the VRIO Framework. Building on
-            Wernerfelt&rsquo;s 1984 Resource-Based View, Barney addressed a critical gap that had
-            limited the practical application of resource-based thinking-the lack of clear,
-            operational criteria for determining which resources truly create sustained competitive
-            advantage.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The VRIO Framework transforms abstract resource-based theory into a practical analytical
-            tool by asking four systematic questions about any organizational resource: Is it
-            Valuable? Is it Rare? Is it difficult to Imitate? Is the Organization structured to
-            exploit it? These four criteria provide managers with a rigorous method for evaluating
-            which capabilities deserve strategic investment and which represent true sources of
-            competitive advantage rather than simply table stakes for competing in an industry.
-          </p>
-
           <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Barney developed the VRIO framework to address critical gaps in how the Resource-Based
-            View could be applied practically by organizational leaders. While Wernerfelt&rsquo;s
-            1984 Resource-Based View had provided a compelling theoretical argument that firms
-            should analyze strategy through their resources rather than product-market positioning,
-            the framework lacked clear, operational criteria for determining which resources should
-            be considered strategically significant.
+            Jay Barney developed the VRIO framework through a series of publications spanning the
+            1990s. His seminal 1991 paper in the Journal of Management introduced the VRIN criteria
+            (Valuable, Rare, Inimitable, Non-substitutable) for evaluating firm resources. In a 1995
+            Academy of Management Executive article, Barney reframed the criteria as the VRIO
+            framework, replacing Non-substitutable with Organized to emphasize that firms must be
+            organized to exploit their resources. He further elaborated the framework in his 1997
+            textbook, making it a centerpiece of strategic management education. This evolution
+            addressed a critical gap between Wernerfelt&rsquo;s Resource-Based View conceptual
+            insight and practical strategy application. Wernerfelt&rsquo;s 1984 RBV paper argued
+            compellingly that resources could provide sustained competitive advantage if they were
+            valuable, rare, and inimitable, but the paper remained largely theoretical without
+            providing specific guidance for practitioners or researchers on how to systematically
+            analyze firm resources using these criteria. Strategic managers could recognize
+            intuitively that some resources seemed important to competitive advantage, but they
+            lacked analytical frameworks for rigorous evaluation. Research lacking the
+            operationalization meant that testing and validating RBV remained difficult -scholars
+            could discuss resources abstractly but could not empirically measure whether specific
+            resources met value, rarity, and inimitability criteria.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The fundamental question Barney sought to answer was:{' '}
-            <em>
-              What characteristics must a firm&rsquo;s resources and capabilities possess in order
-              to create sustained competitive advantage?
-            </em>{' '}
-            This was not merely a theoretical question-it was deeply practical. Managers needed
-            guidance on which resources deserved significant investment, which capabilities should
-            be the focus of organizational development, and which resources represented true
-            strategic advantages versus simply competencies that all industry competitors possessed.
+            Barney recognized that RBV needed operationalization to become actionable. He developed
+            the VRIO framework to provide specific analytical questions managers could ask about
+            firm resources to determine whether those resources could generate sustained competitive
+            advantage. Barney added a fourth dimension to Wernerfelt&rsquo;s three: organization.
+            Resources could be valuable, rare, and inimitable, but if the firm lacked organizational
+            structures, processes, and systems to exploit those resources, the resources would not
+            generate competitive advantage. This expanded framework made RBV testable and teachable.
+            Barney provided decision trees and analytical tools that researchers could use to
+            empirically test whether specific resources met VRIO criteria and what competitive
+            implications followed from different combinations of these attributes.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Without systematic criteria for resource evaluation, the RBV framework risked being
-            dismissed as too vague and theoretical for practical application. Barney responded to
-            criticism that RBV frameworks lacked falsifiability and precision-that any resource
-            leading to superior performance could be retroactively labeled as rare and inimitable,
-            making the theory tautological. By specifying conditions more precisely and creating an
-            operational framework, Barney made the RBV more rigorous and applicable.
+            The VRIO framework also addressed the challenge of translating resource-based thinking
+            into actionable strategy for business schools and organizational strategists. By
+            providing specific analytical criteria and decision frameworks, Barney made RBV
+            accessible to strategy practitioners and academics beyond the small circle of
+            resource-based theorists. The framework became foundational to how strategic management
+            was taught: rather than abstract discussion of resources and advantages, instructors
+            could walk students through VRIO analysis of specific firms, evaluating whether
+            particular resources (brand, technology, customer relationships) met criteria for
+            sustained advantage. This combination of theoretical rigor and practical applicability
+            made the VRIO framework one of the most influential strategic management tools of the
+            1990s and beyond.
           </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The motivation also reflected a recognition that firms often have difficulty
-            distinguishing between resources that create temporary competitive advantage (advantages
-            that competitors can readily replicate) versus resources that create sustained
-            competitive advantage (advantages that are difficult or impossible to replicate even
-            after competitors observe their value). Many firms invest heavily in capabilities that
-            turn out to be easily imitated, wasting resources on competitive advantages that provide
-            no lasting benefit. Barney&rsquo;s framework was designed to help firms avoid this trap
-            by providing clear criteria for assessing the sustainability of competitive advantages
-            before committing significant resources to developing them.
-          </p>
+        </section>
 
-          <h2 className={H2_CLASSES}>The Four VRIO Criteria</h2>
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The VRIO Framework evaluates organizational resources and capabilities through four
-            sequential questions, each building on the previous one to determine the competitive
-            implications of a resource:
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            1. Value: Does the Resource Enable the Firm to Respond to Environmental Opportunities or
-            Threats?
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            A resource is valuable when it enables a firm to exploit opportunities or neutralize
-            threats in its environment. This criterion directly addresses whether a resource
-            contributes to competitive positioning in the firm&rsquo;s specific market context.
-            Resources that do not create value-that do not help the firm increase revenues, decrease
-            costs, or improve competitive positioning-represent competitive disadvantages regardless
-            of their other characteristics.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Value is context-dependent: a resource valuable in one competitive environment may not
-            be valuable in another. For example, advanced manufacturing automation may be highly
-            valuable in high-volume, standardized production but less valuable in highly customized,
-            low-volume manufacturing. Organizations must assess value in their specific competitive
-            context rather than assuming resources valuable elsewhere will be valuable for them.
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            2. Rarity: Is Control of the Resource Currently Limited to a Small Number of Competing
-            Firms?
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            A resource is rare when few competitors possess it. Resources that are valuable but
-            widely available in the industry do not create competitive advantage-they create
-            competitive parity. All firms possessing the resource can neutralize competitive threats
-            or exploit opportunities equally, meaning the resource becomes a requirement for
-            competing but not a source of advantage.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Rarity exists on a spectrum. The fewer competitors possessing a resource, the greater
-            the potential competitive advantage. However, rarity alone is insufficient for sustained
-            advantage if competitors can readily acquire or develop the resource once they recognize
-            its value.
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            3. Imitability: Do Firms Without the Resource Face a Cost Disadvantage in Obtaining or
-            Developing It?
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            A resource is difficult to imitate when competitors cannot easily replicate it, even
-            after recognizing its value. Barney identifies several conditions that make resources
-            difficult to imitate:
+            The VRIO framework is built on four evaluative criteria for analyzing firm resources:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Unique Historical Conditions:</strong> The resource was developed under unique
-              historical circumstances that cannot be recreated. For example, a firm&rsquo;s
-              reputation developed over decades cannot be quickly replicated by competitors.
+              <strong>Valuable (V):</strong> A resource is valuable to the extent that it enables a
+              firm to implement strategies that exploit opportunities or mitigate threats in the
+              environment. Resources enable value creation by improving competitive position,
+              enabling cost leadership, differentiation, or focus strategies, or creating barriers
+              preventing competitive threat. Resources without value do not contribute to
+              competitive advantage.
             </li>
             <li>
-              <strong>Causal Ambiguity:</strong> The relationship between the resource and
-              competitive advantage is unclear or poorly understood, making it difficult for
-              competitors to identify what to imitate or how to replicate success.
+              <strong>Rare (R):</strong> A resource is rare if the number of competing firms
+              possessing it is less than the number of firms required for competitive equilibrium.
+              Rarity is relative; a resource may be held by a few firms (very rare), some firms
+              (moderately rare), or many firms (not rare). Only rare resources can provide
+              competitive advantage since all firms with common resources will achieve similar
+              competitive positions.
             </li>
             <li>
-              <strong>Social Complexity:</strong> The resource is embedded in complex social
-              relationships, organizational culture, or interpersonal dynamics that competitors
-              cannot easily reproduce.
+              <strong>Inimitable (I):</strong> A resource is inimitable if competitors cannot easily
+              duplicate or imitate the resource, even after observing its existence and value.
+              Resources become inimitable through causal ambiguity (unclear how resource creates
+              value), social complexity (resources embedded in relationships and culture),
+              historical contingency (required unique past conditions), or proprietary nature.
+              Non-inimitable resources can provide only temporary advantage until imitation occurs.
+            </li>
+            <li>
+              <strong>Organized (O):</strong> A resource generates competitive advantage only if the
+              firm is organized to effectively exploit the resource. Organization requires
+              appropriate organizational structures, processes, systems, incentives, and management
+              controls that enable resource-based strategies. Resources without organizational
+              infrastructure to exploit them generate no competitive advantage.
+            </li>
+            <li>
+              <strong>Sustained Competitive Advantage:</strong> Performance superiority that a firm
+              maintains over extended time periods by possessing resources meeting all four VRIO
+              criteria (valuable, rare, inimitable, and organized). Sustained advantage is
+              distinguished from temporary advantage (resources meeting only some criteria) and
+              competitive parity (resources not meeting VRIO criteria).
             </li>
           </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            Resources that are difficult to imitate provide sustained competitive advantage because
-            competitors face cost or feasibility disadvantages in replication. Even when competitors
-            recognize the value and rarity of a resource, high imitation costs protect the
-            advantage.
-          </p>
+        </section>
 
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            4. Organization: Is the Firm Organized to Capture the Value from the Resource?
-          </h3>
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The final criterion recognizes that possessing valuable, rare, and inimitable resources
-            is insufficient for competitive advantage if the organization lacks complementary
-            systems, structures, and processes to exploit those resources. An organization must have
-            appropriate reporting structures, management control systems, compensation policies, and
-            organizational culture to effectively deploy its resources.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            This criterion distinguishes the VRIO framework from earlier RBV formulations by
-            explicitly recognizing that resources do not automatically create advantage-the
-            organization must be configured to capture value from its resources. Firms with
-            valuable, rare, and inimitable resources may still fail to achieve competitive advantage
-            if organizational dysfunction, poor coordination, or misaligned incentives prevent
-            effective resource deployment.
-          </p>
-
-          <h2 className={H2_CLASSES}>Competitive Implications of the VRIO Framework</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The VRIO Framework predicts specific competitive outcomes based on how resources perform
-            against the four criteria:
+            The VRIO framework directly builds on and operationalizes previous theories:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Not Valuable:</strong> Resources that fail the value criterion represent
-              competitive disadvantages. The firm should divest or restructure these resources.
-            </li>
-            <li>
-              <strong>Valuable but Not Rare:</strong> Resources that are valuable but widely
-              available create competitive parity. The firm must possess these to compete but gains
-              no advantage from them.
-            </li>
-            <li>
-              <strong>Valuable and Rare but Imitable:</strong> Resources meeting these criteria
-              create temporary competitive advantage. The firm can exploit advantage until
-              competitors successfully imitate the resource.
+              <strong>
+                Resource-Based View (
+                <a
+                  id="cite-ref-wernerfelt-1984-1"
+                  href="#ref-wernerfelt-1984"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Wernerfelt, 1984
+                </a>
+                ):
+              </strong>{' '}
+              VRIO operationalizes and formalizes Wernerfelt&rsquo;s foundational insight that
+              resources meeting value-rarity-inimitability criteria provide competitive advantage.
+              Barney extends RBV by adding the organization dimension.
             </li>
             <li>
               <strong>
-                Valuable, Rare, and Difficult to Imitate, but Not Organizationally Exploited:
+                Penrose&rsquo;s Theory of Firm Growth (
+                <a
+                  id="cite-ref-penrose-1959-1"
+                  href="#ref-penrose-1959"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Penrose, 1959
+                </a>
+                ):
               </strong>{' '}
-              These represent unused competitive potential. The firm possesses resources that could
-              create sustained advantage but fails to capture that value due to organizational
-              limitations.
+              Barney builds on Penrose&rsquo;s insight that firms are fundamentally bundles of
+              resources and that firm growth depends on resource development and organizational
+              capacity to deploy resources.
             </li>
             <li>
-              <strong>Valuable, Rare, Difficult to Imitate, and Organizationally Exploited:</strong>{' '}
-              Resources meeting all four VRIO criteria create sustained competitive advantage. These
-              are the strategic resources deserving significant organizational investment and
-              protection.
+              <strong>
+                Industrial Organization Economics (
+                <a
+                  id="cite-ref-porter-1980-1"
+                  href="#ref-porter-1980"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Porter, 1980
+                </a>
+                ):
+              </strong>{' '}
+              While emphasizing resources over industry structure, VRIO acknowledges that resources
+              create value to extent they address environmental opportunities and threats,
+              incorporating Porter&rsquo;s insights about strategy-environment fit.
+            </li>
+            <li>
+              <strong>
+                Organizational Economics and Transaction Costs (
+                <a
+                  id="cite-ref-coase-1937-1"
+                  href="#ref-coase-1937"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Coase, 1937
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-williamson-1975-1"
+                  href="#ref-williamson-1975"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Williamson, 1975
+                </a>
+                ):
+              </strong>{' '}
+              VRIO incorporates insights that firms organize activities to exploit distinctive
+              capabilities and that organizational structure determines competitive advantage.
+            </li>
+            <li>
+              <strong>
+                Organizational Routines and Capabilities (
+                <a
+                  id="cite-ref-nelson-1982-1"
+                  href="#ref-nelson-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Nelson &amp; Winter, 1982
+                </a>
+                ):
+              </strong>{' '}
+              VRIO treats organizational routines and capabilities as resources that become
+              inimitable through social complexity and causal ambiguity.
+            </li>
+            <li>
+              <strong>Human Capital Theory:</strong> VRIO extends resource-based thinking to human
+              capital by recognizing employee skills, knowledge, and relationships as valuable,
+              rare, and potentially inimitable resources.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The VRIO framework provides a systematic method for analyzing firm resources to predict
+            competitive implications. Managers evaluate each resource across four dimensions,
+            determining whether the resource is valuable, rare, inimitable, and organized. The
+            framework operates as a decision tree: resources meeting all four criteria create
+            sustained competitive advantage; resources meeting three criteria (valuable, rare,
+            inimitable but unorganized) create temporary advantage only until the firm reorganizes
+            to exploit the resource; resources meeting only two criteria (valuable and rare but
+            imitable) create temporary competitive advantage until competitors imitate; and
+            resources meeting only one criterion or none generate no competitive advantage.
+          </p>
+
+          <h3 className={H3_CLASSES}>The Four VRIO Criteria</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Valuable (V):</strong> Does the resource enable the firm to implement
+              strategies that exploit opportunities or mitigate threats? Can the resource reduce
+              costs, increase revenues, or strengthen market position? If the resource does not
+              enable economically superior strategies, it provides no advantage.
+            </li>
+            <li>
+              <strong>Rare (R):</strong> Is the resource possessed by few competitors? Is the
+              resource scarce in the competitive marketplace? Resources held by many competitors do
+              not create competitive advantage regardless of value. Rarity creates advantage
+              potential only when combined with value.
+            </li>
+            <li>
+              <strong>Inimitable (I):</strong> Is the resource difficult for competitors to imitate
+              or duplicate? Are there barriers preventing competitive imitation? Sources of
+              inimitability include causal ambiguity, social complexity, historical contingency, and
+              proprietary protections. Resources easily imitated by competitors provide only
+              temporary advantage.
+            </li>
+            <li>
+              <strong>Organized (O):</strong> Does the firm possess appropriate organizational
+              structures, processes, systems, and incentives to effectively exploit the resource?
+              Does the firm have the management infrastructure to leverage resource value? Resources
+              not organized for exploitation generate no advantage.
             </li>
           </ul>
 
-          <h2 className={H2_CLASSES}>Application to Technology Adoption</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            While the VRIO Framework was developed for general strategic resource analysis, it
-            provides powerful insights for technology adoption decisions. Organizations can apply
-            VRIO criteria to evaluate whether adopting specific technologies will create competitive
-            advantage:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Value Assessment:</strong> Does the technology address genuine competitive
-            threats or opportunities in our specific market context? Technologies valuable for
-            competitors may not be valuable for firms in different competitive positions or serving
-            different market segments. Organizations should assess whether technology adoption will
-            enable them to increase revenues, decrease costs, or improve competitive positioning
-            rather than adopting technologies simply because competitors have done so.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Rarity Assessment:</strong> How many competitors already possess or can easily
-            acquire this technology? Technologies that are widely available or easily purchasable
-            create competitive parity rather than advantage. First-mover advantage in technology
-            adoption may be temporary if competitors can quickly match the technology.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Imitability Assessment:</strong> What barriers prevent competitors from
-            replicating our use of this technology? The technology itself may be easily imitable,
-            but the organizational expertise in deploying the technology, the complementary
-            capabilities supporting effective use, or the unique ways the technology is integrated
-            with other organizational systems may be difficult to imitate. Organizations should
-            focus on building distinctive capabilities around technology deployment rather than
-            assuming the technology itself provides sustained advantage.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Organization Assessment:</strong> Do we have the organizational structures,
-            management systems, personnel expertise, and cultural alignment to effectively exploit
-            this technology? Many technology adoption failures occur not because the technology
-            lacks value but because the organization fails to structure itself appropriately to
-            capture that value.
-          </p>
+          <h3 className={H3_CLASSES}>Competitive Implications of VRIO Combinations</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Not Valuable (Not-V, regardless of R, I, O):</strong> If a resource is not
+              valuable -if it does not enable strategies addressing market opportunities or threats
+              -the resource generates no competitive advantage. Firms with not-valuable resources
+              occupy positions of competitive parity or disadvantage regardless of how rare or
+              inimitable the resource.
+            </li>
+            <li>
+              <strong>Valuable but Not Rare (V, Not-R, regardless of I, O):</strong> Resources
+              valuable but commonly held by many competitors position firms at competitive parity.
+              If all competitors possess the resource, all achieve similar competitive positions.
+              These are table-stakes resources required to compete but insufficient for advantage.
+            </li>
+            <li>
+              <strong>Valuable and Rare but Not Inimitable (V, R, Not-I):</strong> These resources
+              create temporary competitive advantage that persists until competitors imitate.
+              First-mover advantage, novel technologies not protected by patents, and unique
+              strategies easily copied by competitors generate temporary advantage.
+            </li>
+            <li>
+              <strong>Valuable, Rare, and Inimitable but Not Organized (V, R, I, Not-O):</strong>{' '}
+              These resources create sustained advantage potential, but organizational failures
+              prevent advantage realization. Firms with valuable, rare, inimitable resources but
+              poor organizational structures fail to leverage resource potential. Reorganization can
+              unlock advantage.
+            </li>
+            <li>
+              <strong>Valuable, Rare, Inimitable, and Organized (V, R, I, O):</strong> These
+              resources create sustained competitive advantage. Firms can maintain performance
+              superiority over extended periods because competitors cannot imitate resources that
+              are organized for effective exploitation.
+            </li>
+          </ul>
 
-          <h2 className={H2_CLASSES}>Strengths of the VRIO Framework</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The VRIO Framework possesses several significant strengths that have contributed to its
-            enduring influence on strategic management and technology adoption:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Operational Clarity and Practical Accessibility:</strong> The framework&rsquo;s
-            greatest strength is its transformation of abstract resource-based theory into a
-            practical analytical tool. The four VRIO questions are clear, systematic, and accessible
-            to managers without extensive theoretical training. Organizations can readily apply the
-            framework to evaluate their resources and capabilities, making resource-based thinking
-            actionable for strategic decision-making.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Systematic Evaluation Process:</strong> The framework provides a structured
-            analytical process that prevents organizations from overlooking critical dimensions of
-            resource value. By requiring sequential evaluation through all four criteria, the
-            framework prevents common errors such as assuming rare resources automatically create
-            advantage or assuming valuable resources will create advantage without appropriate
-            organizational exploitation.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Emphasis on Sustained Advantage:</strong> Unlike frameworks focusing on
-            immediate competitive positioning, VRIO explicitly addresses sustainability. The
-            framework helps organizations distinguish between temporary advantages that competitors
-            will quickly replicate and sustained advantages that provide long-term strategic value.
-            This temporal perspective is crucial for strategic investment decisions.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Recognition of Organizational Complementarities:</strong> The Organization
-            criterion represents a significant advancement over earlier RBV formulations by
-            explicitly recognizing that resources do not automatically create advantage. The
-            framework acknowledges that effective resource deployment requires appropriate
-            organizational structures, management systems, and capabilities. This recognition helps
-            organizations understand why resource acquisition alone is insufficient-they must also
-            develop organizational capacity to exploit resources.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Flexibility Across Resource Types:</strong> The framework applies equally to
-            tangible resources (physical assets, technology, equipment) and intangible resources
-            (brand reputation, organizational culture, personnel expertise, processes). This
-            flexibility makes VRIO applicable across diverse strategic contexts and resource
-            portfolios.
-          </p>
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Operationalizes RBV concepts:</strong> Provides specific analytical criteria
+              transforming abstract RBV ideas into practical, testable framework applicable to real
+              strategic situations.
+            </li>
+            <li>
+              <strong>Decision-tree clarity:</strong> The framework clearly specifies what
+              competitive implications follow from different combinations of VRIO attributes,
+              providing actionable guidance for strategic decisions.
+            </li>
+            <li>
+              <strong>Empirically testable:</strong> By providing specific questions managers can
+              ask about resources, VRIO becomes amenable to empirical research and validation in
+              ways the abstract RBV was not.
+            </li>
+            <li>
+              <strong>Teachable framework:</strong> The logic is sufficiently simple that strategic
+              management students can apply VRIO analysis to real firms, identifying which resources
+              provide sustainable advantage and why.
+            </li>
+            <li>
+              <strong>Bridges theory and practice:</strong> Balances theoretical sophistication with
+              practical applicability, making the framework valuable both for academic research and
+              management application.
+            </li>
+            <li>
+              <strong>Comprehensive resource scope:</strong> Applies to all resource types:
+              physical, financial, human, organizational, and intellectual property, providing
+              universal analytical framework.
+            </li>
+            <li>
+              <strong>Addresses organization explicitly:</strong> By including organization as
+              fourth criterion, framework recognizes that possessing resources alone is insufficient
+              without effective exploitation systems.
+            </li>
+            <li>
+              <strong>Powerful explanatory capability:</strong> Successfully explains why firms with
+              similar resources achieve different performance, why competitive advantages erode, and
+              how organizational changes influence advantage sustainability.
+            </li>
+          </ul>
 
-          <h2 className={H2_CLASSES}>Limitations and Critiques</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Despite its considerable strengths, the VRIO Framework exhibits certain limitations that
-            scholars and practitioners should understand:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Limited Dynamic Perspective:</strong> The framework focuses on evaluating
-            existing resources rather than addressing how organizations develop new resources or
-            adapt existing resources to changing environments. In rapidly changing markets, the
-            ability to continuously develop new capabilities may be more important than the value of
-            current resource endowments. The framework provides limited guidance on resource
-            development processes or dynamic capability building.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Difficulty in Imitation Assessment:</strong> Determining whether resources are
-            truly difficult to imitate can be challenging in practice. Causal ambiguity-one source
-            of imitation difficulty-means even the firm possessing the resource may not fully
-            understand why it creates value or whether competitors could replicate it. Organizations
-            may overestimate the inimitability of their resources because they underestimate
-            competitors&rsquo; capabilities or fail to recognize alternative approaches competitors
-            might develop.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Static Competitive Analysis:</strong> The framework evaluates resources at a
-            point in time but provides limited guidance on how competitive environments change or
-            how resource value evolves. Resources that are rare today may become common tomorrow as
-            technologies diffuse or competitor capabilities develop. The framework does not
-            explicitly address how organizations should monitor and respond to these competitive
-            dynamics.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Limited Attention to Resource Integration:</strong> While the Organization
-            criterion acknowledges the need for appropriate organizational structures, the framework
-            provides limited guidance on how multiple resources should be integrated and coordinated
-            to create competitive advantage. In practice, competitive advantage typically emerges
-            from how diverse resources are orchestrated together rather than from individual
-            resources in isolation.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Potential for Tautological Reasoning:</strong> Critics note that the framework
-            can become somewhat circular-resources that lead to superior performance are identified
-            as meeting VRIO criteria, but the primary evidence that resources meet VRIO criteria is
-            that they lead to superior performance. This circularity can reduce the
-            framework&rsquo;s predictive power and make it difficult to falsify empirically.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Measurement and Valuation Challenges:</strong> The framework does not provide
-            clear mechanisms for quantifying resource value or predicting the magnitude of
-            competitive advantage particular resources will generate. While the framework identifies
-            whether resources create advantage, it provides limited guidance on how much advantage
-            or how to prioritize among multiple resources meeting VRIO criteria.
-          </p>
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Post-hoc rationalization risk:</strong> Evaluating resources retrospectively
+              after performance outcomes may result in tautological reasoning: inferring resources
+              are valuable because firms with those resources succeed.
+            </li>
+            <li>
+              <strong>Measurement challenges:</strong> Operationalizing value, rarity,
+              inimitability, and organization in practice creates challenges. Determining
+              quantitatively whether a resource is rare or inimitable requires subjective judgment.
+            </li>
+            <li>
+              <strong>Causal ambiguity persistence:</strong> VRIO acknowledges causal ambiguity as
+              source of inimitability but provides limited guidance on how to overcome ambiguity to
+              understand advantage mechanisms.
+            </li>
+            <li>
+              <strong>Limited attention to resource combinations:</strong> Framework analyzes
+              individual resources but provides less guidance on how resources combine and
+              complement each other in creating advantage.
+            </li>
+            <li>
+              <strong>Imitation underestimation:</strong> Framework may underestimate how readily
+              competitors acquire similar resources through acquisitions, hiring, licensing, or
+              rapid technological development.
+            </li>
+            <li>
+              <strong>Dynamic environment guidance limited:</strong> Framework emphasizes
+              sustainable advantage from inimitable resources but provides less guidance for rapidly
+              changing environments where resource value is short-lived.
+            </li>
+            <li>
+              <strong>Organizational criteria vagueness:</strong> While adding organization as
+              fourth criterion addresses a limitation, the criterion remains somewhat vague. What
+              constitutes being &ldquo;organized&rdquo; requires interpretation.
+            </li>
+            <li>
+              <strong>Substitution underappreciated:</strong> While substitution is acknowledged
+              conceptually, the framework gives it less explicit attention than inimitability. In
+              practice, resource substitutes may limit advantage.
+            </li>
+          </ul>
+        </section>
 
-          <h2 className={H2_CLASSES}>Barriers to Technology Adoption Identified</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The VRIO Framework, while not explicitly framed as an adoption barriers theory,
-            identifies several critical barriers that organizations face when attempting to adopt
-            new technologies or develop new capabilities:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Value Realization Barriers:</strong> Technologies may fail to create value in
-            the organization&rsquo;s specific context even if they theoretically create value
-            elsewhere. A technology that creates value for competitors or in other industries may
-            not address threats or exploit opportunities in the adopting organization&rsquo;s
-            particular competitive situation. Organizations can invest in technology adoption only
-            to discover the technology does not create competitive value in their specific market
-            and business model.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Rarity and Competitive Supply Barriers:</strong> When new technologies are
-            readily available to competitors, adoption will not create competitive advantage. Even
-            if an organization successfully adopts a new technology, if competitors can purchase or
-            develop the same technology easily, the adoption provides only competitive parity, not
-            advantage. This represents a barrier in that first-mover advantage in technology
-            adoption may be temporary or nonexistent if the technology is easily accessible to
-            competitors.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Organizational Integration and Implementation Barriers:</strong> The
-            Organization dimension explicitly identifies that organizations may fail to structure
-            themselves appropriately to capture value from technologies they adopt. An organization
-            might acquire valuable technology but lack the organizational systems, management
-            structures, incentives, and personnel capabilities to effectively deploy it. These
-            organizational barriers can prevent technology adoption from generating the competitive
-            value the technology theoretically provides.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Causal Ambiguity and Learning Barriers:</strong> When organizations adopt new
-            technologies but face causal ambiguity about why the technologies create value, they
-            struggle to refine implementation, transfer knowledge to new contexts, or adapt the
-            technology as circumstances change. Organizations may struggle to develop mastery and
-            deep understanding of the adopted technology, limiting their ability to configure
-            technologies for their specific context or troubleshoot problems.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Social Complexity and Organizational Change Barriers:</strong> Technologies
-            embedded in complex social relationships and organizational cultures are difficult to
-            implement. Technologies requiring changes to how organizational members interact,
-            collaborate, or make decisions face barriers from organizational culture and entrenched
-            practices. Personnel may resist technologies that change familiar work patterns, require
-            new skill development, or alter established organizational relationships.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Path Dependence and Historical Barriers:</strong> Organizations develop along
-            historical paths, building capabilities and systems incrementally. When new technologies
-            require fundamentally different organizational capabilities or processes that conflict
-            with existing organizational investments, organizations face significant barriers.
-            Existing investments represent sunk costs in current capability configurations that may
-            be rendered obsolete by new technologies.
-          </p>
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>RBV operationalization:</strong> Successfully translated Wernerfelt&rsquo;s
+              abstract RBV concepts into practical, applicable analytical framework usable by
+              practitioners and researchers.
+            </li>
+            <li>
+              <strong>Added organization dimension:</strong> Extended RBV by recognizing that
+              resource possession alone is insufficient; organizational structures and systems must
+              be aligned to exploit resources.
+            </li>
+            <li>
+              <strong>Predictive framework:</strong> Provided decision-tree logic predicting
+              competitive implications of different resource combinations, moving beyond descriptive
+              framework to prescriptive guidance.
+            </li>
+            <li>
+              <strong>Research validation foundation:</strong> Enabled empirical research testing
+              VRIO predictions by providing operationalizable criteria, advancing from theoretical
+              discussion to empirical science.
+            </li>
+            <li>
+              <strong>Strategic management pedagogy transformation:</strong> Made resource-based
+              strategy teaching practical and case-study compatible, enabling strategy education
+              based on framework application.
+            </li>
+            <li>
+              <strong>Comprehensive resource evaluation:</strong> Established systematic approach
+              evaluating all resource types (physical, financial, human, organizational,
+              intellectual) through unified analytical framework.
+            </li>
+            <li>
+              <strong>Advantage sustainability articulation:</strong> Clearly distinguished between
+              temporary and sustained competitive advantage, explaining what determines advantage
+              persistence.
+            </li>
+            <li>
+              <strong>Foundation for extended research:</strong> Provided foundation for subsequent
+              theory development including dynamic capabilities, organizational ambidexterity, and
+              capability development research.
+            </li>
+          </ul>
+        </section>
 
-          <h2 className={H2_CLASSES}>Strategic Guidance for Leaders</h2>
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The VRIO Framework provides clear strategic guidance that organizational leaders can
-            employ to reduce barriers to technology adoption and ensure that adopted technologies
-            create sustained competitive advantage:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Conduct VRIO Assessments Before Technology Adoption:</strong> Leaders should
-            systematically assess technologies using VRIO criteria before committing to adoption. Is
-            the technology valuable in our specific competitive context? Does it address real
-            competitive threats or opportunities? Is it rare-do competitors already have it or can
-            they easily acquire it? Can competitors imitate or substitute for the technology? Is our
-            organization structured to capture advantage from the technology? This prospective VRIO
-            assessment helps identify whether technology adoption is likely to create competitive
-            advantage or merely provide competitive parity.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Map Competitive Technology Context:</strong> Rather than evaluating technologies
-            in isolation, leaders should map the competitive landscape to understand what
-            technologies competitors possess and are developing. This competitive context analysis
-            directly addresses the Rarity and Imitability dimensions of VRIO, clarifying whether
-            adoption will create competitive advantage or merely parity.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Assess and Develop Complementary Organizational Capabilities:</strong> Leaders
-            must assess whether the organization possesses the systems, structures, incentives, and
-            personnel necessary to capture advantage from the technology. If these organizational
-            capabilities are lacking, leaders should develop them as part of the technology adoption
-            process through restructuring, creating appropriate incentive systems, investing in
-            training, establishing monitoring systems, and modifying organizational culture.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Build Distinctive Organizational Capabilities Around Technology:</strong> While
-            competitors may eventually imitate the technology itself, leaders should build
-            distinctive organizational capabilities and expertise in technology deployment that
-            competitors will find more difficult to replicate. By developing distinctive approaches
-            to technology deployment and optimization, leaders can create sustained competitive
-            advantage even if the technology itself becomes commoditized.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Plan Staged Implementation Aligned with Organizational Readiness:</strong>{' '}
-            Rather than attempting wholesale technology implementation immediately, leaders should
-            plan staged implementation that aligns with organizational readiness. Early stages might
-            focus on pilot programs where organizational readiness is highest, allowing the
-            organization to build mastery progressively and reducing the barrier of attempting too
-            much change too quickly.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Invest in Personnel Development and Expertise Building:</strong> To address
-            knowledge transfer and expertise barriers, leaders should invest substantially in
-            developing personnel capabilities through external experts, training programs,
-            communities of practice, and time for experimentation. By investing in personnel
-            expertise development, organizations develop internal capabilities that competitors may
-            find difficult to replicate.
-          </p>
-
-          <h2 className={H2_CLASSES}>Influence and Legacy</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Barney&rsquo;s VRIO Framework has become one of the most widely taught and applied
-            strategic frameworks in business education and practice. Its clear structure and
-            practical applicability have made it a standard tool for strategic resource analysis in
-            organizations worldwide. The framework has influenced subsequent strategic management
-            research and practice in several ways:
+            As a framework paper extending Wernerfelt&rsquo;s RBV, VRIO&rsquo;s internal validity
+            derives from logical coherence and consistency with established organizational evidence:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Dynamic Capabilities Framework (Teece, Pisano, &amp; Shuen, 1997):</strong>{' '}
-              Extended VRIO by addressing its static limitations, focusing on organizational
-              processes and capabilities for reconfiguring resources in response to changing
-              environments.
+              <strong>Logical consistency:</strong> The framework&rsquo;s core logic is sound:
+              resources creating value become competitive advantages only if they are rare,
+              inimitable, and organized for exploitation. The decision-tree implications follow
+              logically from criteria combinations.
             </li>
             <li>
-              <strong>Capabilities-Based Strategy (Stalk, Evans, &amp; Shulman, 1992):</strong>{' '}
-              Built on VRIO&rsquo;s recognition of organizational capabilities as strategic
-              resources, emphasizing how capabilities should guide competitive positioning.
+              <strong>Grounding in RBV foundation:</strong> VRIO directly operationalizes RBV,
+              maintaining theoretical consistency with Wernerfelt&rsquo;s foundational concepts
+              while extending them with the organization dimension.
             </li>
             <li>
-              <strong>Knowledge-Based View of the Firm (Grant, 1996):</strong> Focused on knowledge
-              and organizational learning as the most strategically significant resources, extending
-              VRIO&rsquo;s analysis to knowledge resources specifically.
+              <strong>Integration with organizational evidence:</strong> VRIO explains
+              well-documented organizational phenomena: why some firms sustain advantage while
+              others erode competitive positions, why organizational structure matters for advantage
+              realization.
             </li>
             <li>
-              <strong>Absorptive Capacity Theory (Cohen & Levinthal, 1990):</strong> Addressed the
-              Organization dimension of VRIO by examining how organizations develop capacity to
-              recognize, assimilate, and apply external knowledge.
+              <strong>Theoretical completeness:</strong> By addressing value, rarity, inimitability,
+              and organization, the framework addresses multiple dimensions of resource advantage
+              rather than treating advantage unidimensionally.
+            </li>
+            <li>
+              <strong>Clear definitional consistency:</strong> Definitions of each VRIO criterion
+              are clearly articulated and internally consistent, reducing ambiguity in framework
+              interpretation.
+            </li>
+            <li>
+              <strong>Comprehensive advantage prediction:</strong> The framework provides
+              predictions for all possible resource combinations, covering competitive parity,
+              temporary advantage, and sustained advantage.
             </li>
           </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            For technology adoption research specifically, the VRIO Framework provided crucial
-            insights into why some organizations successfully adopt new technologies while others
-            struggle. It highlighted that technology adoption is not merely a matter of purchasing
-            systems or implementing tools, but requires building and integrating complementary
-            organizational capabilities. This perspective has informed subsequent frameworks for
-            understanding organizational technology readiness and adoption capacity, emphasizing the
-            critical role of organizational structure and capabilities in technology adoption
-            success.
-          </p>
         </section>
 
-        <section className="pt-8 border-t border-gray-200">
-          <h2 className={REFERENCES_H2_CLASSES}>References</h2>
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations concern generalizability of VRIO across diverse
+            industries and competitive contexts:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Empirical validation mixed:</strong> Subsequent research has produced mixed
+              support for VRIO predictions. Some studies confirm that VRIO-predicted advantages
+              persist while others find limited relationship between VRIO criteria and actual
+              performance.
+            </li>
+            <li>
+              <strong>Industry differences in applicability:</strong> VRIO may better predict
+              advantage sustainability in stable industries where resources retain value. In
+              turbulent, rapidly changing industries, resource value erodes quickly regardless of
+              inimitability.
+            </li>
+            <li>
+              <strong>Imitation velocity variation:</strong> The framework assumes competitors take
+              time to imitate, but some industries enable rapid imitation through technology
+              transfer, hiring, or reverse engineering. Imitation speed varies substantially across
+              industries.
+            </li>
+            <li>
+              <strong>Measurement challenges limit generalization:</strong> Practical application
+              requires judging whether resources are rare and inimitable, determinations requiring
+              subjective assessment rather than objective measurement. Evaluator background
+              influences judgments.
+            </li>
+            <li>
+              <strong>Resource combination effects underexplored:</strong> While VRIO analyzes
+              individual resources, advantage often emerges from resource combinations.
+              Generalization of VRIO to resource bundles requires modification.
+            </li>
+            <li>
+              <strong>Acquisition-based imitation:</strong> VRIO assumes firms must build inimitable
+              resources internally, but in practice firms acquire resources through mergers,
+              acquisitions, hiring, and licensing. The framework may underestimate imitation through
+              acquisition.
+            </li>
+            <li>
+              <strong>Organizational context variation:</strong> VRIO was developed for
+              profit-oriented competitive firms. Applicability to non-profits, government agencies,
+              public institutions, or heavily regulated industries may differ.
+            </li>
+            <li>
+              <strong>Global and cultural generalizability:</strong> Developed in Western strategic
+              management context. Applicability across different governance models, economic
+              systems, and cultural contexts remains understudied.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VRIO explains organizational advantage in technology adoption through a resource lens.
+            Organizations adopting technology require valuable resources: capital for technology
+            purchase, technical expertise to implement systems, organizational infrastructure
+            enabling integration, change management capability, and leadership commitment.
+            Organizations with these valuable resources can adopt more successfully than
+            resource-constrained competitors. However, resource value creates advantage only if
+            resources are rare: organizations with unique technical talent, superior change
+            management capability, or distinctive IT infrastructure outpace competitors in
+            technology adoption speed and effectiveness. Inimitability creates sustained adoption
+            advantage: organizations with organizational cultures supporting innovation and change
+            develop distinctive capabilities competitors cannot quickly copy. Finally, organization
+            determines whether adoption capability translates to advantage: firms with unclear
+            processes, weak project management, or misaligned incentives may possess valuable
+            resources but fail to leverage them effectively. VRIO guides technology leadership to
+            recognize that sustained adoption advantage requires rare, inimitable resources
+            organized for effective technology deployment.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Insufficient valuable resources:</strong> Lack of capital, technical talent,
+              or infrastructure creates barriers preventing technology acquisition and
+              implementation.
+            </li>
+            <li>
+              <strong>Common resource possession:</strong> When all competitors possess equal
+              technical capabilities and resources, none gain adoption advantage. Common resources
+              determine competitive parity on technology adoption.
+            </li>
+            <li>
+              <strong>Easily imitable capabilities:</strong> Organizations with adoption
+              capabilities easily copied by competitors (hiring the same consultants, buying similar
+              technology, recruiting similar talent) achieve only temporary adoption advantage.
+            </li>
+            <li>
+              <strong>Organizational misalignment:</strong> Organizations possessing valuable
+              adoption resources but lacking appropriate organizational structure, clear processes,
+              aligned incentives, or leadership commitment fail to translate resources into adoption
+              advantage.
+            </li>
+            <li>
+              <strong>Fragmented organizational structures:</strong> Organizations with unclear
+              authority, siloed functions, or weak integration between IT and business fail to
+              exploit technical resources effectively.
+            </li>
+            <li>
+              <strong>Inadequate organizational learning:</strong> Organizations lacking knowledge
+              management systems, learning culture, or capability development fail to build
+              distinctive adoption advantage from experience.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Framework Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Identify valuable adoption resources:</strong> Systematically identify which
+              resources (capital, talent, infrastructure, culture) are required for effective
+              technology adoption in the organization&rsquo;s context.
+            </li>
+            <li>
+              <strong>Develop distinctive adoption capabilities:</strong> Build or acquire resources
+              that competitors will find difficult to imitate: unique technical talent, distinctive
+              organizational culture supporting change, superior change management capability.
+            </li>
+            <li>
+              <strong>Create organizational structures enabling resource exploitation:</strong>{' '}
+              Ensure organizational structures, processes, incentives, and governance enable
+              effective leverage of technology adoption resources. Organizational misalignment
+              negates resource value.
+            </li>
+            <li>
+              <strong>Invest in causal ambiguity:</strong> Build adoption advantage through
+              organizational culture, subtle processes, and interconnected routines that competitors
+              will find difficult to understand and imitate.
+            </li>
+            <li>
+              <strong>Develop social capital and relationships:</strong> Build adoption advantages
+              through organizational relationships, networks, and culture that are socially complex
+              and difficult for competitors to transfer.
+            </li>
+            <li>
+              <strong>Path-dependency cultivation:</strong> Early successful technology adoptions
+              build experience, relationships, and expertise creating path-dependent advantage in
+              subsequent adoptions.
+            </li>
+            <li>
+              <strong>Organizational integration:</strong> Align IT, business units, finance, and HR
+              to ensure organizational structures, processes, and systems support technology
+              adoption objectives.
+            </li>
+            <li>
+              <strong>Continuous capability development:</strong> Continuously develop and refine
+              adoption resources (technical skills, change management expertise, organizational
+              learning) to maintain distinctiveness and prevent competitor imitation.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            VRIO has spawned significant theoretical developments extending and refining
+            resource-based strategy:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Dynamic Capabilities (
+                <a
+                  id="cite-ref-teece-1997-1"
+                  href="#ref-teece-1997"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Teece et al., 1997
+                </a>
+                ):
+              </strong>{' '}
+              Extended VRIO by examining how organizations develop and deploy resources dynamically
+              in changing environments. Dynamic capabilities address VRIO limitations in turbulent
+              markets where resources quickly become obsolete.
+            </li>
+            <li>
+              <strong>Knowledge-Based View Extension:</strong> Specialized VRIO focus on knowledge
+              as critical resource, examining knowledge creation, integration, and protection as
+              sources of sustained advantage.
+            </li>
+            <li>
+              <strong>Organizational Ambidexterity:</strong> Applied resource-based thinking to
+              understanding how organizations balance exploitation of existing advantages with
+              exploration of new capabilities and resources.
+            </li>
+            <li>
+              <strong>Capability-Based Strategy:</strong> Extended VRIO by shifting focus from
+              individual resources to bundles and combinations of capabilities creating integrated
+              competitive advantage.
+            </li>
+            <li>
+              <strong>Strategic Human Capital:</strong> Applied VRIO framework specifically to human
+              resources, examining how distinctive workforce capabilities create sustained
+              advantage.
+            </li>
+            <li>
+              <strong>Organizational Resilience Research:</strong> Applied resource-based thinking
+              to understanding how resource diversity, redundancy, and organizational slack create
+              resilience and adaptability.
+            </li>
+            <li>
+              <strong>Intellectual Capital Management:</strong> Extended VRIO to intellectual
+              resources including human capital, structural capital, and customer capital.
+            </li>
+            <li>
+              <strong>Relational View and Network Resources:</strong> Extended VRIO beyond internal
+              firm resources to inter-organizational relationships and network resources as sources
+              of advantage.
+            </li>
+            <li>
+              <strong>Organizational Learning and Routines:</strong> Deepened understanding of how
+              organizational routines, processes, and learning become valuable, rare, and inimitable
+              resources.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
-            <li>
-              Barney, J. B. (1991). Firm resources and sustained competitive advantage. Journal of
-              Management, 17(1), 99-120.{' '}
-              <a
-                href="https://doi.org/10.1177/014920639101700108"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1177/014920639101700108
-              </a>
+            <li id="ref-barney-1991">
+              Barney, J. B. (1991). Firm resources and sustained competitive advantage.
+              <em>Journal of Management</em>, 17(1), 99-120.
+              https://doi.org/10.1177/014920639101700108
             </li>
-            <li>
-              Wernerfelt, B. (1984). A resource-based view of the firm. Strategic Management
-              Journal, 5(2), 171-180.{' '}
-              <a
-                href="https://doi.org/10.1002/smj.4250050207"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1002/smj.4250050207
-              </a>
+            <li id="ref-wernerfelt-1984">
+              Wernerfelt, B. (1984). A resource-based view of the firm.{' '}
+              <em>Strategic Management Journal</em>, 5(2), 171-180.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-wernerfelt-1984-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
+            <li id="ref-penrose-1959">
+              Penrose, E. T. (1959). The theory of the growth of the firm. Oxford University Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-penrose-1959-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-teece-1997">
+              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
+              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
+              https://doi.org/10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z{' '}
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-teece-1997-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-porter-1980">
               Porter, M. E. (1980). Competitive strategy: Techniques for analyzing industries and
               competitors. Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-porter-1980-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Porter, M. E. (1985). Competitive advantage: Creating and sustaining superior
-              performance. Free Press.
+            <li id="ref-coase-1937">
+              Coase, R. H. (1937). The nature of the firm. <em>Economica</em>, 4(16), 386-405.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-coase-1937-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Penrose, E. T. (1959). The theory of the growth of the firm. Oxford: Basil Blackwell.
+            <li id="ref-williamson-1975">
+              Williamson, O. E. (1975). Markets and hierarchies: Analysis and antitrust
+              implications. Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-williamson-1975-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Teece, D. J., Pisano, G., & Shuen, A. (1997). Dynamic capabilities and strategic
-              management. Strategic Management Journal, 18(7), 509-533.{' '}
-              <a
-                href="https://doi.org/10.1002/smj.882"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1002/smj.882
-              </a>
+            <li id="ref-nelson-1982">
+              Nelson, R. R., &amp; Winter, S. G. (1982). An evolutionary theory of economic change.
+              Harvard University Press.
             </li>
-            <li>
-              Stalk, G., Evans, P., & Shulman, L. E. (1992). Competing on capabilities: The new
-              rules of corporate strategy. Harvard Business Review, 70(2), 57-69.
+            <li id="ref-barney-1995">
+              Barney, J. B. (1995). Looking inside for competitive advantage.{' '}
+              <em>Academy of Management Executive</em>, 9(4), 49-61.
+              https://doi.org/10.5465/ame.1995.9512032192
             </li>
-            <li>
-              Cohen, W. M., & Levinthal, D. A. (1990). Absorptive capacity: A new perspective on
-              learning and innovation. Administrative Science Quarterly, 35, 128-152.
-            </li>
-            <li>
-              Grant, R. M. (1996). Toward a knowledge-based theory of the firm. Strategic Management
-              Journal, 17(S2), 109-122.
-            </li>
-            <li>
-              Nelson, R. R., & Winter, S. G. (1982). An evolutionary theory of economic change.
-              Cambridge: Harvard University Press.
-            </li>
-            <li>
-              Leonard-Barton, D. (1992). Core capabilities and core rigidities: A paradox in
-              managing new product development. Strategic Management Journal, 13, 111-125.
+            <li id="ref-barney-1997">
+              Barney, J. B. (1997). <em>Gaining and sustaining competitive advantage</em>.
+              Addison-Wesley.
             </li>
           </ol>
         </section>
 
-        <p className="mt-8 text-sm italic text-gray-600">
-          Note: This article provides an overview based on the comprehensive literature review.
-          Readers are encouraged to consult the original publication for complete details.
-        </p>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-peteraf-1993">
+              Peteraf, M. A. (1993). The cornerstones of competitive advantage: A resource-based
+              view. <em>Strategic Management Journal</em>, 14(3), 179-191.
+            </li>
+            <li id="ref-grant-1996">
+              Grant, R. M. (1996). Toward a knowledge-based theory of the firm.
+              <em>Strategic Management Journal</em>, 17(S2), 109-122.
+            </li>
+            <li id="ref-rumelt-1991">
+              Rumelt, R. P. (1991). How much does industry matter?{' '}
+              <em>Strategic Management Journal</em>, 12(S1), 167-185.
+            </li>
+            <li id="ref-prahalad-1990">
+              Prahalad, C. K., &amp; Hamel, G. (1990). The core competence of the corporation.
+              <em>Harvard Business Review</em>, 68(3), 79-91.
+              https://doi.org/10.1007/3-540-30763-X_14
+            </li>
+          </ol>
+        </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-1-resource-based-view-rbv-wernerfelt-1984"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Resource-Based View (RBV) (Wernerfelt, 1984)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-3-dynamic-capabilities-teece-1997"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Dynamic Capabilities (Teece, 1997) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>
   )
 }
 
-export default VRIOFrameworkPage
+export default BibliographyArticlePage

--- a/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
+++ b/src/app/bibliography-2-2-vrio-framework-barney-1991/page.tsx
@@ -12,37 +12,42 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: VRIO Framework - Barney (1991)',
+  title: 'Bibliography: VRIN/VRIO Framework - Barney (1991)',
   description:
-    'Comprehensive overview of the VRIO (Valuable, Rare, Inimitable, Organized) framework, operationalizing the Resource-Based View of the firm with analytical criteria for identifying sustainable sources of competitive advantage.',
+    'Comprehensive overview of the Barney (1991) VRIN framework (Valuable, Rare, Inimitable, Non-substitutable) for sustained competitive advantage, together with its later VRIO refinement (Barney, 1995, 1997) which substitutes Organization for Non-substitutability.',
 }
 
 const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>VRIO Framework - Barney (1991)</h1>
+        <h1 className={H1_CLASSES}>VRIN/VRIO Framework - Barney (1991)</h1>
 
         {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Framework Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Framework Name:</strong> VRIO Framework (Valuable, Rare, Inimitable,
-              Organized)
+              <strong>Framework Name:</strong> VRIN framework (Valuable, Rare, Imperfectly Imitable,
+              Non-substitutable), as introduced in Barney (1991). Later refined into the VRIO
+              framework (Valuable, Rare, Imperfectly Imitable, Organized) in Barney (1995) and
+              Barney (1997).
             </p>
             <p>
-              <strong>Framework Abbreviation:</strong> VRIO (also known as VRIN - Valuable, Rare,
-              Inimitable, Non-substitutable)
+              <strong>Framework Abbreviation:</strong> VRIN (1991) / VRIO (1995, 1997). The
+              abbreviation &ldquo;VRIN&rdquo; itself does not appear in Barney (1991); the paper
+              labels the four attributes as &ldquo;value, rareness, imitability, and
+              substitutability&rdquo; (p.105). &ldquo;VRIO&rdquo; was coined in Barney (1995) when
+              Organization replaced Non-substitutability as the fourth criterion.
             </p>
             <p>
-              <strong>Target of Framework:</strong> Systematic analysis of firm resources to
-              identify sources of sustained competitive advantage and predict competitive
-              implications of resource possession
+              <strong>Target of Framework:</strong> Identify which firm resources have the potential
+              to generate sustained competitive advantage, operationalizing the resource-based view
+              as a set of empirical indicators.
             </p>
             <p>
-              <strong>Disciplinary Origin:</strong> Strategic Management, Business Policy,
-              Organization Theory
+              <strong>Disciplinary Origin:</strong> Strategic Management, Organizational Economics,
+              Industrial Organization
             </p>
           </div>
         </section>
@@ -115,278 +120,399 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Jay Barney developed the VRIO framework through a series of publications spanning the
-            1990s. His seminal 1991 paper in the Journal of Management introduced the VRIN criteria
-            (Valuable, Rare, Inimitable, Non-substitutable) for evaluating firm resources. In a 1995
-            Academy of Management Executive article, Barney reframed the criteria as the VRIO
-            framework, replacing Non-substitutable with Organized to emphasize that firms must be
-            organized to exploit their resources. He further elaborated the framework in his 1997
-            textbook, making it a centerpiece of strategic management education. This evolution
-            addressed a critical gap between Wernerfelt&rsquo;s Resource-Based View conceptual
-            insight and practical strategy application. Wernerfelt&rsquo;s 1984 RBV paper argued
-            compellingly that resources could provide sustained competitive advantage if they were
-            valuable, rare, and inimitable, but the paper remained largely theoretical without
-            providing specific guidance for practitioners or researchers on how to systematically
-            analyze firm resources using these criteria. Strategic managers could recognize
-            intuitively that some resources seemed important to competitive advantage, but they
-            lacked analytical frameworks for rigorous evaluation. Research lacking the
-            operationalization meant that testing and validating RBV remained difficult -scholars
-            could discuss resources abstractly but could not empirically measure whether specific
-            resources met value, rarity, and inimitability criteria.
+            Barney (1991) was written to give the resource-based view the same analytical
+            tractability that industrial-organization economics (Porter, 1980, 1985) had given to
+            external analysis. Wernerfelt (1984), Rumelt (1984), Penrose (1959), and others had
+            argued that internal resources could be a source of competitive advantage, but the
+            literature lacked a systematic set of empirical indicators to distinguish resources that
+            generate sustained advantage from those that do not. Barney&rsquo;s paper explicitly
+            positions itself as a complement to environmental models: the resource-based model and
+            industry-structure models &ldquo;focus on different aspects of the same
+            phenomenon&rdquo; (Figure 1, p.100).
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Barney recognized that RBV needed operationalization to become actionable. He developed
-            the VRIO framework to provide specific analytical questions managers could ask about
-            firm resources to determine whether those resources could generate sustained competitive
-            advantage. Barney added a fourth dimension to Wernerfelt&rsquo;s three: organization.
-            Resources could be valuable, rare, and inimitable, but if the firm lacked organizational
-            structures, processes, and systems to exploit those resources, the resources would not
-            generate competitive advantage. This expanded framework made RBV testable and teachable.
-            Barney provided decision trees and analytical tools that researchers could use to
-            empirically test whether specific resources met VRIO criteria and what competitive
-            implications followed from different combinations of these attributes.
+            Barney identifies the key analytical move as relaxing two assumptions underlying most
+            strategy theorizing at the time (p.101): (i) that firms within an industry control
+            strategically identical resources (resource homogeneity), and (ii) that resource
+            differences are short-lived because resources can be acquired freely in factor markets
+            (resource mobility). The paper shows that if both assumptions hold, sustained
+            competitive advantage is impossible (p.103-105). Sustained competitive advantage is
+            therefore only possible when firm resources are heterogeneously distributed and
+            imperfectly mobile.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The VRIO framework also addressed the challenge of translating resource-based thinking
-            into actionable strategy for business schools and organizational strategists. By
-            providing specific analytical criteria and decision frameworks, Barney made RBV
-            accessible to strategy practitioners and academics beyond the small circle of
-            resource-based theorists. The framework became foundational to how strategic management
-            was taught: rather than abstract discussion of resources and advantages, instructors
-            could walk students through VRIO analysis of specific firms, evaluating whether
-            particular resources (brand, technology, customer relationships) met criteria for
-            sustained advantage. This combination of theoretical rigor and practical applicability
-            made the VRIO framework one of the most influential strategic management tools of the
-            1990s and beyond.
+            Given those two assumptions, Barney (p.105-106) proposes four empirical indicators that
+            a resource has the potential to generate sustained competitive advantage: it must be (a){' '}
+            <em>valuable</em>, (b) <em>rare</em>, (c) <em>imperfectly imitable</em>, and (d) such
+            that the firm&rsquo;s resources have no <em>strategically equivalent substitutes</em>.
+            This four-attribute model is now widely called &ldquo;VRIN&rdquo;, though the acronym
+            itself is not in the paper. The paper applies the model to several candidate sources of
+            advantage (strategic planning, information processing systems, positive reputations) to
+            illustrate its use. Barney later (1995, Academy of Management Executive; 1997, book)
+            replaces the Non-substitutability criterion with an Organization criterion, producing
+            the VRIO framework used in most strategy textbooks today.
           </p>
         </section>
 
-        {/* 5. Core Concepts and Definitions */}
+        {/* 5. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Barney (1991) is a conceptual paper that proposes the four attributes as
+            &ldquo;empirical indicators&rdquo; (p.106) of how heterogeneous and immobile a
+            firm&rsquo;s resources are. The paper does not provide scales, latent constructs, or
+            statistical operationalizations. Each attribute is a yes/no question about a specific
+            resource:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Value:</strong> Does this resource let the firm implement strategies that
+              exploit opportunities or neutralize threats (p.106)?
+            </li>
+            <li>
+              <strong>Rareness:</strong> Is the resource held by fewer firms than the number
+              required to generate perfect competition dynamics (p.107)?
+            </li>
+            <li>
+              <strong>Imitability:</strong> Can firms without the resource obtain it at a cost
+              disadvantage, because of unique historical conditions, causal ambiguity, or social
+              complexity (p.107-112)?
+            </li>
+            <li>
+              <strong>Substitutability:</strong> Is the resource such that there are no
+              strategically equivalent substitutes that are themselves valuable but neither rare nor
+              imperfectly imitable (p.111-112)?
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            The paper applies these questions to three candidate sources of sustained competitive
+            advantage (p.112-117): <em>strategic planning processes</em>,{' '}
+            <em>information processing systems</em>, and <em>positive reputations</em>. In each case
+            Barney walks through the four attributes to argue which versions of the resource have
+            potential to generate sustained advantage and which do not.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            Later refinement: Barney (1995, Academy of Management Executive; 1997 book) replaces
+            Substitutability with <em>Organization</em>, producing VRIO. Organization asks whether
+            the firm&rsquo;s structures, policies, and processes are arranged such that the firm can
+            actually exploit the resource (not merely possess it). The substitute concern does not
+            disappear; it is folded into the Imitability criterion in the later operationalization.
+          </p>
+        </section>
+
+        {/* 6. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The VRIO framework is built on four evaluative criteria for analyzing firm resources:
+            Barney (1991) defines three central terms before introducing the four attributes
+            (p.101-103):
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Valuable (V):</strong> A resource is valuable to the extent that it enables a
-              firm to implement strategies that exploit opportunities or mitigate threats in the
-              environment. Resources enable value creation by improving competitive position,
-              enabling cost leadership, differentiation, or focus strategies, or creating barriers
-              preventing competitive threat. Resources without value do not contribute to
-              competitive advantage.
+              <strong>Firm resources:</strong> &ldquo;all assets, capabilities, organizational
+              processes, firm attributes, information, knowledge, etc. controlled by a firm that
+              enable the firm to conceive of and implement strategies that improve its efficiency
+              and effectiveness&rdquo; (p.101, drawing on Daft, 1983). Barney groups firm resources
+              into three categories following Tomer (1987) and related work: physical capital
+              resources (Williamson, 1975), human capital resources (Becker, 1964), and
+              organizational capital resources (Tomer, 1987).
             </li>
             <li>
-              <strong>Rare (R):</strong> A resource is rare if the number of competing firms
-              possessing it is less than the number of firms required for competitive equilibrium.
-              Rarity is relative; a resource may be held by a few firms (very rare), some firms
-              (moderately rare), or many firms (not rare). Only rare resources can provide
-              competitive advantage since all firms with common resources will achieve similar
-              competitive positions.
+              <strong>Competitive advantage:</strong> &ldquo;a firm is said to have a competitive
+              advantage when it is implementing a value creating strategy not simultaneously being
+              implemented by any current or potential competitors&rdquo; (p.102). Following Baumol,
+              Panzar, and Willig (1982), &ldquo;competitors&rdquo; includes both current and
+              potential competitors, not just same-industry rivals.
             </li>
             <li>
-              <strong>Inimitable (I):</strong> A resource is inimitable if competitors cannot easily
-              duplicate or imitate the resource, even after observing its existence and value.
-              Resources become inimitable through causal ambiguity (unclear how resource creates
-              value), social complexity (resources embedded in relationships and culture),
-              historical contingency (required unique past conditions), or proprietary nature.
-              Non-inimitable resources can provide only temporary advantage until imitation occurs.
-            </li>
-            <li>
-              <strong>Organized (O):</strong> A resource generates competitive advantage only if the
-              firm is organized to effectively exploit the resource. Organization requires
-              appropriate organizational structures, processes, systems, incentives, and management
-              controls that enable resource-based strategies. Resources without organizational
-              infrastructure to exploit them generate no competitive advantage.
-            </li>
-            <li>
-              <strong>Sustained Competitive Advantage:</strong> Performance superiority that a firm
-              maintains over extended time periods by possessing resources meeting all four VRIO
-              criteria (valuable, rare, inimitable, and organized). Sustained advantage is
-              distinguished from temporary advantage (resources meeting only some criteria) and
-              competitive parity (resources not meeting VRIO criteria).
+              <strong>Sustained competitive advantage:</strong> a competitive advantage that
+              persists after &ldquo;efforts to duplicate that advantage have ceased&rdquo; (p.102,
+              drawing on Lippman &amp; Rumelt, 1982 and Rumelt, 1984). This is an equilibrium-based,
+              not a calendar-based, definition: sustained advantage is not defined by &ldquo;lasts
+              forever&rdquo; (p.103) but by being robust against duplication attempts. Schumpeterian
+              shocks can still competitively displace a sustained advantage.
             </li>
           </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Two assumptions (p.101, 105) drive the whole framework:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Resource heterogeneity:</strong> Different firms within an industry may
+              control different strategically relevant resources.
+            </li>
+            <li>
+              <strong>Resource immobility:</strong> These resource differences can be stable over
+              time - resources are not freely tradeable in factor markets at their full discounted
+              value.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Under perfect homogeneity and mobility, sustained competitive advantage is impossible
+            (the paper&rsquo;s core argument, p.103-105). Under heterogeneity and immobility, it
+            becomes possible - and the four attributes (value, rareness, imitability,
+            substitutability) identify <em>which</em> resources actually generate it.
+          </p>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The VRIO framework directly builds on and operationalizes previous theories:
+            Barney (1991) explicitly cites the following as foundational to the resource-based
+            perspective the paper develops (pp.99-101):
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>
-                Resource-Based View (
-                <a
-                  id="cite-ref-wernerfelt-1984-1"
-                  href="#ref-wernerfelt-1984"
-                  className="text-tabs-teal-deep hover:underline"
-                >
-                  Wernerfelt, 1984
-                </a>
-                ):
-              </strong>{' '}
-              VRIO operationalizes and formalizes Wernerfelt&rsquo;s foundational insight that
-              resources meeting value-rarity-inimitability criteria provide competitive advantage.
-              Barney extends RBV by adding the organization dimension.
-            </li>
-            <li>
-              <strong>
-                Penrose&rsquo;s Theory of Firm Growth (
+                Penrose (
                 <a
                   id="cite-ref-penrose-1959-1"
                   href="#ref-penrose-1959"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Penrose, 1959
+                  1959
                 </a>
-                ):
+                ) - The Theory of the Growth of the Firm:
               </strong>{' '}
-              Barney builds on Penrose&rsquo;s insight that firms are fundamentally bundles of
-              resources and that firm growth depends on resource development and organizational
-              capacity to deploy resources.
+              Supplies the view of firms as bundles of productive resources and the link between
+              resource availability and firm growth. Cited on p.101 as one of the three foundational
+              works.
             </li>
             <li>
               <strong>
-                Industrial Organization Economics (
+                Wernerfelt (
+                <a
+                  id="cite-ref-wernerfelt-1984-1"
+                  href="#ref-wernerfelt-1984"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  1984, 1989
+                </a>
+                ) - A resource-based view of the firm:
+              </strong>{' '}
+              Wernerfelt&rsquo;s paper (and its 1989 follow-up) provides the direct precursor,
+              introducing the concept of resource position barrier and the resource-product matrix.
+              Barney credits Wernerfelt alongside Rumelt and Penrose as the link between firm
+              resources and sustained competitive advantage. Barney (1991) does <em>not</em>
+              attribute the VRIN criteria to Wernerfelt; Wernerfelt&rsquo;s paper introduces
+              resource position barriers rather than the four-attribute framework.
+            </li>
+            <li>
+              <strong>
+                Rumelt (
+                <a
+                  id="cite-ref-rumelt-1984-1"
+                  href="#ref-rumelt-1984"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  1984
+                </a>
+                ) - Towards a Strategic Theory of the Firm:
+              </strong>{' '}
+              Cited on p.101 as the third foundational work; provides the emphasis on firm-level
+              idiosyncratic resources as the primary driver of sustained advantage.
+            </li>
+            <li>
+              <strong>
+                Porter (
                 <a
                   id="cite-ref-porter-1980-1"
                   href="#ref-porter-1980"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Porter, 1980
+                  1980, 1985
                 </a>
-                ):
+                ) - Competitive Strategy / Competitive Advantage:
               </strong>{' '}
-              While emphasizing resources over industry structure, VRIO acknowledges that resources
-              create value to extent they address environmental opportunities and threats,
-              incorporating Porter&rsquo;s insights about strategy-environment fit.
+              Barney positions the resource-based view as <em>complementary</em> to Porter&rsquo;s
+              environmental/industry-structure models (Figure 1, p.100). The paper uses
+              Porter&rsquo;s framework for environmental opportunities and threats; Porter is cited
+              throughout for specific arguments about industry barriers and positioning.
             </li>
             <li>
               <strong>
-                Organizational Economics and Transaction Costs (
+                Lippman &amp; Rumelt (
                 <a
-                  id="cite-ref-coase-1937-1"
-                  href="#ref-coase-1937"
+                  id="cite-ref-lippman-1982-1"
+                  href="#ref-lippman-1982"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Coase, 1937
+                  1982
                 </a>
-                ;{' '}
-                <a
-                  id="cite-ref-williamson-1975-1"
-                  href="#ref-williamson-1975"
-                  className="text-tabs-teal-deep hover:underline"
-                >
-                  Williamson, 1975
-                </a>
-                ):
+                ) - Uncertain Imitability:
               </strong>{' '}
-              VRIO incorporates insights that firms organize activities to exploit distinctive
-              capabilities and that organizational structure determines competitive advantage.
+              Supplies the concept of causal ambiguity (p.108-110), one of Barney&rsquo;s three
+              named mechanisms of imperfect imitability. Also supplies the equilibrium definition of
+              sustained competitive advantage used on p.102.
             </li>
             <li>
               <strong>
-                Organizational Routines and Capabilities (
+                Dierickx &amp; Cool (
                 <a
-                  id="cite-ref-nelson-1982-1"
-                  href="#ref-nelson-1982"
+                  id="cite-ref-dierickx-1989-1"
+                  href="#ref-dierickx-1989"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Nelson &amp; Winter, 1982
+                  1989
+                </a>
+                ) - Asset stock accumulation and sustainability of competitive advantage:
+              </strong>{' '}
+              Supplies the concept of social complexity as a driver of imperfect imitability (p.110)
+              and the asset-stock accumulation view. Cited by Barney as an independently developed
+              but complementary treatment of the imitability problem.
+            </li>
+            <li>
+              <strong>
+                Hirshleifer (
+                <a
+                  id="cite-ref-hirshleifer-1982-1"
+                  href="#ref-hirshleifer-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  1980
+                </a>
+                ) and Barney (
+                <a
+                  id="cite-ref-barney-1986-1"
+                  href="#ref-barney-1986"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  1986a, 1986b
                 </a>
                 ):
               </strong>{' '}
-              VRIO treats organizational routines and capabilities as resources that become
-              inimitable through social complexity and causal ambiguity.
-            </li>
-            <li>
-              <strong>Human Capital Theory:</strong> VRIO extends resource-based thinking to human
-              capital by recognizing employee skills, knowledge, and relationships as valuable,
-              rare, and potentially inimitable resources.
+              Supply the equilibrium-analytic apparatus for reasoning about sustained advantage,
+              Schumpeterian shocks, and the role of factor-market imperfections. Cited on p.102-103
+              and throughout the imitability discussion.
             </li>
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The VRIO framework provides a systematic method for analyzing firm resources to predict
-            competitive implications. Managers evaluate each resource across four dimensions,
-            determining whether the resource is valuable, rare, inimitable, and organized. The
-            framework operates as a decision tree: resources meeting all four criteria create
-            sustained competitive advantage; resources meeting three criteria (valuable, rare,
-            inimitable but unorganized) create temporary advantage only until the firm reorganizes
-            to exploit the resource; resources meeting only two criteria (valuable and rare but
-            imitable) create temporary competitive advantage until competitors imitate; and
-            resources meeting only one criterion or none generate no competitive advantage.
+            Barney (1991) develops the framework in three steps (Figure 1, p.100, and text
+            pp.101-117): (1) define firm resources and competitive advantage, (2) show that
+            sustained competitive advantage requires resource heterogeneity and resource immobility,
+            and (3) specify the four attributes of firm resources (value, rareness, imperfect
+            imitability, non-substitutability) that together constitute empirical indicators of the
+            potential for sustained competitive advantage.
           </p>
 
-          <h3 className={H3_CLASSES}>The Four VRIO Criteria</h3>
+          <h3 className={H3_CLASSES}>The four attributes (Barney, 1991, pp.105-112)</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Valuable (V):</strong> Does the resource enable the firm to implement
-              strategies that exploit opportunities or mitigate threats? Can the resource reduce
-              costs, increase revenues, or strengthen market position? If the resource does not
-              enable economically superior strategies, it provides no advantage.
+              <strong>Value (V):</strong> A resource is valuable when it enables a firm to conceive
+              of or implement strategies that improve its efficiency and effectiveness, or that
+              exploit opportunities or neutralize threats in the firm&rsquo;s environment (p.106).
+              Not all resources are valuable; some may prevent a firm from conceiving of valuable
+              strategies or may generate only competitive parity.
             </li>
             <li>
-              <strong>Rare (R):</strong> Is the resource possessed by few competitors? Is the
-              resource scarce in the competitive marketplace? Resources held by many competitors do
-              not create competitive advantage regardless of value. Rarity creates advantage
-              potential only when combined with value.
+              <strong>Rareness (R):</strong> A resource is rare when the number of competing firms
+              possessing it is less than the number needed to generate perfect-competition dynamics
+              (p.106-107). Barney notes that valuable-but-not-rare resources can still ensure
+              survival at competitive parity.
             </li>
             <li>
-              <strong>Inimitable (I):</strong> Is the resource difficult for competitors to imitate
-              or duplicate? Are there barriers preventing competitive imitation? Sources of
-              inimitability include causal ambiguity, social complexity, historical contingency, and
-              proprietary protections. Resources easily imitated by competitors provide only
-              temporary advantage.
+              <strong>Imperfect imitability (I):</strong> Firm resources can be imperfectly imitable
+              for one or a combination of three reasons (Barney, 1991, p.107, citing Lippman &amp;
+              Rumelt, 1982 and Dierickx &amp; Cool, 1989):
+              <ul className={BODY_LIST_CLASSES}>
+                <li>
+                  <em>Unique historical conditions</em> (p.107-108): a firm&rsquo;s ability to
+                  obtain a resource depends on path-dependent historical conditions (Ansoff, 1965;
+                  Learned et al., 1969; Stinchcombe, 1965; David, 1985).
+                </li>
+                <li>
+                  <em>Causal ambiguity</em> (p.108-110): the link between a firm&rsquo;s resources
+                  and its sustained competitive advantage is not understood or understood only
+                  imperfectly (Lippman &amp; Rumelt, 1982; Reed &amp; DeFillippi, 1990).
+                </li>
+                <li>
+                  <em>Social complexity</em> (p.110-112): the resource is a socially complex
+                  phenomenon (interpersonal relations, culture, reputation) beyond systematic
+                  managerial influence (Dierickx &amp; Cool, 1989; Hambrick, 1987; Porter, 1980;
+                  Klein, Crawford &amp; Alchian, 1978).
+                </li>
+              </ul>
             </li>
             <li>
-              <strong>Organized (O):</strong> Does the firm possess appropriate organizational
-              structures, processes, systems, and incentives to effectively exploit the resource?
-              Does the firm have the management infrastructure to leverage resource value? Resources
-              not organized for exploitation generate no advantage.
+              <strong>Substitutability (N - non-substitutable):</strong> Even if a resource is
+              valuable, rare, and imperfectly imitable, it may not be a source of sustained
+              advantage if there exist strategically equivalent substitutes that are themselves
+              valuable but neither rare nor imperfectly imitable (p.111-112). Two forms of
+              substitution discussed: (i) similar resources (the firm&rsquo;s resource can be
+              replaced by a comparable resource at a competitor); (ii) different resources that can
+              be used to implement the same strategy.
             </li>
           </ul>
 
-          <h3 className={H3_CLASSES}>Competitive Implications of VRIO Combinations</h3>
+          <h3 className={H3_CLASSES}>Applications in the paper (pp.112-117)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Barney applies the four-attribute framework to three candidate sources of sustained
+            competitive advantage:
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Not Valuable (Not-V, regardless of R, I, O):</strong> If a resource is not
-              valuable -if it does not enable strategies addressing market opportunities or threats
-              -the resource generates no competitive advantage. Firms with not-valuable resources
-              occupy positions of competitive parity or disadvantage regardless of how rare or
-              inimitable the resource.
+              <strong>Strategic planning and SCA (pp.112-114):</strong> Formal strategic planning
+              processes by themselves are generally not rare or imperfectly imitable and thus are
+              not sources of sustained advantage. Informal planning processes embedded in socially
+              complex managerial interactions can be sources of sustained advantage.
             </li>
             <li>
-              <strong>Valuable but Not Rare (V, Not-R, regardless of I, O):</strong> Resources
-              valuable but commonly held by many competitors position firms at competitive parity.
-              If all competitors possess the resource, all achieve similar competitive positions.
-              These are table-stakes resources required to compete but insufficient for advantage.
+              <strong>Information processing systems and SCA (pp.114-115):</strong> Computer
+              hardware and software purchasable on the open market are not rare or imperfectly
+              imitable. Information processing systems deeply embedded in the firm&rsquo;s informal
+              and formal management decision-making processes can be rare, imperfectly imitable, and
+              non-substitutable.
             </li>
             <li>
-              <strong>Valuable and Rare but Not Inimitable (V, R, Not-I):</strong> These resources
-              create temporary competitive advantage that persists until competitors imitate.
-              First-mover advantage, novel technologies not protected by patents, and unique
-              strategies easily copied by competitors generate temporary advantage.
+              <strong>Positive reputations and SCA (pp.115-117):</strong> Firm reputations can be
+              valuable, rare, imperfectly imitable (because of unique historical conditions and
+              social complexity), and non-substitutable, qualifying as a source of sustained
+              competitive advantage.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>From VRIN (1991) to VRIO (1995, 1997)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Barney (1995) in the Academy of Management Executive, and Barney (1997) in the textbook{' '}
+            <em>Gaining and Sustaining Competitive Advantage</em>, replace the Non-substitutability
+            criterion with an <em>Organization</em> criterion. The question becomes: is the firm
+            organized - via its structure, formal reporting, management control systems, and
+            compensation policies - to exploit the resource? Substitutability concerns do not
+            disappear; they are subsumed into the Imitability criterion (a resource is imitable in
+            practice if an easily-available substitute can replace it). Most textbook presentations
+            today use the VRIO framework rather than the VRIN framework, though the underlying logic
+            is the same.
+          </p>
+
+          <h3 className={H3_CLASSES}>Competitive implications (VRIO decision logic)</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Not valuable:</strong> Competitive disadvantage. The resource is a cost or
+              constraint, not an advantage source.
             </li>
             <li>
-              <strong>Valuable, Rare, and Inimitable but Not Organized (V, R, I, Not-O):</strong>{' '}
-              These resources create sustained advantage potential, but organizational failures
-              prevent advantage realization. Firms with valuable, rare, inimitable resources but
-              poor organizational structures fail to leverage resource potential. Reorganization can
-              unlock advantage.
+              <strong>Valuable, not rare:</strong> Competitive parity. The resource is a survival
+              condition but not an advantage source.
             </li>
             <li>
-              <strong>Valuable, Rare, Inimitable, and Organized (V, R, I, O):</strong> These
-              resources create sustained competitive advantage. Firms can maintain performance
-              superiority over extended periods because competitors cannot imitate resources that
-              are organized for effective exploitation.
+              <strong>Valuable, rare, but imitable:</strong> Temporary competitive advantage.
+              Advantage erodes as competitors acquire or develop the resource.
+            </li>
+            <li>
+              <strong>Valuable, rare, imperfectly imitable, but not organized to exploit:</strong>
+              Unrealized competitive advantage. The firm holds the resource but cannot capture its
+              rents. VRIO (1995) treatment.
+            </li>
+            <li>
+              <strong>Valuable, rare, imperfectly imitable, and organized:</strong> Sustained
+              competitive advantage. The resource meets all conditions of the equilibrium-based SCA
+              definition (p.102-103).
             </li>
           </ul>
 
@@ -479,7 +605,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -526,7 +652,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -569,7 +695,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -625,7 +751,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -728,7 +854,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -794,7 +920,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -824,21 +950,8 @@ const BibliographyArticlePage = () => {
                 ></a>
               </span>
             </li>
-            <li id="ref-teece-1997">
-              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
-              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
-              https://doi.org/10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z{' '}
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-teece-1997-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>
-              </span>
-            </li>
             <li id="ref-porter-1980">
-              Porter, M. E. (1980). Competitive strategy: Techniques for analyzing industries and
-              competitors. Free Press.
+              Porter, M. E. (1980). <em>Competitive strategy</em>. Free Press.
               <span className="text-xs ml-1">
                 <a
                   href="#cite-ref-porter-1980-1"
@@ -847,35 +960,68 @@ const BibliographyArticlePage = () => {
                 ></a>
               </span>
             </li>
-            <li id="ref-coase-1937">
-              Coase, R. H. (1937). The nature of the firm. <em>Economica</em>, 4(16), 386-405.
+            <li id="ref-rumelt-1984">
+              Rumelt, R. P. (1984). Towards a strategic theory of the firm. In R. B. Lamb (Ed.),{' '}
+              <em>Competitive strategic management</em> (pp. 556-570). Prentice-Hall.
               <span className="text-xs ml-1">
                 <a
-                  href="#cite-ref-coase-1937-1"
+                  href="#cite-ref-rumelt-1984-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
                 ></a>
               </span>
             </li>
-            <li id="ref-williamson-1975">
-              Williamson, O. E. (1975). Markets and hierarchies: Analysis and antitrust
-              implications. Free Press.
+            <li id="ref-lippman-1982">
+              Lippman, S. A., &amp; Rumelt, R. P. (1982). Uncertain imitability: An analysis of
+              interfirm differences in efficiency under competition.{' '}
+              <em>Bell Journal of Economics</em>, 13(2), 418-438.
               <span className="text-xs ml-1">
                 <a
-                  href="#cite-ref-williamson-1975-1"
+                  href="#cite-ref-lippman-1982-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
                 ></a>
               </span>
             </li>
-            <li id="ref-nelson-1982">
-              Nelson, R. R., &amp; Winter, S. G. (1982). An evolutionary theory of economic change.
-              Harvard University Press.
+            <li id="ref-dierickx-1989">
+              Dierickx, I., &amp; Cool, K. (1989). Asset stock accumulation and sustainability of
+              competitive advantage. <em>Management Science</em>, 35(12), 1504-1511.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-dierickx-1989-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-hirshleifer-1982">
+              Hirshleifer, J. (1980). <em>Price theory and applications</em> (2nd ed.).
+              Prentice-Hall.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-hirshleifer-1982-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-barney-1986">
+              Barney, J. B. (1986). Strategic factor markets: Expectations, luck, and business
+              strategy. <em>Management Science</em>, 32(10), 1231-1241.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-barney-1986-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-daft-1983">
+              Daft, R. L. (1983). <em>Organization theory and design</em>. West.
             </li>
             <li id="ref-barney-1995">
               Barney, J. B. (1995). Looking inside for competitive advantage.{' '}
               <em>Academy of Management Executive</em>, 9(4), 49-61.
-              https://doi.org/10.5465/ame.1995.9512032192
             </li>
             <li id="ref-barney-1997">
               Barney, J. B. (1997). <em>Gaining and sustaining competitive advantage</em>.
@@ -884,6 +1030,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -900,14 +1047,17 @@ const BibliographyArticlePage = () => {
               <em>Strategic Management Journal</em>, 12(S1), 167-185.
             </li>
             <li id="ref-prahalad-1990">
-              Prahalad, C. K., &amp; Hamel, G. (1990). The core competence of the corporation.
+              Prahalad, C. K., &amp; Hamel, G. (1990). The core competence of the corporation.{' '}
               <em>Harvard Business Review</em>, 68(3), 79-91.
-              https://doi.org/10.1007/3-540-30763-X_14
+            </li>
+            <li id="ref-teece-1997">
+              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
+              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
             </li>
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 2-2 VRIO Framework (Barney, 1991) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1576
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)