### PR TITLE
fix: DOI Org page corrections from source review

### DIFF
--- a/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
+++ b/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
@@ -12,9 +12,9 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Diffusion of Innovations - Organizational Perspective - Rogers (1962)',
+  title: 'Bibliography: Diffusion of Innovations - Organizational Perspective - Rogers (1962/2003)',
   description:
-    "Comprehensive overview of Rogers' Diffusion of Innovations theory focused on organizational adoption lens. Covers organizational innovativeness, innovation-development process, organizational adoption stages, champions and change agents, and foundational diffusion research across 5,000+ studies.",
+    "Comprehensive overview of Rogers' Diffusion of Innovations theory (1st ed. 1962; 5th ed. 2003) focused on organizational adoption. Covers organizational innovativeness, innovation-development process, organizational adoption stages, champions and change agents, and foundational diffusion research across 5,000+ studies.",
 }
 
 const BibliographyArticlePage = () => {
@@ -915,7 +915,9 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-venkatesh-2003-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                ></a>
+                >
+                  &#8617;
+                </a>
               </span>{' '}
               https://doi.org/10.2307/30036540
             </li>
@@ -926,7 +928,9 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-kotter-1996-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                ></a>
+                >
+                  &#8617;
+                </a>
               </span>
             </li>
             <li id="ref-rogers-2003">

--- a/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
+++ b/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
@@ -4,265 +4,883 @@ import {
   ARTICLE_CLASSES,
   H1_CLASSES,
   H2_CLASSES,
+  H3_CLASSES,
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
-  REFERENCES_H2_CLASSES,
   REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Diffusion of Innovations - Organizational Perspective - Rogers (1962)',
+  title: 'Bibliography: Diffusion of Innovations (Organizational Adoption) - Rogers (1962/2003)',
   description:
-    'An exploration of Diffusion of Innovations by Everett M. Rogers (1962) from an organizational adoption perspective, examining how the five adopter categories, innovation attributes, and diffusion channels apply to enterprise and institutional technology adoption decisions.',
+    "Comprehensive overview of Rogers' Diffusion of Innovations theory focused on organizational adoption lens. Covers organizational innovativeness, innovation-development process, organizational adoption stages, champions and change agents, and foundational diffusion research across 5,000+ studies.",
 }
 
-const DiffusionOrganizationalPage = () => {
+const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
         <h1 className={H1_CLASSES}>
-          Diffusion of Innovations (Organizational Perspective) - Rogers (1962)
+          Diffusion of Innovations: Organizational Adoption Lens - Rogers (1962/2003)
         </h1>
 
-        {/* Framework Identification */}
+        {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
-          <h2 className={H2_CLASSES}>Framework Identification</h2>
+          <h2 className={H2_CLASSES}>Model Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Framework Name:</strong> Diffusion of Innovations (Organizational Perspective)
+              <strong>Model Name:</strong> Diffusion of Innovations (Organizational Adoption Focus)
+            </p>
+            <p>
+              <strong>Model Abbreviation:</strong> DOI (Organizational)
             </p>
             <p>
               <strong>Authors:</strong> Everett M. Rogers
             </p>
             <p>
-              <strong>Publication Date:</strong> 1962
+              <strong>Target of Model:</strong> The organizational adoption dimension of
+              Rogers&rsquo; Diffusion of Innovations theory, addressing how organizations adopt
+              innovations including technology, processes, practices, and products. This entry
+              focuses specifically on organizational-level adoption (Chapters 10-11 of the 5th
+              edition) rather than individual-level adoption, which is covered separately in
+              /bibliography-1-2-diffusion-of-innovations-rogers.
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Communication Studies, Organizational Behavior,
+              Innovation Management, Technology Adoption, Organizational Change, Strategic
+              Management
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Original Publication Date:</strong> 1962 (First Edition)
+            </p>
+            <p>
+              <strong>Current Version:</strong> 2003 (Fifth Edition)
+            </p>
+            <p>
+              <strong>Authors:</strong> Everett M. Rogers
+            </p>
+            <p>
+              <strong>Official Title:</strong> <em>Diffusion of Innovations</em> (5th ed.)
+            </p>
+            <p>
+              <strong>Publisher:</strong> Free Press, Simon &amp; Schuster
+            </p>
+            <p>
+              <strong>Publication Location:</strong> New York
+            </p>
+            <p>
+              <strong>Foundational Research Base:</strong> Synthesis of over 5,000 diffusion studies
+              across rural sociology, public health, marketing, communication, organizational
+              behavior, and technology adoption literatures
+            </p>
+            <p>
+              <strong>ISBN:</strong> 978-0-7432-2209-9
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Rogers, E. M. (1962). <em>Diffusion of innovations.</em> Free Press.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Rogers, E. M. (
+                <a href="#ref-rogers-2003" className="text-tabs-teal-deep hover:underline">
+                  2003
+                </a>
+                ). <em>Diffusion of innovations</em> (5th ed.). Free Press.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Rogers, Everett M. 2003. <em>Diffusion of Innovations</em>. 5th ed. Free Press.
+              </p>
+            </div>
           </div>
         </section>
 
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Everett Rogers&rsquo; <em>Diffusion of Innovations</em> (1962) is among the most cited
-            works in the social sciences, synthesizing research across agriculture, public health,
-            education, and technology to produce a general theory of how new ideas and practices
-            spread through social systems. While Rogers&rsquo; framework has been extensively
-            applied to individual technology adoption decisions - giving rise to the Technology
-            Acceptance Model and related individual-level frameworks - the original work also
-            contains a rich organizational and institutional adoption perspective that is distinct
-            from its application to individual adopters.
+            Beginning in the 1950s, Everett Rogers observed a fundamental puzzle in rural sociology
+            and development work. Development programs frequently introduced agricultural
+            innovations, public health innovations, and new technologies to rural communities and
+            organizations, yet adoption rates varied dramatically. Some innovations spread rapidly
+            and widely, while others languished despite clear advantages. Rogers wanted to
+            understand the systematic patterns underlying this variation.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            This page covers the organizational dimension of Rogers&rsquo; framework: how
-            organizations themselves act as adopter units, how organizational characteristics
-            predict adoption rates, how inter-organizational diffusion networks function, and how
-            institutional norms and change agents drive or impede technology adoption across
-            organizational populations. For the individual-level adopter perspective, see{' '}
-            <Link
-              href="/bibliography-1-2-diffusion-of-innovations-rogers"
-              className="text-blue-600 hover:underline"
-            >
-              Diffusion of Innovations (Individual Perspective)
-            </Link>
-            .
-          </p>
-
-          <h2 className={H2_CLASSES}>Organizational Adopter Categories</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Rogers applied his five-category adopter typology - Innovators, Early Adopters, Early
-            Majority, Late Majority, and Laggards - not only to individual decision- makers but to
-            organizations as collective adopter units. This organizational application has distinct
-            implications for enterprise technology adoption:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Innovator Organizations:</strong> Characterized by high risk tolerance, slack
-              resources dedicated to exploration, informal networks with other innovator
-              organizations, and leadership with cosmopolitan orientations. Often incur higher
-              adoption costs due to immature vendor ecosystems, limited third-party support, and
-              integration challenges with existing infrastructure.
-            </li>
-            <li>
-              <strong>Early Adopter Organizations:</strong> Tend to be opinion leaders within their
-              industry sector, adopting innovations after sufficient proof-of-concept exists but
-              before mainstream adoption. Often have designated innovation functions, active vendor
-              relationships, and capacity to manage adoption risk through piloting.
-            </li>
-            <li>
-              <strong>Early Majority Organizations:</strong> Adopt innovations after seeing evidence
-              from early adopters, but before the majority of peer organizations. Adoption decisions
-              are heavily influenced by industry benchmarking, peer reference cases, and analyst
-              reports. The Early Majority represents the &ldquo;chasm&rdquo; that many technologies
-              must cross to achieve mainstream enterprise adoption.
-            </li>
-            <li>
-              <strong>Late Majority Organizations:</strong> Adopt out of competitive necessity or
-              external pressure (regulatory, customer, partner requirements) rather than proactive
-              opportunity pursuit. Adoption often driven by cost reduction rather than
-              differentiation. Vendor relationships characterized by risk aversion and preference
-              for turnkey solutions.
-            </li>
-            <li>
-              <strong>Laggard Organizations:</strong> Adopt only when older alternatives are no
-              longer viable. Often constrained by legacy infrastructure, limited change management
-              capacity, or cultural resistance embedded in organizational identity. Frequently
-              encounter the highest adoption barriers due to accumulated technical debt and
-              organizational inertia.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Innovation Attributes at the Organizational Level</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Rogers identified five innovation attributes that predict adoption rates. These
-            attributes operate differently at the organizational level compared to the individual
-            level:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Relative Advantage (Organizational):</strong> Organizations evaluate relative
-              advantage through total cost of ownership analyses, competitive benchmarking, and
-              return-on-investment projections rather than individual utility assessments. The
-              organizational evaluation incorporates not just efficiency gains but strategic
-              positioning, vendor viability, and integration costs.
-            </li>
-            <li>
-              <strong>Compatibility (Organizational):</strong> Organizational compatibility
-              encompasses technical integration with existing IT architecture, alignment with
-              existing business processes, fit with regulatory and compliance requirements, and
-              consistency with organizational culture and change management capacity.
-            </li>
-            <li>
-              <strong>Complexity (Organizational):</strong> At the organizational level, complexity
-              incorporates implementation complexity (project management, change management,
-              training), operational complexity (ongoing management requirements), and integration
-              complexity (interfaces with other enterprise systems).
-            </li>
-            <li>
-              <strong>Trialability (Organizational):</strong> Organizations can trial innovations
-              through pilot programs, proof-of-concept deployments, and sandbox environments.
-              Vendors who provide low-cost piloting options reduce adoption barriers significantly
-              by lowering organizational commitment thresholds for initial evaluation.
-            </li>
-            <li>
-              <strong>Observability (Organizational):</strong> Organizations observe adoption
-              outcomes through industry reports, peer networking, analyst research, and vendor case
-              studies. The Gartner Hype Cycle is itself an institutional mechanism for making
-              organizational adoption outcomes observable across a technology&rsquo;s maturity
-              trajectory.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Organizational Change Agents and Opinion Leaders</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Rogers&rsquo; framework assigns critical roles to change agents and opinion leaders in
-            the diffusion process. At the organizational level, these roles are institutionalized in
-            specific functions and relationships:
-          </p>
-          <ul className={BODY_LIST_CLASSES}>
-            <li>
-              <strong>Internal Change Agents:</strong> CIOs, digital transformation leaders, and
-              innovation champions within organizations function as Rogers&rsquo; change agents,
-              bridging the gap between available technology innovations and organizational readiness
-              to adopt. Their effectiveness depends on credibility with both technical and business
-              stakeholders.
-            </li>
-            <li>
-              <strong>External Change Agents:</strong> Management consultants, systems integrators,
-              and technology advisors function as inter-organizational change agents, accelerating
-              diffusion by transferring adoption knowledge, reference cases, and implementation
-              expertise from early adopter organizations to the Early and Late Majority.
-            </li>
-            <li>
-              <strong>Industry Opinion Leaders:</strong> Organizations recognized as technology
-              leaders in their sector influence adoption decisions across the industry. Peer
-              organizations monitor their technology investments and treat adoption announcements as
-              adoption endorsements.
-            </li>
-            <li>
-              <strong>Standards Bodies and Regulators:</strong> Rogers recognized that formal
-              authority can accelerate or mandate diffusion. Regulatory requirements, industry
-              standards, and compliance frameworks function as institutional change agents that
-              drive adoption across organizational populations regardless of individual
-              organizational readiness.
-            </li>
-          </ul>
-
-          <h2 className={H2_CLASSES}>Relevance to Technology Adoption Barriers Research</h2>
-          <p className={PARAGRAPH_CLASSES}>
-            Rogers&rsquo; organizational adoption perspective provides foundational theory for
-            understanding why technology adoption barriers are systematically distributed across the
-            organizational population. Barriers are not uniformly distributed; they cluster around
-            specific adopter category transitions. The chasm between Early Adopters and the Early
-            Majority represents the most challenging barrier zone in enterprise technology adoption,
-            where technologies must overcome organizational risk aversion, achieve sufficient
-            reference cases, develop mature vendor ecosystems, and demonstrate sustained value
-            rather than promise.
+            Rogers recognized that existing theoretical frameworks treated adoption as either an
+            immediate rational economic decision or a random process. Neither perspective explained
+            observed adoption patterns. Rogers hypothesized that adoption follows a predictable
+            social process influenced by individual characteristics, innovation characteristics,
+            communication channels, time, and social system structure. Rather than treating adoption
+            as a binary event, Rogers proposed studying adoption as a social process unfolding over
+            time through communication networks.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            The framework also provides the theoretical basis for understanding how inter-
-            organizational communication networks shape adoption. Organizations embedded in dense
-            professional networks with high-quality information flows adopt earlier and with lower
-            friction than isolated organizations that lack access to peer adoption knowledge. This
-            network structure insight explains why technology adoption barriers are lower in
-            industries with active professional associations, peer benchmarking programs, and
-            vendor-sponsored user communities.
-          </p>
-          <p className={PARAGRAPH_CLASSES}>
-            <em>
-              Note: This article provides an overview based on the comprehensive literature review.
-              Readers are encouraged to consult the original publication for complete details. For
-              the individual-level adopter perspective of the same foundational work, see{' '}
-              <Link
-                href="/bibliography-1-2-diffusion-of-innovations-rogers"
-                className="text-blue-600 hover:underline"
-              >
-                Diffusion of Innovations (Individual Perspective)
-              </Link>
-              .
-            </em>
+            In the organizational context specifically, Rogers noticed that organizations adopt
+            innovations differently from individuals. Organizations face structural constraints,
+            multiple decision-makers, competing priorities, resource limitations, governance
+            structures, and organizational cultures that shape whether and how they adopt
+            innovations. Rogers developed theoretical distinctions between individual adoption and
+            organizational adoption to explain these differences. The organizational adoption
+            dimension addresses questions: How do organizational structures, leader characteristics,
+            and organizational cultures influence innovation adoption? What is the organizational
+            adoption process? What role do champions and change agents play? How does organizational
+            size, centralization, and interconnectedness influence adoptiveness?
           </p>
         </section>
 
+        {/* 5. Core Concepts and Definitions */}
         <section className={SECTION_CLASSES}>
-          <h2 className={REFERENCES_H2_CLASSES}>References</h2>
-          <ol className={REFERENCES_OL_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers&rsquo; organizational adoption framework centers on several core concepts:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
             <li>
-              Rogers, E. M. (1962). <em>Diffusion of innovations.</em> Free Press.
+              <strong>Organizational innovativeness:</strong> The degree to which an organization is
+              relatively early in adopting new innovations compared to other organizations in its
+              reference set. Organizational innovativeness is a stable organizational characteristic
+              influenced by organizational structural and contextual factors.
             </li>
             <li>
+              <strong>Innovation-development process:</strong> The process by which innovations are
+              created, tested, developed, and brought to market through six stages: problem/need
+              recognition, basic and applied research, development, commercialization,
+              diffusion/adoption, and consequences.
+            </li>
+            <li>
+              <strong>Organizational adoption process:</strong> The organizational decision process
+              by which organizations evaluate, decide to implement, implement, and institutionalize
+              innovations, distinguishing initiation and implementation phases.
+            </li>
+            <li>
+              <strong>Adoption decision:</strong> The organizational choice to implement an
+              innovation, involving multiple organizational members, conflicting interests, bounded
+              rationality, and organizational politics beyond individual rational choice models.
+            </li>
+            <li>
+              <strong>Champions:</strong> Organizational members with high credibility and status
+              who champion innovation adoption, providing essential advocacy and overcoming
+              resistance within organizational contexts.
+            </li>
+            <li>
+              <strong>Change agents:</strong> External or internal actors facilitating
+              organizational adoption of innovations through consultation, persuasion, and support
+              services.
+            </li>
+            <li>
+              <strong>Re-invention:</strong> The degree to which adopting organizations modify
+              innovations during implementation, rather than adopting innovations unchanged. Higher
+              re-invention is associated with higher adoption rates and sustainability.
+            </li>
+            <li>
+              <strong>Organizational structure characteristics:</strong> Dimensions of organizations
+              including centralization (versus decentralization), complexity (versus simplicity),
+              formalization (versus informality), interconnectedness, organizational slack (versus
+              resource constraint), and size that influence organizational innovativeness.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers&rsquo; organizational adoption framework built upon and extended several prior
+            theoretical traditions:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Rural Sociology and Agricultural Extension (1930s-1950s):</strong> Early
+              diffusion research in rural sociology documented patterns of agricultural innovation
+              adoption. Rogers synthesized this foundational diffusion research establishing the
+              core S-curve adoption curve concept.
+            </li>
+            <li>
+              <strong>Organizational Behavior Traditions (1950s-1960s):</strong> Organizational
+              behavior scholars studied organizational change, resistance to change, and
+              organizational decision-making. Rogers integrated these perspectives into diffusion
+              theory.
+            </li>
+            <li>
+              <strong>Innovation and Organizational Change Literature (1950s-1960s):</strong>{' '}
+              Organizational scholars examined conditions facilitating or hindering organizational
+              innovation. Rogers synthesized this literature establishing organizational
+              structure-innovation relationships.
+            </li>
+            <li>
+              <strong>Social Network Theory (1950s-1960s):</strong> Network theorists studied
+              information flow through social systems. Rogers applied social network concepts to
+              explain how innovations diffuse through communication networks.
+            </li>
+            <li>
+              <strong>Public Health and Development Work (1950s-1960s):</strong> Development
+              practitioners and public health professionals documented adoption patterns of health
+              and development innovations. Rogers grounded diffusion theory in practical field
+              observations.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers&rsquo; organizational adoption framework describes how organizations adopt
+            innovations through structured organizational processes influenced by organizational
+            characteristics, leader characteristics, and innovation characteristics.
+          </p>
+
+          <h3 className={H3_CLASSES}>Organizational Innovativeness Determinants</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers identified organizational innovativeness - the propensity of organizations to
+            adopt innovations early - as a function of three sets of organizational characteristics:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Leader characteristics:</strong> The organization&rsquo;s leaders shape
+              organizational innovativeness. Leaders with positive attitudes toward change, external
+              orientations, and higher education promote innovation adoption. Conversely, leaders
+              with traditional values and inward orientations inhibit adoption.
+            </li>
+            <li>
+              <strong>Internal organizational structural characteristics:</strong> Organizations
+              adopting innovations early tend to be less centralized (more decentralized
+              decision-making), more complex (more specialized roles), less formalized (more
+              flexible rules), more internally interconnected (more communication), with greater
+              organizational slack (excess resources), and larger in size.
+            </li>
+            <li>
+              <strong>External organizational characteristics:</strong> Organizations adopting
+              innovations early tend to be more open to external systems - better connected to
+              external sources of information, participating in external networks, and engaged with
+              external stakeholders who bring innovations into the organization.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>The Organizational Adoption Process</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers distinguished two phases of organizational adoption - initiation and
+            implementation - each containing distinct sub-stages:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Initiation Phase - Agenda-Setting:</strong> The organization recognizes
+              problems or needs that innovations might address. Organizational problems or failures
+              trigger attention to potential innovations.
+            </li>
+            <li>
+              <strong>Initiation Phase - Matching:</strong> The organization recognizes innovations
+              potentially matching the identified problems. Organizational members become aware of
+              innovations and perceive potential fit.
+            </li>
+            <li>
+              <strong>Implementation Phase - Redefining/Restructuring:</strong> The organization
+              begins implementing the innovation, modifying both the innovation and organizational
+              practices during initial adoption. The innovation is reinvented to fit organizational
+              context.
+            </li>
+            <li>
+              <strong>Implementation Phase - Clarifying:</strong> Through use experience, the
+              organization clarifies the innovation meaning and application within organizational
+              context. Ambiguities diminish through application experience.
+            </li>
+            <li>
+              <strong>Implementation Phase - Routinizing:</strong> The innovation becomes integrated
+              into regular organizational operations, becoming routine practice. The innovation is
+              no longer perceived as new but becomes standard organizational procedure.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>The Innovation-Development Process</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers identified a broader innovation-development process encompassing how innovations
+            move from conception through diffusion:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Recognizing problem or need:</strong> Problems or needs are recognized
+              creating impetus for innovation development.
+            </li>
+            <li>
+              <strong>Basic and applied research:</strong> Researchers conduct basic and applied
+              research exploring potential solutions to identified problems.
+            </li>
+            <li>
+              <strong>Development:</strong> Innovations are developed, tested, and refined through
+              prototyping and pilot testing.
+            </li>
+            <li>
+              <strong>Commercialization:</strong> Successful innovations are packaged, produced, and
+              made available for distribution.
+            </li>
+            <li>
+              <strong>Diffusion and adoption:</strong> Innovations diffuse through organizational
+              populations as organizations adopt innovations.
+            </li>
+            <li>
+              <strong>Consequences:</strong> Organizations experience positive or negative
+              consequences from adoption affecting subsequent innovation attitudes and adoption
+              patterns.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Champions and Change Agents</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers emphasized organizational roles critical to innovation adoption:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Champions:</strong> Individuals within organizations with high credibility,
+              status, and influence who champion innovations through active advocacy, overcoming
+              resistance, and persisting through implementation challenges. Champions are essential
+              for innovation adoption success.
+            </li>
+            <li>
+              <strong>Change agents:</strong> External or internal individuals facilitating
+              organizational innovation adoption through information provision, consultation,
+              persuasion, facilitation, and support. Change agents bridge external innovation
+              sources and internal organizational adoption processes.
+            </li>
+            <li>
+              <strong>Opinion leaders:</strong> Individuals with high credibility and influence
+              within organizations whose adoption decisions influence others&rsquo; adoption
+              decisions through social influence and modeling effects.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Re-invention and Adaptation</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers observed that organizations frequently re-invent innovations during
+            implementation, modifying innovations to fit organizational contexts rather than
+            adopting innovations unchanged. Re-invention reflects organizations adapting innovations
+            to organizational needs, capabilities, and constraints. Importantly, Rogers found that
+            higher re-invention is associated with higher adoption rates and greater innovation
+            sustainability. Organizations that modify innovations to organizational contexts achieve
+            better implementation outcomes than organizations that rigidly implement unchanging
+            innovations.
+          </p>
+
+          <h3 className={H3_CLASSES}>Key Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Comprehensive diffusion synthesis:</strong> Rogers synthesized over 5,000
+              diffusion studies across multiple disciplines into integrated theoretical framework,
+              establishing diffusion of innovations as a central social science concept.
+            </li>
+            <li>
+              <strong>Process perspective:</strong> Framework treats adoption as social process
+              unfolding over time through communication networks rather than binary event or
+              individual rational choice, providing dynamic understanding of adoption.
+            </li>
+            <li>
+              <strong>Organizational focus:</strong> Framework distinguishes organizational adoption
+              from individual adoption, addressing organizational complexity, multiple
+              decision-makers, and organizational structures.
+            </li>
+            <li>
+              <strong>Practical organizational insights:</strong> Framework identifies
+              organizational characteristics promoting innovation adoption, providing actionable
+              guidance for organizations seeking to increase innovativeness.
+            </li>
+            <li>
+              <strong>Role of champions:</strong> Framework emphasizes champions and change agents
+              as essential organizational roles, redirecting attention from innovation
+              characteristics alone to organizational adoption facilitation.
+            </li>
+            <li>
+              <strong>Re-invention recognition:</strong> Framework recognizes re-invention as
+              positive adoption outcome, not implementation failure, aligning theory with
+              organizational practice.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Pro-innovation bias:</strong> Theory assumes innovations are beneficial and
+              adoption should be promoted. Framework may underestimate legitimate reasons for
+              non-adoption or slower adoption of some innovations.
+            </li>
+            <li>
+              <strong>Individual rationality assumption:</strong> While addressing organizational
+              decision-making, framework retains assumptions of rational choice that organizational
+              politics and decision-making processes sometimes violate.
+            </li>
+            <li>
+              <strong>Teleological framing:</strong> Framework presents diffusion as inevitable
+              end-state, potentially underestimating possibilities for non-adoption or rejection of
+              innovations in some organizational contexts.
+            </li>
+            <li>
+              <strong>Limited power analysis:</strong> Framework gives relatively limited attention
+              to power dynamics, resource inequalities, and distributional consequences of
+              innovation adoption.
+            </li>
+            <li>
+              <strong>Contextual variation:</strong> Framework general principles require
+              substantial local customization across different organizational contexts, industries,
+              and innovation types.
+            </li>
+            <li>
+              <strong>Implementation detail:</strong> Framework provides limited guidance on
+              specific implementation approaches organizations should pursue during adoption phases.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Diffusion as central social process:</strong> Rogers established diffusion of
+              innovations as central social science concept, demonstrating adoption follows
+              predictable social process patterns across diverse contexts and domains.
+            </li>
+            <li>
+              <strong>S-curve adoption curve:</strong> Rogers documented S-curve adoption patterns
+              where slow initial adoption accelerates through network effects then decelerates as
+              saturation approaches, becoming standard framework for understanding adoption
+              trajectories.
+            </li>
+            <li>
+              <strong>Organizational adoption determinants:</strong> Framework identified
+              organizational structural characteristics, leader characteristics, and external system
+              connections as determinants of organizational innovation adoption, providing basis for
+              organizational innovation capability assessment.
+            </li>
+            <li>
+              <strong>Adoption as organizational process:</strong> Framework distinguished
+              organizational adoption as distinct process from individual adoption, introducing
+              organizational complexity, multiple decision-makers, and organizational structure
+              considerations into adoption theory.
+            </li>
+            <li>
+              <strong>Champion role formalization:</strong> Framework formalized champions and
+              change agents as essential organizational roles enabling innovation adoption,
+              elevating organizational leadership and change management to central theoretical
+              concepts.
+            </li>
+            <li>
+              <strong>Re-invention as positive outcome:</strong> Framework established re-invention
+              as positive innovation outcome associated with higher adoption rates and greater
+              sustainability, contradicting earlier assumptions that unchanged implementation
+              reflected implementation fidelity.
+            </li>
+            <li>
+              <strong>Communication networks in adoption:</strong> Framework applied social network
+              theory to explain how innovations diffuse through communication networks, establishing
+              social network analysis as adoption understanding method.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers&rsquo; organizational adoption framework demonstrates strong internal validity as
+            comprehensive adoption theory:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Logical adoption process stages:</strong> Adoption process stages follow
+              logical progression from problem recognition through implementation
+              institutionalization, reflecting realistic organizational adoption processes.
+            </li>
+            <li>
+              <strong>Comprehensive variable specification:</strong> Framework comprehensively
+              specifies organization, leader, innovation, and system variables influencing
+              organizational adoption, addressing multiple adoption determinant categories.
+            </li>
+            <li>
+              <strong>Structural-behavioral linkage:</strong> Framework logically connects
+              organizational structural characteristics (centralization, complexity, formalization,
+              interconnectedness, slack, size) to organizational innovativeness through coherent
+              causal mechanisms.
+            </li>
+            <li>
+              <strong>Champion role rationale:</strong> Framework provides compelling rationale for
+              champion importance - champions overcome organizational resistance, provide advocacy
+              overcoming political opposition, and maintain adoption momentum through implementation
+              challenges.
+            </li>
+            <li>
+              <strong>Re-invention mechanism:</strong> Framework logically explains why re-invention
+              improves outcomes - organizations adapting innovations to organizational contexts
+              achieve better fit and organizational member acceptance than rigid unchanged
+              implementation.
+            </li>
+            <li>
+              <strong>Empirical grounding:</strong> Framework grounded in synthesis of over 5,000
+              empirical diffusion studies across multiple disciplines, providing strong empirical
+              foundation for core theoretical propositions.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity considerations concern generalizability of Rogers&rsquo;
+            organizational adoption framework across diverse organizational and contextual contexts:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Cross-sector applicability:</strong> Framework developed across multiple
+              sectors (agriculture, public health, marketing, technology, organizational change).
+              Applicability to diverse sectors is strong, supported by diffusion research across 50+
+              countries.
+            </li>
+            <li>
+              <strong>Innovation type variation:</strong> Framework applies to diverse innovation
+              types (products, processes, practices, policies). Core framework principles generalize
+              across innovation types though specific adoption determinants may vary by innovation
+              type.
+            </li>
+            <li>
+              <strong>Organizational size effect:</strong> Framework identifies size as
+              organizational innovativeness determinant. Smaller organizations may experience
+              different adoption processes than large organizations addressed in framework
+              development.
+            </li>
+            <li>
+              <strong>Organizational maturity variation:</strong> Framework assumes organizational
+              maturity sufficient for structured adoption process. Less organizationally mature
+              organizations may experience different adoption processes.
+            </li>
+            <li>
+              <strong>Resource constraint effects:</strong> Framework less applicable to severely
+              resource-constrained organizations unable to pursue innovations despite structural
+              innovativeness indicators.
+            </li>
+            <li>
+              <strong>Cultural context variation:</strong> Framework developed in North American
+              contexts. Cross-cultural applicability may vary based on organizational cultures,
+              national cultures, and cultural attitudes toward innovation and change.
+            </li>
+            <li>
+              <strong>Environmental turbulence:</strong> Framework assumes relatively stable
+              environments. Applicability to highly turbulent environments requiring rapid
+              organizational adaptation may be limited.
+            </li>
+            <li>
+              <strong>Power and politics considerations:</strong> Framework limited attention to
+              power dynamics and political processes shaping adoption in some organizational
+              contexts, potentially affecting generalizability to highly political organizations.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers&rsquo; organizational adoption framework directly addresses organizational
+            technology adoption, demonstrating that organizations adopt technologies through
+            structured organizational processes influenced by organizational characteristics, leader
+            characteristics, and technology characteristics. The framework emphasizes that
+            organizational technology adoption is not determined solely by technology superiority
+            but by organizational readiness, leadership commitment, champions supporting adoption,
+            organizational structures enabling change, and organizational adaptation of technologies
+            to organizational contexts.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Organizational centralization:</strong> Highly centralized organizations with
+              concentrated decision-making authority adopt technologies more slowly than
+              decentralized organizations with distributed decision-making.
+            </li>
+            <li>
+              <strong>Organizational complexity mismatch:</strong> Organizations with insufficient
+              specialization and role complexity may lack capability for complex technology adoption
+              and implementation.
+            </li>
+            <li>
+              <strong>Organizational formalization:</strong> Highly formalized organizations with
+              rigid rules and procedures resist technologies requiring organizational flexibility
+              and process redesign.
+            </li>
+            <li>
+              <strong>Poor internal interconnectedness:</strong> Organizations with poor internal
+              communication and limited interconnectedness lack information flow enabling technology
+              awareness and adoption.
+            </li>
+            <li>
+              <strong>Insufficient organizational slack:</strong> Resource-constrained organizations
+              lacking slack resources cannot pursue technologies requiring implementation investment
+              and learning time.
+            </li>
+            <li>
+              <strong>Leadership resistance:</strong> Leaders with traditional values and change
+              resistance inhibit organizational technology adoption despite technology potential
+              benefits.
+            </li>
+            <li>
+              <strong>Isolation from external systems:</strong> Organizations isolated from external
+              technology sources and external networks lack technology awareness and access enabling
+              adoption.
+            </li>
+            <li>
+              <strong>Absent or weak champions:</strong> Organizations lacking technology champions
+              with high credibility and influence cannot overcome resistance and provide adoption
+              advocacy enabling successful technology adoption.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Framework Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Assess organizational innovativeness:</strong> Evaluate organizational
+              structural characteristics (centralization, complexity, formalization,
+              interconnectedness, slack, size) determining technology adoption capability.
+            </li>
+            <li>
+              <strong>Establish technology champions:</strong> Identify and empower high-credibility
+              champions advocating technology adoption, overcoming resistance, and maintaining
+              adoption momentum through implementation.
+            </li>
+            <li>
+              <strong>Increase external connections:</strong> Expand organizational connections to
+              external technology sources, networks, and communities enabling technology awareness
+              and access.
+            </li>
+            <li>
+              <strong>Decentralize decision-making:</strong> Distribute decision-making authority
+              enabling faster technology adoption decisions and implementation flexibility.
+            </li>
+            <li>
+              <strong>Increase internal communication:</strong> Enhance internal communication and
+              interconnectedness enabling technology information flow and adoption coordination.
+            </li>
+            <li>
+              <strong>Create organizational slack:</strong> Ensure sufficient resources for
+              technology learning, experimentation, and implementation without disrupting existing
+              operations.
+            </li>
+            <li>
+              <strong>Model technology adoption:</strong> Leaders demonstrate technology openness
+              and adoption commitment through personal technology adoption and change leadership.
+            </li>
+            <li>
+              <strong>Encourage re-invention:</strong> Recognize and encourage technology
+              re-invention and adaptation to organizational contexts as positive implementation
+              approach rather than deviation.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers&rsquo; organizational adoption framework influenced substantial subsequent
+            organizational technology adoption research:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Technology-Organization-Environment Framework (
+                <a
+                  id="cite-ref-tornatzky-1990-1"
+                  href="#ref-tornatzky-1990"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Tornatzky &amp; Fleischer, 1990
+                </a>
+                ):
+              </strong>{' '}
+              Explicitly built on Rogers&rsquo; diffusion theory, adding organizational and
+              environmental context dimensions to technology adoption understanding.
+            </li>
+            <li>
+              <strong>
+                Unified Theory of Acceptance and Use of Technology (
+                <a
+                  id="cite-ref-venkatesh-2003-1"
+                  href="#ref-venkatesh-2003"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Venkatesh et al., 2003
+                </a>
+                ):
+              </strong>{' '}
+              Synthesized multiple technology adoption theories including Rogers&rsquo; diffusion
+              theory, integrating diffusion concepts with individual adoption processes.
+            </li>
+            <li>
+              <strong>
+                Organizational Change Management Frameworks (
+                <a
+                  id="cite-ref-kotter-1996-1"
+                  href="#ref-kotter-1996"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Kotter, 1996
+                </a>
+                ;{' '}
+                <a
+                  id="cite-ref-hiatt-2003-1"
+                  href="#ref-hiatt-2003"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Hiatt &amp; Creasey, 2003
+                </a>
+                ):
+              </strong>{' '}
+              Built on Rogers&rsquo; organizational adoption process and champion concepts,
+              developing change management methodologies for organizational technology
+              implementation.
+            </li>
+            <li>
+              <strong>IT Innovation Adoption Models (2000s-2010s):</strong> Organizational
+              information technology adoption research built directly on Rogers&rsquo; framework,
+              establishing organizational IT adoption as distinct research domain.
+            </li>
+            <li>
+              <strong>Cloud Computing Adoption Frameworks (2010s-2020s):</strong> Cloud adoption
+              frameworks synthesized Rogers&rsquo; organizational adoption concepts with
+              cloud-specific organizational considerations.
+            </li>
+            <li>
+              <strong>Digital Transformation Frameworks (2015-present):</strong> Digital
+              transformation research integrated Rogers&rsquo; organizational adoption concepts with
+              broader organizational transformation perspectives.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-rogers-1962">
+              Rogers, E. M. (1962). <em>Diffusion of innovations</em> (1st ed.). Free Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-rogers-1962-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-venkatesh-2003">
+              Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
+              of information technology: Toward a unified view. <em>MIS Quarterly</em>, 27(3),
+              425-478.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-venkatesh-2003-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>{' '}
+              https://doi.org/10.2307/30036540
+            </li>
+            <li id="ref-kotter-1996">
+              Kotter, J. P. (1996). <em>Leading change</em>. Harvard Business School Press.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-kotter-1996-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                ></a>
+              </span>
+            </li>
+            <li id="ref-rogers-2003">
               Rogers, E. M. (2003). <em>Diffusion of innovations</em> (5th ed.). Free Press.
             </li>
-            <li>
-              Moore, G. A. (1991). <em>Crossing the chasm.</em> Harper Business.
-            </li>
-            <li>
+            <li id="ref-tornatzky-1990">
               Tornatzky, L. G., &amp; Fleischer, M. (1990).{' '}
-              <em>The process of technological innovation.</em> Lexington Books.
+              <em>The processes of technological innovation</em>. Lexington Books. ISBN:
+              978-0-669-20348-6
+            </li>
+            <li id="ref-hiatt-2003">
+              Hiatt, J. M., &amp; Creasey, T. J. (2003). <em>The change management handbook</em>.
+              Prosci Learning Center.
             </li>
           </ol>
         </section>
 
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-rogers-1971">
+              Rogers, E. M., &amp; Shoemaker, F. F. (1971).{' '}
+              <em>Communication of innovations: A cross-cultural approach</em> (2nd ed.). Free
+              Press.
+            </li>
+            <li id="ref-kimberly-1981">
+              Kimberly, J. R., &amp; Evanisko, M. J. (1981). Organizational innovation: The
+              influence of individual, organizational, and contextual factors on hospital adoption
+              of technological and administrative innovations.{' '}
+              <em>Academy of Management Journal</em>, 24(4), 689-713.
+            </li>
+            <li id="ref-damanpour-1991">
+              Damanpour, F. (1991). Organizational innovation: A meta-analysis of effects of
+              determinants and moderators. <em>Academy of Management Journal</em>, 34(3), 555-590.
+            </li>
+            <li id="ref-zaltman-1973">
+              Zaltman, G., Duncan, R., &amp; Holbek, J. (1973).{' '}
+              <em>Innovations and organizations</em>. Wiley.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-2-20-gartner-hype-cycle-methodology-2025"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Gartner Hype Cycle Methodology - Gartner (2025)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-2-diffusion-of-innovations-rogers"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Diffusion of Innovations (Individual Adoption) - Rogers (1962/2003) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Return to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>
   )
 }
 
-export default DiffusionOrganizationalPage
+export default BibliographyArticlePage

--- a/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
+++ b/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
@@ -36,15 +36,21 @@ const BibliographyArticlePage = () => {
               <strong>Model Abbreviation:</strong> DOI (Organizational)
             </p>
             <p>
-              <strong>Authors:</strong> Everett M. Rogers
+              <strong>Author:</strong> Everett M. Rogers
             </p>
             <p>
               <strong>Target of Model:</strong> The organizational adoption dimension of
               Rogers&rsquo; Diffusion of Innovations theory, addressing how organizations adopt
               innovations including technology, processes, practices, and products. This entry
               focuses specifically on organizational-level adoption (Chapters 10-11 of the 5th
-              edition) rather than individual-level adoption, which is covered separately in
-              /bibliography-1-2-diffusion-of-innovations-rogers.
+              edition) rather than individual-level adoption, which is covered separately in{' '}
+              <Link
+                href="/bibliography-1-2-diffusion-of-innovations-rogers"
+                className="text-tabs-teal-deep hover:underline"
+              >
+                Bibliography 1-2
+              </Link>
+              .
             </p>
             <p>
               <strong>Disciplinary Origin:</strong> Communication Studies, Organizational Behavior,
@@ -65,7 +71,7 @@ const BibliographyArticlePage = () => {
               <strong>Current Version:</strong> 2003 (Fifth Edition)
             </p>
             <p>
-              <strong>Authors:</strong> Everett M. Rogers
+              <strong>Author:</strong> Everett M. Rogers
             </p>
             <p>
               <strong>Official Title:</strong> <em>Diffusion of Innovations</em> (5th ed.)
@@ -448,7 +454,7 @@ const BibliographyArticlePage = () => {
           <h3 className={H3_CLASSES}>Organizational Adopter Categories</h3>
           <p className={PARAGRAPH_CLASSES}>
             Rogers applied his five-category adopter typology - Innovators, Early Adopters, Early
-            Majority, Late Majority, and Laggards - not only to individual decision- makers but to
+            Majority, Late Majority, and Laggards - not only to individual decision-makers but to
             organizations as collective adopter units. This organizational application has distinct
             implications for enterprise technology adoption:
           </p>
@@ -524,9 +530,9 @@ const BibliographyArticlePage = () => {
             <li>
               <strong>Observability (Organizational):</strong> Organizations observe adoption
               outcomes through industry reports, peer networking, analyst research, and vendor case
-              studies. The Gartner Hype Cycle is itself an institutional mechanism for making
-              organizational adoption outcomes observable across a technology&rsquo;s maturity
-              trajectory.
+              studies. Industry analyst frameworks (such as the Gartner Hype Cycle) serve as
+              institutional mechanisms that make organizational adoption outcomes observable across
+              a technology&rsquo;s maturity trajectory.
             </li>
           </ul>
 

--- a/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
+++ b/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
@@ -470,8 +470,8 @@ const BibliographyArticlePage = () => {
               <strong>Early Majority Organizations:</strong> Adopt innovations after seeing evidence
               from early adopters, but before the majority of peer organizations. Adoption decisions
               are heavily influenced by industry benchmarking, peer reference cases, and analyst
-              reports. Rogers noted that adoption by this group marks the transition from
-              early to mainstream adoption within an organizational population.
+              reports. Rogers noted that adoption by this group marks the transition from early to
+              mainstream adoption within an organizational population.
             </li>
             <li>
               <strong>Late Majority Organizations:</strong> Adopt out of competitive necessity or
@@ -887,8 +887,8 @@ const BibliographyArticlePage = () => {
                 ):
               </strong>{' '}
               Conducted a meta-analysis of 23 organizational innovation studies, quantifying the
-              relationships between Rogers&rsquo; structural variables (centralization, formalization,
-              complexity, slack) and organizational innovativeness.
+              relationships between Rogers&rsquo; structural variables (centralization,
+              formalization, complexity, slack) and organizational innovativeness.
             </li>
           </ul>
         </section>

--- a/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
+++ b/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
@@ -444,6 +444,126 @@ const BibliographyArticlePage = () => {
               specific implementation approaches organizations should pursue during adoption phases.
             </li>
           </ul>
+
+          <h3 className={H3_CLASSES}>Organizational Adopter Categories</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers applied his five-category adopter typology - Innovators, Early Adopters, Early
+            Majority, Late Majority, and Laggards - not only to individual decision- makers but to
+            organizations as collective adopter units. This organizational application has distinct
+            implications for enterprise technology adoption:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Innovator Organizations:</strong> Characterized by high risk tolerance, slack
+              resources dedicated to exploration, informal networks with other innovator
+              organizations, and leadership with cosmopolitan orientations. Often incur higher
+              adoption costs due to immature vendor ecosystems, limited third-party support, and
+              integration challenges with existing infrastructure.
+            </li>
+            <li>
+              <strong>Early Adopter Organizations:</strong> Tend to be opinion leaders within their
+              industry sector, adopting innovations after sufficient proof-of-concept exists but
+              before mainstream adoption. Often have designated innovation functions, active vendor
+              relationships, and capacity to manage adoption risk through piloting.
+            </li>
+            <li>
+              <strong>Early Majority Organizations:</strong> Adopt innovations after seeing evidence
+              from early adopters, but before the majority of peer organizations. Adoption decisions
+              are heavily influenced by industry benchmarking, peer reference cases, and analyst
+              reports. The Early Majority represents the &ldquo;chasm&rdquo; that many technologies
+              must cross to achieve mainstream enterprise adoption.
+            </li>
+            <li>
+              <strong>Late Majority Organizations:</strong> Adopt out of competitive necessity or
+              external pressure (regulatory, customer, partner requirements) rather than proactive
+              opportunity pursuit. Adoption often driven by cost reduction rather than
+              differentiation. Vendor relationships characterized by risk aversion and preference
+              for turnkey solutions.
+            </li>
+            <li>
+              <strong>Laggard Organizations:</strong> Adopt only when older alternatives are no
+              longer viable. Often constrained by legacy infrastructure, limited change management
+              capacity, or cultural resistance embedded in organizational identity. Frequently
+              encounter the highest adoption barriers due to accumulated technical debt and
+              organizational inertia.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Innovation Attributes at the Organizational Level</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers identified five innovation attributes that predict adoption rates. These
+            attributes operate differently at the organizational level compared to the individual
+            level:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Relative Advantage (Organizational):</strong> Organizations evaluate relative
+              advantage through total cost of ownership analyses, competitive benchmarking, and
+              return-on-investment projections rather than individual utility assessments. The
+              organizational evaluation incorporates not just efficiency gains but strategic
+              positioning, vendor viability, and integration costs.
+            </li>
+            <li>
+              <strong>Compatibility (Organizational):</strong> Organizational compatibility
+              encompasses technical integration with existing IT architecture, alignment with
+              existing business processes, fit with regulatory and compliance requirements, and
+              consistency with organizational culture and change management capacity.
+            </li>
+            <li>
+              <strong>Complexity (Organizational):</strong> At the organizational level, complexity
+              incorporates implementation complexity (project management, change management,
+              training), operational complexity (ongoing management requirements), and integration
+              complexity (interfaces with other enterprise systems).
+            </li>
+            <li>
+              <strong>Trialability (Organizational):</strong> Organizations can trial innovations
+              through pilot programs, proof-of-concept deployments, and sandbox environments.
+              Vendors who provide low-cost piloting options reduce adoption barriers significantly
+              by lowering organizational commitment thresholds for initial evaluation.
+            </li>
+            <li>
+              <strong>Observability (Organizational):</strong> Organizations observe adoption
+              outcomes through industry reports, peer networking, analyst research, and vendor case
+              studies. The Gartner Hype Cycle is itself an institutional mechanism for making
+              organizational adoption outcomes observable across a technology&rsquo;s maturity
+              trajectory.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Organizational Change Agents and Opinion Leaders</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Rogers&rsquo; framework assigns critical roles to change agents and opinion leaders in
+            the diffusion process. At the organizational level, these roles are institutionalized in
+            specific functions and relationships:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Internal Change Agents:</strong> CIOs, digital transformation leaders, and
+              innovation champions within organizations function as Rogers&rsquo; change agents,
+              bridging the gap between available technology innovations and organizational readiness
+              to adopt. Their effectiveness depends on credibility with both technical and business
+              stakeholders.
+            </li>
+            <li>
+              <strong>External Change Agents:</strong> Management consultants, systems integrators,
+              and technology advisors function as inter-organizational change agents, accelerating
+              diffusion by transferring adoption knowledge, reference cases, and implementation
+              expertise from early adopter organizations to the Early and Late Majority.
+            </li>
+            <li>
+              <strong>Industry Opinion Leaders:</strong> Organizations recognized as technology
+              leaders in their sector influence adoption decisions across the industry. Peer
+              organizations monitor their technology investments and treat adoption announcements as
+              adoption endorsements.
+            </li>
+            <li>
+              <strong>Standards Bodies and Regulators:</strong> Rogers recognized that formal
+              authority can accelerate or mandate diffusion. Regulatory requirements, industry
+              standards, and compliance frameworks function as institutional change agents that
+              drive adoption across organizational populations regardless of individual
+              organizational readiness.
+            </li>
+          </ul>
         </section>
 
         {/* 8. Key Contributions */}

--- a/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
+++ b/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
@@ -470,8 +470,8 @@ const BibliographyArticlePage = () => {
               <strong>Early Majority Organizations:</strong> Adopt innovations after seeing evidence
               from early adopters, but before the majority of peer organizations. Adoption decisions
               are heavily influenced by industry benchmarking, peer reference cases, and analyst
-              reports. The Early Majority represents the &ldquo;chasm&rdquo; that many technologies
-              must cross to achieve mainstream enterprise adoption.
+              reports. Rogers noted that adoption by this group marks the transition from
+              early to mainstream adoption within an organizational population.
             </li>
             <li>
               <strong>Late Majority Organizations:</strong> Adopt out of competitive necessity or
@@ -869,24 +869,26 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Built on Rogers&rsquo; organizational adoption process and champion concepts,
-              developing change management methodologies for organizational technology
-              implementation.
+              Addressed overlapping concerns about organizational change and adoption resistance.
+              Kotter&rsquo;s eight-step model and Prosci&rsquo;s ADKAR methodology were developed
+              independently but address similar organizational adoption challenges to those Rogers
+              described.
             </li>
             <li>
-              <strong>IT Innovation Adoption Models (2000s-2010s):</strong> Organizational
-              information technology adoption research built directly on Rogers&rsquo; framework,
-              establishing organizational IT adoption as distinct research domain.
-            </li>
-            <li>
-              <strong>Cloud Computing Adoption Frameworks (2010s-2020s):</strong> Cloud adoption
-              frameworks synthesized Rogers&rsquo; organizational adoption concepts with
-              cloud-specific organizational considerations.
-            </li>
-            <li>
-              <strong>Digital Transformation Frameworks (2015-present):</strong> Digital
-              transformation research integrated Rogers&rsquo; organizational adoption concepts with
-              broader organizational transformation perspectives.
+              <strong>
+                Organizational Innovation Meta-Analysis (
+                <a
+                  id="cite-ref-damanpour-1991-1"
+                  href="#ref-damanpour-1991"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Damanpour, 1991
+                </a>
+                ):
+              </strong>{' '}
+              Conducted a meta-analysis of 23 organizational innovation studies, quantifying the
+              relationships between Rogers&rsquo; structural variables (centralization, formalization,
+              complexity, slack) and organizational innovativeness.
             </li>
           </ul>
         </section>
@@ -897,13 +899,6 @@ const BibliographyArticlePage = () => {
           <ol className={REFERENCES_OL_CLASSES}>
             <li id="ref-rogers-1962">
               Rogers, E. M. (1962). <em>Diffusion of innovations</em> (1st ed.). Free Press.
-              <span className="text-xs ml-1">
-                <a
-                  href="#cite-ref-rogers-1962-1"
-                  className="text-tabs-teal-deep hover:underline"
-                  aria-label="Back to citation 1"
-                ></a>
-              </span>
             </li>
             <li id="ref-venkatesh-2003">
               Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
@@ -937,8 +932,8 @@ const BibliographyArticlePage = () => {
               978-0-669-20348-6
             </li>
             <li id="ref-hiatt-2003">
-              Hiatt, J. M., &amp; Creasey, T. J. (2003). <em>The change management handbook</em>.
-              Prosci Learning Center.
+              Hiatt, J. M., &amp; Creasey, T. J. (2003).{' '}
+              <em>Change management: The people side of change</em>. Prosci Research.
             </li>
           </ol>
         </section>
@@ -974,10 +969,10 @@ const BibliographyArticlePage = () => {
           <div className="space-y-4">
             <p className={PARAGRAPH_CLASSES}>
               <Link
-                href="/bibliography-2-20-gartner-hype-cycle-methodology-2025"
+                href="/bibliography-2-20-cmmc-dod-2020"
                 className="text-blue-600 hover:text-blue-800 underline"
               >
-                &larr; Previous: Gartner Hype Cycle Methodology - Gartner (2025)
+                &larr; Previous: Cybersecurity Maturity Model Certification (CMMC) - DoD (2020)
               </Link>
             </p>
             <p className={PARAGRAPH_CLASSES}>

--- a/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
+++ b/src/app/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Diffusion of Innovations (Organizational Adoption) - Rogers (1962/2003)',
+  title: 'Bibliography: Diffusion of Innovations - Organizational Perspective - Rogers (1962)',
   description:
     "Comprehensive overview of Rogers' Diffusion of Innovations theory focused on organizational adoption lens. Covers organizational innovativeness, innovation-development process, organizational adoption stages, champions and change agents, and foundational diffusion research across 5,000+ studies.",
 }


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.
>
> This PR was originally authored against the earlier 14-section scope. If merged, its page may still need a follow-up to reach the expanded 16-section + review-cycle standard. See umbrella #1553 for current status.

---

## Summary

Source-verified corrections to bibliography page 2-21 (Diffusion of Innovations - Organizational - Rogers, 1962/2003).

**Reviewed against:** Rogers (2003) 5th edition Zotero metadata (TF89QY7M, ISBN 978-0-7432-2209-9). No PDF available (551-page book). Claims verified against well-documented content of Chapters 10-11.

### Issues found and fixed:

- **"Chasm" concept misattributed to Rogers** - The term "chasm" is from Geoffrey Moore (1991) "Crossing the Chasm," not from Rogers. Rogers never uses this term. Replaced with accurate Rogers framing.
- **Hiatt & Creasey (2003) fabricated title** - Page said "The change management handbook." Zotero (LBV73JAN) has actual title: "Change Management: The People Side of Change" (Prosci Research).
- **Kotter/Hiatt claimed to "built on Rogers"** - Kotter's 8-step model and Prosci's ADKAR were developed independently. Softened to "addressed overlapping concerns, developed independently."
- **3 vague Following Models replaced** - "IT Innovation Adoption Models," "Cloud Computing Adoption Frameworks," "Digital Transformation Frameworks" replaced with specific Damanpour (1991) meta-analysis that directly quantified Rogers' structural variables.
- **Navigation link fixed** - Pointed to old Gartner slug; updated to CMMC (2-20 was renamed in prior session).
- **Orphaned back-reference removed** - Rogers (1962) had a back-citation link with no matching forward cite.

### What passed review:
- Organizational innovativeness determinants (leader, internal structure, external) - correct per Ch. 10
- Five-stage adoption process (agenda-setting, matching, redefining/restructuring, clarifying, routinizing) - correct
- Re-invention concept and positive association with adoption rates - correct
- Champions and change agents - correctly described
- Five innovation attributes at organizational level - reasonable extension
- ISBN, publisher, title all match Zotero
- TOE, UTAUT Following Models entries are accurate with proper citations

Supersedes closed PR #1656.

## Test plan
- [ ] Verify 16 H2s present
- [ ] Verify no display bugs
- [ ] Verify navigation link resolves to CMMC page
- [ ] Build succeeds

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)