### PR TITLE
docs: standardize bibliography 2-8 Business Process Redesign (Davenport & Short, 1990)

### DIFF
--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -588,18 +588,19 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Challenged automation paradigm:</strong> Established critical insight that
-              organizations should not automate existing processes but should fundamentally redesign
-              processes using information technology capabilities.
+              <strong>Challenged automation paradigm:</strong> Articulated the argument that
+              organizations should not simply automate existing processes but should redesign them
+              in light of information technology capabilities.
             </li>
             <li>
-              <strong>Established BPR movement:</strong> Co-founded Business Process Reengineering
-              movement (with Hammer, 1993) that became major organizational transformation approach
-              through 1990s and 2000s.
+              <strong>Helped launch the BPR movement:</strong> Davenport &amp; Short&rsquo;s 1990
+              article is commonly cited alongside Hammer&rsquo;s 1990 HBR article and Hammer
+              &amp; Champy (1993) as a founding text of the Business Process Reengineering
+              movement that was widely influential through the 1990s and 2000s.
             </li>
             <li>
-              <strong>Provided practical methodology:</strong> Established five-step process
-              redesign methodology enabling practitioners to conduct systematic process
+              <strong>Provided a practical methodology:</strong> Offered a five-step process
+              redesign methodology that practitioners could apply to systematic process
               transformation.
             </li>
             <li>
@@ -608,9 +609,10 @@ const BibliographyArticlePage = () => {
               decision-support systems, process automation.
             </li>
             <li>
-              <strong>Emphasized radical improvement potential:</strong> Established that
-              information technology could enable dramatic performance improvements when used to
-              fundamentally redesign processes rather than merely automate existing work.
+              <strong>Emphasized radical improvement potential:</strong> Argued that information
+              technology could enable substantial performance improvement when used to redesign
+              processes rather than automate existing ones, framing the argument with
+              author-selected case examples.
             </li>
             <li>
               <strong>Integrated technology and organizational change:</strong> Recognized that
@@ -628,9 +630,10 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
-            As a conceptual framework paper based on case study examples from organizational
-            practice, Business Process Redesign demonstrates strong internal validity through
-            logical coherence and consistency with organizational experience:
+            As a conceptual framework paper illustrated through case study examples,
+            Davenport &amp; Short&rsquo;s BPR is not subject to construct-validity testing in the
+            psychometric sense. Considerations typically raised about its internal consistency
+            include:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
@@ -830,8 +833,9 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Business Process Redesign spawned significant research on process transformation and
-            organizational change:
+            Davenport &amp; Short&rsquo;s BPR sits at the start of a broader stream of process
+            transformation and organizational change work that developed through the 1990s and
+            beyond. Frameworks commonly discussed alongside or after it include:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
@@ -1019,6 +1023,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Business Process Redesign - Davenport & Short (1990)',
+  title: 'Bibliography: Business Process Redesign (BPR) - Davenport & Short (1990)',
   description:
     'Comprehensive overview of Business Process Redesign (BPR) methodology. Explains how information technology enables fundamental redesign of business processes for competitive advantage.',
 }
@@ -21,7 +21,9 @@ const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Business Process Redesign - Davenport &amp; Short (1990)</h1>
+        <h1 className={H1_CLASSES}>
+          Business Process Redesign (BPR) - Davenport &amp; Short (1990)
+        </h1>
 
         {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -75,6 +75,17 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 11-27
             </p>
+            <p>
+              <strong>URL:</strong>{' '}
+              <a
+                href="https://www.proquest.com/docview/1302990349"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                https://www.proquest.com/docview/1302990349
+              </a>
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -4,410 +4,1024 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
-  REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Business Process Redesign (BPR) - Davenport & Short (1990)',
+  title: 'Bibliography: Business Process Redesign - Davenport & Short (1990)',
   description:
-    'An exploration of the Business Process Redesign framework by Davenport and Short, which established how information technology enables radical redesign of core business processes for competitive advantage.',
+    'Comprehensive overview of Business Process Redesign (BPR) methodology. Explains how information technology enables fundamental redesign of business processes for competitive advantage.',
 }
 
-const DavenportShortBPRPage = () => {
+const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>
-          Business Process Redesign (BPR) - Davenport &amp; Short (1990)
-        </h1>
+        <h1 className={H1_CLASSES}>Business Process Redesign - Davenport &amp; Short (1990)</h1>
 
-        {/* Framework Identification */}
+        {/* 1. Framework Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Framework Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Framework Name:</strong> Business Process Redesign (BPR)
+              <strong>Framework Name:</strong> Business Process Redesign
             </p>
             <p>
-              <strong>Authors:</strong> Thomas H. Davenport and James E. Short
+              <strong>Framework Abbreviation:</strong> BPR
             </p>
             <p>
-              <strong>Publication Date:</strong> 1990
+              <strong>Alternative Names:</strong> Business Process Reengineering, The New Industrial
+              Engineering
+            </p>
+            <p>
+              <strong>Target of Framework:</strong> Explanation of how organizations use information
+              technology not to incrementally improve existing business processes but to
+              fundamentally reimagine and restructure processes for substantial improvements in
+              performance, cost, quality, and speed
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Management Information Systems, Operations
+              Management, Strategic Management, Industrial Engineering
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Authors:</strong> Thomas H. Davenport, James E. Short
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 1990
+            </p>
+            <p>
+              <strong>Official Title:</strong> The new industrial engineering: Information
+              technology and business process redesign
+            </p>
+            <p>
+              <strong>Journal:</strong> Sloan Management Review
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 31, No. 4
+            </p>
+            <p>
+              <strong>Pages:</strong> 11-27
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Davenport, T. H., &amp; Short, J. E. (
+                <a href="#ref-davenport-1990" className="text-tabs-teal-deep hover:underline">
+                  1990
+                </a>
+                ). The new industrial engineering: Information technology and business process
+                redesign. <em>Sloan Management Review</em>, 31(4), 11-27.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Davenport, Thomas H., and James E. Short. 1990. &ldquo;The New Industrial
+                Engineering: Information Technology and Business Process Redesign.&rdquo;
+                <em>Sloan Management Review</em> 31, no. 4: 11-27.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* 4. Why Was the Model Created? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            During the 1980s, information technology investments were accelerating dramatically.
+            Organizations were spending billions on computer systems, enterprise software, and IT
+            infrastructure. Yet many organizations were disappointed with returns on technology
+            investment. Systems often automated existing processes without delivering the
+            transformational performance improvements technology promised. A manufacturing company
+            installed a new inventory system but failed to achieve expected cost savings. A bank
+            deployed sophisticated technology but experienced minimal improvement in customer
+            service or operational efficiency. Financial services firms invested heavily in IT yet
+            competed primarily on cost and service quality rather than technological capability.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            Davenport and Short recognized a fundamental problem: organizations were using
+            technology to automate existing processes rather than to enable fundamentally different
+            ways of operating. Industrial engineering had historically focused on optimizing and
+            efficiency-improving existing processes. Modern IT offered much greater potential: the
+            ability to reimagine processes from first principles, create entirely new ways of
+            operating, and transform organizational competitiveness. Yet organizations were
+            squandering this potential by treating technology as tool for incrementally improving
+            legacy processes rather than as enabler of fundamental redesign.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            The authors argued that the industrial engineering paradigm itself required reimagining.
+            Classical industrial engineering sought to optimize existing processes through time and
+            motion studies, efficiency improvements, and waste reduction. Information technology
+            offered capability to fundamentally redesign processes from first principles:
+            questioning why work was performed in current manner, whether all steps were necessary,
+            and how information technology could enable entirely different operational approaches.
+            Davenport and Short sought to establish Business Process Redesign framework providing
+            conceptual approach and practical methodology for organizations to reimagine processes
+            rather than merely automate them.
+          </p>
+        </section>
+
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Business Process Redesign centers on fundamental concepts about how organizations can
+            transform performance through technology-enabled process change:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Business Process:</strong> Set of logically related tasks performed to
+              accomplish specific business objective. Processes span organizational boundaries,
+              involve multiple functions, and produce customer value. Examples include order
+              processing, product development, customer service, financial reporting.
+            </li>
+            <li>
+              <strong>Process Redesign:</strong> Fundamental rethinking and radical redesign of
+              business processes to achieve dramatic improvements in critical performance measures
+              such as cost, quality, service, and speed. Redesign is not incremental process
+              improvement but rather fundamental reconceptualization of how work is performed.
+            </li>
+            <li>
+              <strong>Information Technology Enabler:</strong> Technology capability that enables
+              process design alternatives previously impossible. Examples include shared databases
+              enabling single entry of information used by multiple functions, communication systems
+              enabling remote collaboration, decision-support systems enabling front-line employees
+              to make complex decisions.
+            </li>
+            <li>
+              <strong>Radical Improvement:</strong> Not incremental improvement of 5-10% but rather
+              dramatic performance improvement of 50% or greater. BPR pursues breakthrough
+              improvements rather than incremental optimization.
+            </li>
+            <li>
+              <strong>Cross-functional Process:</strong> Processes spanning multiple organizational
+              functions or departments rather than contained within single function. Redesign often
+              involves restructuring how functions interact and work together.
+            </li>
+            <li>
+              <strong>Information Flow:</strong> The way information moves through organizations and
+              processes. Information technology often enables different information distribution
+              patterns and decision-making approaches.
+            </li>
+            <li>
+              <strong>Customer Value:</strong> Benefits created for customers through organizational
+              processes. Redesign should enhance customer value through improved quality,
+              responsiveness, or reduced cost passed to customers.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Business Process Redesign synthesized insights from prior process improvement and
+            information technology management research:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Industrial Engineering and Scientific Management (
+                <a
+                  id="cite-ref-taylor-1911-1"
+                  href="#ref-taylor-1911"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Taylor, 1911
+                </a>
+                ; Gilbreth, 1911):
+              </strong>{' '}
+              Established tradition of analyzing work processes for efficiency improvement through
+              time and motion studies. BPR extended this tradition by applying information
+              technology to enable more radical process transformation beyond classical industrial
+              engineering optimization.
+            </li>
+            <li>
+              <strong>
+                Quality Management and Continuous Improvement (
+                <a
+                  id="cite-ref-deming-1982-1"
+                  href="#ref-deming-1982"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Deming, 1982
+                </a>
+                ; Juran, 1988; Ishikawa, 1985):
+              </strong>{' '}
+              Established continuous improvement mindset and quality management discipline. While
+              continuous improvement seeks incremental improvement, BPR complemented continuous
+              improvement by enabling breakthrough improvements.
+            </li>
+            <li>
+              <strong>
+                Information Technology Management and Strategic IS (
+                <a
+                  id="cite-ref-porter-1985-1"
+                  href="#ref-porter-1985"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Porter &amp; Millar, 1985
+                </a>
+                ; Rockart &amp; Treacy, 1982):
+              </strong>{' '}
+              Established concept that information technology could provide strategic competitive
+              advantage through enabling new business models and process capabilities.
+            </li>
+            <li>
+              <strong>
+                Organizational Design Theory (
+                <a
+                  id="cite-ref-mintzberg-1979-1"
+                  href="#ref-mintzberg-1979"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Mintzberg, 1979
+                </a>
+                ; Galbraith, 1977):
+              </strong>{' '}
+              Examined how organizational structures, information systems, and decision mechanisms
+              determine organizational performance. BPR incorporated organizational design insights
+              by examining how redesigned processes require aligned organizational structures.
+            </li>
+            <li>
+              <strong>
+                Change Management Theory (
+                <a
+                  id="cite-ref-lewin-1947-1"
+                  href="#ref-lewin-1947"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Lewin, 1947
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-kotter-1995-1"
+                  href="#ref-kotter-1995"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Kotter, 1995
+                </a>
+                ):
+              </strong>{' '}
+              Established change management principles for organizational transformation. BPR
+              emphasized that process redesign requires managing significant organizational change.
+            </li>
+            <li>
+              <strong>
+                Systems Thinking (von Bertalanffy, 1968;{' '}
+                <a
+                  id="cite-ref-senge-1990-1"
+                  href="#ref-senge-1990"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Senge, 1990
+                </a>
+                ):
+              </strong>{' '}
+              Emphasized understanding organizations as systems with interconnected components. BPR
+              incorporated systems perspective by recognizing process interconnections and avoiding
+              isolated process improvements.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Business Process Redesign provides framework for organizations to fundamentally
+            reimagine business processes using information technology enablers to achieve dramatic
+            performance improvements. Rather than viewing information technology as tool for
+            automating existing work, BPR views technology as enabler of fundamentally different
+            ways of operating. The methodology involves analyzing current business processes,
+            identifying information technology opportunities, redesigning processes from first
+            principles, and implementing redesigned processes.
+          </p>
+
+          <h3 className={H3_CLASSES}>Core Methodology: Five Steps</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Step 1: Develop Business Vision and Process Objectives:</strong> Establish
+              compelling organizational vision and specific process performance objectives. Define
+              what success looks like. What customer needs are most important? What performance
+              improvements are critical? Does the organization seek cost reduction, quality
+              improvement, speed enhancement, or improved customer service? Vision provides
+              direction and motivation for fundamental redesign effort.
+            </li>
+            <li>
+              <strong>Step 2: Identify Processes to Redesign:</strong> Prioritize processes for
+              redesign based on strategic importance, improvement potential, and feasibility. Which
+              processes most directly support competitive strategy? Which processes offer greatest
+              improvement opportunity? Which processes are best suited for redesign? Focus limited
+              redesign resources on highest-impact processes.
+            </li>
+            <li>
+              <strong>Step 3: Understand Existing Processes:</strong> Thoroughly understand current
+              process performance, activities, information flows, and organizational involvement.
+              Document how work currently gets done: what steps are involved? Who performs what
+              activities? Where are bottlenecks? What information is created and used? Understanding
+              current state is essential baseline for radical redesign.
+            </li>
+            <li>
+              <strong>
+                Step 4: Identify Information Technology Levers and Redesign Possibilities:
+              </strong>{' '}
+              Identify information technology capabilities that could fundamentally change how
+              processes are performed. How could databases enable single data entry shared by
+              multiple functions? How could communication technology enable remote collaboration?
+              How could decision-support systems enable different decision-making? How could
+              technology eliminate non-value-adding process steps? Technology capabilities inspire
+              process redesign possibilities.
+            </li>
+            <li>
+              <strong>Step 5: Design and Prototype New Process:</strong> Design fundamentally
+              redesigned process using identified technology levers. What would ideal process look
+              like unconstrained by legacy practices? Prototype new process with limited
+              implementation to test and refine design. Evaluate redesigned process impact on
+              customers, employees, and organizational performance before organization-wide
+              implementation.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Key Technology Enablers</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Shared Information Databases:</strong> Enable single data entry shared by
+              multiple functions. Instead of each function maintaining separate data requiring
+              reconciliation, shared databases enable real-time access to consistent information
+              across organization.
+            </li>
+            <li>
+              <strong>Telecommunication and Remote Collaboration Technology:</strong> Enable work to
+              be performed from any location. Instead of requiring co-location or sequential process
+              steps, technology enables distributed, parallel work streams.
+            </li>
+            <li>
+              <strong>Decision-Support and Expert Systems:</strong> Enable front-line employees to
+              make complex decisions without escalation to management. Instead of decisions routing
+              through management hierarchy, technology provides information and decision support
+              enabling front-line decision authority.
+            </li>
+            <li>
+              <strong>Transaction Processing Systems:</strong> Enable rapid, error-free transaction
+              processing. Instead of manual transaction processing requiring multiple verification
+              steps, technology enables high-volume transaction processing with minimal human
+              involvement.
+            </li>
+            <li>
+              <strong>Workflow and Process Automation Systems:</strong> Enable automated process
+              step sequencing and task routing. Instead of manual coordination of process steps,
+              technology routes work based on rules and business logic.
+            </li>
+            <li>
+              <strong>Data Analytics and Business Intelligence:</strong> Enable analytical
+              decision-making based on operational data. Instead of decisions based on incomplete
+              information, technology provides comprehensive data analysis enabling better
+              decisions.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Expected Process Characteristics After Redesign</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Unified information and decision-making:</strong> Single information systems
+              shared across organizational functions. Decisions based on comprehensive, real-time
+              organizational information rather than fragmented departmental data.
+            </li>
+            <li>
+              <strong>Increased process autonomy:</strong> Front-line employees empowered to make
+              decisions and control process flow. Fewer escalation levels and management layers
+              required for decision authority.
+            </li>
+            <li>
+              <strong>Parallel process activities:</strong> Process steps performed in parallel
+              rather than sequential, reducing total process time. Work streams enable simultaneous
+              activities instead of waiting for completion of previous steps.
+            </li>
+            <li>
+              <strong>Reduced non-value-added activities:</strong> Elimination of verification,
+              reconciliation, and administrative steps that do not directly create customer value.
+            </li>
+            <li>
+              <strong>Integration across organizational boundaries:</strong> Process spanning
+              multiple functions operating as unified system rather than separate departments with
+              handoffs.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Illustrative Examples</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Davenport and Short provided case examples of Business Process Redesign in action. At
+            Ford Motor Company, accounts payable processing was transformed using process redesign.
+            The original process involved multiple departments: accounts payable received supplier
+            invoices, purchase orders department provided purchase order information, goods
+            receiving reported receipt of goods, and payment processing verified that invoice
+            matched purchase order and goods receipt before payment. This three-way matching
+            involved significant coordination, verification, and administrative effort. Ford&rsquo;s
+            redesign eliminated the invoice step entirely: when goods were received, goods receiving
+            entered information into shared database, and payment was automatically initiated based
+            on matching purchase order and goods receipt. Elimination of the invoice and the
+            three-way matching verification reduced costs and accelerated payment processing.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            At Mutual Benefit Life Insurance Company, the life insurance application process was
+            redesigned. The original process involved sequential steps: application processing,
+            underwriting assessment, medical review, financial review, and approval. The process
+            required 20-30 days and involved handoffs between multiple departments. Redesign
+            identified information technology opportunity: enable case workers to access all
+            required information systems and make end-to-end decisions. Instead of specialized
+            underwriters, medical reviewers, and financial analysts making sequential decisions,
+            trained case workers could access decision-support systems providing underwriting
+            guidance, medical information access, and financial analysis. Single case worker could
+            complete entire application process in 4-5 days instead of 20-30 days.
+          </p>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Challenges automation mind-set:</strong> Established critical insight that
+              information technology should enable fundamentally different processes, not merely
+              automate existing processes.
+            </li>
+            <li>
+              <strong>Ambitious performance improvements:</strong> Pursues breakthrough improvements
+              rather than incremental optimization, justifying significant investment and
+              organizational change.
+            </li>
+            <li>
+              <strong>Customer-centric approach:</strong> Emphasizes improving customer value and
+              customer experience rather than merely reducing internal costs.
+            </li>
+            <li>
+              <strong>Cross-functional perspective:</strong> Recognizes that many business processes
+              span multiple organizational functions and require integration rather than
+              function-isolated improvement.
+            </li>
+            <li>
+              <strong>Practical methodology:</strong> Provides five-step framework enabling
+              practitioners to conduct process redesign.
+            </li>
+            <li>
+              <strong>Technology-enabled possibilities:</strong> Identifies specific technology
+              capabilities enabling process alternatives.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Implementation difficulty often understated:</strong> While process redesign
+              methodology seems straightforward, actual implementation frequently encounters
+              organizational resistance, technical challenges, and unintended consequences.
+            </li>
+            <li>
+              <strong>High failure rate:</strong> Subsequent research found many Business Process
+              Redesign initiatives failed to achieve promised benefits. Organizations often
+              encountered implementation problems, underestimated change management requirements, or
+              faced unanticipated challenges.
+            </li>
+            <li>
+              <strong>Employee displacement and morale concerns:</strong> Process redesign often
+              eliminates jobs and reduces organizational layers. While presented as performance
+              improvement, redesign frequently creates employee anxiety and organizational
+              disruption.
+            </li>
+            <li>
+              <strong>Limited attention to change management:</strong> Early BPR literature
+              emphasized process design but underemphasized organizational change management
+              required for implementation success.
+            </li>
+            <li>
+              <strong>Technology determinism:</strong> Framework emphasizes technology-enabled
+              possibilities but may overstate technology&apos;s role relative to other change
+              factors including organizational culture, leadership, and employee capability.
+            </li>
+            <li>
+              <strong>Measurement challenges:</strong> While framework promises breakthrough
+              improvements, measuring actual performance improvement and identifying sustainable
+              benefits remains challenging.
+            </li>
+            <li>
+              <strong>Short-term cost focus:</strong> Some BPR initiatives focused narrowly on
+              short-term cost reduction rather than long-term competitive advantage, resulting in
+              damaged organizational capabilities or customer relationships.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Challenged automation paradigm:</strong> Established critical insight that
+              organizations should not automate existing processes but should fundamentally redesign
+              processes using information technology capabilities.
+            </li>
+            <li>
+              <strong>Established BPR movement:</strong> Co-founded Business Process Reengineering
+              movement (with Hammer, 1993) that became major organizational transformation approach
+              through 1990s and 2000s.
+            </li>
+            <li>
+              <strong>Provided practical methodology:</strong> Established five-step process
+              redesign methodology enabling practitioners to conduct systematic process
+              transformation.
+            </li>
+            <li>
+              <strong>Identified key technology enablers:</strong> Specified information technology
+              capabilities enabling process redesign: shared databases, communication technology,
+              decision-support systems, process automation.
+            </li>
+            <li>
+              <strong>Emphasized radical improvement potential:</strong> Established that
+              information technology could enable dramatic performance improvements when used to
+              fundamentally redesign processes rather than merely automate existing work.
+            </li>
+            <li>
+              <strong>Integrated technology and organizational change:</strong> Recognized that
+              process redesign requires both technology implementation and organizational change
+              management.
+            </li>
+            <li>
+              <strong>Customer-centric reframing:</strong> Shifted focus from internal cost
+              reduction to customer value creation and customer experience improvement.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            As a conceptual framework paper based on case study examples from organizational
+            practice, Business Process Redesign demonstrates strong internal validity through
+            logical coherence and consistency with organizational experience:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Synthesis of observed best practices:</strong> The framework synthesizes
+              successful process redesign examples (Ford, Mutual Benefit Life, Otis) into coherent
+              methodology.
+            </li>
+            <li>
+              <strong>Logical coherence:</strong> The argument that information technology enables
+              fundamentally different process designs is logically sound. Technology capabilities
+              can eliminate non-value-adding steps, enable parallel activities, and distribute
+              decision authority.
+            </li>
+            <li>
+              <strong>Integration with organizational theory:</strong> The framework incorporates
+              established organizational design and change management insights about how
+              organizational structures, information systems, and decision mechanisms affect
+              organizational performance.
+            </li>
+            <li>
+              <strong>Addresses documented organizational challenges:</strong> The framework
+              explains well-documented phenomena: why organizations struggle to achieve technology
+              returns on investment when merely automating existing processes, and why some process
+              redesign initiatives achieve dramatic improvements.
+            </li>
+            <li>
+              <strong>Realistic assessment of technology potential:</strong> The framework
+              acknowledges that technology enables but does not determine process redesign. Redesign
+              requires organizational judgment about which technological capabilities align with
+              customer value and competitive strategy.
+            </li>
+            <li>
+              <strong>Comprehensive case examples:</strong> The Ford and Mutual Benefit Life
+              examples provide concrete illustration of concepts and demonstrate practical
+              feasibility.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations concern generalizability of Business Process Redesign
+            framework across diverse organizational contexts and processes:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Cross-industry application:</strong> BPR has been applied across
+              manufacturing, services, finance, insurance, healthcare, government, and other
+              industries, demonstrating broad applicability.
+            </li>
+            <li>
+              <strong>Cross-process application:</strong> While initial examples focused on
+              administrative processes, BPR has been applied to manufacturing processes, product
+              development, customer service, and numerous other process types.
+            </li>
+            <li>
+              <strong>Organizational size variation:</strong> BPR has been attempted in both large
+              enterprises and smaller organizations, though large organizations with greater
+              resources may find implementation more feasible.
+            </li>
+            <li>
+              <strong>Implementation success variation:</strong> While some BPR initiatives achieved
+              promised breakthrough improvements, many faced significant implementation challenges,
+              cost overruns, and failure to realize expected benefits.
+            </li>
+            <li>
+              <strong>Technology context evolution:</strong> The framework was developed in 1990
+              when information technology capabilities were more limited. Contemporary technology
+              (cloud computing, artificial intelligence, blockchain) may enable process alternatives
+              not envisioned in original framework.
+            </li>
+            <li>
+              <strong>Organizational culture variation:</strong> Organizations with change-averse
+              cultures may struggle to implement radical process redesign. Implementation success
+              may depend heavily on organizational readiness for change.
+            </li>
+            <li>
+              <strong>Process type constraints:</strong> Some processes may be constrained by
+              regulatory requirements, customer expectations, or operational characteristics that
+              limit redesign possibilities.
+            </li>
+            <li>
+              <strong>Change management intensity:</strong> Radical process redesign typically
+              requires more intensive change management than incremental improvement, increasing
+              implementation cost and complexity.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Business Process Redesign reframes technology adoption from selecting technology to
+            implement existing processes more efficiently into strategic question of how technology
+            enables different ways of working. Rather than asking &ldquo;How can we automate current
+            operations?&rdquo; BPR asks &ldquo;What fundamentally different ways of operating would
+            create greater value?&rdquo; This reframing shifts technology adoption focus from
+            efficiency improvement to strategic capability enhancement and competitive advantage
+            creation. Organizations adopting BPR perspective pursue adoption of technologies that
+            enable process transformation, customer value creation, and competitive differentiation
+            rather than merely reducing internal costs.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Automation paradigm thinking:</strong> Organizations default to automating
+              existing processes rather than asking how technology enables different processes.
+              Legacy thinking constrains technology utilization.
+            </li>
+            <li>
+              <strong>Function-specific viewpoint:</strong> Organizations optimize individual
+              functions separately without recognizing process integration opportunities.
+              Cross-functional perspective required for most significant process improvements
+              remains underdeveloped.
+            </li>
+            <li>
+              <strong>Limited technology imagination:</strong> Organizations lack understanding of
+              technology capabilities enabling process alternatives. Investment in technology
+              awareness and capability exploration is needed.
+            </li>
+            <li>
+              <strong>Change management underestimation:</strong> Organizations underestimate
+              organizational change requirements for radical process redesign, leading to
+              implementation problems and failed initiatives.
+            </li>
+            <li>
+              <strong>Employee resistance:</strong> Process redesign frequently eliminates jobs or
+              dramatically changes work, creating employee anxiety and organizational resistance
+              that impedes adoption.
+            </li>
+            <li>
+              <strong>Implementation complexity:</strong> Complex process redesign often encounters
+              technical difficulties, organizational obstacles, and unintended consequences
+              requiring extended implementation timelines and increased costs.
+            </li>
+            <li>
+              <strong>Customer or regulatory constraints:</strong> Some processes are constrained by
+              customer expectations, regulatory requirements, or operational characteristics that
+              limit redesign possibilities.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Framework Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Establish compelling vision:</strong> Create clear organizational vision and
+              specific process redesign objectives. Define what customer value redesign should
+              create.
+            </li>
+            <li>
+              <strong>Identify high-impact processes:</strong> Prioritize processes for redesign
+              based on strategic importance and improvement potential. Focus on processes most
+              directly supporting competitive strategy.
+            </li>
+            <li>
+              <strong>Thoroughly understand current processes:</strong> Document existing process
+              performance, activities, bottlenecks, and information flows. Understanding current
+              state is essential for identifying improvement opportunities.
+            </li>
+            <li>
+              <strong>Explore technology possibilities:</strong> Identify information technology
+              capabilities that could enable fundamentally different process designs. Invest in
+              understanding technology potential.
+            </li>
+            <li>
+              <strong>Question fundamental assumptions:</strong> Challenge conventional thinking
+              about how work must be performed. Ask why each process step is necessary and whether
+              alternatives are possible.
+            </li>
+            <li>
+              <strong>Design from first principles:</strong> Rather than incrementally modifying
+              existing processes, design fundamentally different processes unconstrained by legacy
+              practices.
+            </li>
+            <li>
+              <strong>Prototype and test:</strong> Conduct limited-scope process redesign testing
+              before organization-wide implementation. Use prototypes to test design assumptions and
+              refine approach.
+            </li>
+            <li>
+              <strong>Manage organizational change rigorously:</strong> Allocate significant effort
+              to change management, employee communication, training, and managing employee concerns
+              about job displacement.
+            </li>
+            <li>
+              <strong>Focus on customer value:</strong> Ensure redesigned processes create customer
+              value and improve customer experience, not merely reduce internal costs.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Business Process Redesign spawned significant research on process transformation and
+            organizational change:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Business Process Reengineering Expansion (Hammer &amp;{' '}
+                <Link
+                  href="/bibliography-2-9-business-process-reengineering-hammer-champy-1993"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Champy, 1993
+                </Link>
+                ):
+              </strong>{' '}
+              Extended BPR concepts and established BPR as major organizational transformation
+              movement. Hammer &amp; Champy&rsquo;s work popularized BPR and provided additional
+              case examples and implementation guidance.
+            </li>
+            <li>
+              <strong>
+                Critical BPR Implementation Research (
+                <a
+                  id="cite-ref-kettinger-1997-1"
+                  href="#ref-kettinger-1997"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Kettinger, Teng, &amp; Guha, 1997
+                </a>
+                ):
+              </strong>{' '}
+              Examined BPR implementation challenges and identified factors predicting BPR success
+              versus failure. Found many BPR initiatives failed to achieve promised benefits.
+            </li>
+            <li>
+              <strong>Process Mining and Analytics Research:</strong> Applied data analytics to
+              process understanding and optimization, enabling empirical process analysis and
+              improvement identification.
+            </li>
+            <li>
+              <strong>
+                Lean Process Improvement (
+                <a
+                  id="cite-ref-womack-1996-1"
+                  href="#ref-womack-1996"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Womack &amp; Jones, 1996
+                </a>
+                ; George &amp; George, 2003):
+              </strong>{' '}
+              Applied lean manufacturing principles to business process improvement, emphasizing
+              waste elimination and value creation.
+            </li>
+            <li>
+              <strong>
+                Process Capability Maturity (
+                <a
+                  id="cite-ref-paulk-1993-1"
+                  href="#ref-paulk-1993"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Paulk et al., 1993
+                </a>
+                ; Osterweil, 1987):
+              </strong>{' '}
+              Examined how organizations develop process management capability and maturity in
+              process execution.
+            </li>
+            <li>
+              <strong>Digital Transformation Frameworks:</strong> Extended BPR concepts to broader
+              digital transformation initiatives examining how digital technologies enable
+              organizational transformation.
+            </li>
+            <li>
+              <strong>Organizational Capability and Agility Research:</strong> Examined how
+              organizations develop capability for continuous process improvement and rapid
+              adaptation to market changes.
+            </li>
+            <li>
+              <strong>Change Management and Organizational Culture Research:</strong> Examined
+              organizational change management practices required for successful process
+              transformation initiatives.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-davenport-1990">
               Davenport, T. H., &amp; Short, J. E. (1990). The new industrial engineering:
               Information technology and business process redesign. <em>Sloan Management Review</em>
               , 31(4), 11-27.
-            </p>
-          </div>
-        </section>
-
-        <section className={SECTION_CLASSES}>
-          <p className={PARAGRAPH_CLASSES}>
-            In 1990, Thomas H. Davenport and James E. Short published &ldquo;The New Industrial
-            Engineering: Information Technology and Business Process Redesign&rdquo; in the{' '}
-            <em>Sloan Management Review</em>, introducing a framework that fundamentally reoriented
-            how organizations think about leveraging information technology. Rather than treating IT
-            as a tool for automating existing processes, Davenport and Short proposed that IT
-            enables the radical redesign of core business processes - a shift they framed as a new
-            form of industrial engineering appropriate for the information age.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The Business Process Redesign (BPR) model emerged at a moment when competitive pressures
-            were intensifying and IT capabilities were expanding beyond simple automation. The
-            authors observed that organizations routinely applied technology to existing process
-            structures rather than questioning those structures themselves. By synthesizing concepts
-            from industrial engineering, value chain analysis, and organizational theory, Davenport
-            and Short provided practitioners with a conceptual and practical framework for achieving
-            step-change improvements in cost, quality, speed, and customer service through
-            process-level redesign.
-          </p>
-
-          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Davenport and Short developed the Business Process Redesign model in response to
-            fundamental changes occurring in competitive environments and technology capabilities
-            during the late 1980s. Organizations faced mounting pressures from several directions
-            that made traditional approaches insufficient.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Competitive Pressure and Performance Challenges:</strong> Organizations operated
-            in increasingly competitive environments where rivals had restructured their operations
-            to achieve superior performance. Traditional industrial engineering had been applied
-            relatively narrowly to manufacturing, yet competitive advantage increasingly derived
-            from comprehensive business process performance - how effectively organizations managed
-            customer acquisition, product design, order fulfillment, and customer service in
-            addition to manufacturing efficiency.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Information Technology Capability Expansion:</strong> IT had evolved from
-            supporting existing processes to enabling fundamentally different ways of working. Prior
-            IT adoption had primarily focused on automating existing processes - faster, cheaper
-            operations doing the same work. Davenport and Short recognized that emerging IT
-            capabilities could support more radical redesign: information systems could capture
-            customer data comprehensively, enable communication across organizational boundaries,
-            support sophisticated decision-making, and automate complex processes previously
-            requiring significant human judgment.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Limitations of Incremental Approaches:</strong> The authors observed that
-            traditional process improvement had inherent limits. Optimizing an existing process
-            sometimes locked organizations into suboptimal configurations. If a fundamental business
-            process was poorly designed, making it more efficient merely made inefficiency faster.
-            Competitive advantage increasingly came from reconceiving and fundamentally redesigning
-            core business processes, not from incremental optimization.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Integration Opportunity:</strong> The model emerged from recognizing that IT
-            could serve as a bridge for integrating processes previously separated or poorly
-            coordinated. Complex products required coordination across functions (marketing,
-            engineering, manufacturing); customer service required integration across departments.
-            Information technology could connect these previously disconnected activities.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The model synthesized several recognitions: IT capabilities had expanded far beyond
-            simple automation; process structure fundamentally determines organizational
-            performance; organizational functions were fragmented in ways that created
-            inefficiencies; and managers needed frameworks to guide how to leverage IT for business
-            process redesign.
-          </p>
-
-          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            At the heart of the BPR model is a focus on <strong>business processes</strong> -
-            end-to-end sets of activities that together deliver value to customers or the
-            organization. Davenport and Short distinguish between core business processes (customer
-            acquisition, product design, order fulfillment, customer service) and supporting
-            processes (human resources, accounting). Core processes directly impact competitive
-            positioning and should receive priority for redesign efforts.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework identifies five types of IT-enabled process redesign, each representing a
-            distinct way technology can transform how work is performed:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Automational:</strong> Eliminating human labor from a process. Routine,
-              rule-based decisions are delegated to information systems, reducing cost and improving
-              speed.
             </li>
-            <li>
-              <strong>Informational:</strong> Capturing process information for purposes of
-              understanding. Comprehensive data availability enables better decisions and
-              performance monitoring.
-            </li>
-            <li>
-              <strong>Sequential:</strong> Changing process sequence or enabling parallelism.
-              Activities previously performed in sequence can occur simultaneously when information
-              flows electronically.
-            </li>
-            <li>
-              <strong>Tracking:</strong> Monitoring process status and objects closely. Real-time
-              visibility into process state enables proactive management and rapid response to
-              exceptions.
-            </li>
-            <li>
-              <strong>Analytical:</strong> Improving analysis of information and decision-making.
-              Decision support tools and analytical models enable higher-quality decisions based on
-              comprehensive data.
-            </li>
-            <li>
-              <strong>Geographical:</strong> Coordinating processes across distances. IT enables
-              work previously requiring physical proximity to be conducted by geographically
-              distributed teams.
-            </li>
-            <li>
-              <strong>Integrative:</strong> Coordination between tasks and processes. Information
-              systems enable seamless handoffs and coordination across organizational boundaries.
-            </li>
-            <li>
-              <strong>Intellectual:</strong> Capturing and distributing intellectual assets.
-              Knowledge management capabilities enable organizational learning and expertise
-              sharing.
-            </li>
-            <li>
-              <strong>Disintermediating:</strong> Eliminating intermediaries from a process. Direct
-              connections between process participants remove unnecessary steps and improve
-              responsiveness.
-            </li>
-          </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            The authors also articulate a systematic five-step methodology for process redesign: (1)
-            develop the business vision and process objectives; (2) identify the processes to be
-            redesigned; (3) understand and measure the existing process; (4) identify IT levers
-            available; and (5) design and build a prototype of the new process.
-          </p>
-
-          <h2 className={H2_CLASSES}>Internal Validity</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Davenport and Short&rsquo;s BPR model was developed and validated through multiple
-            approaches grounded in real organizational experience.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Case Study Research and Field Experience:</strong> The model was grounded in
-            extensive case study research and consulting engagement across multiple industries. The
-            authors documented actual business process redesign initiatives, examining organizations
-            that successfully leveraged IT for process transformation, the business processes that
-            could be fundamentally redesigned, the outcomes achieved, and the challenges
-            encountered.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The paper provides detailed illustrative examples across diverse industries:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Insurance Claims Processing:</strong> Companies previously handled claims
-              through labor-intensive sequential processes. Information systems enabled redesign
-              that significantly reduced processing time by allowing representatives with
-              comprehensive system support to handle entire claims rather than sequential hand-offs.
-            </li>
-            <li>
-              <strong>Airline Reservation Systems:</strong> Airlines completely restructured
-              customer reservation processes through technology, enabling travel agents and
-              eventually customers to access real-time information and conduct transactions
-              independently.
-            </li>
-            <li>
-              <strong>Telecommunications Service Installation:</strong> Companies redesigned
-              installation processes so technicians could access complete customer information and
-              design specifications in real-time, reducing site visits and improving coordination.
-            </li>
-            <li>
-              <strong>Manufacturing Order Fulfillment:</strong> Firms redesigned order-to-delivery
-              processes by enabling front-line personnel to access inventory, engineering, and
-              manufacturing capability data to respond to customer orders immediately rather than
-              through lengthy internal consultations.
-            </li>
-          </ul>
-          <p className={PARAGRAPH_CLASSES}>
-            The consistency of redesign patterns across telecommunications, insurance, airlines, and
-            manufacturing supports the conclusion that the underlying redesign principles hold
-            generally rather than being industry-specific.
-          </p>
-
-          <h2 className={H2_CLASSES}>External Validity</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The BPR model&rsquo;s external validity was established through several mechanisms that
-            demonstrate generalizability beyond the original case contexts.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Multi-Industry Case Illustrations:</strong> The model was tested across diverse
-            industries - insurance, airlines, telecommunications, and manufacturing - suggesting
-            that business process redesign principles apply broadly. Fundamentally similar redesign
-            patterns emerging across different industries lends credibility to the model&rsquo;s
-            generalizability.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Cross-Functional Process Coverage:</strong> The case examples span diverse
-            functional areas and process types: customer-facing processes (reservations, claims
-            handling, order fulfillment), internal operational processes (manufacturing scheduling,
-            service delivery), and information-intensive processes (claims assessment, system
-            design). This breadth suggests that process redesign principles apply to diverse process
-            types rather than a narrow range.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Organizational Size Variation:</strong> The cases encompassed large
-            organizations (major airlines, large telecommunications companies) as well as mid-sized
-            firms. The applicability across different organizational sizes suggests the model is not
-            limited to particular company profiles.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>IT Technology Span:</strong> The case examples involved different IT
-            technologies - telecommunications systems, database systems, personal computers with
-            information access capabilities - demonstrating that redesign principles apply across
-            technology platforms rather than being dependent on specific systems.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <strong>Theoretical Grounding:</strong> By grounding the model in established industrial
-            engineering principles and extending them to IT-enabled contexts, the authors draw on a
-            well-established theoretical tradition. The framework&rsquo;s acknowledgment of
-            contingencies - particular process characteristics, organizational capability, IT
-            infrastructure, and market conditions - adds nuance without undermining the general
-            applicability of the core principles.
-          </p>
-
-          <h2 className={H2_CLASSES}>Key Contributions</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Davenport &amp; Short BPR model made several contributions that distinguished it
-            from prior frameworks:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Process-Centric View of Organizations:</strong> Rather than viewing
-              organizations primarily through functional hierarchies, the model reframed them as
-              collections of business processes. This shift in perspective opened new avenues for
-              identifying improvement opportunities that cut across organizational silos.
-            </li>
-            <li>
-              <strong>IT as Enabler, Not Automator:</strong> The framework explicitly distinguished
-              between automating existing processes (paving cow paths) and using IT to enable
-              fundamentally different process designs. This distinction was novel and influential.
-            </li>
-            <li>
-              <strong>Systematic Redesign Methodology:</strong> The five-step methodology provided
-              practitioners with actionable guidance for conducting process redesign projects,
-              bridging academic concepts and managerial practice.
-            </li>
-            <li>
-              <strong>Typology of IT-Enabled Change:</strong> The taxonomy of nine IT redesign roles
-              provided a structured vocabulary for describing how technology transforms work,
-              enabling more precise analysis of redesign opportunities.
-            </li>
-            <li>
-              <strong>Industrial Engineering Heritage:</strong> By framing BPR as a natural
-              evolution of industrial engineering, Davenport and Short legitimized the approach
-              within established business disciplines while extending it to the information age.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            The Davenport &amp; Short BPR framework carries direct and enduring relevance for
-            understanding organizational technology adoption. It fundamentally reframes what it
-            means to &ldquo;adopt&rdquo; technology: successful adoption is not simply purchasing
-            and deploying a system, but rethinking how work should be performed and then designing
-            technology-enabled processes to realize that vision.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The model&rsquo;s emphasis on beginning with business objectives rather than technology
-            capabilities is particularly instructive. Organizations that start by asking &ldquo;what
-            does our IT system support?&rdquo; will likely automate existing inefficiencies.
-            Organizations that start by asking &ldquo;what should this process accomplish for
-            customers and the organization?&rdquo; and then determine technology requirements are
-            positioned to achieve genuine transformation.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The framework also highlights that technology adoption barriers often reside in
-            organizational and process structure rather than technology itself. A new system
-            implemented within a fragmented, sequential process may deliver minimal value. The same
-            technology implemented to enable an integrated, parallel process can deliver dramatic
-            improvements. This insight directs attention to organizational redesign as a
-            prerequisite for technology value realization.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            The BPR model&rsquo;s emphasis on change management-establishing transition
-            infrastructure, communicating honestly, and preparing people for new ways of
-            working-anticipates findings from subsequent technology adoption research showing that
-            human and organizational factors consistently explain more variance in adoption outcomes
-            than technical factors.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <em>
-              Note: This article provides an overview based on the comprehensive literature review.
-              Readers are encouraged to consult the original publication for complete details.
-            </em>
-          </p>
-        </section>
-
-        <section className="pt-8 border-t border-gray-200">
-          <h2 className={REFERENCES_H2_CLASSES}>References</h2>
-          <ol className={REFERENCES_OL_CLASSES}>
-            {/* prettier-ignore */}
-            <li>Davenport, T. H., &amp; Short, J. E. (1990). The new industrial engineering: Information technology and business process redesign. <em>Sloan Management Review</em>, 31(4), 11-27.</li>
-            <li>
-              Porter, M. E. (1985).{' '}
-              <em>Competitive advantage: Creating and sustaining superior performance</em>. Free
-              Press.
-            </li>
-            <li>
-              Hammer, M. (1990). Reengineering work: Don&rsquo;t automate, obliterate.{' '}
-              <em>Harvard Business Review</em>, 68(4), 104-112.
-            </li>
-            <li>
-              Hammer, M., &amp; Champy, J. (1993).{' '}
-              <em>Reengineering the corporation: A manifesto for business revolution</em>.
-              HarperBusiness.
-            </li>
-            <li>
-              Venkatraman, N. (1994). IT-enabled business transformation: From automation to
-              business scope redefinition. <em>Sloan Management Review</em>, 35(2), 73-87.
-            </li>
-            <li>
-              Davenport, T. H. (1993).{' '}
-              <em>Process innovation: Reengineering work through information technology</em>.
-              Harvard Business School Press.
-            </li>
-            <li>
-              Kettinger, W. J., Teng, J. T. C., &amp; Guha, S. (1997). Business process change: A
-              study of methodologies, techniques, and tools. <em>MIS Quarterly</em>, 21(1), 55-80.{' '}
-              <a
-                href="https://doi.org/10.2307/249742"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                https://doi.org/10.2307/249742
-              </a>
-            </li>
-            <li>
+            <li id="ref-taylor-1911">
               Taylor, F. W. (1911). <em>The principles of scientific management</em>. Harper &amp;
               Brothers.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-taylor-1911-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-deming-1982">
+              Deming, W. E. (1982). <em>Out of the crisis</em>. MIT Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-deming-1982-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-mintzberg-1979">
+              Mintzberg, H. (1979). <em>The structuring of organizations</em>. Prentice-Hall.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-mintzberg-1979-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-lewin-1947">
+              Lewin, K. (1947). Frontiers in group dynamics: Concept, method and reality in social
+              science. <em>Human Relations</em>, 1(1), 5-41.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-lewin-1947-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-kotter-1995">
+              Kotter, J. P. (1995). Leading change: Why transformation efforts fail.{' '}
+              <em>Harvard Business Review</em>, 73(2), 59-67.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-kotter-1995-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-paulk-1993">
+              Paulk, M. C., Curtis, B., Chrissis, M. B., &amp; Weber, C. V. (1993). Capability
+              maturity model for software. <em>CMU/SEI-93-TR-024</em>.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-paulk-1993-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>{' '}
+              https://doi.org/10.1109/52.219617
+            </li>
+            <li id="ref-senge-1990">
+              Senge, P. M. (1990).{' '}
+              <em>The fifth discipline: The art &amp; practice of the learning organization</em>.
+              Doubleday/Currency.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-senge-1990-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>
+            </li>
+            <li id="ref-porter-1985">
+              Porter, M. E., &amp; Millar, V. E. (1985). How information gives you competitive
+              advantage. <em>Harvard Business Review</em>, 63(4), 149-160.
+            </li>
+            <li id="ref-kettinger-1997">
+              Kettinger, W. J., Teng, J. T., &amp; Guha, S. (1997). Business process change: A study
+              of methodologies, techniques and tools. <em>MIS Quarterly</em>, 21(1), 55-80.
+            </li>
+            <li id="ref-womack-1996">
+              Womack, J. P., &amp; Jones, D. T. (1996).{' '}
+              <em>Lean thinking: Banish waste and create value in your corporation</em>. Simon &amp;
+              Schuster.
             </li>
           </ol>
         </section>
 
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-hammer-1993">
+              Hammer, M., &amp; Champy, J. (1993). <em>Reengineering the corporation</em>.
+              HarperBusiness.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-7-it-implementation-research-cooper-zmud-1990"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: IT Implementation Research (Cooper &amp; Zmud, 1990)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-9-business-process-reengineering-hammer-champy-1993"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Business Process Reengineering (Hammer &amp; Champy, 1993) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>
   )
 }
 
-export default DavenportShortBPRPage
+export default BibliographyArticlePage

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -154,7 +154,44 @@ const BibliographyArticlePage = () => {
           </p>
         </section>
 
-        {/* 5. Core Concepts and Definitions */}
+        {/* 5. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            <strong>Source note:</strong> Davenport &amp; Short (1990) is a Sloan Management Review
+            article on business-process redesign enabled by information technology; the PDF in the
+            project&rsquo;s Zotero library is scanned (image-only), so text-level quote verification
+            on this page is limited to what is visible in page renderings. Claims below match the
+            paper&rsquo;s structure and illustrative cases but are not all direct quotations.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            Davenport &amp; Short (1990) is a conceptual framework paper, not a measurement model.
+            It does not propose scales or psychometric instruments. Its analytical contribution is:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>A definition of &ldquo;business process&rdquo;:</strong> &ldquo;A set of
+              logically related tasks performed to achieve a defined business outcome&rdquo;
+              (Davenport &amp; Short, 1990, p. 12), drawing on Pall (1987).
+            </li>
+            <li>
+              <strong>A recursive framing of IT and BPR:</strong> Figure 1 of the paper posits a
+              two-way relationship: IT capabilities can shape business-process redesign
+              possibilities, and business-process redesign can guide how IT is deployed.
+            </li>
+            <li>
+              <strong>A five-step methodology for IT-enabled process redesign</strong> (see Describe
+              the Model below).
+            </li>
+            <li>
+              <strong>Illustrative case studies:</strong> Ford accounts-payable invoice-less
+              matching; Mutual Benefit Life Insurance case worker redesign. These are worked
+              examples, not an empirical data set.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -182,9 +219,13 @@ const BibliographyArticlePage = () => {
               to make complex decisions.
             </li>
             <li>
-              <strong>Radical Improvement:</strong> Not incremental improvement of 5-10% but rather
-              dramatic performance improvement of 50% or greater. BPR pursues breakthrough
-              improvements rather than incremental optimization.
+              <strong>Substantial (not incremental) improvement:</strong> Davenport &amp; Short
+              frame BPR as enabling substantial performance improvement (cost, quality, speed,
+              service) rather than incremental optimization. The often-cited &ldquo;50% or
+              greater&rdquo; rhetoric is more strongly associated with later BPR writers (notably
+              Hammer &amp; Champy, 1993) than with the 1990 Davenport &amp; Short article; the 1990
+              article uses more measured language while still emphasizing that the goal is redesign
+              rather than automation of existing processes.
             </li>
             <li>
               <strong>Cross-functional Process:</strong> Processes spanning multiple organizational
@@ -204,7 +245,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -318,7 +359,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -542,7 +583,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -583,7 +624,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -629,7 +670,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -681,7 +722,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -785,7 +826,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -876,7 +917,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -988,7 +1029,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -515,7 +515,7 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Technology determinism:</strong> Framework emphasizes technology-enabled
-              possibilities but may overstate technology&apos;s role relative to other change
+              possibilities but may overstate technology&rsquo;s role relative to other change
               factors including organizational culture, leadership, and employee capability.
             </li>
             <li>
@@ -882,9 +882,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-taylor-1911-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-deming-1982">
@@ -894,9 +892,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-deming-1982-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-mintzberg-1979">
@@ -906,9 +902,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-mintzberg-1979-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-lewin-1947">
@@ -919,9 +913,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-lewin-1947-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-kotter-1995">
@@ -932,9 +924,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-kotter-1995-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-paulk-1993">
@@ -945,9 +935,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-paulk-1993-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>{' '}
               https://doi.org/10.1109/52.219617
             </li>
@@ -960,9 +948,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-senge-1990-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>
             </li>
             <li id="ref-porter-1985">

--- a/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
+++ b/src/app/bibliography-2-8-business-process-redesign-davenport-short-1990/page.tsx
@@ -447,13 +447,13 @@ const BibliographyArticlePage = () => {
             At Mutual Benefit Life Insurance Company, the life insurance application process was
             redesigned. The original process involved sequential steps: application processing,
             underwriting assessment, medical review, financial review, and approval. The process
-            required 20-30 days and involved handoffs between multiple departments. Redesign
+            required 5-25 days and involved handoffs between multiple departments. Redesign
             identified information technology opportunity: enable case workers to access all
             required information systems and make end-to-end decisions. Instead of specialized
             underwriters, medical reviewers, and financial analysts making sequential decisions,
             trained case workers could access decision-support systems providing underwriting
             guidance, medical information access, and financial analysis. Single case worker could
-            complete entire application process in 4-5 days instead of 20-30 days.
+            complete entire application process in 4 hours instead of 5-25 days.
           </p>
 
           <h3 className={H3_CLASSES}>Main Strengths</h3>


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary
- Standardize bibliography page 2-8 Business Process Redesign (Davenport & Short, 1990) to canonical 16-section template
- Replaces existing page.tsx with reviewed TSX draft from CRP Appendix G convergence
- Only in-text cited works in References; all other sources in Further Reading

Closes #1582
Part of #1553

## Test plan
- [ ] Page builds without errors
- [ ] 16 canonical H2 sections present in correct order
- [ ] Style constants imported from `@/lib/articleStyles`
- [ ] No em-dashes, en-dashes, or literal smart quotes
- [ ] Series Navigation section present

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)