### PR TITLE
docs: standardize bibliography 2-6 TOE Framework (Tornatzky & Fleischer, 1990)

### DIFF
--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -596,10 +596,9 @@ const BibliographyArticlePage = () => {
               framework organizing diverse research findings.
             </li>
             <li>
-              <strong>Articulated a three-context model:</strong> Organized influences on
-              technology adoption into technological, organizational, and environmental contexts,
-              providing a conceptual structure subsequently widely adopted in the IS adoption
-              literature.
+              <strong>Articulated a three-context model:</strong> Organized influences on technology
+              adoption into technological, organizational, and environmental contexts, providing a
+              conceptual structure subsequently widely adopted in the IS adoption literature.
             </li>
             <li>
               <strong>Provided practical analytical framework:</strong> Created framework enabling
@@ -843,9 +842,9 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The TOE Framework has served as a frequent frame for empirical research on
-            technology adoption, and has been adapted or extended in a number of subsequent
-            studies and frameworks:
+            The TOE Framework has served as a frequent frame for empirical research on technology
+            adoption, and has been adapted or extended in a number of subsequent studies and
+            frameworks:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -596,9 +596,10 @@ const BibliographyArticlePage = () => {
               framework organizing diverse research findings.
             </li>
             <li>
-              <strong>Established three-context model:</strong> Identified technological,
-              organizational, and environmental contexts as three primary factors influencing
-              adoption, establishing conceptual structure for analyzing adoption decisions.
+              <strong>Articulated a three-context model:</strong> Organized influences on
+              technology adoption into technological, organizational, and environmental contexts,
+              providing a conceptual structure subsequently widely adopted in the IS adoption
+              literature.
             </li>
             <li>
               <strong>Provided practical analytical framework:</strong> Created framework enabling
@@ -606,8 +607,8 @@ const BibliographyArticlePage = () => {
               by examining relevant contextual factors.
             </li>
             <li>
-              <strong>Emphasized contextual contingency:</strong> Established that technology
-              adoption depends on alignment among technological characteristics, organizational
+              <strong>Emphasized contextual contingency:</strong> Argued that technology adoption
+              depends on interaction among technological characteristics, organizational
               characteristics, and environmental conditions rather than on any single factor.
             </li>
             <li>
@@ -616,9 +617,9 @@ const BibliographyArticlePage = () => {
               contexts.
             </li>
             <li>
-              <strong>Generalized across technologies and organizations:</strong> Demonstrated that
-              similar adoption factors influence decisions across diverse technologies and
-              organizational types, providing generalizable framework.
+              <strong>Generalized across technologies and organizations:</strong> Structured as a
+              framework applicable to diverse technologies and organizational types, enabling
+              comparison of adoption studies across contexts.
             </li>
             <li>
               <strong>Guided organizational decision-making:</strong> Provided practical guidance
@@ -639,9 +640,9 @@ const BibliographyArticlePage = () => {
             book PDF is not in the project&rsquo;s Zotero library.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            As a comprehensive synthesis of existing research rather than a novel empirical study,
-            the TOE Framework demonstrates strong internal validity through logical coherence and
-            comprehensive integration of established research findings:
+            As a comprehensive synthesis rather than a novel empirical study, the TOE Framework is
+            typically evaluated in terms of logical coherence and fidelity to the research it
+            integrates rather than construct-validity testing:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
@@ -842,7 +843,9 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            The TOE Framework has spawned extensive empirical research and theoretical extensions:
+            The TOE Framework has served as a frequent frame for empirical research on
+            technology adoption, and has been adapted or extended in a number of subsequent
+            studies and frameworks:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -12,7 +12,8 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: TOE Framework - Tornatzky & Fleischer (1990)',
+  title:
+    'Bibliography: Technology-Organization-Environment (TOE) Framework - Tornatzky & Fleischer (1990)',
   description:
     'Comprehensive overview of the Technology-Organization-Environment (TOE) Framework. Explains how technological, organizational, and environmental contexts shape technology adoption decisions in organizations.',
 }
@@ -21,7 +22,9 @@ const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>TOE Framework - Tornatzky &amp; Fleischer (1990)</h1>
+        <h1 className={H1_CLASSES}>
+          Technology-Organization-Environment (TOE) Framework - Tornatzky &amp; Fleischer (1990)
+        </h1>
 
         {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -138,7 +138,51 @@ const BibliographyArticlePage = () => {
           </p>
         </section>
 
-        {/* 5. Core Concepts and Definitions */}
+        {/* 5. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            <strong>Source note:</strong> The project&rsquo;s Zotero library does not contain a PDF
+            of Tornatzky &amp; Fleischer (1990) <em>The Processes of Technological Innovation</em>.
+            A PDF of Drazin&rsquo;s 1991 review of the book is available and confirms publisher
+            (D.C. Heath/Lexington Books), 298 pages, four-part structure, Rogers-diffusion-tradition
+            positioning, and that Everett Rogers wrote the prologue. Detailed page-level claims on
+            this page are not verified against the book itself.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            TOE is a conceptual framework, not a measurement instrument. It does not propose scales,
+            latent constructs, or statistical operationalizations. What it does propose is a
+            three-context taxonomy for organizing variables that research has found to shape
+            organization-level technology adoption:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Technological context:</strong> characteristics of the technology (both
+              internal current technology base and external technologies in the market).
+            </li>
+            <li>
+              <strong>Organizational context:</strong> characteristics of the adopting firm (size,
+              structure, slack, communication, managerial attitudes).
+            </li>
+            <li>
+              <strong>Environmental context:</strong> industry structure, competitive pressure,
+              regulatory environment, trading-partner behavior.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            The &ldquo;TOE&rdquo; acronym itself is a later-literature convention. Secondary sources
+            (e.g., Baker, 2011, <em>Information Systems Theory</em>; Oliveira &amp; Martins, 2011,{' '}
+            <em>EJISE</em>) popularized the three-context label; the book itself introduces the
+            three contexts without the acronym.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            Empirical TOE studies construct their own measurement instruments, typically
+            Likert-scale surveys, for each context dimension; the book does not supply standardized
+            scales.
+          </p>
+        </section>
+
+        {/* 6. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -201,7 +245,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -259,19 +303,16 @@ const BibliographyArticlePage = () => {
                 >
                   Davis, 1989
                 </a>
-                ;{' '}
-                <a
-                  id="cite-ref-venkatesh-2000-1"
-                  href="#ref-venkatesh-2000"
-                  className="text-tabs-teal-deep hover:underline"
-                >
-                  Venkatesh &amp; Davis, 2000
-                </a>
                 ):
               </strong>{' '}
-              Examined how organizational factors influence information technology adoption and
-              implementation. TOE incorporated findings about organizational readiness, resources,
-              and decision structures.
+              Davis&rsquo; (1989) TAM predated the Tornatzky &amp; Fleischer book by one year and
+              addressed individual-level technology acceptance, complementary in focus to
+              TOE&rsquo;s organizational-level concern. Whether Tornatzky &amp; Fleischer directly
+              incorporated TAM findings into TOE is not established from the book PDF (which is not
+              available in the project&rsquo;s Zotero library); secondary treatments list TAM and
+              TOE as contemporary traditions rather than as strict predecessor-successor. (Note:
+              Venkatesh &amp; Davis 2000 TAM2 postdates TOE by a decade and cannot be a TOE
+              precursor.)
             </li>
             <li>
               <strong>
@@ -339,7 +380,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -545,7 +586,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -587,7 +628,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -632,7 +673,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -686,7 +727,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -790,7 +831,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -842,7 +883,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -910,9 +951,28 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-baker-2011">
+              Baker, J. (2011). The Technology-Organization-Environment framework. In Y. K. Dwivedi
+              et al. (Eds.),{' '}
+              <em>Information Systems Theory: Explaining and Predicting Our Digital Society</em>{' '}
+              (Vol. 1, pp. 231-245). Springer. (Popularized the TOE acronym and three-context
+              labeling.)
+            </li>
+            <li id="ref-oliveira-2011">
+              Oliveira, T., &amp; Martins, M. F. (2011). Literature review of Information Technology
+              adoption models at firm level.{' '}
+              <em>Electronic Journal of Information Systems Evaluation</em>, 14(1), 110-121.
+            </li>
+            <li id="ref-drazin-1991">
+              Drazin, R. (1991). The processes of technological innovation [Book review].{' '}
+              <em>Journal of Technology Transfer</em>, Winter 1991, 45-46. (Review of Tornatzky
+              &amp; Fleischer, 1990; secondary source used on this page for structural
+              confirmation.)
+            </li>
             <li id="ref-rogers-1983">
               Rogers, E. M. (1983). <em>Diffusion of innovations</em> (3rd ed.). Free Press.
             </li>
@@ -929,7 +989,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -279,11 +279,11 @@ const BibliographyArticlePage = () => {
                 </a>
                 ;{' '}
                 <a
-                  id="cite-ref-pierce-1977-1"
-                  href="#ref-pierce-1977"
+                  id="cite-ref-kimberly-1981-1"
+                  href="#ref-kimberly-1981"
                   className="text-tabs-teal-deep hover:underline"
                 >
-                  Pierce &amp; Delbecq, 1977
+                  Kimberly &amp; Evanisko, 1981
                 </a>
                 ):
               </strong>{' '}
@@ -901,9 +901,11 @@ const BibliographyArticlePage = () => {
               acceptance model: Four longitudinal field studies. <em>Management Science</em>, 46(2),
               186-204.
             </li>
-            <li id="ref-pierce-1977">
-              Pierce, J. L., &amp; Delbecq, A. L. (1977). Organization structure, individual
-              attitudes and innovation. <em>Academy of Management Review</em>, 2(1), 27-37.
+            <li id="ref-kimberly-1981">
+              Kimberly, J. R., &amp; Evanisko, M. J. (1981). Organizational innovation: The
+              influence of individual, organizational, and contextual factors on hospital adoption
+              of technological and administrative innovations.{' '}
+              <em>Academy of Management Journal</em>, 24(4), 689-713.
             </li>
           </ol>
         </section>

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -632,6 +632,13 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
+            <strong>Note:</strong> TOE is a conceptual organizing framework, not a testable causal
+            model. &ldquo;Internal validity&rdquo; below is assessed as logical coherence and
+            fidelity to the diffusion-of-innovation tradition the book synthesizes. Specific content
+            claims against Tornatzky &amp; Fleischer (1990) are unverified at page level because the
+            book PDF is not in the project&rsquo;s Zotero library.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
             As a comprehensive synthesis of existing research rather than a novel empirical study,
             the TOE Framework demonstrates strong internal validity through logical coherence and
             comprehensive integration of established research findings:

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -606,9 +606,9 @@ const BibliographyArticlePage = () => {
               logically create adoption barriers.
             </li>
             <li>
-              <strong>Consistency with organizational theory:</strong> The framework&apos;s emphasis
-              on contingency between organizational characteristics and environmental conditions
-              reflects established organizational contingency theory principle.
+              <strong>Consistency with organizational theory:</strong> The framework&rsquo;s
+              emphasis on contingency between organizational characteristics and environmental
+              conditions reflects established organizational contingency theory principle.
             </li>
             <li>
               <strong>Addresses documented adoption phenomena:</strong> The framework explains
@@ -856,16 +856,12 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-davis-1989-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>{' '}
+                ></a>{' '}
                 <a
                   href="#cite-ref-davis-1989-2"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 2"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>{' '}
               https://doi.org/10.2307/249008
             </li>
@@ -876,9 +872,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-thompson-1967-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-lawrence-1967">

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -4,407 +4,962 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
-  REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title:
-    'Bibliography: Technology-Organization-Environment (TOE) Framework - Tornatzky, Fleischer & Chakrabarti (1990)',
+  title: 'Bibliography: TOE Framework - Tornatzky & Fleischer (1990)',
   description:
-    'An exploration of the Technology-Organization-Environment (TOE) Framework by Tornatzky, Fleischer, and Chakrabarti, a foundational model for understanding organizational technology adoption through three comprehensive contextual dimensions.',
+    'Comprehensive overview of the Technology-Organization-Environment (TOE) Framework. Explains how technological, organizational, and environmental contexts shape technology adoption decisions in organizations.',
 }
 
-const TOEFrameworkPage = () => {
+const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>
-          Technology-Organization-Environment (TOE) Framework - Tornatzky, Fleischer &amp;
-          Chakrabarti (1990)
-        </h1>
+        <h1 className={H1_CLASSES}>TOE Framework - Tornatzky &amp; Fleischer (1990)</h1>
 
-        {/* Framework Identification */}
+        {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Framework Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Framework Name:</strong> Technology-Organization-Environment (TOE) Framework
+              <strong>Framework Name:</strong> Technology-Organization-Environment Framework
             </p>
             <p>
-              <strong>Authors:</strong> Louis G. Tornatzky, Mitchell Fleischer, and Atul K.
-              Chakrabarti
+              <strong>Framework Abbreviation:</strong> TOE
             </p>
             <p>
-              <strong>Publication Date:</strong> 1990
+              <strong>Target of Framework:</strong> Explanation of how three contextual dimensions -
+              technological characteristics, organizational characteristics, and environmental
+              characteristics - jointly influence organizational decisions about technology adoption
+              and implementation
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Management Information Systems, Organizational
+              Economics, Strategic Management
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Authors:</strong> Louis G. Tornatzky, Mitchell Fleischer
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 1990
+            </p>
+            <p>
+              <strong>Official Title:</strong> The Processes of Technological Innovation
+            </p>
+            <p>
+              <strong>Publisher:</strong> Lexington Books
+            </p>
+            <p>
+              <strong>Book Format:</strong> Scholarly monograph synthesizing prior research on
+              technological innovation
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Tornatzky, L. G., Fleischer, M., &amp; Chakrabarti, A. K. (1990).{' '}
-              <em>The processes of technological innovation.</em> Lexington Books.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Tornatzky, L. G., &amp; Fleischer, M. (
+                <a href="#ref-tornatzky-1990" className="text-tabs-teal-deep hover:underline">
+                  1990
+                </a>
+                ). <em>The processes of technological innovation</em>. Lexington Books.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Tornatzky, Louis G., and Mitchell Fleischer. 1990.{' '}
+                <em>The Processes of Technological Innovation</em>. Lexington Books.
+              </p>
+            </div>
           </div>
         </section>
 
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <p className={PARAGRAPH_CLASSES}>
-            The Technology-Organization-Environment (TOE) Framework, developed by Louis Tornatzky,
-            Mitchell Fleischer, and Atul Chakrabarti, represents one of the most influential and
-            widely applied models in organizational technology adoption research. Rather than
-            examining why individuals adopt technology, the TOE framework shifts the analytical lens
-            to the organizational level, identifying three comprehensive contexts that shape
-            whether, how, and when organizations decide to adopt innovations.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            This multidimensional approach has become the foundational architecture for hundreds of
-            empirical studies examining organizational IT/IS adoption decisions, ranging from ERP
-            systems and e-commerce platforms to cloud computing and advanced manufacturing
-            technologies. Published in <em>The Processes of Technological Innovation</em> (Lexington
-            Books, 1990), the framework synthesizes decades of innovation adoption research into a
-            coherent organizational model.
-          </p>
-
           <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Tornatzky, Fleischer, and Chakrabarti developed the TOE framework to address a critical
-            gap in innovation adoption research. While Rogers&rsquo; Diffusion of Innovation theory
-            successfully explained individual adoption patterns, organizational technology adoption
-            involved distinct dynamics. Organizations are not simply individuals writ large; they
-            have structural properties, resource constraints, managerial hierarchies, and
-            stakeholder considerations that individuals do not. Additionally, organizations operate
-            within competitive environments, regulatory frameworks, and industry structures that
-            directly influence technology adoption possibilities.
+            During the 1980s, research on technology adoption and innovation was fragmented across
+            multiple disciplines and research traditions. Information systems researchers studied
+            information technology adoption in organizations. Sociology and diffusion research
+            studied how innovations spread through populations. Management researchers studied
+            innovation and entrepreneurship. However, these research streams operated largely
+            independently, developing different theoretical frameworks, using different terminology,
+            and failing to synthesize insights across disciplines. Practitioners attempting to
+            understand technology adoption faced conflicting findings, unclear guidance, and
+            difficulty integrating research insights into organizational decision-making.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The authors recognized that organizational adoption decisions are fundamentally
-            different from individual adoption. A single person may adopt a smartphone based on
-            personal preferences and peer influence. An organization adopting an enterprise resource
-            planning (ERP) system must consider dozens of factors: technical compatibility with
-            existing systems, organizational readiness and capability, costs, alignment with
-            business strategy, competitive pressures, regulatory requirements, and more.
+            Tornatzky and Fleischer recognized that fragmented research lacked coherent theoretical
+            integration. They undertook comprehensive synthesis of technology adoption and
+            innovation research across multiple disciplines to identify common patterns and
+            fundamental principles underlying technology adoption processes. Their goal was not to
+            develop entirely new theory but to distill essential insights from decades of scattered
+            research into coherent framework enabling practitioners and researchers to understand
+            how organizations make technology adoption decisions.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The TOE framework was created to provide organizational technology researchers and
-            practitioners with a conceptually clear, empirically grounded model that captured the
-            full complexity of organizational adoption contexts. By identifying three primary
-            domains - technological, organizational, and environmental - the framework offered
-            researchers a systematic way to organize their inquiries and identify relevant
-            variables.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Several preceding models and theories shaped the TOE framework&rsquo;s development:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Rogers&rsquo; Diffusion of Innovation Theory (1962, updated 1983):</strong>{' '}
-              Rogers identified five adopter categories and emphasized individual characteristics
-              that influence adoption decisions. However, Rogers&rsquo; work emphasized individual
-              and interpersonal communication channels, leaving organizational dynamics
-              underexplored.
-            </li>
-            <li>
-              <strong>Organizational Innovation Literature:</strong> Researchers had begun to
-              distinguish organizational adoption from individual adoption, recognizing that
-              organizational decisions involve multiple stakeholders, complex resource
-              considerations, and structural constraints not present in individual adoption.
-            </li>
-            <li>
-              <strong>Contingency Theory:</strong> This theoretical lens provided a framework for
-              understanding how organizational and environmental contexts moderate adoption
-              decisions, suggesting that effectiveness depends on fit between organizational
-              characteristics and environmental demands.
-            </li>
-            <li>
-              <strong>Industrial Organization Economics:</strong> This contributed thinking about
-              competitive pressures, market structure, and industry dynamics that influence
-              organizational decisions to adopt technologies.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The TOE framework&rsquo;s theoretical strength rests on three interconnected contexts:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Technological Context</strong> encompasses both the technologies currently in
-            use within the organization and those available for adoption. This context includes
-            technology availability (which technologies are available given market and supply
-            conditions), technology characteristics (functional capabilities, costs, quality, and
-            performance characteristics of available technologies), and compatibility (how well new
-            technologies fit with existing technical systems, organizational processes, and work
-            practices). The technological context recognizes that adoption decisions depend not just
-            on the absolute quality of a technology, but on how it aligns with what the organization
-            already uses.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Organizational Context</strong> reflects the characteristics of the adopting
-            organization itself, including organization size (larger organizations often have
-            greater resource slack and different capability needs than smaller organizations),
-            organizational scope (complexity and diversification of an organization&rsquo;s
-            products, services, and operations), managerial structure (degree of centralization and
-            clarity of decision-making authority), management attitudes and leadership receptiveness
-            to innovation and change, slack resources (whether the organization has discretionary
-            resources available to invest in technology adoption), and communication processes. The
-            organizational context recognizes that identical technologies will be adopted
-            differently by organizations with different structures, resources, and cultures.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Environmental Context</strong> captures the broader industry, market, and
-            regulatory landscape, including industry characteristics (maturity, competitiveness, and
-            technological intensity of the industry), market structure (degree of competition and
-            market concentration), regulatory environment (government regulations, compliance
-            requirements, and industry standards that constrain or mandate technology use),
-            competitive pressures (extent to which competitors have adopted similar technologies),
-            government support (subsidies, incentives, or mandates regarding technology adoption),
-            and external support (availability of vendors, consultants, and implementation
-            partners). The environmental context recognizes that organizational adoption decisions
-            are never purely internal.
-          </p>
-
-          <h2 className={H2_CLASSES}>Internal Validity</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The TOE framework demonstrates strong internal validity through its comprehensive
-            coverage of adoption decision space. The three-context structure is both conceptually
-            distinct and mutually reinforcing. Each context addresses a different level of
-            analysis-technological characteristics exist at the artifact level, organizational
-            characteristics exist at the firm level, and environmental characteristics exist at the
-            industry and market level. This multi-level structure captures interactions that
-            single-level models necessarily miss.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework guides measurement of three distinct domains. Technological measurements
-            include technical compatibility with existing systems, functional capabilities, ease of
-            use and learning requirements, cost of acquisition and implementation, quality and
-            reliability characteristics, and scalability. Organizational measurements include
-            financial resources available for adoption, technical expertise and capability gaps,
-            organizational readiness and change capacity, managerial support and strategic
-            alignment, organizational culture and innovativeness, and communication channels.
-            Environmental measurements include industry adoption rates and competitive pressures,
-            regulatory compliance requirements, market conditions and supplier availability,
-            industry standards and interoperability requirements, government incentives or mandates,
-            and external support ecosystem.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework&rsquo;s contrast with Rogers&rsquo; Diffusion of Innovation model
-            illuminates its internal logic. Rogers&rsquo; model explains adoption as an
-            individual-level process driven by perceived characteristics of the innovation and
-            shaped by interpersonal communication. Rogers treats organizations as simply aggregates
-            of individuals. The TOE framework, by contrast, recognizes organizations as complex
-            entities with their own structures, resources, and dynamics. A technology that appears
-            advantageous at the individual level might still fail if organizational resources are
-            insufficient or environmental regulations prohibit it.
-          </p>
-
-          <h2 className={H2_CLASSES}>External Validity</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The TOE framework demonstrates exceptional external validity, having been successfully
-            applied across:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Industry Contexts:</strong> The framework has been applied to technology
-              adoption in manufacturing, healthcare, finance, retail, education, agriculture, and
-              government sectors across both private and public organizations.
-            </li>
-            <li>
-              <strong>Technology Types:</strong> The framework accommodates diverse
-              technologies-from enterprise systems (ERP, CRM) and telecommunications infrastructure
-              to e-commerce platforms, cloud computing, advanced manufacturing systems, and emerging
-              digital technologies. The framework&rsquo;s generality across technology types is one
-              of its primary strengths.
-            </li>
-            <li>
-              <strong>Organization Sizes:</strong> The framework is valid across small businesses,
-              medium enterprises, and large multinational corporations, explicitly acknowledging
-              that organizational size influences adoption.
-            </li>
-            <li>
-              <strong>Geographic Contexts:</strong> TOE-based research has been conducted in
-              developed economies (North America, Western Europe, East Asia) and developing
-              economies (Latin America, Southeast Asia, Africa), demonstrating cross-cultural
-              validity.
-            </li>
-            <li>
-              <strong>Time Periods:</strong> Since 1990, the framework has been applied to
-              technology adoption across multiple decades, including the rapid digitalization of the
-              2000s-2010s and the recent AI and cloud computing transformation.
-            </li>
-          </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            This exceptional external validity explains why the TOE framework has become one of the
-            most cited models in information systems and organizational technology adoption
-            research, generating hundreds of successful empirical studies.
-          </p>
-
-          <h2 className={H2_CLASSES}>Key Contributions</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Comprehensive Scope:</strong> By encompassing technological, organizational, and
-            environmental contexts, the framework captures the full decision space. Researchers
-            cannot simply blame technology characteristics or organizational limitations; they must
-            examine the interaction across all three contexts.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Theoretical Parsimony:</strong> While comprehensive, the framework remains
-            conceptually manageable. The three-context structure is simple enough for practitioners
-            to understand and apply, yet rich enough for sophisticated empirical research.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Proven Empirical Applicability:</strong> The framework has generated hundreds of
-            successful empirical studies, creating a rich cumulative research tradition. Researchers
-            can easily identify variables corresponding to TOE contexts and conduct
-            hypothesis-driven research.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Accommodation of Organizational Heterogeneity:</strong> The framework explicitly
-            recognizes that organizations differ in ways that matter for adoption. Size, structure,
-            resources, and culture all influence adoption outcomes. This prevents oversimplified
-            &ldquo;one-size-fits-all&rdquo; conclusions.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Guidance for Action:</strong> Organizations can assess their own contexts and
-            identify barriers that require mitigation before adoption. This practical guidance
-            extends beyond purely descriptive models.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Flexibility Across Technologies:</strong> The framework is technology-agnostic,
-            applying equally well to ERP systems and cloud computing, manufacturing technologies and
-            digital platforms. This generalizability is valuable in a rapidly changing technological
-            landscape.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Integration with Strategic Management:</strong> The framework naturally connects
-            organizational technology adoption to strategic management concerns about competitive
-            positioning, resource allocation, and organizational capability building.
-          </p>
-
-          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The TOE framework directly addresses organizational technology adoption contexts. It has
-            become an essential tool for organizational decision-makers and technology consultants
-            across several practice applications:
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Technology Investment Decisions:</strong> CIOs and IT directors use the
-            framework to systematically assess whether an organization is ready for a particular
-            technology adoption. By evaluating technological fit, organizational capability, and
-            environmental pressures, organizations can make more informed investment decisions and
-            better anticipate implementation challenges.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Implementation Planning:</strong> The framework guides organizations in
-            identifying potential barriers before committing to adoption. If organizational context
-            analysis reveals insufficient technical expertise or managerial resistance, the
-            organization can address these gaps before implementation rather than discovering them
-            mid-project.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Change Management:</strong> The framework helps change management teams
-            understand why adoption succeeds or fails. By examining the three contexts, teams can
-            identify which factors (lack of resources, unclear strategy alignment, competitive
-            threat) are driving or hindering adoption.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Risk Assessment:</strong> Organizations can use the framework to assess adoption
-            risks. Technologies that create organizational friction-poor fit with existing systems,
-            misalignment with organizational culture, insufficient resources-typically face
-            implementation delays, cost overruns, and user resistance.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework also naturally suggests categories of adoption barriers. Technological
-            barriers include incompatibility with existing systems, insufficient functionality,
-            unproven reliability, high implementation complexity, and steep learning curves.
-            Organizational barriers include insufficient financial resources, lack of technical
-            expertise, inadequate management support, organizational culture resistant to change,
-            and poor internal communication. Environmental barriers include insufficient competitive
-            pressure to justify adoption costs, regulatory constraints, lack of vendor or consultant
-            support, and unfavorable market conditions.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Several limitations should be acknowledged. The framework provides limited guidance
-            about which specific variables within each context are most important for particular
-            technologies or industries. It also provides limited theoretical guidance about how the
-            three contexts interact-when organizational resources are abundant but technological
-            compatibility is poor, which factor dominates? The framework emphasizes contextual
-            factors but provides less guidance about implementation success and technology outcomes
-            after the adoption decision has been made. Strategic agency may be
-            underemphasized-adoption decisions reflect not just structural constraints but also
-            power dynamics and strategic choices by organizational leaders.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            Despite these limitations, the TOE framework remains the dominant organizational-level
-            framework for technology adoption research. Its ability to encompass the full complexity
-            of organizational adoption decisions while remaining practically applicable has made it
-            an enduring contribution to both research and practice.
+            The authors observed that technology adoption research repeatedly identified three
+            categories of factors influencing adoption decisions: characteristics of the technology
+            itself (does it match organizational needs? Is it compatible with existing systems? Is
+            it complex?), characteristics of the adopting organization (does the organization have
+            resources? Is it innovative? What is the decision-making structure?), and
+            characteristics of the external environment (what is the competitive pressure? What
+            regulatory requirements exist? What do competitors do?). Rather than treating these as
+            separate influence categories, Tornatzky and Fleischer synthesized them into integrated
+            framework emphasizing that adoption decisions reflect joint influence of technological,
+            organizational, and environmental contexts.
           </p>
         </section>
 
-        <p className="mt-8 text-sm italic text-gray-600">
-          Note: This article provides an overview based on the comprehensive literature review.
-          Readers are encouraged to consult the original publication for complete details.
-        </p>
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The TOE Framework structures technology adoption influences into three primary contexts:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Technological Context:</strong> Characteristics of the technology being
+              adopted. Includes both internal technologies currently used by the organization (the
+              existing technology base determining compatibility and integration requirements) and
+              external technologies available in the marketplace (new technologies offering
+              potential benefits). Key technological dimensions include innovation complexity,
+              compatibility with existing systems, trial-ability (can organizations experiment with
+              the technology in limited scope before full adoption?), observability (are benefits
+              clearly visible?), and relative advantage over existing technologies.
+            </li>
+            <li>
+              <strong>Organizational Context:</strong> Characteristics of the organization that
+              influence adoption decisions. Includes organizational structure (centralization,
+              formalization, specialization), organizational size and resources, managerial
+              preferences and values, organizational slack (available resources for investment in
+              new initiatives), organizational scope and diversity, and history of prior innovation
+              adoption. Organizations with greater resources, higher innovation orientation, less
+              centralized decision structures, and positive prior innovation experiences are more
+              likely to adopt new technologies.
+            </li>
+            <li>
+              <strong>Environmental Context:</strong> Characteristics of the external competitive,
+              regulatory, and social environment within which organizations operate. Includes
+              competitive pressure (do competitors adopt the technology?), regulatory requirements
+              (does law or regulation mandate adoption?), industry characteristics (does the
+              industry adopt technologies quickly?), availability of external support (does
+              technology vendor provide implementation support?), and trading partner adoption (do
+              suppliers or customers adopt the technology, creating pressure for compatibility?).
+              Environmental pressure increases technology adoption likelihood.
+            </li>
+            <li>
+              <strong>Technology Adoption Decision:</strong> Organizational choices about whether to
+              adopt new technologies. Adoption decisions are not binary yes/no choices but rather
+              multidimensional decisions about which technologies to adopt, when to adopt, how
+              extensively to adopt, and how to implement adoption.
+            </li>
+            <li>
+              <strong>Technology Innovation:</strong> Introduction of new or significantly improved
+              technologies into organizational practice. Innovations may be entirely new
+              technologies, significant improvements on existing technologies, or combinations of
+              existing technologies producing new capabilities.
+            </li>
+            <li>
+              <strong>Compatibility:</strong> The degree to which a new technology fits with
+              existing technologies, organizational processes, values, and work practices. High
+              compatibility reduces adoption barriers; low compatibility requires organizational
+              changes to enable technology integration.
+            </li>
+            <li>
+              <strong>Technology Complexity:</strong> The degree to which a technology is difficult
+              to understand or use. More complex technologies require greater training, expertise,
+              and organizational change, raising adoption barriers.
+            </li>
+          </ul>
+        </section>
 
-        <section className="pt-8 border-t border-gray-200">
-          <h2 className={REFERENCES_H2_CLASSES}>References</h2>
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The TOE Framework synthesized insights from multiple prior research traditions:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Diffusion of Innovations Theory (
+                <Link
+                  href="/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Rogers, 1962, 1983
+                </Link>
+                ):
+              </strong>{' '}
+              Established fundamental insight that innovation characteristics (relative advantage,
+              compatibility, complexity, trial-ability, observability) influence adoption. TOE
+              incorporated these innovation characteristics into the technological context
+              dimension.
+            </li>
+            <li>
+              <strong>
+                Contingency Theory (
+                <a
+                  id="cite-ref-lawrence-1967-1"
+                  href="#ref-lawrence-1967"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Lawrence &amp; Lorsch, 1967
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-burns-1961-1"
+                  href="#ref-burns-1961"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Burns &amp; Stalker, 1961
+                </a>
+                ):
+              </strong>{' '}
+              Established insight that organizational structure and characteristics must align with
+              environmental conditions for effectiveness. TOE incorporated contingency principle by
+              emphasizing that technology adoption depends on alignment between technological
+              opportunities and organizational characteristics.
+            </li>
+            <li>
+              <strong>
+                Information Systems Implementation Research (
+                <a
+                  id="cite-ref-davis-1989-1"
+                  href="#ref-davis-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis, 1989
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-venkatesh-2000-1"
+                  href="#ref-venkatesh-2000"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Venkatesh &amp; Davis, 2000
+                </a>
+                ):
+              </strong>{' '}
+              Examined how organizational factors influence information technology adoption and
+              implementation. TOE incorporated findings about organizational readiness, resources,
+              and decision structures.
+            </li>
+            <li>
+              <strong>
+                Organizational Theory of Innovation (
+                <a
+                  id="cite-ref-zaltman-1973-1"
+                  href="#ref-zaltman-1973"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Zaltman, Duncan, &amp; Holbeck, 1973
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-pierce-1977-1"
+                  href="#ref-pierce-1977"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Pierce &amp; Delbecq, 1977
+                </a>
+                ):
+              </strong>{' '}
+              Established insight that organizational characteristics including structure, size,
+              culture, and resources predict innovation adoption. TOE incorporated these
+              organizational predictors.
+            </li>
+            <li>
+              <strong>
+                Environmental Contingency Theory (
+                <a
+                  id="cite-ref-thompson-1967-1"
+                  href="#ref-thompson-1967"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Thompson, 1967
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-dess-1984-1"
+                  href="#ref-dess-1984"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Dess &amp; Beard, 1984
+                </a>
+                ):
+              </strong>{' '}
+              Established that organizational strategy and structure must align with environmental
+              characteristics. TOE incorporated environmental contingency principle by emphasizing
+              that technology adoption depends on environmental pressure and opportunity.
+            </li>
+            <li>
+              <strong>
+                Technology Acceptance Model (
+                <a
+                  id="cite-ref-davis-1989-2"
+                  href="#ref-davis-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis, 1989
+                </a>
+                ):
+              </strong>{' '}
+              Emphasized perceived usefulness and perceived ease of use as technology adoption
+              drivers. TOE incorporated these perceived technology characteristics.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The TOE Framework provides comprehensive structure for analyzing technology adoption
+            decisions by examining how technological, organizational, and environmental contexts
+            jointly influence adoption. Rather than treating these contexts as independent
+            influences, the framework emphasizes interaction: the same technology may be adopted by
+            organizations in one environment but rejected by organizations in another environment;
+            the same organizational characteristics may predict adoption in one competitive context
+            but not in another. Technology adoption emerges from complex interplay among these three
+            contexts.
+          </p>
+
+          <h3 className={H3_CLASSES}>Technological Context</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Relative Advantage:</strong> The degree to which a technology provides
+              benefits compared to existing alternatives. Technologies offering clear, measurable
+              advantages are more likely to be adopted. Advantages may be cost reduction, efficiency
+              improvement, revenue enhancement, or quality improvement.
+            </li>
+            <li>
+              <strong>Compatibility:</strong> The degree to which a technology fits with existing
+              organizational technologies, processes, and values. Compatible technologies require
+              less organizational change and are easier to integrate, reducing adoption barriers.
+            </li>
+            <li>
+              <strong>Complexity:</strong> The degree of difficulty in understanding or using a
+              technology. Complex technologies require specialized expertise, extensive training,
+              and organizational change. Greater complexity raises adoption barriers and slows
+              adoption.
+            </li>
+            <li>
+              <strong>Trial-ability:</strong> The degree to which organizations can experiment with
+              technologies in limited scope before full commitment. Technologies allowing
+              limited-scope experimentation enable risk reduction and learning before major
+              investment.
+            </li>
+            <li>
+              <strong>Observability:</strong> The degree to which benefits from technology adoption
+              are visible to stakeholders. Observable benefits increase organizational and
+              stakeholder confidence in adoption value.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Organizational Context</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Organizational Size and Resources:</strong> Larger organizations with greater
+              financial and human resources have greater capacity to invest in technology adoption,
+              experimentation, and implementation. Smaller, resource-constrained organizations may
+              struggle to fund technology adoption or implementation.
+            </li>
+            <li>
+              <strong>Organizational Scope and Diversity:</strong> Organizations with broader
+              operational scope, more diverse business units, and greater functional specialization
+              may have greater need for integrating technologies. Diversity can also make adoption
+              more complex due to varied requirements.
+            </li>
+            <li>
+              <strong>Organizational Structure:</strong> Organizations with less centralized
+              decision structures, greater specialization, and more lateral communication enable
+              faster technology adoption and implementation. Highly centralized organizations may
+              face slowed decision-making.
+            </li>
+            <li>
+              <strong>Organizational Slack:</strong> Financial and human resources available for
+              discretionary allocation toward new initiatives influence adoption likelihood.
+              Organizations with greater slack can more easily fund adoption.
+            </li>
+            <li>
+              <strong>Innovation History:</strong> Organizations with positive experiences adopting
+              prior innovations and strong innovation culture are more likely to adopt new
+              technologies. Prior negative experiences or innovation failures may reduce adoption
+              likelihood.
+            </li>
+            <li>
+              <strong>Managerial Values and Preferences:</strong> Leadership commitment to
+              innovation, risk tolerance, technology understanding, and strategic priorities
+              influence technology adoption decisions.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Environmental Context</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Competitive Pressure:</strong> Intensity of competition and technology
+              adoption by competitors influence organizational technology adoption. Organizations in
+              highly competitive industries adopt technologies more rapidly to maintain competitive
+              parity or advantage.
+            </li>
+            <li>
+              <strong>Regulatory Pressure:</strong> Legal requirements, regulatory mandates, and
+              industry standards requiring technology adoption create adoption pressure. Some
+              technologies are adopted not because of perceived benefit but because regulation
+              mandates adoption.
+            </li>
+            <li>
+              <strong>Industry Technology Maturity:</strong> Whether technologies are nascent,
+              growing, or mature influences adoption likelihood. Mature technologies face clearer
+              performance records and lower risk. Nascent technologies face greater uncertainty.
+            </li>
+            <li>
+              <strong>Supply-Chain Integration Requirements:</strong> When suppliers, customers, or
+              trading partners adopt technologies, organizations face pressure to adopt compatible
+              technologies to enable integration, communication, and transaction.
+            </li>
+            <li>
+              <strong>Technology Support and Vendor Ecosystem:</strong> Availability of
+              implementation support, training, consulting, and complementary services influences
+              adoption likelihood. Mature vendor ecosystems reduce adoption risk and cost.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Framework Structure and Application</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            The TOE Framework provides structure for analyzing technology adoption by examining
+            which technological, organizational, and environmental factors influence adoption. The
+            framework does not prescribe a single adoption path or outcome; rather, it identifies
+            relevant contextual factors enabling systematic analysis of why organizations adopt or
+            reject technologies. Different organizations may adopt the same technology for different
+            reasons: Organization A adopts due to competitive pressure, Organization B due to cost
+            reduction benefits, Organization C due to regulatory requirement. The framework
+            accommodates these varied adoption pathways by examining all three contexts.
+          </p>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Comprehensive contextual framework:</strong> Integrates technological,
+              organizational, and environmental factors into unified framework, avoiding fragmented
+              analysis that examines only single context.
+            </li>
+            <li>
+              <strong>Flexible and generalizable:</strong> The framework applies across diverse
+              technologies, organizations, and industries. Research has successfully applied TOE to
+              e-commerce adoption, cloud computing, enterprise resource planning, supply chain
+              technologies, and numerous other innovations.
+            </li>
+            <li>
+              <strong>Practical guidance:</strong> The framework identifies specific organizational
+              and environmental factors practitioners should assess when making technology adoption
+              decisions.
+            </li>
+            <li>
+              <strong>Acknowledges environmental contingency:</strong> Recognizes that technology
+              adoption depends not just on individual organizational characteristics but on how
+              organizational characteristics interact with environmental conditions.
+            </li>
+            <li>
+              <strong>Integrates multiple research traditions:</strong> Synthesizes insights from
+              diffusion theory, organizational theory, and information systems research into
+              coherent framework.
+            </li>
+            <li>
+              <strong>Foundation for extensive empirical research:</strong> Has become foundation
+              for hundreds of empirical studies examining technology adoption across diverse
+              technologies and organizational contexts.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Descriptive rather than predictive:</strong> The framework identifies relevant
+              factors but provides limited guidance on how factors interact or which factors most
+              strongly influence adoption decisions. Different organizations may weight factors
+              differently.
+            </li>
+            <li>
+              <strong>Limited specificity on mechanisms:</strong> The framework does not specify
+              mechanisms through which contextual factors influence adoption decisions. Does
+              relative advantage influence adoption through perceived usefulness, cost-benefit
+              analysis, or other mechanisms?
+            </li>
+            <li>
+              <strong>Adoption versus implementation distinction unclear:</strong> The framework
+              addresses adoption decisions but provides limited guidance on implementation.
+              Organizations may adopt technologies for multiple reasons but implement them
+              differently or fail to realize expected benefits.
+            </li>
+            <li>
+              <strong>Individual decision-maker factors under-specified:</strong> The framework
+              focuses on organizational and environmental factors but under-specifies individual
+              decision-maker characteristics, preferences, and beliefs influencing adoption
+              decisions.
+            </li>
+            <li>
+              <strong>Dynamic factors under-emphasized:</strong> The framework provides static
+              snapshot of adoption conditions but under-emphasizes how organizational capacity
+              evolves over time or how technology characteristics change as technologies mature.
+            </li>
+            <li>
+              <strong>Measurement challenges:</strong> While the framework identifies factors to
+              examine, operationalizing many factors (organizational slack, innovation culture,
+              relative advantage) for empirical measurement remains challenging.
+            </li>
+            <li>
+              <strong>Limited guidance on factor weights:</strong> Does competitive pressure have
+              stronger influence on adoption than relative advantage? Does organizational size
+              matter more than innovation culture? The framework does not specify.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Integrated multiple research traditions:</strong> Successfully synthesized
+              fragmented technology adoption research from multiple disciplines into coherent
+              framework organizing diverse research findings.
+            </li>
+            <li>
+              <strong>Established three-context model:</strong> Identified technological,
+              organizational, and environmental contexts as three primary factors influencing
+              adoption, establishing conceptual structure for analyzing adoption decisions.
+            </li>
+            <li>
+              <strong>Provided practical analytical framework:</strong> Created framework enabling
+              practitioners and researchers to systematically analyze technology adoption decisions
+              by examining relevant contextual factors.
+            </li>
+            <li>
+              <strong>Emphasized contextual contingency:</strong> Established that technology
+              adoption depends on alignment among technological characteristics, organizational
+              characteristics, and environmental conditions rather than on any single factor.
+            </li>
+            <li>
+              <strong>Foundation for empirical research:</strong> Provided structure enabling
+              hundreds of subsequent empirical studies examining technology adoption across diverse
+              contexts.
+            </li>
+            <li>
+              <strong>Generalized across technologies and organizations:</strong> Demonstrated that
+              similar adoption factors influence decisions across diverse technologies and
+              organizational types, providing generalizable framework.
+            </li>
+            <li>
+              <strong>Guided organizational decision-making:</strong> Provided practical guidance
+              for organizational leaders assessing technology adoption decisions by identifying
+              relevant contextual factors.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            As a comprehensive synthesis of existing research rather than a novel empirical study,
+            the TOE Framework demonstrates strong internal validity through logical coherence and
+            comprehensive integration of established research findings:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Integration of established research findings:</strong> The framework
+              synthesizes decades of empirical research identifying technological, organizational,
+              and environmental adoption factors. All major factors identified in prior research are
+              incorporated into the framework.
+            </li>
+            <li>
+              <strong>Logical coherence:</strong> The argument that adoption decisions depend on
+              alignment among technological characteristics, organizational characteristics, and
+              environmental conditions is logically sound. Misalignment in any dimension would
+              logically create adoption barriers.
+            </li>
+            <li>
+              <strong>Consistency with organizational theory:</strong> The framework&apos;s emphasis
+              on contingency between organizational characteristics and environmental conditions
+              reflects established organizational contingency theory principle.
+            </li>
+            <li>
+              <strong>Addresses documented adoption phenomena:</strong> The framework explains
+              well-documented patterns: why similar technologies are adopted more quickly in some
+              industries than others, why larger organizations adopt technologies earlier than
+              smaller organizations, and why competitive pressure accelerates adoption.
+            </li>
+            <li>
+              <strong>Multi-dimensional perspective:</strong> The framework avoids single-factor
+              explanations, recognizing that adoption decisions rarely result from single dominant
+              factor but rather from complex interaction among multiple factors.
+            </li>
+            <li>
+              <strong>Comprehensive coverage:</strong> The three-context framework appears to
+              encompass primary categories of factors influencing adoption, though peripheral
+              factors may be overlooked.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations concern generalizability of the TOE Framework across
+            diverse technologies, organizational types, and industries:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Empirically validated across technologies:</strong> Subsequent research has
+              successfully applied the TOE Framework to e-commerce, cloud computing, enterprise
+              resource planning, supply chain technologies, artificial intelligence, digital
+              transformation, and numerous other technologies, demonstrating broad applicability.
+            </li>
+            <li>
+              <strong>Cross-organizational validation:</strong> The framework has been successfully
+              applied across small businesses, large enterprises, nonprofit organizations, and
+              government agencies, suggesting broad organizational applicability.
+            </li>
+            <li>
+              <strong>Cross-industry validation:</strong> Empirical research has applied the
+              framework to manufacturing, services, healthcare, finance, retail, education, and
+              government, suggesting broad industry applicability.
+            </li>
+            <li>
+              <strong>Geographic variation:</strong> While developed in Western research tradition,
+              the framework has been applied globally, suggesting potential cross-cultural
+              applicability, though research explicitly examining cultural variation is limited.
+            </li>
+            <li>
+              <strong>Temporal variation:</strong> The framework was developed in 1990 but continues
+              to be applied to contemporary technologies, suggesting enduring relevance, though
+              digital economy specifics may differ from 1990 conditions.
+            </li>
+            <li>
+              <strong>Individual versus organizational decision-making:</strong> The framework
+              emphasizes organizational decision-making but under-specifies individual
+              decision-maker characteristics, limiting applicability to understanding individual
+              adoption decisions.
+            </li>
+            <li>
+              <strong>Factor weight variation across contexts:</strong> While the framework
+              identifies relevant factors, different technologies and organizational contexts may
+              weight factors differently. Research provides limited guidance on identifying
+              appropriate weights.
+            </li>
+            <li>
+              <strong>Adoption versus implementation distinction:</strong> The framework addresses
+              adoption decisions but provides limited guidance on implementation variation.
+              Different organizations may adopt same technology but implement differently.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The TOE Framework directly addresses technology adoption by providing comprehensive
+            structure for analyzing adoption decisions. Organizations considering technology
+            adoption should assess technological context (does the technology offer relative
+            advantage? How complex is it? How compatible is it with existing systems?),
+            organizational context (does the organization have resources? Is the decision structure
+            conducive to adoption? What is the innovation culture?), and environmental context (do
+            competitors adopt? Do regulations require adoption? Do trading partners require
+            compatibility?). The framework predicts that technologies with high relative advantage,
+            low complexity, high compatibility, supportive organizational resources, and
+            environmental pressure are more likely to be adopted.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Low relative advantage:</strong> Technologies offering unclear benefits
+              compared to existing alternatives face adoption barriers. Organizations rationally
+              decline to adopt technologies without clear value proposition.
+            </li>
+            <li>
+              <strong>High complexity:</strong> Complex technologies requiring specialized
+              expertise, extensive training, and organizational learning face adoption barriers.
+              Complexity increases implementation cost and risk.
+            </li>
+            <li>
+              <strong>Low compatibility:</strong> Technologies incompatible with existing systems,
+              processes, or organizational values require significant organizational change, raising
+              adoption barriers.
+            </li>
+            <li>
+              <strong>Limited organizational resources:</strong> Organizations lacking financial or
+              human resources struggle to fund adoption, implement changes, or provide training.
+            </li>
+            <li>
+              <strong>Centralized decision structures:</strong> Organizations with highly
+              centralized decision structures may face slowed adoption decisions compared to
+              organizations with distributed decision-making.
+            </li>
+            <li>
+              <strong>Innovation-averse culture:</strong> Organizations with history of resisting
+              change or negative prior innovation experiences may avoid adoption despite objective
+              technology merits.
+            </li>
+            <li>
+              <strong>Weak competitive pressure:</strong> Organizations without competitive pressure
+              may rationally defer adoption, waiting for technologies to mature and costs to
+              decline.
+            </li>
+            <li>
+              <strong>Lack of regulatory mandate:</strong> Without regulatory requirements driving
+              adoption, organizations may postpone discretionary technology investments.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Framework Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Assess technological context:</strong> Conduct systematic assessment of
+              technology characteristics including relative advantage, compatibility, complexity,
+              trial-ability, and observability. Ensure leadership understands technology merits and
+              limitations.
+            </li>
+            <li>
+              <strong>Evaluate organizational readiness:</strong> Assess organizational resources,
+              decision structure, innovation culture, and capacity to implement changes. Address
+              resource gaps or organizational barriers before adoption.
+            </li>
+            <li>
+              <strong>Monitor environmental factors:</strong> Track competitive technology adoption,
+              regulatory developments, and trading partner requirements that may influence adoption
+              decisions.
+            </li>
+            <li>
+              <strong>Communicate relative advantage:</strong> Clearly communicate technology
+              benefits, making advantages observable to stakeholders. Address skepticism through
+              evidence and pilots demonstrating value.
+            </li>
+            <li>
+              <strong>Manage complexity:</strong> Reduce implementation complexity through training,
+              process redesign, phased rollout, and vendor support. Avoid overwhelming organization
+              with complexity.
+            </li>
+            <li>
+              <strong>Ensure compatibility:</strong> Assess integration requirements and
+              compatibility with existing systems. Avoid technologies requiring extensive
+              organizational change unless benefits clearly justify change.
+            </li>
+            <li>
+              <strong>Pilot and learn:</strong> Conduct limited-scope pilots enabling risk reduction
+              and learning before organization-wide adoption. Use pilots to demonstrate value and
+              address concerns.
+            </li>
+            <li>
+              <strong>Leadership commitment:</strong> Ensure leadership demonstrates commitment to
+              technology adoption through resource allocation, participation in implementation, and
+              communication of strategic rationale.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The TOE Framework has spawned extensive empirical research and theoretical extensions:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>TOE-Based Empirical Studies (thousands published 1990-present):</strong> The
+              framework has become foundation for hundreds of empirical studies examining adoption
+              of specific technologies (e-commerce, cloud computing, artificial intelligence,
+              blockchain, etc.) across diverse organizational types and industries.
+            </li>
+            <li>
+              <strong>Extended TOE Models:</strong> Researchers have extended the framework by
+              adding constructs including organizational learning, innovation capability, change
+              readiness, and absorptive capacity.
+            </li>
+            <li>
+              <strong>TOE &amp; Technology Acceptance Model Integration:</strong> Combined TOE with
+              Technology Acceptance Model to examine how perceived usefulness and ease of use (TAM
+              constructs) mediate relationships between contextual factors and adoption.
+            </li>
+            <li>
+              <strong>Digital Transformation Models:</strong> Applied TOE framework to understanding
+              digital transformation, examining how technological, organizational, and environmental
+              contexts influence comprehensive organizational digitization.
+            </li>
+            <li>
+              <strong>Supply Chain Technology Adoption:</strong> Applied TOE to supply chain
+              technologies, examining how supply chain position and trading partner relationships
+              (environmental factors) influence technology adoption.
+            </li>
+            <li>
+              <strong>Cloud Computing Adoption Research:</strong> Extensively applied TOE to cloud
+              computing adoption, examining how cloud characteristics (technological),
+              organizational capabilities (organizational), and competitive pressure (environmental)
+              influence adoption.
+            </li>
+            <li>
+              <strong>Innovation Implementation Research:</strong> Extended TOE by examining
+              implementation factors determining whether technology adoption results in realized
+              benefits.
+            </li>
+            <li>
+              <strong>Behavioral Technology Adoption Models:</strong> Integrated behavioral
+              economics, psychology, and technology adoption, examining how individual and group
+              behaviors mediate contextual effects on adoption.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
-            <li>
-              Tornatzky, L. G., Fleischer, M., &amp; Chakrabarti, A. K. (1990).{' '}
-              <em>The processes of technological innovation.</em> Lexington Books.
+            <li id="ref-tornatzky-1990">
+              Tornatzky, L. G., &amp; Fleischer, M. (1990).{' '}
+              <em>The processes of technological innovation</em>. Lexington Books. ISBN:
+              978-0-669-20348-6
             </li>
-            <li>
-              Rogers, E. M. (1983). <em>Diffusion of innovations</em> (3rd ed.). Free Press.
+            <li id="ref-davis-1989">
+              Davis, F. D. (1989). Perceived usefulness, perceived ease of use, and user acceptance
+              of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-davis-1989-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>{' '}
+                <a
+                  href="#cite-ref-davis-1989-2"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 2"
+                >
+                  ↩
+                </a>
+              </span>{' '}
+              https://doi.org/10.2307/249008
             </li>
-            <li>
-              Zhu, K., Kraemer, K., &amp; Xu, S. (2003). Electronic business adoption by European
-              firms: A cross-country assessment of the facilitators and inhibitors.{' '}
-              <em>European Journal of Information Systems, 12</em>(4), 251-268.
+            <li id="ref-thompson-1967">
+              Thompson, J. D. (1967). <em>Organizations in action</em>. McGraw-Hill.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-thompson-1967-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
             </li>
-            <li>
-              Pan, M. J., &amp; Jang, W. Y. (2008). Determinants of the adoption of enterprise
-              resource planning within the technology-organization-environment framework:
-              Taiwan&rsquo;s communications industry.{' '}
-              <em>Journal of Computer Information Systems, 48</em>(3), 94-102.
+            <li id="ref-lawrence-1967">
+              Lawrence, P. R., &amp; Lorsch, J. W. (1967).{' '}
+              <em>Organization and environment: Managing differentiation and integration</em>.
+              Harvard Business School Press.
             </li>
-            <li>
-              Baker, J. (2012). The technology-organization-environment framework. In Y. K. Dwivedi
-              et al. (Eds.), <em>Information systems theory</em> (pp. 231-245). Springer.{' '}
-              <a
-                href="https://doi.org/10.1007/978-1-4419-6108-2_12"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.1007/978-1-4419-6108-2_12
-              </a>
+            <li id="ref-burns-1961">
+              Burns, T., &amp; Stalker, G. M. (1961). <em>The management of innovation</em>.
+              Tavistock Publications.
             </li>
-            <li>
-              Thompson, J. D. (1967).{' '}
-              <em>Organizations in action: Social science bases of administrative theory.</em>{' '}
-              McGraw-Hill.
+            <li id="ref-zaltman-1973">
+              Zaltman, G., Duncan, R., &amp; Holbeck, J. (1973).{' '}
+              <em>Innovations and organizations</em>. John Wiley &amp; Sons.
+            </li>
+            <li id="ref-dess-1984">
+              Dess, G. G., &amp; Beard, D. W. (1984). Dimensions of organizational task
+              environments.
+              <em>Administrative Science Quarterly</em>, 29(1), 52-73.
+            </li>
+            <li id="ref-venkatesh-2000">
+              Venkatesh, V., &amp; Davis, F. D. (2000). A theoretical extension of the technology
+              acceptance model: Four longitudinal field studies. <em>Management Science</em>, 46(2),
+              186-204.
+            </li>
+            <li id="ref-pierce-1977">
+              Pierce, J. L., &amp; Delbecq, A. L. (1977). Organization structure, individual
+              attitudes and innovation. <em>Academy of Management Review</em>, 2(1), 27-37.
             </li>
           </ol>
         </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-rogers-1983">
+              Rogers, E. M. (1983). <em>Diffusion of innovations</em> (3rd ed.). Free Press.
+            </li>
+            <li id="ref-barney-1991">
+              Barney, J. B. (1991). Firm resources and sustained competitive advantage.
+              <em>Journal of Management</em>, 17(1), 99-120.
+              https://doi.org/10.1177/014920639101700108
+            </li>
+            <li id="ref-frambach-2002">
+              Frambach, R. T., &amp; Schillewaert, N. (2002). Organizational innovation adoption: A
+              multi-level framework of determinants and opportunities for future research.
+              <em>Journal of Business Research</em>, 55(2), 163-176.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-5-capability-maturity-model-cmm-humphrey-1989"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Capability Maturity Model (CMM) (Humphrey, 1989)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-7-it-implementation-research-cooper-zmud-1990"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: IT Implementation Research (Cooper &amp; Zmud, 1990) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>
   )
 }
 
-export default TOEFrameworkPage
+export default BibliographyArticlePage

--- a/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
+++ b/src/app/bibliography-2-6-toe-framework-tornatzky-1990/page.tsx
@@ -69,6 +69,9 @@ const BibliographyArticlePage = () => {
               <strong>Book Format:</strong> Scholarly monograph synthesizing prior research on
               technological innovation
             </p>
+            <p>
+              <strong>ISBN:</strong> 978-0-669-20348-6
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -594,9 +594,9 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Helped launch the BPR movement:</strong> Davenport &amp; Short&rsquo;s 1990
-              article is commonly cited alongside Hammer&rsquo;s 1990 HBR article and Hammer
-              &amp; Champy (1993) as a founding text of the Business Process Reengineering
-              movement that was widely influential through the 1990s and 2000s.
+              article is commonly cited alongside Hammer&rsquo;s 1990 HBR article and Hammer &amp;
+              Champy (1993) as a founding text of the Business Process Reengineering movement that
+              was widely influential through the 1990s and 2000s.
             </li>
             <li>
               <strong>Provided a practical methodology:</strong> Offered a five-step process
@@ -630,10 +630,9 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            As a conceptual framework paper illustrated through case study examples,
-            Davenport &amp; Short&rsquo;s BPR is not subject to construct-validity testing in the
-            psychometric sense. Considerations typically raised about its internal consistency
-            include:
+            As a conceptual framework paper illustrated through case study examples, Davenport &amp;
+            Short&rsquo;s BPR is not subject to construct-validity testing in the psychometric
+            sense. Considerations typically raised about its internal consistency include:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 2-6 TOE Framework (Tornatzky & Fleischer, 1990) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1580
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)