### PR TITLE
docs: standardize bibliography 2-3 Dynamic Capabilities (Teece, 1997)

### DIFF
--- a/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
+++ b/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
@@ -1037,7 +1037,155 @@ const BibliographyArticlePage = () => {
         {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Works cited by Teece, Pisano &amp; Shuen (1997) that are also referenced in-text on this
+            page:
+          </p>
           <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-teece-1997">
+              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
+              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
+              https://doi.org/10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z
+            </li>
+            <li id="ref-argyris-1978">
+              Argyris, C., &amp; Sch&ouml;n, D. A. (1978). <em>Organizational learning</em>.
+              Addison-Wesley.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-argyris-1978-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-arthur-1983">
+              Arthur, W. B. (1983). <em>On competing technologies and historical small events</em>.
+              IIASA Working Paper (later published as Arthur, 1989, Economic Journal).
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-arthur-1983-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-barney-1991">
+              Barney, J. B. (1991). Firm resources and sustained competitive advantage.{' '}
+              <em>Journal of Management</em>, 17(1), 99-120.
+              https://doi.org/10.1177/014920639101700108{' '}
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-barney-1991-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>{' '}
+                <a
+                  href="#cite-ref-barney-1991-2"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 2"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-david-1985">
+              David, P. A. (1985). Clio and the economics of QWERTY.{' '}
+              <em>American Economic Review</em>, 75(2), 332-337.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-david-1985-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-leonard-1992">
+              Leonard-Barton, D. (1992). Core capabilities and core rigidities: A paradox in
+              managing new product development. <em>Strategic Management Journal</em>, 13(S1),
+              111-125.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-leonard-1992-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-levitt-1988">
+              Levitt, B., &amp; March, J. G. (1988). Organizational learning.{' '}
+              <em>Annual Review of Sociology</em>, 14, 319-340.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-levitt-1988-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-nelson-1982">
+              Nelson, R. R., &amp; Winter, S. G. (1982).{' '}
+              <em>An evolutionary theory of economic change</em>. Harvard University Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-nelson-1982-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-penrose-1959">
+              Penrose, E. T. (1959). <em>The theory of the growth of the firm</em>. Oxford
+              University Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-penrose-1959-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-porter-1980">
+              Porter, M. E. (1980). <em>Competitive strategy</em>. Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-porter-1980-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-prahalad-1990">
+              Prahalad, C. K., &amp; Hamel, G. (1990). The core competence of the corporation.{' '}
+              <em>Harvard Business Review</em>, 68(3), 79-91.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-prahalad-1990-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-rumelt-1984">
+              Rumelt, R. P. (1984). Towards a strategic theory of the firm. In R. B. Lamb (Ed.),{' '}
+              <em>Competitive strategic management</em> (pp. 556-570). Prentice-Hall.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-rumelt-1984-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-teece-1986">
+              Teece, D. J. (1986). Profiting from technological innovation: Implications for
+              integration, collaboration, licensing and public policy. <em>Research Policy</em>,
+              15(6), 285-305.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-teece-1986-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
             <li id="ref-wernerfelt-1984">
               Wernerfelt, B. (1984). A resource-based view of the firm.{' '}
               <em>Strategic Management Journal</em>, 5(2), 171-180.
@@ -1054,97 +1202,46 @@ const BibliographyArticlePage = () => {
                 ></a>
               </span>
             </li>
-            <li id="ref-barney-1991">
-              Barney, J. B. (1991). Firm resources and sustained competitive advantage.
-              <em>Journal of Management</em>, 17(1), 99-120.
-              https://doi.org/10.1177/014920639101700108{' '}
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-barney-1991-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>{' '}
-                <a
-                  href="#cite-ref-barney-1991-2"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 2"
-                ></a>
-              </span>
-            </li>
-            <li id="ref-arthur-1989">
-              Arthur, W. B. (1989). Competing technologies, increasing returns, and lock-in by
-              historical events. <em>Economic Journal</em>, 99(394), 116-131.
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-arthur-1989-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>
-              </span>
-            </li>
+          </ol>
+        </section>
+
+        {/* 15. Further Reading */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The following works are <em>not</em> cited by Teece, Pisano &amp; Shuen (1997). They
+            represent the post-1997 dynamic-capabilities tradition and are listed here for readers
+            tracing the development of the framework:
+          </p>
+          <ol className={REFERENCES_OL_CLASSES}>
             <li id="ref-teece-2007">
               Teece, D. J. (2007). Explicating dynamic capabilities: The nature and microfoundations
               of (sustainable) enterprise performance. <em>Strategic Management Journal</em>,
-              28(13), 1319-1350. https://doi.org/10.1002/smj.640{' '}
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-teece-2007-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>
-              </span>
+              28(13), 1319-1350. https://doi.org/10.1002/smj.640
             </li>
-            <li id="ref-dosi-1982">
-              Dosi, G. (1982). Technological paradigms and technological trajectories.
-              <em>Research Policy</em>, 11(3), 147-162.
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-dosi-1982-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>
-              </span>
+            <li id="ref-eisenhardt-2000">
+              Eisenhardt, K. M., &amp; Martin, J. A. (2000). Dynamic capabilities: What are they?{' '}
+              <em>Strategic Management Journal</em>, 21(10-11), 1105-1121.
             </li>
-            <li id="ref-rosenberg-1982">
-              Rosenberg, N. (1982). Inside the black box: Technology and economics. Cambridge
-              University Press.
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-rosenberg-1982-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>
-              </span>
+            <li id="ref-zollo-2002">
+              Zollo, M., &amp; Winter, S. G. (2002). Deliberate learning and the evolution of
+              dynamic capabilities. <em>Organization Science</em>, 13(3), 339-351.
             </li>
-            <li id="ref-teece-1997">
-              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
-              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
-              https://doi.org/10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z
-            </li>
-            <li id="ref-nelson-1982">
-              Nelson, R. R., &amp; Winter, S. G. (1982). An evolutionary theory of economic change.
-              Harvard University Press.
-            </li>
-            <li id="ref-hamel-1989">
-              Hamel, G., &amp; Prahalad, C. K. (1989). Strategic intent.{' '}
-              <em>Harvard Business Review</em>, 67(3), 63-76.
+            <li id="ref-helfat-2003">
+              Helfat, C. E., &amp; Peteraf, M. A. (2003). The dynamic resource-based view:
+              Capability lifecycles. <em>Strategic Management Journal</em>, 24(10), 997-1010.
             </li>
             <li id="ref-sambamurthy-2003">
               Sambamurthy, V., Bharadwaj, A., &amp; Grover, V. (2003). Shaping agility through
               digital options. <em>MIS Quarterly</em>, 27(2), 237-263.
             </li>
-          </ol>
-        </section>
-
-        <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Further Reading</h2>
-          <ol className={REFERENCES_OL_CLASSES}>
-            <li id="ref-unknown-2004">
-              O&rsquo;Reilly, C. A., &amp; Tushman, M. L. (2004). The ambidextrous organization.
+            <li id="ref-oreilly-2004">
+              O&rsquo;Reilly, C. A., &amp; Tushman, M. L. (2004). The ambidextrous organization.{' '}
               <em>Harvard Business Review</em>, 82(4), 74-81.
             </li>
-            <li id="ref-penrose-1959">
-              Penrose, E. T. (1959). The theory of the growth of the firm. Oxford University Press.
+            <li id="ref-hamel-1989">
+              Hamel, G., &amp; Prahalad, C. K. (1989). Strategic intent.{' '}
+              <em>Harvard Business Review</em>, 67(3), 63-76.
             </li>
           </ol>
         </section>

--- a/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
+++ b/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
@@ -871,16 +871,12 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-wernerfelt-1984-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>{' '}
+                ></a>{' '}
                 <a
                   href="#cite-ref-wernerfelt-1984-2"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 2"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-barney-1991">
@@ -892,16 +888,12 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-barney-1991-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>{' '}
+                ></a>{' '}
                 <a
                   href="#cite-ref-barney-1991-2"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 2"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-arthur-1989">
@@ -912,9 +904,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-arthur-1989-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-teece-2007">
@@ -926,9 +916,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-teece-2007-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-dosi-1982">
@@ -939,9 +927,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-dosi-1982-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-rosenberg-1982">
@@ -952,9 +938,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-rosenberg-1982-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-teece-1997">

--- a/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
+++ b/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
@@ -4,27 +4,26 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
-  REFERENCES_H2_CLASSES,
+  BODY_LIST_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Dynamic Capabilities Framework - Teece, Pisano, & Shuen (1997)',
+  title: 'Bibliography: Dynamic Capabilities - Teece, Pisano, & Shuen (1997)',
   description:
-    'An exploration of the Dynamic Capabilities Framework and how it extends the Resource-Based View to address sustained competitive advantage in rapidly changing, turbulent environments through organizational sensing, seizing, and transformation.',
+    'Comprehensive overview of Dynamic Capabilities theory, extending the Resource-Based View to dynamic environments by emphasizing organizational capabilities to sense market changes, seize opportunities, and reconfigure resources rapidly as sources of sustained competitive advantage.',
 }
 
-const DynamicCapabilitiesPage = () => {
+const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>
-          Bibliography: Dynamic Capabilities Framework - Teece, Pisano, &amp; Shuen (1997)
-        </h1>
+        <h1 className={H1_CLASSES}>Dynamic Capabilities - Teece, Pisano, &amp; Shuen (1997)</h1>
 
-        {/* Framework Identification */}
+        {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Framework Identification</h2>
           <div className="space-y-2">
@@ -32,518 +31,996 @@ const DynamicCapabilitiesPage = () => {
               <strong>Framework Name:</strong> Dynamic Capabilities Framework
             </p>
             <p>
-              <strong>Authors:</strong> David J. Teece, Gary Pisano, and Amy Shuen
+              <strong>Framework Abbreviation:</strong> DC
             </p>
             <p>
-              <strong>Publication Date:</strong> 1997
+              <strong>Target of Framework:</strong> Explanation of how organizations sustain
+              competitive advantage in dynamic, fast-moving environments by developing capabilities
+              to sense market changes, seize new opportunities, and reconfigure internal and
+              external resources to respond to shifting competitive conditions
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Strategic Management, Organization Theory,
+              Technology Management, Economics of Innovation
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Authors:</strong> David J. Teece, Gary Pisano, Amy Shuen
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 1997
+            </p>
+            <p>
+              <strong>Official Title:</strong> Dynamic capabilities and strategic management
+            </p>
+            <p>
+              <strong>Journal:</strong> Strategic Management Journal
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 18, No. 7
+            </p>
+            <p>
+              <strong>Pages:</strong> 509-533
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
-              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Teece, D. J., Pisano, G., &amp; Shuen, A. (
+                <a href="#ref-teece-1997" className="text-tabs-teal-deep hover:underline">
+                  1997
+                </a>
+                ). Dynamic capabilities and strategic management.{' '}
+                <em>Strategic Management Journal</em>, 18(7), 509-533.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Teece, David J., Gary Pisano, and Amy Shuen. 1997. &ldquo;Dynamic Capabilities and
+                Strategic Management.&rdquo; <em>Strategic Management Journal</em> 18, no. 7:
+                509-533.
+              </p>
+            </div>
           </div>
         </section>
 
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            In 1997, David J. Teece, Gary Pisano, and Amy Shuen published &ldquo;Dynamic
-            Capabilities and Strategic Management&rdquo; in the Strategic Management Journal,
-            creating what would become one of the most influential frameworks for understanding
-            organizational adaptation and sustained competitive advantage in turbulent environments.
-            Building on the Resource-Based View of the Firm (Wernerfelt, 1984) and the VRIO
-            Framework (Barney, 1991), the Dynamic Capabilities Framework addressed a critical
-            limitation that had become increasingly apparent by the mid-1990s: static frameworks
-            were inadequate for explaining sustained competitive advantage when competitive
-            environments change rapidly and unpredictably.
+            The Resource-Based View of the firm (
+            <a
+              id="cite-ref-wernerfelt-1984-1"
+              href="#ref-wernerfelt-1984"
+              className="text-tabs-teal-deep hover:underline"
+            >
+              Wernerfelt, 1984
+            </a>
+            ;{' '}
+            <a
+              id="cite-ref-barney-1991-1"
+              href="#ref-barney-1991"
+              className="text-tabs-teal-deep hover:underline"
+            >
+              Barney, 1991
+            </a>
+            ) provided powerful strategic insight into competitive advantage through control of
+            valuable, rare, inimitable resources. However, RBV had significant limitations in
+            explaining sustained competitive advantage in environments characterized by rapid
+            technological change, shifting customer preferences, and dynamic competitive conditions.
+            In stable environments where resources maintain value over extended periods, RBV
+            explained strategy effectively. But in fast-moving industries such as semiconductors,
+            pharmaceuticals, biotechnology, software, and telecommunications, today&rsquo;s
+            inimitable resources became obsolete quickly. Static resources and capabilities that
+            created yesterday&rsquo;s competitive advantages often became liabilities as markets
+            shifted. RBV provided limited guidance on how organizations adapt when resource bases
+            become outdated or market conditions fundamentally change.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The fundamental insight of the Dynamic Capabilities Framework is that sustained
-            competitive advantage in turbulent environments requires more than simply possessing
-            valuable, rare, and inimitable resources. Organizations must continuously develop new
-            capabilities and transform existing resources as environments change. The framework
-            identifies three core organizational capabilities that enable sustained adaptation:
-            sensing market opportunities and technological possibilities, seizing opportunities by
-            developing new products and services, and transforming organizational assets and
-            structures in response to environmental change.
-          </p>
-
-          <h2 className={H2_CLASSES}>Why Was the Framework Created?</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Teece, Pisano, and Shuen developed the Dynamic Capabilities Framework to address
-            critical gaps in how the Resource-Based View and VRIO frameworks explained competitive
-            advantage in rapidly changing industries. While Wernerfelt and Barney had provided
-            powerful frameworks for understanding competitive advantage based on the endowment of
-            firm resources, their frameworks gave insufficient attention to how firms continuously
-            renew, reconfigure, and transform resources as competitive environments change.
+            Teece, Pisano, and Shuen recognized that explaining competitive advantage in dynamic
+            environments required a different theoretical focus. Rather than asking &ldquo;What
+            static resources provide competitive advantage?&rdquo; they asked &ldquo;What
+            capabilities enable organizations to continuously sense market changes, quickly seize
+            new opportunities, and rapidly reconfigure their resource bases to respond to shifting
+            competitive conditions?&rdquo; This shift from static resources to dynamic capabilities
+            represented a fundamental evolution in strategic management thinking. Organizations
+            operating in fast-moving environments compete not based on what they possess today, but
+            on their ability to identify emerging opportunities before competitors and execute
+            faster than rivals.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The authors observed that many firms possessing valuable, rare, inimitable resources
-            found those resources becoming obsolete as industries evolved, technologies changed, and
-            competitive dynamics shifted. Sony&rsquo;s capabilities in transistor technology, which
-            had provided sustained competitive advantage through the 1970s and 1980s, became less
-            important as the industry shifted toward digital technologies. Kodak&rsquo;s
-            extraordinary capabilities in chemical photography became a liability as digital
-            photography emerged. These real-world examples demonstrated that sustained competitive
-            advantage required not merely possessing valuable resources but continuously developing
-            new resources and capabilities as environments changed.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework was motivated by recognition that in hypercompetitive industries,
-            technological turbulence, and rapidly changing markets (exemplified by the information
-            technology, telecommunications, and biotechnology sectors), traditional competitive
-            advantage grounded in stable, inimitable resource positions was insufficient. Firms
-            needed different capabilities - not just the ability to exploit existing resources but
-            the ability to sense market opportunities and threats, to seize opportunities through
-            organizational restructuring, and to continuously reconfigure organizational assets and
-            resources in response to environmental change.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Additionally, the framework was motivated by observation that many firms failed to adapt
-            as environments changed because they were locked into existing capabilities and
-            resources. What Teece and colleagues termed &ldquo;organizational rigidities&rdquo; or
-            &ldquo;core rigidities&rdquo; - deep organizational commitments to particular resource
-            configurations that had worked well in the past - prevented organizations from adapting
-            when environments changed. The framework provides guidance for overcoming these
-            organizational rigidities and maintaining organizational flexibility and adaptive
-            capacity.
-          </p>
-
-          <h2 className={H2_CLASSES}>The Three Core Dynamic Capabilities</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Dynamic Capabilities Framework identifies three fundamental organizational
-            capabilities that enable sustained adaptation in turbulent environments:
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            1. Sensing: Identifying and Assessing Market Opportunities and Threats
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            Sensing capability refers to the organizational capacity to identify, monitor, and
-            assess market opportunities and technological possibilities before they become obvious
-            to the entire market. Rather than simply responding to competitive threats or market
-            demands that are already evident, organizations with strong sensing capabilities
-            anticipate future market needs and technological possibilities.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Effective sensing requires establishing systems and processes for monitoring
-            technological developments, tracking customer needs and preferences, conducting market
-            research, and maintaining awareness of competitors&rsquo; activities and strategic
-            directions. Organizations should invest in environmental scanning processes that monitor
-            technological change, competitive changes, customer changes, and regulatory changes. By
-            developing sensing capabilities, organizations can identify opportunities before they
-            become obvious to the entire market, enabling first-mover advantages and strategic
-            flexibility.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            For technology adoption specifically, sensing capability involves monitoring emerging
-            technologies, understanding how technologies might address organizational needs,
-            evaluating technology maturity and readiness, and assessing when emerging technologies
-            become viable for organizational deployment.
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            2. Seizing: Mobilizing Resources to Capture Value from Opportunities
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            Seizing capability refers to the organizational capacity to quickly develop products,
-            services, or business models that address identified opportunities. Organizations that
-            sense opportunities but lack seizing capabilities fail to convert those insights into
-            competitive advantages. Effective seizing requires product development capabilities that
-            enable rapid commercialization of new ideas, business model innovation capabilities,
-            marketing and customer development capabilities, and decision-making structures that
-            enable fast action.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Seizing capability depends on organizational structures that facilitate rapid
-            decision-making, cross-functional collaboration, and resource mobilization.
-            Organizations with rigid hierarchies, slow decision-making processes, strong functional
-            silos, and constrained internal communication will struggle to develop seizing
-            capabilities. Leaders should design organizational structures that enable decisive
-            seizing of opportunities through fast decision-making, resource flexibility, and
-            collaborative processes.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            In the context of technology adoption, seizing capability involves the ability to pilot
-            new technologies quickly, secure organizational resources and commitment for technology
-            initiatives, integrate new technologies with existing systems and processes, and scale
-            successful technology pilots into enterprise-wide implementations.
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            3. Transforming: Reconfiguring Assets and Organizational Structures
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            Transforming capability (also called reconfiguring capability) refers to the
-            organizational capacity to reconfigure organizational assets, structures, and processes
-            as competitive environments change. Organizations lacking transforming capabilities find
-            themselves constrained by historical asset configurations and strategic directions,
-            unable to adapt as environments change.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Effective transforming capability involves organizational redesign, restructuring, and
-            change management capabilities; capabilities for retraining personnel to develop new
-            skills; capabilities for divesting businesses or assets that no longer fit the
-            organization&rsquo;s strategic direction; capabilities for acquiring or licensing new
-            technologies and integrating them into organizational operations; and capabilities for
-            evolving organizational culture and values as strategic direction changes.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            For technology adoption, transforming capability includes the ability to redesign
-            business processes around new technologies, develop new organizational roles and skills
-            to support new technologies, retire legacy systems and processes that are being
-            replaced, and manage organizational change and resistance during technology transitions.
-          </p>
-
-          <h2 className={H2_CLASSES}>From Static Resources to Dynamic Adaptation</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Dynamic Capabilities Framework represents a fundamental evolution in strategic
-            management thinking, shifting focus from what resources the organization currently
-            possesses to how organizations develop new resources and transform existing resources as
-            environments change. This shift from static to dynamic represents a fundamental
-            reorientation-from what the organization has to what the organization can do and become.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            While earlier frameworks focused on resource stocks (what the organization possesses),
-            the Dynamic Capabilities Framework emphasizes capability processes (how the organization
-            develops, integrates, and deploys resources). The distinction is important: two
-            organizations might possess similar resource stocks but differ dramatically in their
-            capacity to continuously renew and reconfigure those resources.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework also shifts from pursuing sustainable advantage to pursuing dynamic
-            adaptation. While Barney&rsquo;s VRIO framework focused on creating sustained
-            competitive advantage by developing resources that competitors cannot imitate, the
-            Dynamic Capabilities Framework acknowledges that in turbulent environments, sustained
-            advantage is often impossible-the best organizations can do is continuously adapt faster
-            than competitors. This shift from pursuing sustainable advantage to pursuing dynamic
-            adaptation represents a fundamental change in strategic thinking.
-          </p>
-
-          <h2 className={H2_CLASSES}>Application to Technology Adoption</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Dynamic Capabilities Framework provides crucial insights for technology adoption in
-            organizations operating in rapidly changing technological environments. Technology
-            adoption is not merely a matter of purchasing systems or implementing tools, but
-            requires building and integrating complementary organizational capabilities for sensing
-            technological opportunities, seizing those opportunities through effective
-            implementation, and transforming organizational processes and structures to fully
-            leverage new technologies.
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            Sensing Technological Opportunities
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            Organizations should develop capabilities for monitoring emerging technologies, tracking
-            technological developments, conducting technology assessments, and understanding how
-            technologies might address organizational needs. This involves establishing
-            relationships with technology suppliers and service providers, participating in
-            technology industry consortia and standards organizations, monitoring technology
-            research and publications, and maintaining technical expertise that enables evaluation
-            of new technologies.
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            Seizing Technology Implementation Opportunities
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            Organizations should develop capabilities for rapidly piloting new technologies,
-            evaluating technology performance and fit with organizational needs, securing resources
-            and organizational commitment for promising technologies, and scaling successful pilots
-            into enterprise implementations. This requires establishing innovation governance and
-            resource allocation processes that enable investment in promising technology
-            initiatives, creating dedicated roles and teams for technology evaluation and
-            implementation, and developing project management capabilities for technology
-            deployment.
-          </p>
-
-          <h3 className="text-base sm:text-lg md:text-xl font-semibold text-gray-900 mb-3 sm:mb-4">
-            Transforming Organizations Around New Technologies
-          </h3>
-          <p className={PARAGRAPH_CLASSES}>
-            Organizations should develop capabilities for redesigning business processes to leverage
-            new technologies, developing new organizational roles and skills, retiring legacy
-            systems and processes, and managing organizational change and resistance. This involves
-            investing substantially in organizational change management capabilities, creating
-            learning systems that enable organizational learning about new technologies, and
-            establishing governance structures specifically designed to foster innovation and
-            technology adoption.
-          </p>
-
-          <h2 className={H2_CLASSES}>Organizational Learning and Path Dependence</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework places learning and knowledge development at the center of sustained
-            competitive advantage. Organizations that systematically learn from experience, capture
-            learning in organizational routines and processes, and continuously improve their
-            capabilities will sustain advantage longer than organizations that do not invest in
-            learning. This emphasis on learning as central to competitive advantage represents an
-            important contribution to strategic management thinking.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            However, the framework also acknowledges the constraints imposed by path
-            dependence-organizational capabilities and competitive positions are shaped by
-            historical development paths and previous resource commitments. Some capabilities can be
-            readily changed while others are constrained by historical choices, investments, and
-            organizational commitments. Understanding these path dependencies helps organizations
-            recognize which aspects of their strategic position are flexible and subject to change
-            versus constrained by historical commitments.
-          </p>
-
-          <h2 className={H2_CLASSES}>Strengths of the Framework</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Dynamic Capabilities Framework possesses several significant strengths that have
-            contributed to its widespread adoption and influence:
-          </p>
-          <ul className="list-disc pl-6 mb-3 sm:mb-6 space-y-2 text-gray-800">
-            <li>
-              <strong>Addresses Turbulent Environment Adaptation:</strong> The framework explains
-              how organizations maintain competitive advantage in rapidly changing environments
-              where static resource positions become obsolete. This makes it invaluable for
-              organizations operating in technology-driven, fast-changing, or disruptive industries.
-            </li>
-            <li>
-              <strong>Integrates Multiple Theoretical Perspectives:</strong> The framework
-              successfully integrates insights from evolutionary economics, organizational learning
-              theory, organizational routines research, and strategic management, providing a more
-              comprehensive understanding of organizational adaptation.
-            </li>
-            <li>
-              <strong>Distinguishes Between Static and Dynamic Capabilities:</strong> The framework
-              clarifies the distinction between ordinary capabilities (executing existing processes)
-              and dynamic capabilities (changing and renewing capabilities). This helps explain why
-              organizations that excel at current operations sometimes struggle to adapt to changing
-              environments.
-            </li>
-            <li>
-              <strong>Explains Organizational Rigidity:</strong> The framework provides powerful
-              explanation for why organizations with valuable resources and successful competitive
-              positions sometimes fail to adapt as environments change, offering valuable guidance
-              for avoiding these failure modes.
-            </li>
-            <li>
-              <strong>Provides Guidance for Organizational Design:</strong> Unlike frameworks that
-              focus primarily on resources without guidance on organizational structure, the Dynamic
-              Capabilities Framework suggests that organizations should have structures that enable
-              fast sensing, rapid decision-making, cross-functional collaboration, and
-              organizational flexibility.
-            </li>
-            <li>
-              <strong>Addresses Technology Change and Innovation:</strong> The framework provides
-              excellent guidance for understanding how organizations should manage technological
-              change and invest in innovation, showing how innovation capability is embedded in
-              organizational routines, structures, and processes.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Limitations and Challenges</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Despite its considerable strengths, the Dynamic Capabilities Framework exhibits certain
-            limitations that scholars and practitioners should understand:
-          </p>
-          <ul className="list-disc pl-6 mb-3 sm:mb-6 space-y-2 text-gray-800">
-            <li>
-              <strong>Operationalization and Measurement Challenges:</strong> While the framework
-              provides conceptual clarity about what dynamic capabilities are, operationalizing and
-              measuring sensing, seizing, and transforming capabilities remains challenging.
-              Different research studies use different operationalizations, making it difficult to
-              compare findings across contexts.
-            </li>
-            <li>
-              <strong>Difficulty Distinguishing Ordinary from Dynamic Capabilities:</strong> The
-              distinction between ordinary and dynamic capabilities is conceptually clear but
-              operationally ambiguous in practice. Some scholars argue that all capabilities are
-              dynamic to some degree, making it difficult to determine which capabilities to
-              prioritize.
-            </li>
-            <li>
-              <strong>Tendency Toward Tautology:</strong> Organizations that successfully adapt are
-              said to possess strong dynamic capabilities, but the evidence for possession of
-              dynamic capabilities often is that the organization successfully adapted. This
-              circular reasoning makes the framework difficult to test falsifiably.
-            </li>
-            <li>
-              <strong>Limited Attention to Resource Constraints:</strong> The framework gives
-              limited attention to resource constraints that limit organizations&rsquo; ability to
-              invest in dynamic capability development simultaneously across all three dimensions.
-            </li>
-            <li>
-              <strong>Incomplete Specification of Transformation Mechanisms:</strong> While the
-              framework identifies that organizations must continuously reconfigure assets and
-              processes, it provides incomplete specification of the actual transformation
-              mechanisms, such as how organizations divest legacy assets while maintaining current
-              profitability.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Relationship to Organizational Learning and Innovation</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Dynamic Capabilities Framework has important connections to organizational learning
-            theory and innovation research. The framework suggests that organizations develop
-            dynamic capabilities through organizational learning processes-by systematically
-            learning from experience, capturing learning in organizational routines, and
-            continuously improving capabilities. This connection to learning theory enriches
-            understanding of how dynamic capabilities develop over time.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            For innovation, the framework shows that innovation capability is not an isolated
-            function but is embedded in organizational routines, structures, and processes.
-            Organizations should systematically invest in building sensing, seizing, and
-            transforming capabilities related to technology and innovation. This perspective has
-            informed subsequent frameworks for understanding organizational innovation capacity and
-            technology readiness.
-          </p>
-
-          <h2 className={H2_CLASSES}>Subsequent Developments and Extensions</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Since its 1997 publication, the Dynamic Capabilities Framework has spawned extensive
-            empirical research and theoretical extensions. Subsequent work has examined:
-          </p>
-          <ul className="list-disc pl-6 mb-3 sm:mb-6 space-y-2 text-gray-800">
-            <li>
-              <strong>Sensing-Seizing-Transforming Refinements (Teece, 2007):</strong> Further
-              refinement of the three-capability model with more detailed specification of
-              organizational processes and microfoundations.
-            </li>
-            <li>
-              <strong>Organizational Ambidexterity Theory:</strong> Integration with research on how
-              organizations balance exploitation of existing capabilities with exploration of new
-              possibilities (March, 1991; O&rsquo;Reilly &amp; Tushman, 2008).
-            </li>
-            <li>
-              <strong>Dynamic Capabilities in Digital and Platform Contexts:</strong> Extensions
-              examining how dynamic capabilities operate in multi-sided platform business models and
-              digital ecosystem contexts.
-            </li>
-            <li>
-              <strong>Knowledge Management and Learning:</strong> Integration with knowledge
-              management frameworks and organizational learning theory to better understand how
-              organizations develop and maintain dynamic capabilities.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Implications for Technology Adoption Research</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            For technology adoption research specifically, the Dynamic Capabilities Framework
-            provided crucial insights into why some organizations successfully adopt new
-            technologies while others struggle. The framework highlights that technology adoption is
-            not merely a matter of purchasing systems or implementing tools, but requires building
-            and integrating complementary organizational capabilities.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            This perspective has informed subsequent frameworks for understanding organizational
-            technology readiness and adoption capacity, emphasizing the critical role of
-            organizational structure, learning capabilities, and change management in technology
-            adoption success. Organizations that develop strong sensing capabilities can identify
-            valuable technologies early; organizations with strong seizing capabilities can rapidly
-            implement and scale new technologies; and organizations with strong transforming
-            capabilities can successfully redesign processes and structures to fully leverage
-            technological capabilities.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework also suggests that organizations should view technology adoption not as
-            isolated projects but as opportunities to develop and enhance organizational dynamic
-            capabilities. Each technology adoption initiative provides opportunities for
-            organizational learning, capability development, and organizational transformation that
-            build capacity for future technology adoption and organizational adaptation.
+            The framework emerged from empirical investigation of high-technology firms operating in
+            turbulent competitive environments. Teece and colleagues examined how pharmaceutical
+            firms, semiconductor companies, and software organizations sustained competitive
+            advantage despite constant technological disruption. They identified patterns in how
+            successful organizations managed the innovation process: sensing technological and
+            market trends before competitors, recognizing which new opportunities aligned with
+            organizational capabilities and market needs, assembling resources and capabilities to
+            pursue opportunities quickly, and integrating new technologies and capabilities into
+            existing operational systems. These dynamic capabilities - the ability to sense, seize,
+            and reconfigure - distinguished organizations that thrived amid disruption from those
+            that faltered.
           </p>
         </section>
 
-        <section className="pt-8 border-t border-gray-200">
-          <h2 className={REFERENCES_H2_CLASSES}>References</h2>
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Dynamic Capabilities framework is built on fundamental concepts about how
+            organizations survive and succeed in dynamic environments:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Dynamic Capabilities:</strong> The organization&rsquo;s ability to sense
+              external change, make strategic decisions about which changes to respond to, mobilize
+              resources to address those changes, and reconfigure operational systems and resource
+              bases. Dynamic capabilities are not static resources but rather the organizational
+              processes, routines, and competencies enabling continuous adaptation and renewal.
+            </li>
+            <li>
+              <strong>Sensing Capability:</strong> The organizational capacity to scan the external
+              environment for technological change, emerging customer preferences, competitor
+              actions, and new market opportunities. Sensing involves boundary-spanning activities,
+              external relationship networks, scanning systems, and cognitive frameworks enabling
+              identification of relevant change signals and pattern recognition in market dynamics.
+            </li>
+            <li>
+              <strong>Seizing Capability:</strong> The organizational capacity to evaluate
+              opportunities identified through sensing activities, make strategic decisions about
+              which opportunities deserve resource commitment, and assemble resources and
+              capabilities to pursue selected opportunities. Seizing translates opportunity
+              recognition into specific strategic actions and resource allocation decisions.
+            </li>
+            <li>
+              <strong>Reconfiguring Capability:</strong> The organizational capacity to realign
+              internal and external resource bases, recombine organizational capabilities,
+              reengineer business processes, and reorganize internal structures to execute selected
+              strategies. Reconfiguring transforms identified opportunities into operational
+              capabilities and market implementations.
+            </li>
+            <li>
+              <strong>Asset Orchestration:</strong> The strategic alignment and integration of
+              assets (physical, financial, human, organizational, and intellectual property) and
+              capabilities to create customer value and competitive advantage. Orchestration
+              involves decisions about which assets to acquire, develop, lease, or divest as markets
+              shift.
+            </li>
+            <li>
+              <strong>Technology Management:</strong> The organizational processes for monitoring
+              technological development, evaluating technological relevance to future strategy,
+              building technological competencies, and integrating new technologies into operational
+              systems. Technology management is a core dynamic capability as technological change is
+              the primary source of disruption in many industries.
+            </li>
+            <li>
+              <strong>Complementary Assets:</strong> Resources and capabilities that enhance the
+              value of core technological or competitive assets. A firm may develop superior
+              technology but fail if it lacks complementary assets such as manufacturing capability,
+              distribution networks, marketing competence, or customer relationships to
+              commercialize the technology.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Dynamic Capabilities theory built on and extended previous strategic management
+            frameworks:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Resource-Based View of the Firm (
+                <a
+                  id="cite-ref-wernerfelt-1984-2"
+                  href="#ref-wernerfelt-1984"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Wernerfelt, 1984
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-barney-1991-2"
+                  href="#ref-barney-1991"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Barney, 1991
+                </a>
+                ):
+              </strong>{' '}
+              Established the foundation for capabilities-based strategy by arguing that resources
+              create competitive advantage. Dynamic Capabilities extended RBV from static resources
+              to dynamic processes enabling resource renewal and adaptation.
+            </li>
+            <li>
+              <strong>
+                Organizational Capabilities and Routines (
+                <a
+                  id="cite-ref-nelson-1982-1"
+                  href="#ref-nelson-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Nelson &amp; Winter, 1982
+                </a>
+                ):
+              </strong>{' '}
+              Emphasized that firms develop distinctive capabilities and organizational routines
+              that enable specific performance and constrain behavior. Dynamic Capabilities built on
+              this insight by emphasizing capabilities for change rather than just execution of
+              existing routines.
+            </li>
+            <li>
+              <strong>
+                Technology and Innovation Management (
+                <a
+                  id="cite-ref-rosenberg-1982-1"
+                  href="#ref-rosenberg-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Rosenberg, 1982
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-dosi-1982-1"
+                  href="#ref-dosi-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Dosi, 1982
+                </a>
+                ):
+              </strong>{' '}
+              Emphasized that technological trajectories constrain and enable firm development.
+              Dynamic Capabilities incorporated technological evolution and the organizational
+              challenge of continuously updating technological competencies.
+            </li>
+            <li>
+              <strong>
+                Organizational Learning Theory (Argyris &amp; Schon, 1978; Levitt &amp; March,
+                1988):
+              </strong>{' '}
+              Examined how organizations learn from experience and develop increasingly
+              sophisticated capabilities. Dynamic Capabilities emphasized learning processes
+              enabling organizational adaptation and evolution.
+            </li>
+            <li>
+              <strong>
+                Strategic Intent and Core Competencies (
+                <a
+                  id="cite-ref-hamel-1989-1"
+                  href="#ref-hamel-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Hamel &amp; Prahalad, 1989
+                </a>
+                , 1994):
+              </strong>{' '}
+              Emphasized that sustained competitive advantage comes from organizational competencies
+              that create customer value and are difficult for competitors to replicate. Dynamic
+              Capabilities extended this by emphasizing the capability to develop new competencies
+              continuously.
+            </li>
+            <li>
+              <strong>
+                Path Dependency and Lock-In (
+                <a
+                  id="cite-ref-arthur-1989-1"
+                  href="#ref-arthur-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Arthur, 1989
+                </a>
+                ; David, 1985):
+              </strong>{' '}
+              Examined how historical choices constrain future options and create path dependency in
+              organizational development. Dynamic Capabilities acknowledged path dependency while
+              emphasizing organizational capacity to break unfavorable paths and create new
+              trajectories.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Dynamic Capabilities framework proposes that sustained competitive advantage in
+            dynamic environments derives from organizational capabilities to continuously sense
+            external change, seize new opportunities, and reconfigure internal and external
+            resources to capitalize on identified opportunities. Rather than viewing strategy as
+            selecting favorable positions within relatively stable industry structures, the Dynamic
+            Capabilities approach views strategy as building organizational capacity for continuous
+            adaptation and renewal. Competitive advantage is temporal and fragile in dynamic
+            environments; it persists only as long as organizations can identify emerging
+            opportunities before competitors and execute faster than rivals.
+          </p>
+
+          <h3 className={H3_CLASSES}>The Sensing-Seizing-Reconfiguring Framework</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Sensing:</strong> Scanning and interpreting the external environment to
+              identify technological trends, emerging market opportunities, customer preference
+              shifts, and competitor actions. Sensing requires organizational structures, processes,
+              and relationships enabling recognition of relevant change signals. Sensing
+              capabilities include environmental scanning, market research, technology monitoring,
+              customer engagement, and external partnerships providing access to emerging
+              information.
+            </li>
+            <li>
+              <strong>Seizing:</strong> Making strategic decisions about which identified
+              opportunities to pursue and mobilizing resources to address selected opportunities.
+              Seizing involves evaluating which opportunities align with organizational
+              capabilities, market potential, and strategic priorities. Seizing decisions determine
+              resource allocation, strategic investments, and pursuit directions. Organizations with
+              weak seizing capabilities may identify emerging opportunities but fail to commit
+              sufficient resources to capitalize on them.
+            </li>
+            <li>
+              <strong>Reconfiguring:</strong> Realigning internal operations, reengineer business
+              processes, integrate new capabilities, and mobilize existing resources to execute
+              strategies targeting identified opportunities. Reconfiguring translates strategic
+              intent into operational execution. Successful reconfiguring requires change management
+              capability, organizational flexibility, and capacity to learn and adapt organizational
+              systems.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Positions, Processes, and Paths Framework</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Positions:</strong> The organization&rsquo;s current asset base including
+              physical assets, financial resources, human capital, intellectual property, and
+              relationships. Positions constrain and enable future strategic options. Organizations
+              with complementary asset positions can capitalize on technology innovations more
+              effectively than organizations lacking position-relevant assets. Position development
+              requires years of investment and cannot be quickly replicated.
+            </li>
+            <li>
+              <strong>Processes:</strong> The organizational capabilities, routines, decision-making
+              procedures, and governance mechanisms enabling strategy execution. Processes determine
+              how efficiently organizations can mobilize resources, make decisions, execute
+              initiatives, and learn. Process capabilities are embedded in organizational culture
+              and routines; they are partially tacit and difficult for competitors to imitate.
+            </li>
+            <li>
+              <strong>Paths:</strong> The strategic options available to organizations given their
+              current positions and historical choices. Historical decisions create path dependency;
+              organizations cannot reverse history or arbitrarily shift strategic directions without
+              significant costs. However, within path constraints, organizations maintain strategic
+              agency and can influence which future paths become available through current
+              decisions.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Key Mechanisms</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Asset Orchestration:</strong> Strategic decisions about acquiring, developing,
+              leasing, or divesting assets and capabilities as competitive conditions shift.
+              Successful asset orchestration aligns organizational asset base with market
+              opportunities, enabling value creation.
+            </li>
+            <li>
+              <strong>Complementary Asset Integration:</strong> Ensuring that organizations possess
+              or can access complementary assets enhancing core capabilities. A superior technology
+              lacks competitive value without complementary manufacturing, distribution, and
+              marketing capabilities.
+            </li>
+            <li>
+              <strong>Learning and Knowledge Development:</strong> Organizational processes for
+              learning from market feedback, assimilating new information, and developing updated
+              capabilities. Learning capabilities enable organizations to improve performance over
+              time and avoid repeating past mistakes.
+            </li>
+            <li>
+              <strong>Technology Management:</strong> Organizational capacity to evaluate emerging
+              technologies, build technological competencies, integrate new technologies into
+              operations, and make strategic technology choices. Technology management is
+              particularly critical in technology-intensive industries where technological
+              obsolescence is rapid.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Addresses RBV limitations:</strong> Extends Resource-Based View to dynamic
+              environments by explaining how organizations sustain competitive advantage when
+              resources continuously become outdated.
+            </li>
+            <li>
+              <strong>Explains within-industry heterogeneity in dynamic environments:</strong>{' '}
+              Accounts for why some organizations thrive amid technological disruption while others
+              falter. Organizations differ not just in resource positions but in capabilities for
+              adaptation and renewal.
+            </li>
+            <li>
+              <strong>Integrates external and internal perspectives:</strong> Combines external
+              opportunity recognition (sensing) with internal capabilities and processes (seizing
+              and reconfiguring).
+            </li>
+            <li>
+              <strong>Acknowledges path dependency:</strong> Recognizes that historical choices
+              constrain future options while emphasizing that organizations can influence future
+              possibilities through current decisions.
+            </li>
+            <li>
+              <strong>Emphasizes process capabilities:</strong> Highlights that organizational
+              capabilities for adaptation, learning, and decision-making create competitive value
+              beyond static resources.
+            </li>
+            <li>
+              <strong>Applicable to technology-intensive industries:</strong> Provides powerful
+              explanatory framework for competitive dynamics in industries characterized by rapid
+              technological change.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Complex to operationalize:</strong> The framework introduces complex
+              constructs (sensing, seizing, reconfiguring) that are difficult to measure and observe
+              empirically. Defining boundaries between capabilities and identifying what enables
+              each capability remains challenging.
+            </li>
+            <li>
+              <strong>Limited practical guidance:</strong> While the framework identifies necessary
+              capabilities, it provides limited specific guidance on how organizations should
+              develop sensing, seizing, and reconfiguring capabilities or how to measure capability
+              strength.
+            </li>
+            <li>
+              <strong>Circularity risks:</strong> Similar to RBV, Dynamic Capabilities can risk
+              tautology: if organizations outperform competitors in dynamic environments, we infer
+              they possess superior dynamic capabilities; but we may lack independent measures of
+              capability strength.
+            </li>
+            <li>
+              <strong>Path dependency can be overstated:</strong> While acknowledging path
+              dependency, the framework may underestimate organizational capacity to create
+              discontinuous strategic shifts or to overcome historical constraints through
+              aggressive resource investment.
+            </li>
+            <li>
+              <strong>Difficulty distinguishing static from dynamic capabilities:</strong> The
+              framework emphasizes dynamic capabilities but provides limited guidance on how to
+              distinguish dynamic capabilities from static resources or on when dynamic capabilities
+              create sustainable versus temporary advantage.
+            </li>
+            <li>
+              <strong>Insufficient attention to failure modes:</strong> The framework describes
+              successful adaptation but provides limited analysis of when sensing, seizing, or
+              reconfiguring capabilities fail and what organizational characteristics predict
+              failure.
+            </li>
+            <li>
+              <strong>Limited applicability to stable environments:</strong> The framework is
+              tailored to dynamic environments; applicability to stable, mature industries where
+              rapid adaptation may not create competitive advantage remains unclear.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Extended RBV to dynamic environments:</strong> Successfully extended the
+              Resource-Based View from static resources to dynamic processes enabling adaptation in
+              changing environments, addressing major RBV limitation.
+            </li>
+            <li>
+              <strong>Explained sustained advantage in disruption:</strong> Provided theoretical
+              explanation for why some organizations sustain competitive advantage through
+              technological and market disruptions while others fail to adapt.
+            </li>
+            <li>
+              <strong>Introduced sensing-seizing-reconfiguring framework:</strong> Established
+              conceptually distinct organizational capabilities for sensing external changes,
+              seizing opportunities, and reconfiguring resources to enable sustained advantage.
+            </li>
+            <li>
+              <strong>Integrated positions-processes-paths perspective:</strong> Synthesized the
+              current asset position, organizational processes, and historical path dependency as
+              interconnected determinants of strategic options and competitive advantage.
+            </li>
+            <li>
+              <strong>Emphasized learning and adaptation:</strong> Elevated organizational learning,
+              adaptation, and continuous renewal as sources of competitive value rather than
+              treating them as operational necessities.
+            </li>
+            <li>
+              <strong>Recognized complementary assets:</strong> Highlighted importance of
+              complementary assets and capabilities in creating customer value, explaining why firms
+              with superior technology sometimes failed commercially without supporting asset bases.
+            </li>
+            <li>
+              <strong>Provided framework for analyzing high-technology industries:</strong>{' '}
+              Established theoretical framework specifically suited to analyzing competitive
+              dynamics in technology-intensive industries characterized by rapid change.
+            </li>
+            <li>
+              <strong>Foundation for future strategic theory:</strong> Created foundation for
+              subsequent developments in organizational agility, resilience, innovation capability,
+              and ambidextrous organization theory.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            As a conceptual framework paper grounded in empirical observation of
+            technology-intensive firms, the Dynamic Capabilities framework demonstrates strong
+            internal validity through logical coherence and consistency with observable
+            organizational phenomena:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Logical consistency:</strong> The core argument that organizations require
+              distinct capabilities for sensing opportunities, seizing selected opportunities, and
+              reconfiguring resources to execute strategies is logically sound. Organizations
+              lacking any component capability would struggle with adaptation and innovation.
+            </li>
+            <li>
+              <strong>Integration with empirical observation:</strong> The framework emerged from
+              empirical investigation of how semiconductor, pharmaceutical, and biotechnology firms
+              managed innovation and adaptation. Proposed mechanisms reflect observed organizational
+              practices in these industries.
+            </li>
+            <li>
+              <strong>Consistency with organizational learning theory:</strong> The framework
+              incorporates established insights from organizational learning theory about how
+              organizations develop capabilities, learn from experience, and adapt to environmental
+              changes.
+            </li>
+            <li>
+              <strong>Addresses documented organizational challenges:</strong> The framework
+              explains well-documented phenomena: why incumbent firms struggle with disruptive
+              innovation, why startup firms sometimes outpace established competitors despite having
+              fewer resources, and why organizational success in one era sometimes predicts
+              organizational failure in the next era.
+            </li>
+            <li>
+              <strong>Acknowledges path dependency:</strong> Explicit recognition of path dependency
+              and historical constraint on organizational options reflects organizational reality
+              and prevents unfounded claims of unlimited strategic optionality.
+            </li>
+            <li>
+              <strong>Balance of mechanism specificity:</strong> The framework is specific enough to
+              distinguish sense-seize-reconfigure capabilities yet flexible enough to encompass
+              diverse organizational forms and industry contexts.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations concern generalizability of Dynamic Capabilities
+            framework across diverse organizational contexts and competitive environments:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Industry-dependent applicability:</strong> The framework is particularly
+              well-suited to technology-intensive industries characterized by rapid technological
+              change and dynamic competitive conditions. Applicability to stable, mature industries
+              with predictable competitive dynamics may be more limited.
+            </li>
+            <li>
+              <strong>Organizational size variation:</strong> The framework may apply differently to
+              large, established organizations with formalized capabilities compared to small,
+              flexible startups with less formal capabilities but potentially greater adaptive
+              flexibility.
+            </li>
+            <li>
+              <strong>Measurement and empirical validation challenges:</strong> Operationalizing
+              sensing, seizing, and reconfiguring capabilities and establishing empirical
+              relationships remains methodologically challenging. Proposed mechanisms are difficult
+              to measure directly.
+            </li>
+            <li>
+              <strong>Causality direction uncertain:</strong> While the framework proposes that
+              dynamic capabilities enable adaptation, establishing clear causality (do organizations
+              with strong capabilities adapt faster, or does successful adaptation build stronger
+              capabilities?) is complicated.
+            </li>
+            <li>
+              <strong>Cultural and national context variation:</strong> The framework was developed
+              in Western research traditions studying American and European technology firms.
+              Applicability to different cultural contexts, governance systems, or national
+              economies requires investigation.
+            </li>
+            <li>
+              <strong>Organizational structure variation:</strong> The framework assumes certain
+              organizational structural characteristics enabling sensing and adaptation.
+              Organizations with highly centralized decision structures may struggle to implement
+              the framework despite recognizing its value.
+            </li>
+            <li>
+              <strong>Resource constraint effects:</strong> The framework assumes organizations have
+              adequate resources to sense opportunities, evaluate opportunities, and execute
+              strategies. Severely resource-constrained organizations may lack capacity to fully
+              implement the framework.
+            </li>
+            <li>
+              <strong>Institutional and regulatory context:</strong> In heavily regulated industries
+              or environments with significant institutional constraints, the freedom to reconfigure
+              resources and adapt may be more limited than the framework assumes.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Dynamic Capabilities theory explains organizational capacity for technology adoption as
+            dependent on organizational capabilities for sensing emerging technologies, seizing
+            opportunities to adopt relevant technologies, and reconfiguring internal operations to
+            integrate technologies successfully. Organizations with strong dynamic capabilities
+            recognize technology opportunities earlier than competitors, evaluate technology
+            relevance systematically, commit resources to adoption, and integrate technologies
+            effectively into operations. Conversely, organizations with weak dynamic capabilities
+            may fail to recognize technology opportunities until technologies are mature, struggle
+            to commit resources for adoption despite recognizing value, or fail to integrate
+            technologies into operations effectively. Dynamic Capabilities theory predicts that
+            organizations successful with technology adoption possess strong capabilities across all
+            three dimensions: sensing technology trends, seizing adoption opportunities, and
+            reconfiguring operations.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Weak environmental sensing:</strong> Organizations may fail to recognize
+              emerging technology opportunities. Limited market scanning, external relationships,
+              and technology monitoring result in delayed recognition of adoption opportunities.
+            </li>
+            <li>
+              <strong>Inability to seize opportunities:</strong> Organizations may recognize
+              technology opportunities but struggle to evaluate their strategic relevance or fail to
+              commit resources despite recognizing value. Weak seizing capabilities result in missed
+              adoption windows.
+            </li>
+            <li>
+              <strong>Limited reconfiguration capability:</strong> Organizations may commit to
+              technology adoption but struggle to integrate technologies into operations, modify
+              business processes, or change organizational structures to capitalize on technology
+              benefits.
+            </li>
+            <li>
+              <strong>Path dependency constraints:</strong> Historical investments, existing
+              technology bases, and organizational commitments to legacy systems constrain
+              organizational flexibility to adopt new technologies. Organizations with heavy sunk
+              costs in existing technologies face barriers to switching.
+            </li>
+            <li>
+              <strong>Insufficient complementary capabilities:</strong> Organizations may adopt
+              technologies but lack complementary capabilities required to create customer value
+              from technologies. Adoption of collaboration technology, for example, requires change
+              management, training, and process redesign capabilities.
+            </li>
+            <li>
+              <strong>Learning limitations:</strong> Organizations may lack capacity to learn from
+              technology adoption experience, repeating past mistakes rather than improving adoption
+              effectiveness.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Framework Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Develop sensing capabilities:</strong> Establish environmental scanning
+              processes, build external relationships enabling early identification of emerging
+              technologies, monitor technology trends relevant to organizational strategy, and
+              create organizational forums for discussing technology trends.
+            </li>
+            <li>
+              <strong>Establish formal evaluation processes:</strong> Create systematic mechanisms
+              for evaluating technology opportunities, assessing strategic relevance, estimating
+              implementation costs, and comparing technology alternatives.
+            </li>
+            <li>
+              <strong>Commit strategic resources:</strong> Allocate adequate resources to technology
+              adoption initiatives when evaluation determines strategic relevance. Avoid
+              underfunding adoption efforts.
+            </li>
+            <li>
+              <strong>Build reconfiguration capability:</strong> Develop organizational change
+              management expertise, process redesign capabilities, and integration competencies
+              required to implement technologies in operational systems.
+            </li>
+            <li>
+              <strong>Identify complementary capability gaps:</strong> Assess whether organizations
+              possess complementary capabilities required to create value from technologies. Develop
+              or acquire complementary capabilities when gaps are identified.
+            </li>
+            <li>
+              <strong>Establish learning systems:</strong> Create mechanisms for capturing learning
+              from technology adoption experiences, documenting lessons, and improving future
+              adoption effectiveness.
+            </li>
+            <li>
+              <strong>Manage organizational inertia:</strong> Acknowledge and actively address
+              organizational inertia and path dependency constraints. Create change initiatives
+              specifically designed to overcome commitment to legacy systems.
+            </li>
+            <li>
+              <strong>Develop leadership capability:</strong> Ensure leadership possesses
+              understanding of emerging technologies, demonstrates commitment to adoption, and
+              supports organizational changes required for successful integration.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Dynamic Capabilities theory has spawned significant theoretical developments and
+            extensions building on and refining the original framework:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Microfoundations of Dynamic Capabilities (
+                <a
+                  id="cite-ref-teece-2007-1"
+                  href="#ref-teece-2007"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Teece, 2007
+                </a>
+                ):
+              </strong>{' '}
+              Refined and extended dynamic capabilities theory by developing detailed
+              microfoundations explaining which specific organizational routines, processes, and
+              governance mechanisms enable sensing, seizing, and reconfiguring. This development
+              addressed criticisms that dynamic capabilities were too abstract and difficult to
+              observe.
+            </li>
+            <li>
+              <strong>
+                Organizational Agility Framework (
+                <a
+                  id="cite-ref-sambamurthy-2003-1"
+                  href="#ref-sambamurthy-2003"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Sambamurthy, Bharadwaj, &amp; Grover, 2003
+                </a>
+                ):
+              </strong>{' '}
+              Applied dynamic capabilities concepts to information technology and organizational
+              agility, exploring how information technology capabilities enable organizational
+              sensing, decision-making, and responsive action.
+            </li>
+            <li>
+              <strong>
+                Ambidextrous Organization Theory (O&rsquo;Reilly &amp; Tushman, 2004, 2008):
+              </strong>{' '}
+              Extended dynamic capabilities to explain how organizations balance exploitation of
+              existing capabilities with exploration of new opportunities, arguing that
+              ambidexterity requires distinct organizational structures and management processes.
+            </li>
+            <li>
+              <strong>Organizational Resilience Framework:</strong> Applied dynamic capabilities
+              concepts to organizational resilience and disaster recovery, examining how
+              organizational capabilities for sensing disruptions, deciding responses, and
+              reconfiguring operations enable continuation through disruptions.
+            </li>
+            <li>
+              <strong>Innovation Capability Models:</strong> Extended dynamic capabilities framework
+              to detailed analysis of innovation processes, exploring how organizations develop
+              capabilities for recognizing innovation opportunities, funding innovation projects,
+              and integrating innovations into operations.
+            </li>
+            <li>
+              <strong>Digital Transformation Capability Models:</strong> Applied dynamic
+              capabilities framework to digital transformation, examining how organizations develop
+              capabilities for sensing digital disruption risks, seizing digital opportunities, and
+              reconfiguring business models and operations for digital-first competition.
+            </li>
+            <li>
+              <strong>Evolutionary Strategy Theory:</strong> Integration of dynamic capabilities
+              with evolutionary economics perspectives on how organizations adapt through variation,
+              selection, and retention processes.
+            </li>
+            <li>
+              <strong>Strategic Foresight and Scenario Planning:</strong> Extended dynamic
+              capabilities framework to strategic foresight and scenario planning, examining how
+              organizations improve sensing capabilities through structured approaches to exploring
+              possible future conditions.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
-            <li>
-              Teece, D. J., Pisano, G., & Shuen, A. (1997). Dynamic capabilities and strategic
-              management. Strategic Management Journal, 18(7), 509-533.{' '}
-              <a
-                href="https://doi.org/10.1002/smj.882"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1002/smj.882
-              </a>
+            <li id="ref-wernerfelt-1984">
+              Wernerfelt, B. (1984). A resource-based view of the firm.{' '}
+              <em>Strategic Management Journal</em>, 5(2), 171-180.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-wernerfelt-1984-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>{' '}
+                <a
+                  href="#cite-ref-wernerfelt-1984-2"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 2"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Wernerfelt, B. (1984). A resource-based view of the firm. Strategic Management
-              Journal, 5(2), 171-180.{' '}
-              <a
-                href="https://doi.org/10.1002/smj.4250050207"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1002/smj.4250050207
-              </a>
+            <li id="ref-barney-1991">
+              Barney, J. B. (1991). Firm resources and sustained competitive advantage.
+              <em>Journal of Management</em>, 17(1), 99-120.
+              https://doi.org/10.1177/014920639101700108{' '}
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-barney-1991-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>{' '}
+                <a
+                  href="#cite-ref-barney-1991-2"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 2"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Barney, J. B. (1991). Firm resources and sustained competitive advantage. Journal of
-              Management, 17(1), 99-120.{' '}
-              <a
-                href="https://doi.org/10.1177/014920639101700108"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1177/014920639101700108
-              </a>
+            <li id="ref-arthur-1989">
+              Arthur, W. B. (1989). Competing technologies, increasing returns, and lock-in by
+              historical events. <em>Economic Journal</em>, 99(394), 116-131.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-arthur-1989-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Nelson, R. R., & Winter, S. G. (1982). An evolutionary theory of economic change.
-              Cambridge: Harvard University Press.
-            </li>
-            <li>
+            <li id="ref-teece-2007">
               Teece, D. J. (2007). Explicating dynamic capabilities: The nature and microfoundations
-              of (sustainable) enterprise performance. Strategic Management Journal, 28(13),
-              1319-1350.
+              of (sustainable) enterprise performance. <em>Strategic Management Journal</em>,
+              28(13), 1319-1350. https://doi.org/10.1002/smj.640{' '}
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-teece-2007-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              March, J. G. (1991). Exploration and exploitation in organizational learning.
-              Organization Science, 2(1), 71-87.
+            <li id="ref-dosi-1982">
+              Dosi, G. (1982). Technological paradigms and technological trajectories.
+              <em>Research Policy</em>, 11(3), 147-162.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-dosi-1982-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              O&rsquo;Reilly, C. A., &amp; Tushman, M. L. (2008). Ambidexterity as a dynamic
-              capability: Resolving the innovator&rsquo;s dilemma. Research in Organizational
-              Behavior, 28, 185-206.
+            <li id="ref-rosenberg-1982">
+              Rosenberg, N. (1982). Inside the black box: Technology and economics. Cambridge
+              University Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-rosenberg-1982-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Cohen, W. M., & Levinthal, D. A. (1990). Absorptive capacity: A new perspective on
-              learning and innovation. Administrative Science Quarterly, 35(1), 128-152.
+            <li id="ref-teece-1997">
+              Teece, D. J., Pisano, G., &amp; Shuen, A. (1997). Dynamic capabilities and strategic
+              management. <em>Strategic Management Journal</em>, 18(7), 509-533.
+              https://doi.org/10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z
             </li>
-            <li>
-              Leonard-Barton, D. (1992). Core capabilities and core rigidities: A paradox in
-              managing new product development. Strategic Management Journal, 13(S1), 111-125.
+            <li id="ref-nelson-1982">
+              Nelson, R. R., &amp; Winter, S. G. (1982). An evolutionary theory of economic change.
+              Harvard University Press.
             </li>
-            <li>
-              Eisenhardt, K. M., & Martin, J. A. (2000). Dynamic capabilities: What are they?
-              Strategic Management Journal, 21(10-11), 1105-1121.
+            <li id="ref-hamel-1989">
+              Hamel, G., &amp; Prahalad, C. K. (1989). Strategic intent.{' '}
+              <em>Harvard Business Review</em>, 67(3), 63-76.
+            </li>
+            <li id="ref-sambamurthy-2003">
+              Sambamurthy, V., Bharadwaj, A., &amp; Grover, V. (2003). Shaping agility through
+              digital options. <em>MIS Quarterly</em>, 27(2), 237-263.
             </li>
           </ol>
         </section>
 
-        <p className="mt-8 text-sm italic text-gray-600">
-          Note: This article provides an overview based on the comprehensive literature review.
-          Readers are encouraged to consult the original publication for complete details.
-        </p>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-unknown-2004">
+              O&rsquo;Reilly, C. A., &amp; Tushman, M. L. (2004). The ambidextrous organization.
+              <em>Harvard Business Review</em>, 82(4), 74-81.
+            </li>
+            <li id="ref-penrose-1959">
+              Penrose, E. T. (1959). The theory of the growth of the firm. Oxford University Press.
+            </li>
+          </ol>
+        </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-2-vrio-framework-barney-1991"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: VRIO Framework (Barney, 1991)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-4-total-quality-management-tqm-deming-1982"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Total Quality Management (TQM) (Deming, 1982/1986) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>
   )
 }
 
-export default DynamicCapabilitiesPage
+export default BibliographyArticlePage

--- a/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
+++ b/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
@@ -70,6 +70,17 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 509-533
             </p>
+            <p>
+              <strong>DOI:</strong>{' '}
+              <a
+                href="https://doi.org/10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.1002/(SICI)1097-0266(199708)18:7%3C509::AID-SMJ882%3E3.0.CO;2-Z
+              </a>
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
+++ b/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
@@ -14,7 +14,7 @@ import {
 export const metadata: Metadata = {
   title: 'Bibliography: Dynamic Capabilities Framework - Teece, Pisano, & Shuen (1997)',
   description:
-    'Comprehensive overview of Dynamic Capabilities theory, extending the Resource-Based View to dynamic environments by emphasizing organizational capabilities to sense market changes, seize opportunities, and reconfigure resources rapidly as sources of sustained competitive advantage.',
+    'Comprehensive overview of the Teece, Pisano & Shuen (1997) dynamic capabilities framework, defined as the firm ability to integrate, build, and reconfigure internal and external competences, and organized around the three Ps - processes, positions, paths - as sources of competitive advantage in regimes of rapid technological change.',
 }
 
 const BibliographyArticlePage = () => {
@@ -36,10 +36,11 @@ const BibliographyArticlePage = () => {
               <strong>Framework Abbreviation:</strong> DC
             </p>
             <p>
-              <strong>Target of Framework:</strong> Explanation of how organizations sustain
-              competitive advantage in dynamic, fast-moving environments by developing capabilities
-              to sense market changes, seize new opportunities, and reconfigure internal and
-              external resources to respond to shifting competitive conditions
+              <strong>Target of Framework:</strong> Explain sources of competitive advantage in
+              regimes of rapid technological change by analyzing a firm&rsquo;s managerial and
+              organizational processes, asset positions, and evolution paths. Defines dynamic
+              capabilities as the ability to <em>integrate, build, and reconfigure</em> internal and
+              external competences (p.516).
             </p>
             <p>
               <strong>Disciplinary Origin:</strong> Strategic Management, Organization Theory,
@@ -586,9 +587,9 @@ const BibliographyArticlePage = () => {
               adaptation and renewal.
             </li>
             <li>
-              <strong>Integrates external and internal perspectives:</strong> Combines external
-              opportunity recognition (sensing) with internal capabilities and processes (seizing
-              and reconfiguring).
+              <strong>Integrates external and internal perspectives:</strong> The three-Ps framework
+              combines external opportunity structure (paths, co-specialized positions) with
+              internal capabilities and processes (routines, learning, and reconfiguration).
             </li>
             <li>
               <strong>Acknowledges path dependency:</strong> Recognizes that historical choices
@@ -610,45 +611,49 @@ const BibliographyArticlePage = () => {
           <h3 className={H3_CLASSES}>Main Weaknesses</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Complex to operationalize:</strong> The framework introduces complex
-              constructs (sensing, seizing, reconfiguring) that are difficult to measure and observe
-              empirically. Defining boundaries between capabilities and identifying what enables
-              each capability remains challenging.
+              <strong>Complex to operationalize:</strong> The three Ps (processes, positions, paths)
+              and the hierarchy of factors-to-capabilities are difficult to measure and observe
+              empirically. Boundaries between &ldquo;competences&rdquo;, &ldquo;core
+              competences&rdquo;, and &ldquo;dynamic capabilities&rdquo; remain contested.
+              Eisenhardt &amp; Martin (2000) was one of several follow-up papers responding
+              specifically to this operationalization gap.
             </li>
             <li>
-              <strong>Limited practical guidance:</strong> While the framework identifies necessary
-              capabilities, it provides limited specific guidance on how organizations should
-              develop sensing, seizing, and reconfiguring capabilities or how to measure capability
-              strength.
+              <strong>Limited empirical test in the paper itself:</strong> The 1997 paper relies on
+              illustrative firm-level examples (Xerox, IBM, semiconductor firms, Japanese auto
+              makers) rather than systematic empirical tests. Teece et al. explicitly call the piece
+              &ldquo;conceptual&rdquo; and identify empirical validation as a research agenda, not a
+              deliverable.
             </li>
             <li>
-              <strong>Circularity risks:</strong> Similar to RBV, Dynamic Capabilities can risk
-              tautology: if organizations outperform competitors in dynamic environments, we infer
-              they possess superior dynamic capabilities; but we may lack independent measures of
-              capability strength.
+              <strong>Tautology risk:</strong> Similar to RBV, the framework can risk tautology: if
+              a firm performs well in rapid change we infer it has good dynamic capabilities, and if
+              it has good dynamic capabilities we expect it to perform well. Independent measurement
+              of the three Ps is required to break the circle.
             </li>
             <li>
-              <strong>Path dependency can be overstated:</strong> While acknowledging path
-              dependency, the framework may underestimate organizational capacity to create
-              discontinuous strategic shifts or to overcome historical constraints through
-              aggressive resource investment.
+              <strong>Scope limited to rapid-change environments:</strong> The framework is
+              explicitly aimed at regimes of rapid technological change (pharmaceuticals,
+              semiconductors, consumer electronics). Its value-added in stable or slow-changing
+              industries is modest; the 1997 paper does not claim otherwise.
             </li>
             <li>
-              <strong>Difficulty distinguishing static from dynamic capabilities:</strong> The
-              framework emphasizes dynamic capabilities but provides limited guidance on how to
-              distinguish dynamic capabilities from static resources or on when dynamic capabilities
-              create sustainable versus temporary advantage.
+              <strong>Processes vs. positions vs. paths are interdependent:</strong> The three Ps
+              are presented as analytically distinct but empirically co-determine one another
+              (current position shapes available processes, paths taken shape current position, and
+              so on). This makes causal inference difficult.
             </li>
             <li>
-              <strong>Insufficient attention to failure modes:</strong> The framework describes
-              successful adaptation but provides limited analysis of when sensing, seizing, or
-              reconfiguring capabilities fail and what organizational characteristics predict
-              failure.
+              <strong>No formal treatment of failure:</strong> The paper focuses on how successful
+              dynamic capabilities generate advantage; it does not formally treat when
+              reconfiguration fails, produces negative returns, or generates core rigidities
+              (Leonard-Barton, 1992, is acknowledged but not developed).
             </li>
             <li>
-              <strong>Limited applicability to stable environments:</strong> The framework is
-              tailored to dynamic environments; applicability to stable, mature industries where
-              rapid adaptation may not create competitive advantage remains unclear.
+              <strong>Path-dependency and managerial agency tension:</strong> The paper
+              simultaneously emphasizes strong path dependency and managerial ability to
+              reconfigure. The boundary between these two is not sharp; critics (e.g. Pisano, 1994,
+              cited p.520) have noted the difficulty.
             </li>
           </ul>
         </section>
@@ -720,17 +725,17 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            As a conceptual framework paper grounded in empirical observation of
-            technology-intensive firms, the Dynamic Capabilities framework demonstrates strong
-            internal validity through logical coherence and consistency with observable
-            organizational phenomena:
+            Teece, Pisano &amp; Shuen (1997) is a conceptual paper. Its internal validity is
+            therefore assessed as logical coherence and fidelity to the literature it synthesizes,
+            not as statistical validity. The paper is careful about attribution and limits:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Logical consistency:</strong> The core argument that organizations require
-              distinct capabilities for sensing opportunities, seizing selected opportunities, and
-              reconfiguring resources to execute strategies is logically sound. Organizations
-              lacking any component capability would struggle with adaptation and innovation.
+              <strong>Logical consistency:</strong> The argument chain - three precursor paradigms
+              reviewed, their limits identified, hierarchy of firm-level factors defined, three Ps
+              introduced as interacting sources of competence, definitional verb triplet
+              &ldquo;integrate, build, reconfigure&rdquo; proposed - is internally coherent. Each
+              step follows the previous.
             </li>
             <li>
               <strong>Integration with empirical observation:</strong> The framework emerged from
@@ -758,8 +763,21 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Balance of mechanism specificity:</strong> The framework is specific enough to
-              distinguish sense-seize-reconfigure capabilities yet flexible enough to encompass
-              diverse organizational forms and industry contexts.
+              distinguish processes, positions, and paths as different sources of capability, yet
+              flexible enough to encompass diverse organizational forms and industry contexts.
+            </li>
+            <li>
+              <strong>Careful terminology with admitted discomfort:</strong> The authors note they
+              &ldquo;do not like the term &rsquo;resource&rsquo; and believe it is misleading&rdquo;
+              (p.516 footnote 23) but retain it to preserve links to the RBV literature. This kind
+              of flagged-tension is good scholarly practice and is preserved on this page.
+            </li>
+            <li>
+              <strong>Known internal-validity limitations:</strong> The paper is largely
+              illustrative rather than formal. Many of the causal claims (e.g. &ldquo;distinctive
+              coordinative routines drive quality performance&rdquo;) are supported by field studies
+              (Garvin 1988; Clark &amp; Fujimoto 1991) but not by statistical tests within this
+              paper itself.
             </li>
           </ul>
         </section>
@@ -785,10 +803,11 @@ const BibliographyArticlePage = () => {
               flexibility.
             </li>
             <li>
-              <strong>Measurement and empirical validation challenges:</strong> Operationalizing
-              sensing, seizing, and reconfiguring capabilities and establishing empirical
-              relationships remains methodologically challenging. Proposed mechanisms are difficult
-              to measure directly.
+              <strong>Measurement and empirical validation challenges:</strong> Operationalizing the
+              three Ps (processes, positions, paths) and establishing empirical relationships
+              between them and performance remains methodologically challenging. Proposed mechanisms
+              are difficult to measure directly; Eisenhardt &amp; Martin (2000), Zollo &amp; Winter
+              (2002), and subsequent empirical work attempted to narrow this gap.
             </li>
             <li>
               <strong>Causality direction uncertain:</strong> While the framework proposes that
@@ -804,9 +823,10 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Organizational structure variation:</strong> The framework assumes certain
-              organizational structural characteristics enabling sensing and adaptation.
-              Organizations with highly centralized decision structures may struggle to implement
-              the framework despite recognizing its value.
+              organizational structural characteristics (decentralized decision-making,
+              cross-functional teams, tight coupling between R&amp;D and manufacturing) enable
+              reconfiguration. Organizations with highly centralized decision structures may
+              struggle to leverage dynamic capabilities even when they recognize the need.
             </li>
             <li>
               <strong>Resource constraint effects:</strong> The framework assumes organizations have
@@ -826,101 +846,108 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Dynamic Capabilities theory explains organizational capacity for technology adoption as
-            dependent on organizational capabilities for sensing emerging technologies, seizing
-            opportunities to adopt relevant technologies, and reconfiguring internal operations to
-            integrate technologies successfully. Organizations with strong dynamic capabilities
-            recognize technology opportunities earlier than competitors, evaluate technology
-            relevance systematically, commit resources to adoption, and integrate technologies
-            effectively into operations. Conversely, organizations with weak dynamic capabilities
-            may fail to recognize technology opportunities until technologies are mature, struggle
-            to commit resources for adoption despite recognizing value, or fail to integrate
-            technologies into operations effectively. Dynamic Capabilities theory predicts that
-            organizations successful with technology adoption possess strong capabilities across all
-            three dimensions: sensing technology trends, seizing adoption opportunities, and
-            reconfiguring operations.
+            Applied to organizational technology adoption, the Teece, Pisano &amp; Shuen (1997)
+            framework treats adoption as a function of the adopter&rsquo;s three Ps: its{' '}
+            <em>processes</em> for evaluating, integrating, and learning about new technology; its{' '}
+            <em>positions</em> in the relevant technological, complementary, and institutional asset
+            classes; and the <em>paths</em> available to it given its history of prior technology
+            adoption and investment. Organizations with strong coordinative, learning, and
+            reconfiguring processes (the three roles of organizational processes on pp.518-520) tend
+            to integrate new technology faster and more durably. Organizations with favorable
+            complementary-asset positions (Teece, 1986) can capture more of the rents from the
+            technology. Organizations with history-conditioned paths of cumulative know-how can
+            sometimes leverage new technology better than rivals starting from similar positions but
+            without the cumulative path.
           </p>
 
           <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Weak environmental sensing:</strong> Organizations may fail to recognize
-              emerging technology opportunities. Limited market scanning, external relationships,
-              and technology monitoring result in delayed recognition of adoption opportunities.
+              <strong>Weak coordinative / integrative processes:</strong> Organizations that cannot
+              coordinate internal functions (engineering, operations, marketing) or external
+              partners (suppliers, complementors) struggle to integrate new technologies into
+              production. Empirical examples in the paper include differences in
+              new-product-development cycle times between firms (Clark &amp; Fujimoto, 1991).
             </li>
             <li>
-              <strong>Inability to seize opportunities:</strong> Organizations may recognize
-              technology opportunities but struggle to evaluate their strategic relevance or fail to
-              commit resources despite recognizing value. Weak seizing capabilities result in missed
-              adoption windows.
+              <strong>Weak learning processes:</strong> Organizations that do not capture and codify
+              experience across repeated uses of a technology fail to improve speed and quality over
+              time (Nelson &amp; Winter, 1982; Leonard-Barton, 1995, cited p.519).
             </li>
             <li>
-              <strong>Limited reconfiguration capability:</strong> Organizations may commit to
-              technology adoption but struggle to integrate technologies into operations, modify
-              business processes, or change organizational structures to capitalize on technology
-              benefits.
+              <strong>Limited reconfiguration capacity:</strong> Organizations embedded in
+              entrenched routines cannot rearrange internal structure, processes, and external
+              linkages as the technology or its market shifts. Core rigidities (Leonard-Barton,
+              1992) and organizational inertia constrain reconfiguration.
             </li>
             <li>
-              <strong>Path dependency constraints:</strong> Historical investments, existing
-              technology bases, and organizational commitments to legacy systems constrain
-              organizational flexibility to adopt new technologies. Organizations with heavy sunk
-              costs in existing technologies face barriers to switching.
+              <strong>Missing complementary assets:</strong> Organizations that possess a technology
+              but lack the complementary manufacturing, distribution, or marketing assets (Teece,
+              1986) often fail to appropriate rents from the technology - other players capture them
+              instead.
             </li>
             <li>
-              <strong>Insufficient complementary capabilities:</strong> Organizations may adopt
-              technologies but lack complementary capabilities required to create customer value
-              from technologies. Adoption of collaboration technology, for example, requires change
-              management, training, and process redesign capabilities.
+              <strong>Unfavorable path dependencies:</strong> Legacy technology commitments, prior
+              capital investments, and accumulated routines can lock an organization into paths that
+              made sense historically but foreclose current adoption options (Arthur, 1983; David,
+              1985).
             </li>
             <li>
-              <strong>Learning limitations:</strong> Organizations may lack capacity to learn from
-              technology adoption experience, repeating past mistakes rather than improving adoption
-              effectiveness.
+              <strong>Imitatability of capability by rivals:</strong> Even when the focal firm has
+              adopted successfully, if its adoption routines are easily imitatable (low tacitness,
+              low social complexity), rivals can replicate quickly and erode any first-mover
+              advantage.
+            </li>
+            <li>
+              <strong>Institutional / regulatory constraints:</strong> In sectors where
+              institutional assets (regulation, IP regime, national innovation system) restrict how
+              technology can be deployed, the freedom to reconfigure around the new technology is
+              limited regardless of internal capability.
             </li>
           </ul>
 
           <h3 className={H3_CLASSES}>Leadership Actions the Framework Prescribes</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Develop sensing capabilities:</strong> Establish environmental scanning
-              processes, build external relationships enabling early identification of emerging
-              technologies, monitor technology trends relevant to organizational strategy, and
-              create organizational forums for discussing technology trends.
+              <strong>Invest in coordinative processes:</strong> Build cross-functional and
+              cross-organizational coordination capability - structures, shared information systems,
+              incentive alignment - that let the firm integrate external technology into internal
+              operations quickly.
             </li>
             <li>
-              <strong>Establish formal evaluation processes:</strong> Create systematic mechanisms
-              for evaluating technology opportunities, assessing strategic relevance, estimating
-              implementation costs, and comparing technology alternatives.
+              <strong>Invest in learning processes:</strong> Put in place systems for capturing,
+              codifying, and sharing what is learned during each adoption cycle - pilots,
+              post-implementation reviews, centers of expertise.
             </li>
             <li>
-              <strong>Commit strategic resources:</strong> Allocate adequate resources to technology
-              adoption initiatives when evaluation determines strategic relevance. Avoid
-              underfunding adoption efforts.
+              <strong>Build reconfiguration capacity:</strong> Develop explicit competence at
+              reorganizing internal structure, process, and external partnerships as the technology
+              or its market shifts. Avoid embedding current structure so deeply that future
+              reconfiguration becomes prohibitive.
             </li>
             <li>
-              <strong>Build reconfiguration capability:</strong> Develop organizational change
-              management expertise, process redesign capabilities, and integration competencies
-              required to implement technologies in operational systems.
+              <strong>Assess and assemble complementary assets:</strong> Before or during adoption,
+              evaluate whether the complementary manufacturing, distribution, reputational, and
+              institutional assets needed to appropriate rents are in place; build, lease, or
+              partner for the missing ones.
             </li>
             <li>
-              <strong>Identify complementary capability gaps:</strong> Assess whether organizations
-              possess complementary capabilities required to create value from technologies. Develop
-              or acquire complementary capabilities when gaps are identified.
+              <strong>Manage paths with awareness:</strong> Recognize that technology choices commit
+              the firm to paths with their own dependencies; make commitments with deliberate
+              awareness of the increasing-returns dynamics (Arthur, 1983) that will reinforce or
+              trap those choices.
             </li>
             <li>
-              <strong>Establish learning systems:</strong> Create mechanisms for capturing learning
-              from technology adoption experiences, documenting lessons, and improving future
-              adoption effectiveness.
+              <strong>Make adoption routines tacit and socially complex:</strong> To the extent the
+              firm wants sustained advantage from its adoption competence, rely on tacit,
+              team-based, culturally embedded routines rather than on explicit procedures that
+              rivals can easily observe and copy.
             </li>
             <li>
-              <strong>Manage organizational inertia:</strong> Acknowledge and actively address
-              organizational inertia and path dependency constraints. Create change initiatives
-              specifically designed to overcome commitment to legacy systems.
-            </li>
-            <li>
-              <strong>Develop leadership capability:</strong> Ensure leadership possesses
-              understanding of emerging technologies, demonstrates commitment to adoption, and
-              supports organizational changes required for successful integration.
+              <strong>Keep position and process co-specialized:</strong> The dynamic capabilities
+              argument is that assets, processes, and paths must be co-specialized. Don&rsquo;t hire
+              new capabilities without evolving the processes and the asset base they are meant to
+              work with (Teece, Pisano &amp; Shuen, 1997, p.527).
             </li>
           </ul>
         </section>

--- a/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
+++ b/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
@@ -116,138 +116,192 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The Resource-Based View of the firm (
-            <a
-              id="cite-ref-wernerfelt-1984-1"
-              href="#ref-wernerfelt-1984"
-              className="text-tabs-teal-deep hover:underline"
-            >
-              Wernerfelt, 1984
-            </a>
-            ;{' '}
-            <a
-              id="cite-ref-barney-1991-1"
-              href="#ref-barney-1991"
-              className="text-tabs-teal-deep hover:underline"
-            >
-              Barney, 1991
-            </a>
-            ) provided powerful strategic insight into competitive advantage through control of
-            valuable, rare, inimitable resources. However, RBV had significant limitations in
-            explaining sustained competitive advantage in environments characterized by rapid
-            technological change, shifting customer preferences, and dynamic competitive conditions.
-            In stable environments where resources maintain value over extended periods, RBV
-            explained strategy effectively. But in fast-moving industries such as semiconductors,
-            pharmaceuticals, biotechnology, software, and telecommunications, today&rsquo;s
-            inimitable resources became obsolete quickly. Static resources and capabilities that
-            created yesterday&rsquo;s competitive advantages often became liabilities as markets
-            shifted. RBV provided limited guidance on how organizations adapt when resource bases
-            become outdated or market conditions fundamentally change.
+            Teece, Pisano &amp; Shuen (1997) open (p.509) with the question &ldquo;how firms achieve
+            and sustain competitive advantage&rdquo; in a Schumpeterian world of innovation-based
+            competition, price/performance rivalry, increasing returns, and the &ldquo;creative
+            destruction&rdquo; of existing competences. The paper argues that then-dominant
+            frameworks handled sustaining and safeguarding extant advantage well but had performed
+            less well on how firms build advantage under rapid change.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Teece, Pisano, and Shuen recognized that explaining competitive advantage in dynamic
-            environments required a different theoretical focus. Rather than asking &ldquo;What
-            static resources provide competitive advantage?&rdquo; they asked &ldquo;What
-            capabilities enable organizations to continuously sense market changes, quickly seize
-            new opportunities, and rapidly reconfigure their resource bases to respond to shifting
-            competitive conditions?&rdquo; This shift from static resources to dynamic capabilities
-            represented a fundamental evolution in strategic management thinking. Organizations
-            operating in fast-moving environments compete not based on what they possess today, but
-            on their ability to identify emerging opportunities before competitors and execute
-            faster than rivals.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework emerged from empirical investigation of high-technology firms operating in
-            turbulent competitive environments. Teece and colleagues examined how pharmaceutical
-            firms, semiconductor companies, and software organizations sustained competitive
-            advantage despite constant technological disruption. They identified patterns in how
-            successful organizations managed the innovation process: sensing technological and
-            market trends before competitors, recognizing which new opportunities aligned with
-            organizational capabilities and market needs, assembling resources and capabilities to
-            pursue opportunities quickly, and integrating new technologies and capabilities into
-            existing operational systems. These dynamic capabilities - the ability to sense, seize,
-            and reconfigure - distinguished organizations that thrived amid disruption from those
-            that faltered.
-          </p>
-        </section>
-
-        {/* 5. Core Concepts and Definitions */}
-        <section className={SECTION_CLASSES}>
-          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Dynamic Capabilities framework is built on fundamental concepts about how
-            organizations survive and succeed in dynamic environments:
+            The paper positions itself against three precursor paradigms that it reviews and
+            critiques (Sections I-III, pp.509-516):
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Dynamic Capabilities:</strong> The organization&rsquo;s ability to sense
-              external change, make strategic decisions about which changes to respond to, mobilize
-              resources to address those changes, and reconfigure operational systems and resource
-              bases. Dynamic capabilities are not static resources but rather the organizational
-              processes, routines, and competencies enabling continuous adaptation and renewal.
+              <strong>Models of strategy emphasizing market power</strong> - the Competitive Forces
+              approach (Porter, 1980) and Strategic Conflict game-theoretic approach (Shapiro, 1989)
+              - emphasize industry structure and strategic interaction, but treat firms inside an
+              industry as relatively interchangeable.
             </li>
             <li>
-              <strong>Sensing Capability:</strong> The organizational capacity to scan the external
-              environment for technological change, emerging customer preferences, competitor
-              actions, and new market opportunities. Sensing involves boundary-spanning activities,
-              external relationship networks, scanning systems, and cognitive frameworks enabling
-              identification of relevant change signals and pattern recognition in market dynamics.
+              <strong>Models of strategy emphasizing efficiency</strong> - the Resource-Based
+              Perspectives (Penrose, 1959; Rumelt, 1984; Wernerfelt, 1984, 1989; Teece, 1984) -
+              emphasize firm-specific assets and idiosyncratic efficiency, but treat competences and
+              asset positions as relatively static.
             </li>
             <li>
-              <strong>Seizing Capability:</strong> The organizational capacity to evaluate
-              opportunities identified through sensing activities, make strategic decisions about
-              which opportunities deserve resource commitment, and assemble resources and
-              capabilities to pursue selected opportunities. Seizing translates opportunity
-              recognition into specific strategic actions and resource allocation decisions.
-            </li>
-            <li>
-              <strong>Reconfiguring Capability:</strong> The organizational capacity to realign
-              internal and external resource bases, recombine organizational capabilities,
-              reengineer business processes, and reorganize internal structures to execute selected
-              strategies. Reconfiguring transforms identified opportunities into operational
-              capabilities and market implementations.
-            </li>
-            <li>
-              <strong>Asset Orchestration:</strong> The strategic alignment and integration of
-              assets (physical, financial, human, organizational, and intellectual property) and
-              capabilities to create customer value and competitive advantage. Orchestration
-              involves decisions about which assets to acquire, develop, lease, or divest as markets
-              shift.
-            </li>
-            <li>
-              <strong>Technology Management:</strong> The organizational processes for monitoring
-              technological development, evaluating technological relevance to future strategy,
-              building technological competencies, and integrating new technologies into operational
-              systems. Technology management is a core dynamic capability as technological change is
-              the primary source of disruption in many industries.
-            </li>
-            <li>
-              <strong>Complementary Assets:</strong> Resources and capabilities that enhance the
-              value of core technological or competitive assets. A firm may develop superior
-              technology but fail if it lacks complementary assets such as manufacturing capability,
-              distribution networks, marketing competence, or customer relationships to
-              commercialize the technology.
+              <strong>Dynamic capabilities approach</strong> - proposed by this paper - adds the
+              ability to adapt, integrate, and reconfigure competences as external conditions
+              change.
             </li>
           </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Teece et al.&rsquo;s specific argument is that in regimes of rapid technological change,
+            private wealth creation depends &ldquo;in large measure on honing internal
+            technological, organizational, and managerial processes inside the firm&rdquo; rather
+            than on strategizing in the game-theoretic sense (abstract, p.509). The paper presents
+            the framework conceptually (pp.509-524) and then illustrates it via examples of
+            strategic capabilities in real firms (pp.524-533).
+          </p>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 5. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Teece, Pisano &amp; Shuen (1997) is a conceptual framework paper, not a measurement
+            model. It does not propose scales, latent constructs, or formal empirical
+            operationalizations. Instead, it proposes a vocabulary - the <em>three Ps</em>
+            (processes, positions, paths) - for analyzing the sources of competitive advantage in
+            regimes of rapid change, and a definition of <em>dynamic capabilities</em> that sits
+            above the resource-based view&rsquo;s inventory of static resources.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            The paper&rsquo;s canonical definition (p.516): dynamic capabilities are &ldquo;the
+            firm&rsquo;s ability to integrate, build, and reconfigure internal and external
+            competences to address rapidly changing environments&rdquo;. This is the verbatim 1997
+            definition. A popular later refinement by Teece (2007) reorganized the same logic into
+            three microfoundations - <em>sensing, seizing, and reconfiguring/transforming</em> -
+            which are widely attributed to this 1997 paper but are actually the 2007 paper&rsquo;s
+            framing (Teece, 2007, &ldquo;Explicating dynamic capabilities: the nature and
+            microfoundations of (sustainable) enterprise performance&rdquo;, SMJ 28:13,
+            pp.1319-1350).
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            The 1997 paper&rsquo;s analytical method is: (i) define the hierarchy of firm-level
+            factors that might generate advantage; (ii) distinguish paradigms of strategy; (iii)
+            identify the three Ps that shape dynamic capabilities; (iv) show by case-example how
+            each of the three Ps generates or erodes competitive advantage in technology-intensive
+            industries (semiconductors, biotechnology, consumer electronics).
+          </p>
+        </section>
+
+        {/* 6. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Teece, Pisano &amp; Shuen (1997, pp.515-518) lay out an explicit vocabulary with six
+            levels, distinguishing dynamic capabilities from other firm-level factors:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Factors of production:</strong> Undifferentiated inputs available in
+              disaggregate form in factor markets. Land, unskilled labor, capital. Lack a
+              firm-specific component. Non-strategic (p.516).
+            </li>
+            <li>
+              <strong>Resources:</strong> Firm-specific assets that are difficult or impossible to
+              imitate - trade secrets, specialized production facilities, engineering experience.
+              Difficult to transfer because of transactions costs, transfer costs, and tacit
+              knowledge (p.516). The authors note they dislike the term &ldquo;resource&rdquo; but
+              retain it to keep links to the RBV literature.
+            </li>
+            <li>
+              <strong>Organizational routines / competences:</strong> Integrated clusters of
+              firm-specific assets spanning individuals and groups that enable distinctive
+              activities. Examples include quality, miniaturization, and systems integration
+              (p.516). Typically viable across multiple product lines.
+            </li>
+            <li>
+              <strong>Core competences:</strong> Competences that define a firm&rsquo;s fundamental
+              business; must be derived by looking across the firm&rsquo;s and competitors&rsquo;
+              product ranges (p.516, Footnote 24 gives Kodak=imaging, IBM=integrated data
+              processing, Motorola=untethered communications as illustrative examples).
+            </li>
+            <li>
+              <strong>Dynamic capabilities:</strong> &ldquo;The firm&rsquo;s ability to integrate,
+              build, and reconfigure internal and external competences to address rapidly changing
+              environments&rdquo; (p.516). Reflect an organization&rsquo;s ability to achieve new
+              and innovative forms of competitive advantage given path dependencies and market
+              positions (Leonard-Barton, 1992).
+            </li>
+            <li>
+              <strong>Products:</strong> The final goods and services produced by the firm, drawing
+              on the competences that it possesses. The performance (price, quality) of products at
+              any point in time depends on competences, which in turn depend on capabilities
+              (p.516).
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            The paper&rsquo;s central analytical device is the <em>three Ps</em> - processes,
+            positions, paths - which together shape a firm&rsquo;s competences and dynamic
+            capabilities (p.518):
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Processes (managerial and organizational):</strong> The way things are done in
+              the firm - routines, patterns of current practice and learning. Processes have three
+              roles: <em>coordination/integration</em> (a static concept),
+              <em>learning</em> (dynamic), and <em>reconfiguration</em> (transformational)
+              (p.518-524).
+            </li>
+            <li>
+              <strong>Positions:</strong> The firm&rsquo;s current specific endowments of
+              technology, intellectual property, complementary assets, customer base, and external
+              relations with suppliers and complementors. The paper enumerates seven illustrative
+              asset classes: technological, complementary, financial, reputational, structural,
+              institutional, market-structure, and organizational-boundary assets (p.521-523).
+            </li>
+            <li>
+              <strong>Paths:</strong> The strategic alternatives available to the firm, and the
+              presence or absence of increasing returns and path dependencies. Where a firm can go
+              is a function of its current position and the paths ahead; current position is often
+              shaped by the path traveled (p.522-524).
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Note on terminology: the 1997 paper does <em>not</em> use the &ldquo;sensing - seizing -
+            reconfiguring&rdquo; vocabulary that has since become the popular summary of dynamic
+            capabilities. That restatement is Teece (2007). The 1997 paper&rsquo;s equivalent
+            locution is &ldquo;integrate, build, and reconfigure&rdquo;, with the three Ps as the
+            organizing substructure.
+          </p>
+        </section>
+
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Dynamic Capabilities theory built on and extended previous strategic management
-            frameworks:
+            Teece, Pisano &amp; Shuen (1997) synthesize and cite a substantial body of prior work.
+            The most important precursors they credit:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>
-                Resource-Based View of the Firm (
+                Resource-Based Perspective (
+                <a
+                  id="cite-ref-penrose-1959-1"
+                  href="#ref-penrose-1959"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Penrose, 1959
+                </a>
+                ;{' '}
                 <a
                   id="cite-ref-wernerfelt-1984-2"
                   href="#ref-wernerfelt-1984"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Wernerfelt, 1984
+                  Wernerfelt, 1984, 1989
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-rumelt-1984-1"
+                  href="#ref-rumelt-1984"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Rumelt, 1984
                 </a>
                 ;{' '}
                 <a
@@ -259,13 +313,38 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Established the foundation for capabilities-based strategy by arguing that resources
-              create competitive advantage. Dynamic Capabilities extended RBV from static resources
-              to dynamic processes enabling resource renewal and adaptation.
+              The &ldquo;models of strategy emphasizing efficiency&rdquo; strand. Supplies the
+              firm-specific-asset foundation on which dynamic capabilities builds. Teece et al.
+              explicitly position dynamic capabilities as an <em>extension</em> of RBV, not a
+              replacement.
             </li>
             <li>
               <strong>
-                Organizational Capabilities and Routines (
+                Competitive forces / industry structure (
+                <a
+                  id="cite-ref-porter-1980-1"
+                  href="#ref-porter-1980"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Porter, 1980
+                </a>
+                , 1985):
+              </strong>{' '}
+              The first of the three paradigms reviewed in Section I. Supplies the language of
+              industry structure, entry deterrence, and positioning. Teece et al. retain the
+              environmental-analysis concerns but shift the analytical focus inside the firm.
+            </li>
+            <li>
+              <strong>
+                Strategic conflict / game-theoretic approach (Shapiro, 1989; Ghemawat, 1991):
+              </strong>{' '}
+              The second paradigm reviewed. Supplies the sequential-move and commitment framework.
+              Teece et al. argue it is most powerful when rivals have roughly equal competences and
+              least powerful when firms differ fundamentally in capabilities.
+            </li>
+            <li>
+              <strong>
+                Evolutionary economics / organizational routines (
                 <a
                   id="cite-ref-nelson-1982-1"
                   href="#ref-nelson-1982"
@@ -275,181 +354,223 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Emphasized that firms develop distinctive capabilities and organizational routines
-              that enable specific performance and constrain behavior. Dynamic Capabilities built on
-              this insight by emphasizing capabilities for change rather than just execution of
-              existing routines.
+              Central reference. Supplies the concept of organizational routines as the unit of
+              analysis for competence and for evolutionary selection. Cited repeatedly throughout
+              the paper (pp.515, 519, 526, 529).
             </li>
             <li>
               <strong>
-                Technology and Innovation Management (
+                Organizational learning (
                 <a
-                  id="cite-ref-rosenberg-1982-1"
-                  href="#ref-rosenberg-1982"
+                  id="cite-ref-argyris-1978-1"
+                  href="#ref-argyris-1978"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Rosenberg, 1982
+                  Argyris &amp; Sch&ouml;n, 1978
                 </a>
                 ;{' '}
                 <a
-                  id="cite-ref-dosi-1982-1"
-                  href="#ref-dosi-1982"
+                  id="cite-ref-levitt-1988-1"
+                  href="#ref-levitt-1988"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Dosi, 1982
+                  Levitt &amp; March, 1988
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-leonard-1992-1"
+                  href="#ref-leonard-1992"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Leonard-Barton, 1992
                 </a>
                 ):
               </strong>{' '}
-              Emphasized that technological trajectories constrain and enable firm development.
-              Dynamic Capabilities incorporated technological evolution and the organizational
-              challenge of continuously updating technological competencies.
+              Supplies the theoretical grounding for the &ldquo;learning&rdquo; role of
+              organizational processes. Leonard-Barton&rsquo;s core-capabilities treatment is
+              particularly important for the definition of dynamic capabilities (p.516).
             </li>
             <li>
               <strong>
-                Organizational Learning Theory (Argyris &amp; Schon, 1978; Levitt &amp; March,
-                1988):
-              </strong>{' '}
-              Examined how organizations learn from experience and develop increasingly
-              sophisticated capabilities. Dynamic Capabilities emphasized learning processes
-              enabling organizational adaptation and evolution.
-            </li>
-            <li>
-              <strong>
-                Strategic Intent and Core Competencies (
+                Increasing returns and path dependency (
                 <a
-                  id="cite-ref-hamel-1989-1"
-                  href="#ref-hamel-1989"
+                  id="cite-ref-arthur-1983-1"
+                  href="#ref-arthur-1983"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Hamel &amp; Prahalad, 1989
+                  Arthur, 1983
                 </a>
-                , 1994):
+                ;{' '}
+                <a
+                  id="cite-ref-david-1985-1"
+                  href="#ref-david-1985"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  David, 1985
+                </a>
+                ):
               </strong>{' '}
-              Emphasized that sustained competitive advantage comes from organizational competencies
-              that create customer value and are difficult for competitors to replicate. Dynamic
-              Capabilities extended this by emphasizing the capability to develop new competencies
-              continuously.
+              Cited on p.518 and p.522. Supplies the argument that path dependencies matter most
+              where conditions of increasing returns obtain. Essential to the &ldquo;paths&rdquo;
+              leg of the three-Ps framework.
             </li>
             <li>
               <strong>
-                Path Dependency and Lock-In (
+                Core competencies (
                 <a
-                  id="cite-ref-arthur-1989-1"
-                  href="#ref-arthur-1989"
+                  id="cite-ref-prahalad-1990-1"
+                  href="#ref-prahalad-1990"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Arthur, 1989
+                  Prahalad &amp; Hamel, 1990
                 </a>
-                ; David, 1985):
+                ):
               </strong>{' '}
-              Examined how historical choices constrain future options and create path dependency in
-              organizational development. Dynamic Capabilities acknowledged path dependency while
-              emphasizing organizational capacity to break unfavorable paths and create new
-              trajectories.
+              Supplies the &ldquo;core competence&rdquo; vocabulary that the paper builds on and
+              refines (p.516 defines core competences by reference to this literature).
+            </li>
+            <li>
+              <strong>
+                Teece on complementary assets and appropriability (
+                <a
+                  id="cite-ref-teece-1986-1"
+                  href="#ref-teece-1986"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Teece, 1986
+                </a>
+                ):
+              </strong>{' '}
+              Teece&rsquo;s own earlier paper on profiting from technological innovation. Supplies
+              the argument that successful commercialization requires complementary assets, a
+              central theme in the Positions discussion.
             </li>
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The Dynamic Capabilities framework proposes that sustained competitive advantage in
-            dynamic environments derives from organizational capabilities to continuously sense
-            external change, seize new opportunities, and reconfigure internal and external
-            resources to capitalize on identified opportunities. Rather than viewing strategy as
-            selecting favorable positions within relatively stable industry structures, the Dynamic
-            Capabilities approach views strategy as building organizational capacity for continuous
-            adaptation and renewal. Competitive advantage is temporal and fragile in dynamic
-            environments; it persists only as long as organizations can identify emerging
-            opportunities before competitors and execute faster than rivals.
+            Teece, Pisano &amp; Shuen (1997) develop the framework in four steps: (1) review and
+            critique three precursor paradigms of strategy; (2) lay out a hierarchical vocabulary of
+            firm-level factors; (3) advance the three-Ps argument - competitive advantage is shaped
+            by processes, positions, and paths; (4) apply the framework to illustrative firm cases
+            (the paper discusses cases in semiconductors, consumer electronics, and biotechnology,
+            pp.524-533).
           </p>
 
-          <h3 className={H3_CLASSES}>The Sensing-Seizing-Reconfiguring Framework</h3>
+          <h3 className={H3_CLASSES}>Three precursor paradigms critiqued (pp.509-515)</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Sensing:</strong> Scanning and interpreting the external environment to
-              identify technological trends, emerging market opportunities, customer preference
-              shifts, and competitor actions. Sensing requires organizational structures, processes,
-              and relationships enabling recognition of relevant change signals. Sensing
-              capabilities include environmental scanning, market research, technology monitoring,
-              customer engagement, and external partnerships providing access to emerging
-              information.
+              <strong>Competitive forces (Porter, 1980):</strong> Industry structure - the five
+              forces of rivalry, supplier power, buyer power, entry threat, and substitute threat -
+              determines firm performance. Strategy is industry selection and positioning. Critique:
+              treats firms as relatively interchangeable within an industry and is silent on
+              within-industry performance dispersion.
             </li>
             <li>
-              <strong>Seizing:</strong> Making strategic decisions about which identified
-              opportunities to pursue and mobilizing resources to address selected opportunities.
-              Seizing involves evaluating which opportunities align with organizational
-              capabilities, market potential, and strategic priorities. Seizing decisions determine
-              resource allocation, strategic investments, and pursuit directions. Organizations with
-              weak seizing capabilities may identify emerging opportunities but fail to commit
-              sufficient resources to capitalize on them.
+              <strong>
+                Strategic conflict / game-theoretic approach (Shapiro, 1989; Ghemawat, 1991):
+              </strong>{' '}
+              Strategy is understood through the lens of sequential-move and commitment games
+              between rivals. Critique: treats strategy as chess against adversaries; produces
+              elegant theorems but gives little guidance when firms differ in capabilities, not just
+              moves.
             </li>
             <li>
-              <strong>Reconfiguring:</strong> Realigning internal operations, reengineer business
-              processes, integrate new capabilities, and mobilize existing resources to execute
-              strategies targeting identified opportunities. Reconfiguring translates strategic
-              intent into operational execution. Successful reconfiguring requires change management
-              capability, organizational flexibility, and capacity to learn and adapt organizational
-              systems.
+              <strong>
+                Resource-based perspectives (Penrose, 1959; Rumelt, 1984; Wernerfelt, 1984, 1989;
+                Teece, 1984):
+              </strong>{' '}
+              Competitive advantage comes from firm-specific assets that are difficult to imitate.
+              Critique: useful but relatively static - explains persistence of advantage, not how
+              firms build new competences under rapid technological change.
             </li>
           </ul>
 
-          <h3 className={H3_CLASSES}>Positions, Processes, and Paths Framework</h3>
+          <h3 className={H3_CLASSES}>The three Ps: processes, positions, paths (pp.518-524)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            &ldquo;We thus advance the argument that the competitive advantage of firms lies with
+            its managerial and organizational processes, shaped by its (specific) asset position,
+            and the paths available to it&rdquo; (p.518).
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Positions:</strong> The organization&rsquo;s current asset base including
-              physical assets, financial resources, human capital, intellectual property, and
-              relationships. Positions constrain and enable future strategic options. Organizations
-              with complementary asset positions can capitalize on technology innovations more
-              effectively than organizations lacking position-relevant assets. Position development
-              requires years of investment and cannot be quickly replicated.
+              <strong>Processes:</strong> The way things are done in the firm - routines and
+              patterns of current practice and learning. Three roles (p.518-520):
+              <ul className={BODY_LIST_CLASSES}>
+                <li>
+                  <em>Coordination / integration</em> (static): how efficiently the firm coordinates
+                  internal and external activity. Empirical support from Garvin (1988) on
+                  air-conditioner quality, Clark &amp; Fujimoto (1991) on auto development, and
+                  Fujimoto (1994) on lean production.
+                </li>
+                <li>
+                  <em>Learning</em> (dynamic): processes by which repetition and experimentation
+                  enable tasks to be performed better and faster, and new opportunities identified.
+                  Rooted in Nelson &amp; Winter (1982), Argyris &amp; Sch&ouml;n (1978), Levitt
+                  &amp; March (1988), Leonard-Barton (1995).
+                </li>
+                <li>
+                  <em>Reconfiguration and transformation</em>: ability to sense the need to
+                  reconfigure and accomplish the necessary internal and external transformation.
+                  Requires constant surveillance of markets and technologies, and willingness to
+                  adopt best practice (p.520).
+                </li>
+              </ul>
             </li>
             <li>
-              <strong>Processes:</strong> The organizational capabilities, routines, decision-making
-              procedures, and governance mechanisms enabling strategy execution. Processes determine
-              how efficiently organizations can mobilize resources, make decisions, execute
-              initiatives, and learn. Process capabilities are embedded in organizational culture
-              and routines; they are partially tacit and difficult for competitors to imitate.
+              <strong>Positions:</strong> Specific asset endowments that shape the firm&rsquo;s
+              strategic posture. Seven illustrative classes (p.521-523):{' '}
+              <em>technological assets</em>, <em>complementary assets</em>,{' '}
+              <em>financial assets</em>,<em>reputational assets</em>, <em>structural assets</em>{' '}
+              (formal/informal structure and governance), <em>institutional assets</em> (regulatory,
+              IP regimes, education systems), <em>market-structure assets</em>, and{' '}
+              <em>organizational boundaries</em>
+              (degree of integration).
             </li>
             <li>
-              <strong>Paths:</strong> The strategic options available to organizations given their
-              current positions and historical choices. Historical decisions create path dependency;
-              organizations cannot reverse history or arbitrarily shift strategic directions without
-              significant costs. However, within path constraints, organizations maintain strategic
-              agency and can influence which future paths become available through current
-              decisions.
+              <strong>Paths:</strong> Strategic alternatives given current position and the paths
+              ahead. Path dependencies matter when conditions of increasing returns exist (Arthur,
+              1983). Technological opportunities matter - they are often not exogenous to the firm
+              but shaped by the firm&rsquo;s R&amp;D activities and the state of applied science.
+              Replicability and imitatability (the ease with which competitors can copy) determine
+              how quickly advantage erodes.
             </li>
           </ul>
 
-          <h3 className={H3_CLASSES}>Key Mechanisms</h3>
+          <h3 className={H3_CLASSES}>Illustrative mechanisms the paper highlights</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Asset Orchestration:</strong> Strategic decisions about acquiring, developing,
-              leasing, or divesting assets and capabilities as competitive conditions shift.
-              Successful asset orchestration aligns organizational asset base with market
-              opportunities, enabling value creation.
+              <strong>Replicability vs. imitatability:</strong> Replicability is the firm&rsquo;s
+              ability to expand internally by copying its own operations; imitatability is the
+              competitor&rsquo;s ability to copy the firm&rsquo;s operations. Both are harder when
+              routines are tacit and organizationally embedded (p.525-527).
             </li>
             <li>
-              <strong>Complementary Asset Integration:</strong> Ensuring that organizations possess
-              or can access complementary assets enhancing core capabilities. A superior technology
-              lacks competitive value without complementary manufacturing, distribution, and
-              marketing capabilities.
+              <strong>Complementary assets:</strong> Following Teece (1986), successful
+              commercialization often requires complementary assets (manufacturing, distribution,
+              reputation). A firm with a novel competence but without complementary assets may fail
+              to capture the rents.
             </li>
             <li>
-              <strong>Learning and Knowledge Development:</strong> Organizational processes for
-              learning from market feedback, assimilating new information, and developing updated
-              capabilities. Learning capabilities enable organizations to improve performance over
-              time and avoid repeating past mistakes.
-            </li>
-            <li>
-              <strong>Technology Management:</strong> Organizational capacity to evaluate emerging
-              technologies, build technological competencies, integrate new technologies into
-              operations, and make strategic technology choices. Technology management is
-              particularly critical in technology-intensive industries where technological
-              obsolescence is rapid.
+              <strong>Co-specialization of assets:</strong> Dynamic capabilities arise from the way
+              the firm&rsquo;s processes, positions, and paths are co-specialized to one another;
+              reconfiguration involves rebuilding these links when conditions change (p.527).
             </li>
           </ul>
+
+          <h3 className={H3_CLASSES}>On the &ldquo;sense, seize, reconfigure&rdquo; vocabulary</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Many textbook summaries of dynamic capabilities reduce the framework to &ldquo;sensing,
+            seizing, and reconfiguring / transforming&rdquo;. That reduction comes from Teece
+            (2007), which explicated the <em>microfoundations</em> of dynamic capabilities. It is a
+            valid later restatement, but it is <em>not</em> what the 1997 paper says - the 1997
+            paper uses the three Ps as its organizing substructure and &ldquo;integrate, build, and
+            reconfigure&rdquo; as its definitional verb triplet. Be careful not to retroject 2007
+            vocabulary onto the 1997 paper.
+          </p>
 
           <h3 className={H3_CLASSES}>Main Strengths</h3>
           <ul className={BODY_LIST_CLASSES}>
@@ -532,54 +653,70 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The specific contributions of Teece, Pisano &amp; Shuen (1997) to the strategic
+            management literature:
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Extended RBV to dynamic environments:</strong> Successfully extended the
-              Resource-Based View from static resources to dynamic processes enabling adaptation in
-              changing environments, addressing major RBV limitation.
+              <strong>Canonical definition of dynamic capabilities:</strong> &ldquo;The firm&rsquo;s
+              ability to integrate, build, and reconfigure internal and external competences to
+              address rapidly changing environments&rdquo; (p.516). This definition has become the
+              most-cited definition in the dynamic capabilities literature.
             </li>
             <li>
-              <strong>Explained sustained advantage in disruption:</strong> Provided theoretical
-              explanation for why some organizations sustain competitive advantage through
-              technological and market disruptions while others fail to adapt.
+              <strong>Three-Ps organizing framework:</strong> Established processes, positions, and
+              paths as the three interacting sources of competence and dynamic capabilities (p.518).
+              The three Ps remain the dominant organizing device of the 1997 paper, distinct from
+              the sensing-seizing-reconfiguring vocabulary popularized by Teece (2007).
             </li>
             <li>
-              <strong>Introduced sensing-seizing-reconfiguring framework:</strong> Established
-              conceptually distinct organizational capabilities for sensing external changes,
-              seizing opportunities, and reconfiguring resources to enable sustained advantage.
+              <strong>Hierarchy of firm-level factors:</strong> Distinguished factors of production,
+              resources, routines/competences, core competences, dynamic capabilities, and products
+              as six analytically distinct levels (p.515-517). This hierarchy is used to separate
+              dynamic capabilities from lower-order concepts.
             </li>
             <li>
-              <strong>Integrated positions-processes-paths perspective:</strong> Synthesized the
-              current asset position, organizational processes, and historical path dependency as
-              interconnected determinants of strategic options and competitive advantage.
+              <strong>Three-paradigm synthesis:</strong> Reviewed the competitive forces, strategic
+              conflict, and resource-based paradigms and located dynamic capabilities as a fourth
+              paradigm addressing rapid change - a synthesis widely adopted in strategy teaching.
             </li>
             <li>
-              <strong>Emphasized learning and adaptation:</strong> Elevated organizational learning,
-              adaptation, and continuous renewal as sources of competitive value rather than
-              treating them as operational necessities.
+              <strong>Three roles of organizational processes:</strong> Coordination/integration
+              (static), learning (dynamic), and reconfiguration (transformational) (p.518-520). Gave
+              empirical researchers named, distinct process functions to operationalize.
             </li>
             <li>
-              <strong>Recognized complementary assets:</strong> Highlighted importance of
-              complementary assets and capabilities in creating customer value, explaining why firms
-              with superior technology sometimes failed commercially without supporting asset bases.
+              <strong>Seven asset classes for &ldquo;positions&rdquo;:</strong> Technological,
+              complementary, financial, reputational, structural, institutional, market, and
+              organizational-boundary assets (p.521-523). A useful typology that has influenced
+              subsequent capabilities research.
             </li>
             <li>
-              <strong>Provided framework for analyzing high-technology industries:</strong>{' '}
-              Established theoretical framework specifically suited to analyzing competitive
-              dynamics in technology-intensive industries characterized by rapid change.
+              <strong>Replicability vs. imitatability distinction:</strong> Separated the
+              firm&rsquo;s internal-expansion challenge from the competitor&rsquo;s imitation
+              challenge (p.525-527). Both depend on how tacit and socially embedded the relevant
+              routines are.
             </li>
             <li>
-              <strong>Foundation for future strategic theory:</strong> Created foundation for
-              subsequent developments in organizational agility, resilience, innovation capability,
-              and ambidextrous organization theory.
+              <strong>Schumpeterian-rent framing:</strong> Reframed competitive advantage in regimes
+              of rapid technological change in terms of Schumpeterian innovation rents, pulling
+              strategic management closer to evolutionary economics.
+            </li>
+            <li>
+              <strong>Foundation for the dynamic capabilities tradition:</strong> Provided the
+              conceptual ground from which Eisenhardt &amp; Martin (2000), Zollo &amp; Winter
+              (2002), Helfat &amp; Peteraf (2003), and Teece (2007) subsequently built; also for the
+              sensing-seizing-reconfiguring microfoundations treatment (Teece, 2007), which is often
+              incorrectly attributed to the 1997 paper.
             </li>
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -627,7 +764,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -685,7 +822,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -788,7 +925,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -870,7 +1007,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -985,7 +1122,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
+++ b/src/app/bibliography-2-3-dynamic-capabilities-teece-1997/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Dynamic Capabilities - Teece, Pisano, & Shuen (1997)',
+  title: 'Bibliography: Dynamic Capabilities Framework - Teece, Pisano, & Shuen (1997)',
   description:
     'Comprehensive overview of Dynamic Capabilities theory, extending the Resource-Based View to dynamic environments by emphasizing organizational capabilities to sense market changes, seize opportunities, and reconfigure resources rapidly as sources of sustained competitive advantage.',
 }
@@ -21,7 +21,9 @@ const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Dynamic Capabilities - Teece, Pisano, &amp; Shuen (1997)</h1>
+        <h1 className={H1_CLASSES}>
+          Dynamic Capabilities Framework - Teece, Pisano, &amp; Shuen (1997)
+        </h1>
 
         {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 2-3 Dynamic Capabilities (Teece, 1997) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1577
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)