### PR TITLE
docs: standardize bibliography 2-5 CMM (Humphrey, 1989)

### DIFF
--- a/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
+++ b/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
@@ -481,8 +481,8 @@ const BibliographyArticlePage = () => {
               software development processes.
             </li>
             <li>
-              <strong>Advanced process measurement in software:</strong> Emphasized measurement
-              and metrics as central to process management, contributing to subsequent software
+              <strong>Advanced process measurement in software:</strong> Emphasized measurement and
+              metrics as central to process management, contributing to subsequent software
               engineering practice.
             </li>
             <li>
@@ -699,9 +699,9 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The Capability Maturity Model sits at the start of a significant stream of
-            theoretical and practical developments around process capability, with subsequent
-            extensions building on and refining the original framework:
+            The Capability Maturity Model sits at the start of a significant stream of theoretical
+            and practical developments around process capability, with subsequent extensions
+            building on and refining the original framework:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>

--- a/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
+++ b/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
@@ -113,7 +113,7 @@ const BibliographyArticlePage = () => {
           </p>
           <p className={PARAGRAPH_CLASSES}>
             Humphrey recognized that the software development field lacked fundamental practices and
-            processes that had proven essential in other engineering disciplines. Manufacturing and
+            processes that were well-established in other engineering disciplines. Manufacturing and
             hardware development had standardized processes, documented procedures, and measurement
             systems enabling prediction and control of outcomes. Software development, by contrast,
             was often ad hoc, driven by individual developer heroics, and lacking systematic
@@ -466,9 +466,9 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Brought process discipline to software development:</strong> Established that
+              <strong>Brought process discipline to software development:</strong> Argued that
               software development could benefit from process discipline, standardization, and
-              measurement similar to manufacturing and engineering disciplines.
+              measurement similar to that of manufacturing and engineering disciplines.
             </li>
             <li>
               <strong>Defined software maturity progression:</strong> Provided framework for
@@ -481,8 +481,9 @@ const BibliographyArticlePage = () => {
               software development processes.
             </li>
             <li>
-              <strong>Established process measurement in software:</strong> Emphasized measurement
-              and metrics as central to process management, improving software engineering rigor.
+              <strong>Advanced process measurement in software:</strong> Emphasized measurement
+              and metrics as central to process management, contributing to subsequent software
+              engineering practice.
             </li>
             <li>
               <strong>Addressed software scaling challenges:</strong> Provided framework for
@@ -698,7 +699,8 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The Capability Maturity Model has spawned significant theoretical developments and
+            The Capability Maturity Model sits at the start of a significant stream of
+            theoretical and practical developments around process capability, with subsequent
             extensions building on and refining the original framework:
           </p>
           <ul className={BODY_LIST_CLASSES}>

--- a/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
+++ b/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
@@ -65,6 +65,9 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Book Format:</strong> Authored book, not journal article
             </p>
+            <p>
+              <strong>ISBN:</strong> 978-0-201-18095-4
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
+++ b/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
@@ -727,9 +727,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-beck-2000-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-poppendieck-2003">
@@ -740,9 +738,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-poppendieck-2003-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-schwaber-2002">

--- a/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
+++ b/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
@@ -509,9 +509,10 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            As a process maturity framework grounded in empirical observation and software
-            engineering practice, CMM demonstrates strong internal validity through logical
-            coherence and consistency with observed software development patterns:
+            CMM is a practitioner-oriented process framework rather than a tested empirical theory.
+            &ldquo;Internal validity&rdquo; here is assessed as logical coherence, the ordinal
+            structure of the five-level scale, and fidelity to the quality-management lineage the
+            SEI explicitly cites:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>

--- a/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
+++ b/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
@@ -135,7 +135,57 @@ const BibliographyArticlePage = () => {
           </p>
         </section>
 
-        {/* 5. Core Concepts and Definitions */}
+        {/* 5. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            <strong>Source note:</strong> The project&rsquo;s Zotero library does not contain a PDF
+            of Humphrey (1989) <em>Managing the Software Process</em>. Claims on this page are
+            anchored to the SEI/CMU formalization of the CMM published as Paulk, Curtis, Chrissis,
+            &amp; Weber (1993) <em>Capability Maturity Model, Version 1.1</em> (IEEE Software, July
+            1993), for which a PDF is available in the project&rsquo;s Zotero library. Paulk et al.
+            (1993) explicitly extends the process-maturity framework first described in
+            Humphrey&rsquo;s 1989 book.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            CMM measures <em>process maturity</em> on an ordinal five-point scale (Paulk et al.,
+            1993, p. 21), not a continuous psychometric scale. The measurement apparatus consists
+            of:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Five Maturity Levels (1-5):</strong> An ordinal scale for measuring process
+              maturity and evaluating process capability. Each level &ldquo;comprises a set of
+              process goals that, when satisfied, stabilize an important component of a software
+              process&rdquo; (Paulk et al., 1993, p. 21).
+            </li>
+            <li>
+              <strong>Key Process Areas (KPAs):</strong> Each maturity level (except Level 1) is
+              characterized by specific KPAs that must be institutionalized. Achievement of the
+              KPAs, assessed via a maturity questionnaire and on-site appraisal, is the operational
+              criterion for assigning a level.
+            </li>
+            <li>
+              <strong>Maturity Questionnaire:</strong> The SEI developed a maturity questionnaire
+              (Paulk et al., 1993, p. 18) as a preliminary assessment instrument. Formal appraisals
+              use Software Process Assessment (SPA) or Software Capability Evaluation (SCE).
+            </li>
+            <li>
+              <strong>Process measures at Level 4+:</strong> Organizations operating at Maturity
+              Level 4 (Managed) and above collect quantitative process and product measurements
+              (Paulk et al., 1993, pp. 22-23) against which process performance can be controlled
+              statistically.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            CMM does <em>not</em> provide a validated instrument for measuring software quality
+            itself, developer skill, or project success. It measures process <em>maturity</em>
+            only. The relationship between maturity level and project outcomes is a claim CMM
+            proponents advanced; see the Internal Validity section for caveats.
+          </p>
+        </section>
+
+        {/* 6. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -183,57 +233,68 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The Capability Maturity Model drew on and synthesized previous process management and
-            quality theories:
+            Paulk et al. (1993, p. 21) explicitly credit the staged structure of the CMM to
+            &ldquo;principles of product quality espoused by Walter Shewhart, W. Edwards Deming,
+            Joseph Juran, and Philip Crosby.&rdquo; The CMM is a direct application of this
+            quality-management lineage to the domain of software engineering.
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
+              <strong>Statistical Process Control (Shewhart, 1931):</strong> The foundational
+              distinction between common-cause and special-cause variation, and the use of control
+              limits to know when to intervene, are inherited directly by CMM Level 4
+              (&ldquo;Managed&rdquo;), where project processes are controlled statistically (Paulk
+              et al., 1993, p. 22).
+            </li>
+            <li>
               <strong>
-                Total Quality Management and Deming (
+                TQM / Deming philosophy (
                 <Link
                   href="/bibliography-2-4-total-quality-management-tqm-deming-1982"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Deming, 1986
+                  Deming, 1982/1986
                 </Link>
                 ):
               </strong>{' '}
-              CMM incorporated TQM principles emphasizing continuous improvement, measurement, and
-              statistical process control. Deming&rsquo;s focus on process improvement provided
-              philosophical foundation for CMM maturity progression.
+              Continuous improvement, the 14 Points, and the PDCA cycle inform CMM&rsquo;s
+              process-improvement orientation. The evolutionary-small-steps framing of CMM (Paulk et
+              al., 1993, p. 21) closely echoes Deming.
             </li>
             <li>
-              <strong>Software Engineering Principles (Boehm, Brooks):</strong> CMM built on
-              emerging software engineering discipline insights about software development
-              challenges, complexity, and need for disciplined processes.
+              <strong>Juran on quality management:</strong> Juran&rsquo;s quality trilogy (planning,
+              control, improvement) parallels the CMM&rsquo;s movement from disciplined planning
+              (Level 2) through process definition (Level 3), quantitative control (Level 4), and
+              optimization (Level 5).
             </li>
             <li>
-              <strong>Organizational Capabilities and Learning (Nelson &amp; Winter):</strong> CMM
-              incorporated insights about organizational routines and capabilities as sources of
-              performance differentiation.
+              <strong>Crosby on quality maturity:</strong> Crosby&rsquo;s own maturity grid (Crosby,
+              1979, <em>Quality Is Free</em>) is a closer organizational precursor: a five-stage
+              scale for quality-management maturity that parallels the CMM&rsquo;s five-level
+              staging.
             </li>
             <li>
-              <strong>Systems Engineering and Process Discipline (Crosby, Juran):</strong> CMM
-              adapted quality management frameworks from manufacturing and systems engineering to
-              software development context.
+              <strong>Humphrey&rsquo;s process-maturity framework (SEI, 1987):</strong> The
+              immediate precursor. Paulk et al. (1993, p. 18) describe how the SEI released a brief
+              description of the process-maturity framework in September 1987, expanded in
+              Humphrey&rsquo;s 1989 book <em>Managing the Software Process</em>, and subsequently
+              refined into CMM v1.0 (1991) and v1.1 (1993).
             </li>
             <li>
-              <strong>Project Management Practices (PMI, Kerzner):</strong> CMM incorporated project
-              management discipline emphasizing planning, monitoring, control, and organizational
-              processes.
-            </li>
-            <li>
-              <strong>Process Maturity Concepts:</strong> Influenced by manufacturing and quality
-              management concepts of process capability and progressive improvement.
+              <strong>Software engineering context (Boehm, Brooks):</strong> The CMM was developed
+              within the mature software-engineering literature of the 1980s, including Boehm (1988)
+              on the spiral model and Brooks (1975/1995) on the inherent difficulties of software
+              development. These form the domain context rather than direct inputs to the
+              CMM&rsquo;s staged structure.
             </li>
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -247,50 +308,52 @@ const BibliographyArticlePage = () => {
             new practices.
           </p>
 
-          <h3 className={H3_CLASSES}>Five Maturity Levels</h3>
+          <h3 className={H3_CLASSES}>Five Maturity Levels (Paulk et al., 1993, pp. 21-23)</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Level names and characterizations below follow Paulk et al. (1993), the SEI/CMU
+            formalization that builds on Humphrey (1989). Note: later models including CMMI renamed
+            Levels 2 and 4 (&ldquo;Managed&rdquo; and &ldquo;Quantitatively Managed&rdquo;), but the
+            CMM v1.1 names are as given here.
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Level 1 - Initial/Ad Hoc:</strong> Software development processes are
-              unpredictable, poorly controlled, and reactive. Success depends on individual heroics
-              rather than organizational processes. Organizations at this level lack defined
-              processes, documented procedures, or measurement systems. Project outcomes (schedule,
-              budget, quality) are difficult to predict. Software development is chaotic;
-              organizations may not sustain repeatable success.
+              <strong>Level 1 - Initial:</strong> The software process is ad hoc, occasionally
+              chaotic. Few processes are defined and success depends on individual heroics.
+              &ldquo;At level 1, capability is a characteristic of individuals, not
+              organizations&rdquo; (Paulk et al., 1993, p. 21). Organizations at Level 1 may still
+              deliver functioning products, but cannot reliably repeat success.
             </li>
             <li>
-              <strong>Level 2 - Repeatable/Managed:</strong> Basic project management processes are
-              established enabling some project predictability. Key Process Areas include
-              requirements management, software planning, project tracking, supplier agreement
-              management, and change management. Processes are documented and followed for
-              individual projects. Project planning and tracking occur systematically. Some
-              historical data becomes available enabling basic process predictions. Organizations
-              can repeat past successes in similar contexts.
+              <strong>Level 2 - Repeatable:</strong> Basic project management processes are
+              established to track cost, schedule, and functionality. The CMM v1.1 Key Process Areas
+              at Level 2 are (per Paulk et al., 1993): Requirements Management, Software Project
+              Planning, Software Project Tracking and Oversight, Software Subcontract Management,
+              Software Quality Assurance, and Software Configuration Management. Process capability
+              is summarized as &ldquo;disciplined&rdquo;; earlier successes can be repeated.
             </li>
             <li>
-              <strong>Level 3 - Defined/Standardized:</strong> Organizational standard processes are
-              defined, documented, and tailored for specific projects. Key Process Areas include
-              process definition, process focus, peer review, training, product engineering,
-              integration engineering, verification and validation. Software development processes
-              are standardized across the organization enabling consistency and knowledge sharing.
-              Processes are measured and analyzed; improvement recommendations emerge from process
-              data. Organizational culture emphasizes process discipline.
+              <strong>Level 3 - Defined:</strong> Both software-engineering and management processes
+              are documented, standardized, and integrated into an organization&rsquo;s standard
+              software process. The CMM v1.1 Key Process Areas at Level 3 are: Organization Process
+              Focus, Organization Process Definition, Training Program, Integrated Software
+              Management, Software Product Engineering, Intergroup Coordination, and Peer Reviews.
+              Process capability is summarized as &ldquo;standard and consistent&rdquo; (Paulk et
+              al., 1993, p. 22).
             </li>
             <li>
-              <strong>Level 4 - Managed/Quantitatively Managed:</strong> Processes are defined
-              quantitatively with statistical process control and quantitative performance targets.
-              Key Process Areas include quantitative process management and software quality
-              management. Process performance is monitored using statistical techniques and
-              controlled within quantitatively defined limits. Organizations set quantitative
-              quality goals and measure progress toward goals. Process variation is understood and
-              controlled.
+              <strong>Level 4 - Managed:</strong> Detailed measurements of the software process and
+              product quality are collected and analyzed. The CMM v1.1 Key Process Areas at Level 4
+              are: Quantitative Process Management and Software Quality Management. Projects control
+              products and processes by narrowing variation to fall within &ldquo;acceptable
+              quantitative boundaries&rdquo; (Paulk et al., 1993, p. 22). Process capability is
+              summarized as &ldquo;quantifiable and predictable.&rdquo;
             </li>
             <li>
-              <strong>Level 5 - Optimizing/Continuously Improving:</strong> Processes are
-              continuously improved through measurement-based feedback and experimentation. Key
-              Process Areas include process improvement focus and technology change management.
-              Organizations systematically optimize processes and experiment with innovations. New
-              technologies are evaluated and integrated. Organizations maintain processes at the
-              leading edge of software engineering practice.
+              <strong>Level 5 - Optimizing:</strong> The entire organization is focused on
+              continuous process improvement. The CMM v1.1 Key Process Areas at Level 5 are: Defect
+              Prevention, Technology Change Management, and Process Change Management. Teams analyze
+              defects to determine causes and propose changes to prevent recurrence (Paulk et al.,
+              1993, pp. 22-23).
             </li>
           </ul>
 
@@ -341,9 +404,12 @@ const BibliographyArticlePage = () => {
               required at each level.
             </li>
             <li>
-              <strong>Empirically validated:</strong> Organizations improving maturity levels have
-              demonstrated improved schedule predictability, cost control, and quality. Defensible
-              claim of business value.
+              <strong>Claimed business value:</strong> SEI and consulting studies through the
+              1990s-2000s (e.g., Herbsleb &amp; Goldenson, 1996; Galin &amp; Avrahami, 2006)
+              reported that organizations advancing maturity levels saw improvements in schedule
+              predictability, cost control, and defect density. Attribution of performance
+              improvements specifically to CMM (as opposed to selection bias, co-occurring process
+              investments, or broader management change) is contested in the empirical literature.
             </li>
             <li>
               <strong>Addresses scaling challenges:</strong> Enables organizations to scale beyond
@@ -395,7 +461,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -439,7 +505,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -483,7 +549,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -534,7 +600,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -627,7 +693,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -715,12 +781,28 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
             <li id="ref-humphrey-1989">
-              Humphrey, W. S. (1989). <em>Managing the software process</em>. Addison-Wesley.
+              Humphrey, W. S. (1989). <em>Managing the Software Process</em>. Addison-Wesley. ISBN
+              978-0-201-18095-4. <strong>(PDF not available in project Zotero.)</strong>
+            </li>
+            <li id="ref-paulk-1993">
+              Paulk, M. C., Curtis, B., Chrissis, M. B., &amp; Weber, C. V. (1993). Capability
+              Maturity Model, Version 1.1. <em>IEEE Software</em>, 10(4), 18-27. SEI/CMU. (This is
+              the authoritative SEI paper formalizing the Humphrey 1989 framework; primary source
+              available in project Zotero library and used as ground truth for this page&rsquo;s
+              claims about level names, Key Process Areas, and lineage.)
+            </li>
+            <li id="ref-shewhart-1931">
+              Shewhart, W. A. (1931). <em>Economic Control of Quality of Manufactured Product</em>.
+              D. Van Nostrand Company.
+            </li>
+            <li id="ref-crosby-1979">
+              Crosby, P. B. (1979). <em>Quality is Free: The Art of Making Quality Certain</em>.
+              McGraw-Hill. (Source of an earlier five-stage quality-management maturity grid.)
             </li>
             <li id="ref-beck-2000">
               Beck, K. (2000). <em>Extreme programming explained: Embrace change</em>.
@@ -759,6 +841,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -793,7 +876,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
+++ b/src/app/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989/page.tsx
@@ -4,389 +4,829 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
-  REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
   title: 'Bibliography: Capability Maturity Model (CMM) - Humphrey (1989)',
   description:
-    "An exploration of Watts S. Humphrey's Capability Maturity Model, a foundational framework for assessing and improving software development capability through five distinct maturity levels.",
+    'Comprehensive overview of the Capability Maturity Model, a five-level framework for assessing and improving software development process maturity, foundational methodology for IT process improvement emphasizing standardization, measurement, and continuous advancement.',
 }
 
-const CMMHumphreyPage = () => {
+const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Capability Maturity Model (CMM) - Watts S. Humphrey (1989)</h1>
+        <h1 className={H1_CLASSES}>Capability Maturity Model (CMM) - Humphrey (1989)</h1>
 
-        {/* Framework Identification */}
+        {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Framework Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Framework Name:</strong> Capability Maturity Model (CMM)
+              <strong>Framework Name:</strong> Capability Maturity Model for Software
             </p>
             <p>
-              <strong>Authors:</strong> Watts S. Humphrey
+              <strong>Framework Abbreviation:</strong> CMM
             </p>
             <p>
-              <strong>Publication Date:</strong> 1989
+              <strong>Target of Framework:</strong> Assessment and improvement of software
+              development process maturity through a five-level framework emphasizing
+              standardization, measurement, and continuous advancement enabling organizations to
+              predict and control software development costs, schedules, and quality
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Software Engineering, Process Management,
+              Quality Management, Organizational Capability Development, Technology Management
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Author:</strong> Watts S. Humphrey
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 1989
+            </p>
+            <p>
+              <strong>Official Title:</strong> Managing the Software Process
+            </p>
+            <p>
+              <strong>Publisher:</strong> Addison-Wesley
+            </p>
+            <p>
+              <strong>Book Format:</strong> Authored book, not journal article
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Humphrey, W. S. (1989). <em>Managing the software process.</em> Addison-Wesley.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Humphrey, W. S. (
+                <a href="#ref-humphrey-1989" className="text-tabs-teal-deep hover:underline">
+                  1989
+                </a>
+                ). <em>Managing the software process</em>. Addison-Wesley.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Humphrey, Watts S. 1989. <em>Managing the Software Process</em>. Reading, MA:
+                Addison-Wesley.
+              </p>
+            </div>
           </div>
         </section>
 
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <p className={PARAGRAPH_CLASSES}>
-            Watts S. Humphrey&rsquo;s Capability Maturity Model (CMM), developed at Carnegie Mellon
-            University&rsquo;s Software Engineering Institute (SEI) for the U.S. Department of
-            Defense, transformed how organizations assess and improve software development
-            capability. Published comprehensively in <em>Managing the Software Process</em> (1989),
-            the CMM introduced the revolutionary idea that software development capability can be
-            assessed through five distinct maturity levels, and that organizations move through
-            these levels through deliberate investment in process improvement.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Rather than viewing software quality as dependent primarily on individual programmer
-            talent, the CMM reframes software development as a management and organizational
-            problem. Organizations can improve software quality, predictability, and productivity by
-            systematically improving their development processes. This reorientation has profoundly
-            influenced how organizations approach technology adoption and process
-            institutionalization.
-          </p>
-
           <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Humphrey and SEI developed the CMM because the U.S. Department of Defense faced a
-            critical problem: software development was unpredictable and unreliable. DoD software
-            projects frequently exceeded budgets by 50-300%, took years longer than planned, and
-            delivered unreliable software. Meanwhile, DoD personnel noticed that some contractors
-            consistently delivered quality software on schedule and budget. What distinguished
-            successful contractors from unsuccessful ones?
+            Watts Humphrey developed the Capability Maturity Model in direct response to a critical
+            crisis in U.S. Department of Defense software development practices. Throughout the
+            1970s and 1980s, the Department of Defense managed thousands of software development
+            contracts with varying outcomes. Some contractors consistently delivered software on
+            time and within budget while others chronically exceeded schedules, budgets, and quality
+            expectations. Identical hardware development contracts under identical managers showed
+            vast differences in software development outcomes. The Department of Defense and
+            contractors struggled to understand what distinguished successful software organizations
+            from chronically troubled ones.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Initial theories suggested it was about talent-successful contractors employed better
-            programmers. But investigations revealed that talent alone was insufficient. Contractors
-            with excellent individual programmers sometimes failed catastrophically if
-            organizational processes were chaotic. Conversely, contractors with well-established
-            processes could manage projects reliably even with more typical programmer talent.
+            Humphrey recognized that the software development field lacked fundamental practices and
+            processes that had proven essential in other engineering disciplines. Manufacturing and
+            hardware development had standardized processes, documented procedures, and measurement
+            systems enabling prediction and control of outcomes. Software development, by contrast,
+            was often ad hoc, driven by individual developer heroics, and lacking systematic
+            processes or quality measurement. Software success depended more on having exceptional
+            developers than on having good processes; this created unpredictability and limited
+            scaling. Humphrey proposed that the solution required establishing a scientific basis
+            for software process management through process definition, process measurement, and
+            systematic process improvement.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            Humphrey&rsquo;s insight was that software development capability was fundamentally an
-            organizational and management question. Immature organizations operate reactively. When
-            projects encounter problems, they solve them ad hoc, with no systematic process. When
-            experienced people leave, institutional knowledge departs. Promising estimates prove
-            wildly inaccurate because they&rsquo;re not based on data about organizational
-            capability.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The CMM was created to provide a measurement framework that would allow the DoD to
-            assess contractor capability and that would help software organizations understand how
-            to improve. Humphrey and SEI believed that software problems were primarily
-            organizational and management problems-not technical problems that could be solved with
-            better programming languages or tools. Better processes would solve the real problems.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The CMM emerged from and built upon several intellectual traditions:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Software Engineering as a Discipline (1960s-1980s):</strong> The software
-              crisis of the 1960s-1970s generated calls for software engineering as a discipline.
-              Barry Boehm&rsquo;s Spiral Model (1986) and others demonstrated that large software
-              systems required process discipline, management, and systematic approaches beyond
-              programming skill.
-            </li>
-            <li>
-              <strong>Deming&rsquo;s Quality Management Principles:</strong> Humphrey explicitly
-              applied Deming-like thinking to software development-quality is not a matter of
-              individual programmer excellence but of organizational processes and systems.
-            </li>
-            <li>
-              <strong>Manufacturing Process Maturity Thinking:</strong> The idea that processes
-              could be characterized by maturity levels (initial, repeatable, defined, managed,
-              optimized) paralleled thinking in manufacturing quality management.
-            </li>
-            <li>
-              <strong>Defense Department Requirements:</strong> The DoD was the largest software
-              purchaser in the world and needed a systematic way to assess contractor capability and
-              guide procurement decisions.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The central premise of the CMM is that software development capability is
-            organizational, not individual. Organizations that depend on heroic individuals to
-            succeed are inherently fragile; when key people leave, capability departs with them.
-            Organizations that embed capability in processes, documentation, and institutional
-            knowledge are resilient and improvable.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The model measures process maturity on a five-level scale, with each level building on
-            the capabilities established at the previous level. The assessment framework enables
-            organizations to understand where they currently stand, what practices must be
-            established to advance, and how to prioritize improvement investments.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Key measurement dimensions across maturity levels include:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Level 2 Measurements:</strong> Project completion against schedule and budget,
-              requirements completeness and stability, configuration management metrics, software
-              quality metrics (defects, reliability).
-            </li>
-            <li>
-              <strong>Level 3 Measurements:</strong> Process compliance (are projects following the
-              standard process?), process consistency (how much do projects vary in their
-              tailoring?), organizational performance against process standards.
-            </li>
-            <li>
-              <strong>Level 4 Measurements:</strong> Process capability (what performance is
-              statistically achievable from this process?), process performance trends, process
-              control metrics, quantitative quality targets and achievement, productivity metrics
-              and trends.
-            </li>
-            <li>
-              <strong>Level 5 Measurements:</strong> Innovation pipeline (how many improvement ideas
-              are being tested?), improvement implementation rate, quantitative improvement trends
-              (productivity gains, quality gains).
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Internal Validity</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The CMM&rsquo;s core framework consists of five maturity levels, each characterized by
-            specific capabilities and practices:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Level 1: Initial (Chaotic).</strong> Level 1 organizations have essentially no
-            defined software development process. Projects succeed or fail based primarily on
-            individual effort and heroics. Success is unpredictable; it depends on having the right
-            people or getting lucky. Processes are undefined and frequently change, costs and
-            schedules are unpredictable, problems are addressed reactively, and there are no metrics
-            or data about process performance.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Level 2: Repeatable.</strong> Level 2 organizations have established basic
-            project management practices. Successful techniques are documented and repeated on
-            subsequent projects. Organizations track requirements, schedule projects, and manage
-            changes systematically. Data about completed projects (effort, schedule, defects) is
-            collected, creating a foundation for estimating future projects. Processes are
-            repeatable but not yet standardized across the organization.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Level 3: Defined.</strong> Level 3 organizations have standardized their
-            software development processes. Rather than different projects using different
-            approaches, organizations have defined a standard process that all projects are expected
-            to follow, tailored for specific contexts. Knowledge is institutionalized in documented
-            processes rather than residing in individual heads. New team members can be trained on
-            the organizational standard process.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Level 4: Managed.</strong> Level 4 organizations manage software development
-            through detailed measurements and controls. Processes are not only defined but also
-            measured. Organizations track process performance data and understand variation-both
-            common cause variation inherent in the process and special cause variation from unusual
-            circumstances. Estimates are based on measurement data; quality is managed through
-            understanding process capability.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Level 5: Optimizing.</strong> Level 5 organizations are continuously improving
-            their processes. Data is analyzed to identify bottlenecks and improvement opportunities.
-            New technologies and techniques are piloted and, if successful, incorporated into
-            organizational processes. Continuous process improvement is built into organizational
-            culture; organizations see continuous improvement as a competitive necessity.
-          </p>
-
-          <h2 className={H2_CLASSES}>External Validity</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The CMM has been applied successfully across a wide range of contexts, demonstrating
-            strong external validity:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Organization Sizes:</strong> The CMM has been applied to small software
-              companies, medium organizations, and large enterprises. The principles scale across
-              organization sizes, though large organizations typically implement through divisional
-              structures.
-            </li>
-            <li>
-              <strong>Technology Types:</strong> The CMM was originally designed for traditional
-              software development but has been successfully adapted to distributed development, web
-              development, embedded systems, and other specializations.
-            </li>
-            <li>
-              <strong>Industry Applications:</strong> Software organizations across defense,
-              commercial, telecom, finance, healthcare, and other industries have implemented
-              CMM-based improvements.
-            </li>
-            <li>
-              <strong>Geographic Scope:</strong> The CMM has been applied globally, including in
-              developed economies and developing economies. It has been translated into multiple
-              languages and adapted to different cultural contexts.
-            </li>
-            <li>
-              <strong>Sustained Application:</strong> Unlike management fads, the CMM has sustained
-              credibility for decades. CMM-based assessments and improvements have continued from
-              the 1990s through today, with evolution from CMM to CMMI (Capability Maturity Model
-              Integration) that integrates multiple discipline perspectives.
-            </li>
-            <li>
-              <strong>Quantifiable Results:</strong> Organizations implementing CMM-based
-              improvements have demonstrated significant gains in software quality, schedule
-              predictability, and cost management. These measurable results support the
-              model&rsquo;s validity.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Key Contributions</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Empirically Grounded:</strong> The CMM emerged from investigation of what
-            distinguished capable from incapable software organizations. It&rsquo;s not theoretical
-            speculation; it&rsquo;s based on studying successful and unsuccessful organizations.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Practical and Actionable:</strong> Unlike purely academic models, the CMM
-            provides specific guidance about what organizations should do to improve. Organizations
-            understand what practices are needed at each level.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Provides Structure and Roadmap:</strong> Rather than overwhelming organizations
-            with numerous improvement options, the CMM provides a structured roadmap. Level 1
-            organizations focus first on establishing basic project management (Level 2), then
-            standardizing processes (Level 3), then implementing quantitative management (Level 4).
-            This staged approach focuses effort on the most critical improvements first.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Measurable and Assessable:</strong> Organizations can formally assess their
-            maturity level, creating clarity about current state and progress. This objectivity is
-            valuable; organizations cannot claim higher maturity without demonstrated evidence.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Connects Process to Business Outcomes:</strong> The CMM explicitly connects
-            process maturity to business outcomes-project predictability, cost control, quality.
-            Organizations understand the business case for process improvement.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Organizational Learning:</strong> The CMM embeds organizational learning and
-            continuous improvement into the model itself, recognizing that improvement is not a
-            one-time effort but an ongoing capability.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>De-emphasizes Individual Heroics:</strong> By focusing on organizational
-            processes rather than individual talent, the CMM provides an alternative to
-            organizations that depend on heroic individuals. This creates sustainability and
-            knowledge preservation.
-          </p>
-
-          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The CMM directly addresses organizational adoption of software development practices and
-            processes. Software development organizations face distinctive adoption challenges:
-            recruiting and retaining talented individuals, establishing repeatable processes in
-            creative work, managing distributed teams, and ensuring product quality. The CMM
-            provides a roadmap for how organizations systematically improve their capability to
-            adopt and effectively implement software development disciplines and technologies.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            For technology adoption broadly, the CMM&rsquo;s maturity-level concept is highly
-            transferable. Organizations at Level 1 for any technology adoption will struggle with
-            unpredictability and heroic dependency; advancing to Level 2 by establishing basic
-            repeatable practices, and then to Level 3 by standardizing organizational processes,
-            dramatically improves adoption outcomes. The CMM demonstrates that adoption success is
-            not primarily about the technology itself but about organizational process maturity.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The CMM also highlights critical barriers to technology adoption. Organizations that
-            lack documented processes cannot effectively train new users, maintain consistency, or
-            improve systematically-each of these is a barrier to successful technology rollout. The
-            model&rsquo;s emphasis on measurement at higher levels directly supports evidence-based
-            technology management: organizations that measure technology performance can distinguish
-            genuine improvement from variation and make adoption decisions based on data.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Several limitations should be acknowledged. Critics argue that CMM-based improvements
-            can create bureaucratic, process-heavy organizations where compliance with procedures
-            takes precedence over pragmatism and results. Individual talent still matters; process
-            cannot substitute for incompetent people, and rigid adherence to process can stifle
-            talented individuals&rsquo; contributions. The model was designed for traditional
-            software development; applying it to agile, distributed, or open-source development
-            requires adaptation. CMM assessments are also expensive and time-consuming, and
-            organizations sometimes game assessments by documenting processes that do not actually
-            reflect practice.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Despite these limitations, the CMM&rsquo;s foundational insight-that organizational
-            process maturity is the primary driver of software quality and technology adoption
-            success-has been validated across decades of research and practice. Its evolution into
-            CMMI and related frameworks demonstrates the enduring relevance of maturity-based
-            thinking for organizational capability development.
+            The CMM emerged from Humphrey&rsquo;s work at the Software Engineering Institute (SEI)
+            at Carnegie Mellon University, chartered by the U.S. Department of Defense to improve
+            software development practices. Humphrey synthesized insights from quality management,
+            manufacturing engineering, and organizational development into a framework specifically
+            tailored to software development process improvement. The framework proposed that
+            software development organizations evolve through predictable maturity levels, each
+            level building on the previous level and enabling improved predictability, control, and
+            effectiveness.
           </p>
         </section>
 
-        <p className="mt-8 text-sm italic text-gray-600">
-          Note: This article provides an overview based on the comprehensive literature review.
-          Readers are encouraged to consult the original publication for complete details.
-        </p>
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Capability Maturity Model is built on fundamental concepts about how organizations
+            mature in process capability:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Process Maturity:</strong> The extent to which an organization has explicitly
+              defined, documented, and standardized software development processes. Maturity
+              progresses from ad hoc, undocumented practices (initial) to standardized, measured,
+              optimized processes (optimizing).
+            </li>
+            <li>
+              <strong>Key Process Areas (KPAs):</strong> Functional elements of software processes
+              that must be established and institutionalized at each maturity level. Each level
+              requires implementation of specific KPAs and integration with existing processes.
+            </li>
+            <li>
+              <strong>Process Institutionalization:</strong> The extent to which practices are
+              documented in standards, procedures, and training; embedded in organizational
+              routines; assessed for compliance; and reinforced through organizational culture and
+              management attention.
+            </li>
+            <li>
+              <strong>Predictability:</strong> The capability to reliably predict software project
+              outcomes (schedule, budget, quality) based on historical data and process knowledge.
+              Predictability increases with maturity level.
+            </li>
+            <li>
+              <strong>Measurement:</strong> Systematic collection of project metrics and process
+              metrics enabling understanding of process performance, identification of improvement
+              opportunities, and evidence-based process adjustments.
+            </li>
+            <li>
+              <strong>Process Improvement:</strong> Systematic activities to evaluate processes,
+              identify improvement opportunities, experiment with improvements, and institutionalize
+              successful improvements.
+            </li>
+            <li>
+              <strong>Quality Assurance:</strong> Activities to ensure that software development
+              follows defined processes, product quality meets standards, and problems are
+              identified and corrected.
+            </li>
+          </ul>
+        </section>
 
-        <section className="pt-8 border-t border-gray-200">
-          <h2 className={REFERENCES_H2_CLASSES}>References</h2>
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Capability Maturity Model drew on and synthesized previous process management and
+            quality theories:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Total Quality Management and Deming (
+                <Link
+                  href="/bibliography-2-4-total-quality-management-tqm-deming-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Deming, 1986
+                </Link>
+                ):
+              </strong>{' '}
+              CMM incorporated TQM principles emphasizing continuous improvement, measurement, and
+              statistical process control. Deming&rsquo;s focus on process improvement provided
+              philosophical foundation for CMM maturity progression.
+            </li>
+            <li>
+              <strong>Software Engineering Principles (Boehm, Brooks):</strong> CMM built on
+              emerging software engineering discipline insights about software development
+              challenges, complexity, and need for disciplined processes.
+            </li>
+            <li>
+              <strong>Organizational Capabilities and Learning (Nelson &amp; Winter):</strong> CMM
+              incorporated insights about organizational routines and capabilities as sources of
+              performance differentiation.
+            </li>
+            <li>
+              <strong>Systems Engineering and Process Discipline (Crosby, Juran):</strong> CMM
+              adapted quality management frameworks from manufacturing and systems engineering to
+              software development context.
+            </li>
+            <li>
+              <strong>Project Management Practices (PMI, Kerzner):</strong> CMM incorporated project
+              management discipline emphasizing planning, monitoring, control, and organizational
+              processes.
+            </li>
+            <li>
+              <strong>Process Maturity Concepts:</strong> Influenced by manufacturing and quality
+              management concepts of process capability and progressive improvement.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Capability Maturity Model proposes that software development organizations progress
+            through five maturity levels, each representing greater process definition,
+            standardization, measurement, and optimization capability. Organizations at higher
+            maturity levels can more reliably predict and control software development outcomes,
+            achieve better quality with fewer surprises, and execute complex projects with lower
+            risk. Progression through maturity levels requires systematic implementation of Key
+            Process Areas specific to each level, followed by organizational institutionalization of
+            new practices.
+          </p>
+
+          <h3 className={H3_CLASSES}>Five Maturity Levels</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Level 1 - Initial/Ad Hoc:</strong> Software development processes are
+              unpredictable, poorly controlled, and reactive. Success depends on individual heroics
+              rather than organizational processes. Organizations at this level lack defined
+              processes, documented procedures, or measurement systems. Project outcomes (schedule,
+              budget, quality) are difficult to predict. Software development is chaotic;
+              organizations may not sustain repeatable success.
+            </li>
+            <li>
+              <strong>Level 2 - Repeatable/Managed:</strong> Basic project management processes are
+              established enabling some project predictability. Key Process Areas include
+              requirements management, software planning, project tracking, supplier agreement
+              management, and change management. Processes are documented and followed for
+              individual projects. Project planning and tracking occur systematically. Some
+              historical data becomes available enabling basic process predictions. Organizations
+              can repeat past successes in similar contexts.
+            </li>
+            <li>
+              <strong>Level 3 - Defined/Standardized:</strong> Organizational standard processes are
+              defined, documented, and tailored for specific projects. Key Process Areas include
+              process definition, process focus, peer review, training, product engineering,
+              integration engineering, verification and validation. Software development processes
+              are standardized across the organization enabling consistency and knowledge sharing.
+              Processes are measured and analyzed; improvement recommendations emerge from process
+              data. Organizational culture emphasizes process discipline.
+            </li>
+            <li>
+              <strong>Level 4 - Managed/Quantitatively Managed:</strong> Processes are defined
+              quantitatively with statistical process control and quantitative performance targets.
+              Key Process Areas include quantitative process management and software quality
+              management. Process performance is monitored using statistical techniques and
+              controlled within quantitatively defined limits. Organizations set quantitative
+              quality goals and measure progress toward goals. Process variation is understood and
+              controlled.
+            </li>
+            <li>
+              <strong>Level 5 - Optimizing/Continuously Improving:</strong> Processes are
+              continuously improved through measurement-based feedback and experimentation. Key
+              Process Areas include process improvement focus and technology change management.
+              Organizations systematically optimize processes and experiment with innovations. New
+              technologies are evaluated and integrated. Organizations maintain processes at the
+              leading edge of software engineering practice.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Key Mechanisms</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Key Process Areas (KPAs):</strong> Functional elements that must be
+              established at each maturity level. KPAs define what practices must be implemented and
+              institutionalized for organizations to achieve that maturity level.
+            </li>
+            <li>
+              <strong>Common Features:</strong> Characteristics present in organizations
+              implementing KPAs effectively: commitment to perform, ability to perform, activities
+              performed, measurement and analysis, verification of implementation.
+            </li>
+            <li>
+              <strong>Process Definition and Documentation:</strong> Software processes must be
+              explicitly defined, documented in standards and procedures, and made accessible to
+              software developers.
+            </li>
+            <li>
+              <strong>Process Measurement:</strong> Organizations collect metrics on process
+              performance, project performance, and product quality. Metrics enable understanding of
+              process effectiveness and identification of improvement opportunities.
+            </li>
+            <li>
+              <strong>Organizational Learning and Improvement:</strong> Organizations capture
+              lessons learned, analyze process data, and systematically improve processes based on
+              evidence.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Directly addresses software development challenges:</strong> Developed
+              specifically for software context, addressing documented software development problems
+              and challenges.
+            </li>
+            <li>
+              <strong>Practical assessment methodology:</strong> Provides concrete assessment
+              criteria and detailed practices enabling organizations to assess current maturity
+              level and identify improvement path.
+            </li>
+            <li>
+              <strong>Predictable progression path:</strong> Specifies maturity progression path
+              with clear criteria for moving between levels. Organizations understand what is
+              required at each level.
+            </li>
+            <li>
+              <strong>Empirically validated:</strong> Organizations improving maturity levels have
+              demonstrated improved schedule predictability, cost control, and quality. Defensible
+              claim of business value.
+            </li>
+            <li>
+              <strong>Addresses scaling challenges:</strong> Enables organizations to scale beyond
+              individual hero developers to reliable organizational capability.
+            </li>
+            <li>
+              <strong>Measurement emphasis:</strong> Emphasizes measurement and data-driven
+              decision-making enabling evidence-based improvement and objective progress assessment.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Slow progression through levels:</strong> Moving from one maturity level to
+              the next typically requires 2-4 years of sustained effort. Organizations seeking rapid
+              improvement find CMM progression slow.
+            </li>
+            <li>
+              <strong>Risk of bureaucratization:</strong> Process documentation and standardization
+              can create bureaucracy if not managed carefully. Excessive documentation and process
+              adherence can inhibit innovation.
+            </li>
+            <li>
+              <strong>Complex assessment and implementation:</strong> CMM assessment is expensive
+              and time-consuming. Implementation requires significant organizational change and
+              resource commitment.
+            </li>
+            <li>
+              <strong>Limited applicability to innovation and small projects:</strong> CMM emphasis
+              on standardized processes may be less applicable to innovative work, research
+              projects, or small software developments requiring flexibility.
+            </li>
+            <li>
+              <strong>Context and industry variation:</strong> CMM was developed for DoD software
+              development. Applicability to other industries, contexts, or software types (e.g., web
+              development, startup environments) may vary.
+            </li>
+            <li>
+              <strong>Agile methodology tensions:</strong> CMM emphasis on planning and
+              documentation can tension with Agile methodologies emphasizing iterative development
+              and adaptive planning. Integration of CMM and Agile practices remains challenging.
+            </li>
+            <li>
+              <strong>Organizational culture requirements:</strong> CMM implementation requires
+              significant organizational culture change. Organizations resistant to process
+              discipline struggle with CMM adoption.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Brought process discipline to software development:</strong> Established that
+              software development could benefit from process discipline, standardization, and
+              measurement similar to manufacturing and engineering disciplines.
+            </li>
+            <li>
+              <strong>Defined software maturity progression:</strong> Provided framework for
+              understanding organizational software development maturity and maturity progression
+              path.
+            </li>
+            <li>
+              <strong>Operationalized software process improvement:</strong> Provided concrete
+              practices and assessment criteria enabling organizations to systematically improve
+              software development processes.
+            </li>
+            <li>
+              <strong>Established process measurement in software:</strong> Emphasized measurement
+              and metrics as central to process management, improving software engineering rigor.
+            </li>
+            <li>
+              <strong>Addressed software scaling challenges:</strong> Provided framework for
+              organizations to scale beyond small team dynamics to organizational capability.
+            </li>
+            <li>
+              <strong>Created standardization opportunity:</strong> Provided common framework
+              enabling software organizations globally to assess and compare maturity levels.
+            </li>
+            <li>
+              <strong>Foundation for subsequent frameworks:</strong> Provided foundation for CMMI
+              (Capability Maturity Model Integration), ISO/IEC 15504, and other software process
+              improvement frameworks.
+            </li>
+            <li>
+              <strong>Influenced DoD and government practice:</strong> Influenced procurement
+              practices and contractor selection, driving widespread CMM adoption across software
+              industry.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            As a process maturity framework grounded in empirical observation and software
+            engineering practice, CMM demonstrates strong internal validity through logical
+            coherence and consistency with observed software development patterns:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Logical progression:</strong> The maturity level progression logically builds:
+              organizations must have basic project management before standardizing processes; must
+              standardize processes before measuring them quantitatively; must measure before
+              optimizing.
+            </li>
+            <li>
+              <strong>Grounding in software engineering experience:</strong> The framework emerged
+              from empirical investigation of successful and unsuccessful software development
+              organizations. Identified practices reflect observed patterns in high-performing
+              organizations.
+            </li>
+            <li>
+              <strong>Consistency with process management theory:</strong> The framework
+              incorporates established process management concepts: process definition, measurement,
+              control, and improvement.
+            </li>
+            <li>
+              <strong>Addresses documented software problems:</strong> The framework addresses
+              well-documented software development problems: schedule predictability, quality
+              consistency, cost control, and scaling challenges.
+            </li>
+            <li>
+              <strong>Mutual reinforcement of practices:</strong> Practices at each level build on
+              and reinforce each other. Process definition enables measurement; measurement enables
+              control; control enables optimization.
+            </li>
+            <li>
+              <strong>Clear assessment criteria:</strong> Framework provides clear, observable
+              criteria for assessing maturity level enabling objective assessment rather than
+              subjective judgment.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations concern generalizability of CMM across diverse software
+            development contexts and organizational types:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>DoD context origin:</strong> CMM was developed in Department of Defense
+              context with emphasis on large-scale, mission-critical software. Applicability to
+              commercial software development, startups, or web development may differ.
+            </li>
+            <li>
+              <strong>Software development context variation:</strong> CMM applicability may vary by
+              software type. Applicability to innovative research software, exploratory prototypes,
+              or Agile development may be less straightforward than to mission-critical systems.
+            </li>
+            <li>
+              <strong>Organizational size effects:</strong> CMM was developed in large organizations
+              with dedicated process management resources. Applicability to small software
+              organizations or startups may be limited due to resource constraints.
+            </li>
+            <li>
+              <strong>Agile methodology tensions:</strong> CMM emphasis on planning and
+              documentation can conflict with Agile methodologies. Organizations using Agile
+              approaches may struggle to implement CMM practices.
+            </li>
+            <li>
+              <strong>Industry and cultural variation:</strong> CMM was developed in American
+              software engineering culture. Applicability to different national cultures or
+              organizational contexts may require adaptation.
+            </li>
+            <li>
+              <strong>Organizational resistance:</strong> CMM implementation requires significant
+              organizational change. Organizations with strong resistance to process discipline may
+              struggle with adoption.
+            </li>
+            <li>
+              <strong>Innovation and flexibility concerns:</strong> CMM emphasis on standardization
+              and documentation may inhibit innovation in certain contexts requiring high
+              flexibility and rapid adaptation.
+            </li>
+            <li>
+              <strong>Measurement capability variation:</strong> CMM implementation requires
+              organizational capability to collect, analyze, and act on process metrics.
+              Organizations lacking analytical capability may struggle.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            CMM explains organizational success with technology adoption through process capability
+            and maturity progression. Organizations at higher CMM maturity levels have standardized,
+            measured processes enabling more effective technology adoption. Technology adoption
+            success depends on organizational capability to define requirements, plan implementation
+            systematically, track implementation progress, manage changes rigorously, and measure
+            adoption outcomes. Organizations at CMM Level 1 (ad hoc) struggle with technology
+            adoption because they lack basic planning, tracking, and management processes.
+            Organizations at CMM Level 3+ (defined/standardized) have established processes enabling
+            more systematic, predictable technology adoption. CMM predicts that technology adoption
+            success correlates with organizational maturity level.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Lack of defined processes:</strong> Organizations without defined software
+              development processes struggle to define technology adoption requirements
+              systematically or plan adoption implementation.
+            </li>
+            <li>
+              <strong>Weak project management:</strong> Absence of basic project management
+              practices (planning, tracking, change management) creates chaos in technology adoption
+              projects.
+            </li>
+            <li>
+              <strong>Insufficient measurement:</strong> Organizations lacking measurement systems
+              cannot track adoption progress or identify problems early.
+            </li>
+            <li>
+              <strong>Uncontrolled change:</strong> Organizations without change management
+              processes cannot manage the scope, impact, and pace of technology adoption changes.
+            </li>
+            <li>
+              <strong>Poor requirements definition:</strong> Organizations without requirements
+              management practices struggle to define what success means for technology adoption.
+            </li>
+            <li>
+              <strong>Inadequate quality assurance:</strong> Organizations without quality assurance
+              practices may not identify technology adoption problems until late in implementation.
+            </li>
+            <li>
+              <strong>Lack of lessons capture:</strong> Organizations may repeat technology adoption
+              mistakes because they do not systematically capture and share lessons learned.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Framework Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Establish basic project management practices:</strong> Implement fundamental
+              project planning, tracking, and control processes for technology adoption projects.
+            </li>
+            <li>
+              <strong>Define adoption process standards:</strong> Establish organizational standards
+              for how technology adoption will be managed, including planning, testing, rollout, and
+              support.
+            </li>
+            <li>
+              <strong>Implement requirements management:</strong> Define and manage technology
+              adoption requirements systematically. Ensure requirements are clear, traceable, and
+              validated.
+            </li>
+            <li>
+              <strong>Establish change management:</strong> Implement formal change control
+              processes for technology adoption changes. Control scope changes and prevent unmanaged
+              growth.
+            </li>
+            <li>
+              <strong>Implement measurement and tracking:</strong> Collect metrics on adoption
+              progress, schedule conformance, budget conformance, and quality. Use metrics to guide
+              management decisions.
+            </li>
+            <li>
+              <strong>Institute quality assurance:</strong> Establish QA practices to verify that
+              technology adoption follows defined processes and meets quality standards.
+            </li>
+            <li>
+              <strong>Systematize lessons capture:</strong> Document lessons learned from technology
+              adoption experiences. Share lessons across the organization to improve future
+              adoptions.
+            </li>
+            <li>
+              <strong>Pursue continuous improvement:</strong> Treat each technology adoption as
+              opportunity to improve adoption processes. Incorporate improvements into
+              organizational standards for future adoptions.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Capability Maturity Model has spawned significant theoretical developments and
+            extensions building on and refining the original framework:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>CMMI (Capability Maturity Model Integration, 2000):</strong> Extended and
+              integrated CMM with related models (IPPD, Systems Engineering) into unified framework.
+              CMMI incorporated lessons learned from CMM implementations and addressed CMM
+              limitations.
+            </li>
+            <li>
+              <strong>ISO/IEC 15504 (SPICE):</strong> International standard for software process
+              assessment based on CMM concepts but providing more flexible assessment approach and
+              broader process areas.
+            </li>
+            <li>
+              <strong>
+                Agile and Iterative Models (
+                <a
+                  id="cite-ref-beck-2000-1"
+                  href="#ref-beck-2000"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Beck, 2000
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-schwaber-2002-1"
+                  href="#ref-schwaber-2002"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Schwaber &amp; Sutherland, 2002
+                </a>
+                ):
+              </strong>{' '}
+              Developed as alternatives to CMM-style formal process discipline, emphasizing adaptive
+              planning and iterative development. Later work explored integration of Agile and CMM
+              approaches.
+            </li>
+            <li>
+              <strong>
+                DevOps and Continuous Integration (
+                <a
+                  id="cite-ref-humble-2010-1"
+                  href="#ref-humble-2010"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Humble &amp; Farley, 2010
+                </a>
+                ):
+              </strong>{' '}
+              Extended software process concepts to emphasize continuous integration, deployment,
+              and feedback. Incorporated measurement and automation concepts from CMM.
+            </li>
+            <li>
+              <strong>
+                Lean Software Development (Poppendieck &amp;{' '}
+                <a
+                  id="cite-ref-poppendieck-2003-1"
+                  href="#ref-poppendieck-2003"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Poppendieck, 2003
+                </a>
+                ):
+              </strong>{' '}
+              Applied Lean principles to software development, emphasizing value delivery and waste
+              elimination while incorporating process discipline concepts from CMM.
+            </li>
+            <li>
+              <strong>Organizational Process Asset (OPA) Management:</strong> Extended CMM concepts
+              to managing organizational knowledge and process assets across the enterprise.
+            </li>
+            <li>
+              <strong>Software Process Simulation:</strong> Used computational models to simulate
+              software process performance and explore process improvement scenarios.
+            </li>
+            <li>
+              <strong>Process Mining and Analytics:</strong> Applied data analytics to process
+              execution data to understand, analyze, and improve software development processes.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
-            <li>
-              Humphrey, W. S. (1989). <em>Managing the software process.</em> Addison-Wesley.
+            <li id="ref-humphrey-1989">
+              Humphrey, W. S. (1989). <em>Managing the software process</em>. Addison-Wesley.
             </li>
-            <li>
-              Boehm, B. W. (1986). A spiral model of software development and enhancement.{' '}
-              <em>ACM SIGSOFT Software Engineering Notes, 11</em>(4), 14-24.
-            </li>
-            <li>
-              Paulk, M. C., Weber, C. V., Curtis, B., &amp; Chrissis, M. B. (1995).{' '}
-              <em>The capability maturity model: Guidelines for improving the software process.</em>{' '}
+            <li id="ref-beck-2000">
+              Beck, K. (2000). <em>Extreme programming explained: Embrace change</em>.
               Addison-Wesley.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-beck-2000-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Deming, W. E. (1982). <em>Quality, productivity, and competitive position.</em>{' '}
-              Massachusetts Institute of Technology, Center for Advanced Engineering Study.
+            <li id="ref-poppendieck-2003">
+              Poppendieck, M., &amp; Poppendieck, T. (2003).{' '}
+              <em>Lean software development: An agile toolkit</em>. Addison-Wesley.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-poppendieck-2003-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Software Engineering Institute. (2010). <em>CMMI for development, version 1.3.</em>{' '}
-              Carnegie Mellon University.
+            <li id="ref-schwaber-2002">
+              Schwaber, K., &amp; Sutherland, J. (2002).{' '}
+              <em>The Scrum guide: The definitive guide to Scrum</em>. Scrum.org.
             </li>
-            <li>
-              Krishnan, M. S., &amp; Kellner, M. I. (1999). Measuring process consistency:
-              Implications for reducing software defects.{' '}
-              <em>IEEE Transactions on Software Engineering, 25</em>(6), 800-815.
+            <li id="ref-humble-2010">
+              Humble, J., &amp; Farley, D. (2010).{' '}
+              <em>
+                Continuous delivery: Reliable software releases through build, test, and deployment
+                automation
+              </em>
+              . Addison-Wesley.
             </li>
           </ol>
         </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-carnegie-1993">
+              Carnegie Mellon University Software Engineering Institute. (1993).{' '}
+              <em>Capability maturity model for software</em> (Version 1.1). CMU/SEI-93-TR-24.
+            </li>
+            <li id="ref-chrissis-2003">
+              Chrissis, M. B., Konrad, M., &amp; Shrum, S. (2003).{' '}
+              <em>CMMI: Guidelines for process integration and product improvement</em>.
+              Addison-Wesley.
+            </li>
+            <li id="ref-international-2007">
+              International Organization for Standardization. (2007).{' '}
+              <em>ISO/IEC 15504-1: Information technology - Process assessment</em>. ISO.
+            </li>
+            <li id="ref-pressman-2014">
+              Pressman, R. S., &amp; Maxim, B. R. (2014).{' '}
+              <em>Software engineering: A practitioner&rsquo;s approach</em> (8th ed.). McGraw-Hill.
+            </li>
+            <li id="ref-sommerville-2015">
+              Sommerville, I. (2015). <em>Software engineering</em> (10th ed.). Addison-Wesley.
+            </li>
+            <li id="ref-boehm-1988">
+              Boehm, B. W. (1988). A spiral model of software development and enhancement.
+              <em>Computer</em>, 21(5), 61-72.
+            </li>
+            <li id="ref-brooks-1995">
+              Brooks, F. P. (1995). <em>The mythical man-month: Essays on software engineering</em>
+              (anniversary ed.). Addison-Wesley.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-4-total-quality-management-tqm-deming-1982"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Total Quality Management (TQM) (Deming, 1982/1986)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-6-toe-framework-tornatzky-1990"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Technology-Organization-Environment (TOE) Framework (Tornatzky, 1990) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>
   )
 }
 
-export default CMMHumphreyPage
+export default BibliographyArticlePage

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -594,9 +594,9 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Helped launch the BPR movement:</strong> Davenport &amp; Short&rsquo;s 1990
-              article is commonly cited alongside Hammer&rsquo;s 1990 HBR article and Hammer
-              &amp; Champy (1993) as a founding text of the Business Process Reengineering
-              movement that was widely influential through the 1990s and 2000s.
+              article is commonly cited alongside Hammer&rsquo;s 1990 HBR article and Hammer &amp;
+              Champy (1993) as a founding text of the Business Process Reengineering movement that
+              was widely influential through the 1990s and 2000s.
             </li>
             <li>
               <strong>Provided a practical methodology:</strong> Offered a five-step process
@@ -630,10 +630,9 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            As a conceptual framework paper illustrated through case study examples,
-            Davenport &amp; Short&rsquo;s BPR is not subject to construct-validity testing in the
-            psychometric sense. Considerations typically raised about its internal consistency
-            include:
+            As a conceptual framework paper illustrated through case study examples, Davenport &amp;
+            Short&rsquo;s BPR is not subject to construct-validity testing in the psychometric
+            sense. Considerations typically raised about its internal consistency include:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 2-5 CMM (Humphrey, 1989) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1579
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)