### PR TITLE
fix: IEM page corrections from source PDF review

### DIFF
--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -14,7 +14,7 @@ import {
 export const metadata: Metadata = {
   title: 'Bibliography: Intrinsic & Extrinsic Motivation - Davis et al. (1992)',
   description:
-    'In-depth exploration of intrinsic and extrinsic motivation in technology adoption, examining how enjoyment and perceived usefulness jointly predict computer usage intentions.',
+    'Deep dive into intrinsic and extrinsic motivation in technology adoption, examining how enjoyment and perceived usefulness jointly predict computer usage intentions.',
 }
 
 const BibliographyArticlePage = () => {
@@ -596,11 +596,27 @@ const BibliographyArticlePage = () => {
             <li id="ref-venkatesh-2003">
               Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
               of information technology: Toward a unified view. <em>MIS Quarterly</em>, 27(3),
-              425-478. https://doi.org/10.2307/30036540
+              425-478.{' '}
+              <a
+                href="https://doi.org/10.2307/30036540"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-tabs-teal-deep hover:underline"
+              >
+                https://doi.org/10.2307/30036540
+              </a>
             </li>
             <li id="ref-goodhue-1995">
               Goodhue, D. L., &amp; Thompson, R. L. (1995). Task-technology fit and individual
-              performance. <em>MIS Quarterly</em>, 19(2), 213-236. https://doi.org/10.2307/249689
+              performance. <em>MIS Quarterly</em>, 19(2), 213-236.{' '}
+              <a
+                href="https://doi.org/10.2307/249689"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-tabs-teal-deep hover:underline"
+              >
+                https://doi.org/10.2307/249689
+              </a>
             </li>
             <li id="ref-ryan-2000">
               Ryan, R. M., &amp; Deci, E. L. (2000). Intrinsic and extrinsic motivations: Classic

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -12,8 +12,7 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title:
-    'Bibliography: Extrinsic and Intrinsic Motivation to Use Computers - Davis, Bagozzi, & Warshaw (1992)',
+  title: 'Bibliography: Intrinsic & Extrinsic Motivation - Davis et al. (1992)',
   description:
     'In-depth exploration of intrinsic and extrinsic motivation in technology adoption, examining how enjoyment and perceived usefulness jointly predict computer usage intentions.',
 }
@@ -22,9 +21,7 @@ const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>
-          Extrinsic and Intrinsic Motivation to Use Computers - Davis, Bagozzi, &amp; Warshaw (1992)
-        </h1>
+        <h1 className={H1_CLASSES}>Intrinsic &amp; Extrinsic Motivation - Davis et al. (1992)</h1>
 
         {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -67,6 +67,28 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>Pages:</strong> 1111-1132
             </p>
+            <p>
+              <strong>DOI:</strong>{' '}
+              <a
+                href="https://doi.org/10.2307/249008"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.2307/249008
+              </a>
+            </p>
+            <p>
+              <strong>DOI:</strong>{' '}
+              <a
+                href="https://doi.org/10.2307/249008"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                10.2307/249008
+              </a>
+            </p>
           </div>
         </section>
 

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -12,7 +12,8 @@ import {
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Intrinsic & Extrinsic Motivation - Davis et al. (1992)',
+  title:
+    'Bibliography: Extrinsic and Intrinsic Motivation to Use Computers - Davis, Bagozzi, & Warshaw (1992)',
   description:
     'In-depth exploration of intrinsic and extrinsic motivation in technology adoption, examining how enjoyment and perceived usefulness jointly predict computer usage intentions.',
 }
@@ -21,7 +22,9 @@ const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Intrinsic &amp; Extrinsic Motivation - Davis et al. (1992)</h1>
+        <h1 className={H1_CLASSES}>
+          Extrinsic and Intrinsic Motivation to Use Computers - Davis, Bagozzi, &amp; Warshaw (1992)
+        </h1>
 
         {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -544,20 +544,36 @@ const BibliographyArticlePage = () => {
             <li id="ref-davis-1989">
               Davis, F. D. (1989). Perceived usefulness, perceived ease of use, and user acceptance
               of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.
-              <span className="text-xs ml-1">
+              <span className="ml-1 text-xs">
                 <a
                   href="#cite-ref-davis-1989-1"
-                  className="text-tabs-teal-deep hover:underline"
+                  className="inline-block text-tabs-teal-deep hover:underline focus-visible:underline"
                   aria-label="Back to citation 1"
-                ></a>
+                >
+                  ↩︎
+                </a>
               </span>{' '}
-              https://doi.org/10.2307/249008
+              <a
+                href="https://doi.org/10.2307/249008"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-tabs-teal-deep hover:underline"
+              >
+                https://doi.org/10.2307/249008
+              </a>
             </li>
             <li id="ref-davis-1992">
               Davis, F. D., Bagozzi, R. P., &amp; Warshaw, P. R. (1992). Extrinsic and intrinsic
               motivation to use computers in the workplace.{' '}
-              <em>Journal of Applied Social Psychology</em>, 22(14), 1111-1132.
-              https://doi.org/10.1111/j.1559-1816.1992.tb00945.x
+              <em>Journal of Applied Social Psychology</em>, 22(14), 1111-1132.{` `}
+              <a
+                href="https://doi.org/10.1111/j.1559-1816.1992.tb00945.x"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-tabs-teal-deep hover:underline"
+              >
+                https://doi.org/10.1111/j.1559-1816.1992.tb00945.x
+              </a>
             </li>
           </ol>
         </section>

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -70,23 +70,12 @@ const BibliographyArticlePage = () => {
             <p>
               <strong>DOI:</strong>{' '}
               <a
-                href="https://doi.org/10.2307/249008"
+                href="https://doi.org/10.1111/j.1559-1816.1992.tb00945.x"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
-                10.2307/249008
-              </a>
-            </p>
-            <p>
-              <strong>DOI:</strong>{' '}
-              <a
-                href="https://doi.org/10.2307/249008"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
-              >
-                10.2307/249008
+                10.1111/j.1559-1816.1992.tb00945.x
               </a>
             </p>
           </div>
@@ -163,9 +152,9 @@ const BibliographyArticlePage = () => {
               instrumental value - using technology to accomplish work tasks effectively.
             </li>
             <li>
-              <strong>Perceived Ease of Use (Extrinsic):</strong> The degree to which users perceive
-              the system is easy to learn and operate. This reflects effort-minimization motivation
-              - reducing cognitive and behavioral burden in system interaction.
+              <strong>Perceived Ease of Use:</strong> The degree to which users perceive the system
+              is easy to learn and operate. In this model, PEOU operates as an antecedent whose
+              effects on intentions are fully mediated by usefulness and enjoyment.
             </li>
             <li>
               <strong>Perceived Enjoyment (Intrinsic):</strong> The extent to which users find the

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -565,7 +565,7 @@ const BibliographyArticlePage = () => {
             <li id="ref-davis-1992">
               Davis, F. D., Bagozzi, R. P., &amp; Warshaw, P. R. (1992). Extrinsic and intrinsic
               motivation to use computers in the workplace.{' '}
-              <em>Journal of Applied Social Psychology</em>, 22(14), 1111-1132.{` `}
+              <em>Journal of Applied Social Psychology</em>, 22(14), 1111-1132.{' '}
               <a
                 href="https://doi.org/10.1111/j.1559-1816.1992.tb00945.x"
                 target="_blank"

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -8,730 +8,615 @@ import {
   SECTION_CLASSES,
   PARAGRAPH_CLASSES,
   BODY_LIST_CLASSES,
+  REFERENCES_OL_CLASSES,
 } from '@/lib/articleStyles'
 
 export const metadata: Metadata = {
-  title: 'Bibliography: Intrinsic & Extrinsic Motivation - Davis et al. (1992)',
+  title:
+    'Bibliography: Extrinsic and Intrinsic Motivation to Use Computers - Davis, Bagozzi, & Warshaw (1992)',
   description:
-    'Deep dive into Extrinsic and Intrinsic Motivation Framework for Technology by Fred D. Davis, Richard P. Bagozzi, and Paul R. Warshaw (1992), exploring its foundational contributions to technology adoption research.',
+    'In-depth exploration of intrinsic and extrinsic motivation in technology adoption, examining how enjoyment and perceived usefulness jointly predict computer usage intentions.',
 }
 
 const BibliographyArticlePage = () => {
   return (
     <main className="pt-20 sm:pt-[120px] min-h-screen bg-white">
       <article className={ARTICLE_CLASSES}>
-        <h1 className={H1_CLASSES}>Intrinsic & Extrinsic Motivation - Davis et al. (1992)</h1>
+        <h1 className={H1_CLASSES}>
+          Extrinsic and Intrinsic Motivation to Use Computers - Davis, Bagozzi, &amp; Warshaw (1992)
+        </h1>
 
-        {/* Model Identification */}
+        {/* 1. Model Identification */}
         <section className={`${SECTION_CLASSES} bg-gray-50 p-6 rounded-lg`}>
           <h2 className={H2_CLASSES}>Model Identification</h2>
           <div className="space-y-2">
             <p>
-              <strong>Model Name:</strong> Extrinsic and Intrinsic Motivation Framework for
-              Technology
+              <strong>Model Name:</strong> Extrinsic and Intrinsic Motivation Extension to the
+              Technology Acceptance Model
             </p>
             <p>
-              <strong>Authors:</strong> Fred D. Davis, Richard P. Bagozzi, and Paul R. Warshaw
+              <strong>Model Abbreviation:</strong> TAM with Motivation Dynamics
             </p>
             <p>
-              <strong>Publication Date:</strong> 1992
+              <strong>Target of Model:</strong> Individual Motivation and System Usage Intentions
+            </p>
+            <p>
+              <strong>Disciplinary Origin:</strong> Information Systems, Motivation Psychology,
+              Behavioral Research
             </p>
           </div>
         </section>
 
-        {/* Citation Information */}
+        {/* 2. Theory Publication Information */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Theory Publication Information</h2>
+          <div className="space-y-2">
+            <p>
+              <strong>Authors:</strong> Fred D. Davis, Richard P. Bagozzi, Paul R. Warshaw
+            </p>
+            <p>
+              <strong>Formal Publication Date:</strong> 1992
+            </p>
+            <p>
+              <strong>Official Title:</strong> Extrinsic and Intrinsic Motivation to Use Computers
+              in the Workplace
+            </p>
+            <p>
+              <strong>Journal:</strong> Journal of Applied Social Psychology
+            </p>
+            <p>
+              <strong>Volume &amp; Issue:</strong> Vol. 22, No. 14
+            </p>
+            <p>
+              <strong>Pages:</strong> 1111-1132
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Citation Information */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Citation Information</h2>
-          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500">
-            <p className="text-sm font-mono">
-              Davis, F. D., Bagozzi, R. P., & Warshaw, P. R. (1992). Extrinsic and intrinsic
-              motivation to use computers in the workplace. Journal of Applied Social Psychology, 22
-              (14), 1111-1132.
-            </p>
+          <div className="bg-blue-50 p-4 rounded border-l-4 border-blue-500 space-y-3">
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">APA (7th ed.)</p>
+              <p className="text-sm font-mono">
+                Davis, F. D., Bagozzi, R. P., &amp; Warshaw, P. R. (
+                <a href="#ref-davis-1992" className="text-tabs-teal-deep hover:underline">
+                  1992
+                </a>
+                ). Extrinsic and intrinsic motivation to use computers in the workplace.{' '}
+                <em>Journal of Applied Social Psychology</em>, 22(14), 1111-1132.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase text-blue-900 mb-1">
+                Chicago (Author-Date)
+              </p>
+              <p className="text-sm font-mono">
+                Davis, Fred D., Richard P. Bagozzi, and Paul R. Warshaw. 1992. &ldquo;Extrinsic and
+                Intrinsic Motivation to Use Computers in the Workplace.&rdquo;{' '}
+                <em>Journal of Applied Social Psychology</em> 22, no. 14: 1111-1132.
+              </p>
+            </div>
           </div>
         </section>
 
-        {/* Main Content */}
+        {/* 4. Why Was the Model Created? */}
         <section className={SECTION_CLASSES}>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>Why was the model made?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Davis, Bagozzi, and Warshaw developed the Extrinsic and Intrinsic Motivation framework
-              to extend understanding of technology adoption motivation beyond the Technology
-              Acceptance Model’s exclusive focus on extrinsic motivators (usefulness and ease of
-              use). The fundamental motivation for this framework stemmed from recognizing that the
-              TAM, while successfully predicting technology acceptance, did not capture the full
-              range of motivational factors driving technology use in organizational contexts. The
-              authors recognized that the TAM treated technology adoption as instrumental
-              behavior-individuals adopt technology because it provides external benefits (improved
-              performance, productivity) and requires manageable effort (ease of use). However, this
-              extrinsic motivation perspective overlooked that some individuals adopt technology due
-              to intrinsic motivation: they find the technology enjoyable, interesting, or
-              inherently satisfying to use, independent of external benefit.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              Some workers enjoy using computers, find them stimulating and engaging, or experience
-              pleasure in technology mastery. These intrinsic motivations influence technology
-              adoption independently of performance benefits. The authors further recognized that
-              exclusive attention to extrinsic motivators might overlook how technology
-              characteristics influence motivation. Technologies varying in how engaging or
-              stimulating they are might produce different adoption patterns beyond what perceived
-              usefulness and ease of use predict. A system perceived as similarly useful and easy
-              might generate different usage patterns if one system proves more stimulating and
-              enjoyable while another feels dull and routine. The gap between TAM’s focus on
-              usefulness and ease and actual usage patterns suggested that intrinsic motivation
-              dimensions required theoretical integration. The framework development also reflected
-              recognition that long-term technology adoption may depend differently on extrinsic
-              versus intrinsic motivation.
-            </p>
-            <p className={PARAGRAPH_CLASSES}>
-              If adoption relies solely on extrinsic benefits (performance improvement), then
-              sustained adoption depends on technology continuing to provide performance benefits.
-              However, intrinsic motivation might sustain usage even when extrinsic benefits decline
-              or performance plateaus. Understanding both motivation types proved important for
-              predicting not just initial adoption but sustained usage over extended periods. The
-              authors were also motivated by cognitive evaluation theory, which proposes that
-              extrinsic rewards can undermine intrinsic motivation. When external rewards become
-              prominent, individuals may shift from viewing behavior as intrinsically satisfying
-              toward viewing it as externally driven. This theoretical perspective suggested that
-              implementation approaches emphasizing extrinsic benefits and monitoring performance
-              improvements might paradoxically undermine intrinsic motivation, creating unintended
-              motivational shifts. Understanding extrinsic-intrinsic motivation interactions proved
-              theoretically important.
-            </p>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How was the model’s internal validity tested?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Davis, Bagozzi, and Warshaw established the framework’s internal validity through
-              multiple theoretical and empirical approaches: Theoretical grounding in established
-              motivation theory: The distinction between extrinsic and intrinsic motivation builds
-              on well- established psychological theory. Self-determination theory, cognitive
-              evaluation theory, and motivation psychology research provided extensive theoretical
-              foundation for the extrinsic-intrinsic distinction. By grounding their framework in
-              established motivation theories, the authors imported theoretical validity from
-              broader psychological literature while applying it to technology use contexts.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Clear construct operationalization:</strong> The authors operationalized
-                intrinsic motivation through measures of enjoyment, interest, and inherent
-                satisfaction with computer use. Items assessed whether participants found computer
-                use enjoyable, whether they found computers stimulating and engaging, whether they
-                would like to use computers even without performance benefits. This
-                operationalization directly measured the psychological experience of enjoyment and
-                engagement central to intrinsic motivation theory. Extrinsic motivation
-                operationalization focused on perceived usefulness and ease of use, as in the
-                original TAM, capturing outcome expectations and instrumental benefits
-              </li>
-              <li>
-                <strong>Measurement development and validation:</strong> The authors developed and
-                validated multi-item measures for intrinsic motivation alongside established TAM
-                measures. Validation included assessment of measure reliability (internal
-                consistency), convergent validity (whether different intrinsic motivation items
-                correlated with each other), and discriminant validity (whether intrinsic motivation
-                measures remained distinct from extrinsic motivation measures). These validity
-                assessments provided evidence that intrinsic motivation could be validly measured
-                distinct from extrinsic motivation
-              </li>
-              <li>
-                <strong>Structural relationships tested:</strong> The authors tested hypothesized
-                relationships through structural equation modeling. Specific hypotheses about how
-                extrinsic and intrinsic motivation influenced usage intentions and actual behavior
-                were tested against data. Support for predicted relationships provided evidence that
-                the theoretical framework accurately captured actual motivation structures. Testing
-                specifically examined whether intrinsic motivation independently influenced usage
-                beyond extrinsic motivation factors
-              </li>
-              <li>
-                <strong>Empirical evidence from quantitative analysis:</strong> The authors
-                conducted statistical analyses demonstrating that intrinsic motivation significantly
-                predicted technology usage intentions and behavior independent of extrinsic
-                motivation. This finding provided empirical evidence that intrinsic motivation
-                constitutes a distinct, measurable motivational force affecting technology adoption.
-                The finding that intrinsic motivation added predictive power beyond TAM constructs
-                supported the framework’s theoretical innovation
-              </li>
-              <li>
-                <strong>Application across user populations:</strong> The framework was tested with
-                different user populations in organizational settings, demonstrating consistency of
-                intrinsic-extrinsic motivation distinctions across groups. This population
-                consistency suggested the framework captured fundamental aspects of motivation
-                rather than group-specific phenomena
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How was the model’s external validity tested?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              External validity was established through application across diverse technology
-              contexts and organizational settings: Multiple computer applications: The framework
-              was applied to various computer applications used in workplaces including office
-              productivity tools and specialized organizational systems. Demonstrating that
-              intrinsic motivation influenced adoption across different application types suggested
-              generalizability beyond any single technology context.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Different organizational contexts:</strong> Application across different
-                organizational environments and industry sectors provided evidence for external
-                validity. The distinction between intrinsic and extrinsic motivation appeared
-                consistent whether organizations emphasized performance metrics, organizational
-                cultures emphasized innovation and engagement, or organizations operated in
-                traditional hierarchical structures
-              </li>
-              <li>
-                <strong>Diverse user populations:</strong> Testing with different user groups
-                (administrative staff, professionals, managers, technical specialists) demonstrated
-                that extrinsic-intrinsic motivation distinctions applied consistently across
-                educational backgrounds, job types, and organizational positions. This population
-                diversity suggested robust external validity rather than effects limited to
-                particular user types
-              </li>
-              <li>
-                <strong>Real organizational usage:</strong> Application in actual organizational
-                settings where real technologies addressed real work demands provided evidence for
-                external validity in ecologically meaningful contexts. Results from authentic
-                organizational technology adoption proved more convincing than laboratory studies
-                using simulated systems
-              </li>
-              <li>
-                <strong>Behavioral prediction validity:</strong> The framework demonstrated that
-                measured motivations predicted actual technology usage patterns. This behavioral
-                prediction validity provided evidence that intrinsic and extrinsic motivation
-                measures validly captured forces actually driving usage decisions. Relationships
-                between measured motivation and actual behavior suggested real-world applicability
-                beyond correlational associations
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How is the model intended to be used in practice?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Davis, Bagozzi, and Warshaw designed the extrinsic-intrinsic motivation framework as
-              both theoretical advancement and practical tool for understanding and optimizing
-              technology adoption: Comprehensive motivation assessment: Organizations can use the
-              framework to assess both extrinsic and intrinsic motivation dimensions before
-              technology implementation. Rather than assuming that perceived usefulness (extrinsic)
-              sufficiently explains adoption readiness, organizations should measure whether
-              potential users find technology enjoyable and engaging (intrinsic). Assessments
-              revealing high extrinsic but low intrinsic motivation suggest different implementation
-              approaches than assessments revealing high intrinsic but low extrinsic motivation.
-              Comprehensive assessment enables nuanced understanding of motivation readiness.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Motivation barrier diagnosis:</strong> The framework enables organizations
-                to diagnose which motivation types create adoption barriers. If technology
-                acceptance problems emerge despite adequate perceived usefulness, the barriers might
-                reflect low intrinsic motivation-potential users see utility but find technology
-                boring or unengaging
-              </li>
-              <li>
-                <strong>This diagnostic distinction guides intervention design:</strong> low
-                usefulness requires benefit demonstration, while low intrinsic motivation requires
-                system redesign emphasizing engagement. Organizations can measure both motivation
-                types, identifying which dimension most strongly limits adoption
-              </li>
-              <li>
-                <strong>Implementation strategy design considering motivation effects:</strong>{' '}
-                Organizations can design implementation strategies emphasizing different motivation
-                dimensions strategically. Some implementation approaches might emphasize extrinsic
-                motivation through performance benefits, competitive incentives, or usage
-                requirements. Alternative approaches might emphasize intrinsic motivation through
-                user engagement, system design prioritizing enjoyment and interest, or empowerment
-                approaches giving users discretion in adoption timing and approach. Different
-                population segments might require different motivation-focused strategies
-              </li>
-              <li>
-                <strong>System design considerations:</strong> The framework instructs system
-                designers that technology acceptance depends not only on usefulness and ease of use
-                but also on whether systems engage and stimulate users. Designers should consider
-                intrinsic motivation in system design, creating interfaces that interest users,
-                provide engaging experiences, enable skill development and mastery, or create
-                satisfying interaction experiences. Systems can be functionally similar yet produce
-                different adoption if one proves more engaging than another
-              </li>
-              <li>
-                <strong>User experience optimization:</strong> Organizations can use the framework
-                to guide user experience improvements beyond functionality. While adequate
-                functionality ensures minimum usefulness, additional attention to user
-                experience-visual design, interactive responsiveness, engaging feedback, aesthetic
-                appeal-can enhance intrinsic motivation. Systems feeling polished and well-designed
-                create more engaging experiences than functionally equivalent systems with poor
-                visual design or frustrating interactions
-              </li>
-              <li>
-                <strong>Motivation maintenance for long-term adoption:</strong> The framework
-                suggests that initial adoption may rely on extrinsic motivation (performance
-                benefits) but sustained adoption may depend increasingly on intrinsic motivation.
-                Once performance benefits plateau or become routine, intrinsic motivation-finding
-                usage enjoyable and stimulating-sustains continued adoption. Organizations should
-                design systems and implementation approaches supporting intrinsic motivation
-                development, recognizing that long-term success depends on moving beyond purely
-                instrumental relationships with technology toward engaging technology experiences
-              </li>
-              <li>
-                <strong>Intervention targeting for different populations:</strong> Organizations can
-                segment populations by motivation profiles: high extrinsic/high intrinsic (ready
-                adopters), high extrinsic/low intrinsic (need engagement focus), low extrinsic/high
-                intrinsic (need benefit clarity), or low extrinsic/low intrinsic (need comprehensive
-                intervention). Different segments require different intervention strategies.
-                High-extrinsic/low-intrinsic populations need system redesign emphasizing
-                engagement; low-extrinsic/high-intrinsic populations need benefit communication
-                emphasizing performance improvements. Differentiated intervention matching
-                motivation profiles increases effectiveness
-              </li>
-              <li>
-                <strong>Understanding discontinuance risk:</strong> The framework suggests that
-                discontinuance risk varies by motivation type. Users adopting primarily for
-                extrinsic benefits might discontinue when benefits plateau or workarounds enable
-                avoiding adoption. Users with strong intrinsic motivation might persist despite
-                diminished extrinsic benefits because they find technology inherently satisfying.
-                Organizations can assess discontinuance risk by evaluating motivation profiles,
-                recognizing that intrinsically motivated adopters represent more stable long-term
-                users
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What does the model measure?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The extrinsic-intrinsic motivation framework operationalizes several key measurement
-              constructs: Intrinsic motivation: Measured through multi-item scales assessing
-              enjoyment, interest, and inherent satisfaction from computer use. Items capture
-              whether participants find computer use enjoyable, whether they feel computers are
-              stimulating and engaging, whether they would want to use computers even without
-              external benefits or performance improvement. Intrinsic motivation measures the
-              affective experience and inherent satisfaction associated with technology use.
-              Conceptually, intrinsic motivation reflects the degree to which technology use is
-              pursued for its own sake because users find it inherently satisfying.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Extrinsic motivation:</strong> Measured through perceived usefulness and
-                perceived ease of use, consistent with the Technology Acceptance Model. Perceived
-                usefulness captures beliefs that technology use enhances performance and
-                productivity. Perceived ease of use captures beliefs that technology requires
-                manageable effort
-              </li>
-              <li>
-                <strong>Extrinsic motivation reflects instrumental value:</strong> technology
-                adoption is pursued because it produces valued external outcomes (performance,
-                efficiency) rather than because use itself is satisfying
-              </li>
-              <li>
-                <strong>Behavioral intention:</strong> Measured through items assessing intentions
-                to use or continue using computers. Behavioral intention represents readiness or
-                commitment to technology use, influenced by both intrinsic and extrinsic motivation
-              </li>
-              <li>
-                <strong>Actual technology usage:</strong> Measured through system usage metrics,
-                frequency of use, or duration of use. Actual usage represents behavioral outcomes
-                influenced by both motivation types
-              </li>
-              <li>
-                <strong>Enjoyment:</strong> Measured through specific items assessing whether
-                computer use is enjoyable and satisfying. Enjoyment captures the emotional-affective
-                component central to intrinsic motivation
-              </li>
-              <li>
-                <strong>Engagement and interest:</strong> Measured through items assessing whether
-                computers are stimulating, interesting, and engaging to use. This dimension captures
-                the cognitive engagement and interest central to intrinsic motivation distinct from
-                enjoyment
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What are the main strengths of the model?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The extrinsic-intrinsic motivation framework possesses several significant strengths:
-              Theoretical enrichment of TAM: By explicitly incorporating intrinsic motivation
-              alongside TAM’s extrinsic motivation constructs, the framework enriches understanding
-              of technology adoption. The TAM successfully explained adoption through outcome
-              expectations and effort, but this extrinsic focus overlooked that some adopters are
-              motivated by enjoyment.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>The framework makes explicit what TAM left implicit:</strong> that
-                technology adoption involves multiple motivation types, not just instrumental
-                benefits. This enrichment creates more comprehensive adoption understanding
-              </li>
-              <li>
-                <strong>Recognition of affect in adoption decisions:</strong> The framework
-                explicitly recognizes that emotional and affective dimensions-finding technology
-                enjoyable, engaging, or stimulating-influence adoption. Many adoption models focus
-                on cognition (beliefs about usefulness, ease) and behavior (intentions, usage) but
-                underemphasize emotion and affect. This framework explicitly measures enjoyment and
-                engagement, giving affect appropriate theoretical prominence in adoption
-                understanding
-              </li>
-              <li>
-                <strong>Distinction between motivation types:</strong> The clear conceptual
-                distinction between extrinsic (benefits-oriented) and intrinsic (enjoyment-oriented)
-                motivation enables nuanced analysis. Different adoption barriers reflect different
-                motivation deficits, requiring different interventions
-              </li>
-              <li>
-                <strong>This distinction provides diagnostic precision:</strong> a low-adoption
-                problem reflects either inadequate extrinsic motivation or inadequate intrinsic
-                motivation - each requiring distinct solutions
-              </li>
-              <li>
-                <strong>Practical implementation guidance:</strong> The framework provides practical
-                guidance for implementation design. Organizations can assess whether adoption
-                barriers reflect usefulness and ease (extrinsic) or enjoyment and engagement
-                (intrinsic) deficits, enabling targeted interventions. System designers can consider
-                intrinsic motivation in design, not just functionality. Implementation strategies
-                can address motivation comprehensively rather than assuming extrinsic motivation
-                suffices
-              </li>
-              <li>
-                <strong>Temporal implications for adoption sustainability:</strong> The framework
-                suggests that extrinsic motivation drives initial adoption but intrinsic motivation
-                sustains long-term usage
-              </li>
-              <li>
-                <strong>This temporal insight has important implications:</strong> implementations
-                emphasizing extrinsic benefits might achieve initial adoption but fail to sustain
-                usage unless intrinsic motivation develops. Understanding this dynamic enables
-                implementation approaches supporting intrinsic motivation development
-              </li>
-              <li>
-                <strong>Grounding in broader motivation theory:</strong> The framework builds on
-                established psychological theories of motivation, importing theoretical credibility
-                from broader motivation science. The extrinsic-intrinsic distinction reflects
-                long-standing motivation theory perspectives, suggesting this distinction captures
-                fundamental aspects of human motivation
-              </li>
-              <li>
-                <strong>Expansion of Technology Acceptance Model:</strong> Rather than replacing
-                TAM, the framework complements it by adding intrinsic motivation to TAM’s extrinsic
-                motivation constructs. This complementary relationship maintains TAM’s parsimony and
-                proven effectiveness while addressing documented limitations. The framework can be
-                viewed as TAM extension rather than fundamental challenge
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>What are the main weaknesses of the model?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              Despite significant strengths, the extrinsic-intrinsic motivation framework has
-              notable limitations: Limited attention to motivation interaction mechanisms: While the
-              framework identifies both extrinsic and intrinsic motivation as important, it provides
-              limited specification of how these motivation types interact. Cognitive evaluation
-              theory suggests that extrinsic rewards can undermine intrinsic motivation, but the
-              framework provides limited investigation of whether extrinsic motivation approaches
-              implemented in organizations actually undermine intrinsic motivation development. The
-              interaction mechanisms deserve deeper theoretical explication.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Insufficient attention to individual differences in motivation:</strong> The
-                framework treats intrinsic motivation as universal-assuming all potential adopters
-                could find technology enjoyable if designed appropriately. However, individual
-                differences in stimulation preferences, engagement styles, and enjoyment capacities
-                likely vary substantially. Some individuals inherently find technology engaging
-                while others find it tedious regardless of design. The framework provides limited
-                attention to how individual differences moderate intrinsic motivation or predict who
-                will find particular technologies intrinsically motivating. Underspecified
-                relationships between intrinsic motivation and system characteristics: The framework
-                identifies intrinsic motivation as important but provides limited specification of
-                which system characteristics enhance intrinsic motivation. The authors suggest that
-                engagement and interest matter, but detailed guidance on designing for intrinsic
-                motivation remains limited. What system features create engagement for spreadsheet
-                applications? Which design principles enhance intrinsic motivation for security
-                software users find inherently boring? The relationship between specific design
-                choices and intrinsic motivation deserves greater elaboration
-              </li>
-              <li>
-                <strong>Limited attention to long-term motivation changes:</strong> The framework
-                treats intrinsic and extrinsic motivation as relatively stable. However, motivation
-                likely changes as technology use becomes routine and habituated. Initial enthusiasm
-                (high intrinsic motivation) may decline through repetition and routinization.
-                Extrinsic motivation changes as users become confident and efficient. The framework
-                provides limited specification of how motivation evolves from adoption through
-                sustained usage
-              </li>
-              <li>
-                <strong>Unclear practical implementation guidance for intrinsic motivation:</strong>{' '}
-                While the framework identifies intrinsic motivation’s importance, it provides
-                limited guidance for implementation approaches actually enhancing intrinsic
-                motivation. Increasing extrinsic motivation through benefit communication and
-                training proves straightforward. Enhancing intrinsic motivation through user
-                experience design, engagement optimization, or empowerment approaches remains less
-                clearly operationalized. The practical gap between theoretical insight and
-                actionable implementation strategies requires attention
-              </li>
-              <li>
-                <strong>
-                  Limited attention to organizational constraints on intrinsic motivation:
-                </strong>{' '}
-                While the framework emphasizes user intrinsic motivation, organizational contexts
-                may constrain opportunities for motivated use. Mandatory technology adoption
-                requirements, surveillance and monitoring, or rigid work processes may prevent the
-                autonomous, choice-rich contexts where intrinsic motivation flourishes. The
-                framework provides limited attention to organizational factors enabling or
-                constraining intrinsic motivation development
-              </li>
-              <li>
-                <strong>Measurement of intrinsic motivation specificity:</strong> The framework
-                measures enjoyment and engagement broadly, but these affective experiences differ
-                substantially across contexts and technologies. What creates engagement for some
-                technologies (games, creative tools) might not create engagement for others
-                (compliance software, security tools). The generalizability of intrinsic motivation
-                measures across all technology contexts remains uncertain. Context-specific
-                operationalization of intrinsic motivation might improve the framework’s
-                applicability
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>How does this model differ from older models?</h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The extrinsic-intrinsic motivation framework represented significant advancement from
-              prior technology adoption models: Explicit inclusion of intrinsic motivation
-              dimension: While earlier motivation theory recognized intrinsic motivation importance,
-              the Technology Acceptance Model focused exclusively on extrinsic motivation
-              (usefulness and ease of use). The framework’s fundamental innovation was explicitly
-              incorporating intrinsic motivation alongside extrinsic motivation, recognizing that
-              comprehensive adoption understanding requires both. This addition overcame TAM’s
-              limitation of focusing narrowly on instrumental benefits.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>Affect-inclusive adoption understanding:</strong> Earlier technology
-                adoption models, including TAM, treated adoption as primarily cognitive-behavioral
-                phenomenon: individuals form beliefs about technology, develop attitudes, form
-                intentions, and act. The framework elevated affective dimensions (enjoyment,
-                interest, engagement) to theoretical prominence alongside cognition. This
-                recognition that affect substantially influences adoption represented important
-                conceptual advancement
-              </li>
-              <li>
-                <strong>Distinction from purely behavioral models:</strong> Earlier purely
-                behavioral adoption models treated technology adoption as response to performance
-                benefits or task requirements, overlooking that users might adopt because they enjoy
-                technology independent of instrumental benefits. The framework recognized that some
-                adoption results from intrinsic satisfaction rather than extrinsic benefit
-                optimization
-              </li>
-              <li>
-                <strong>Conceptual advance over reward-focused adoption approaches:</strong> Earlier
-                organizational implementation approaches emphasized extrinsic rewards, incentives,
-                and performance metrics to drive adoption. The framework suggested that exclusive
-                emphasis on external rewards might prove suboptimal, that intrinsic motivation
-                development should be valued alongside extrinsic incentives. This represented
-                important conceptual shift toward more holistic motivation understanding
-              </li>
-              <li>
-                <strong>Recognition of technology experience quality:</strong> Earlier models
-                focused on system functionality and user beliefs about that functionality. The
-                framework emphasized that technology adoption depends also on the quality of user
-                experience itself-how engaging, enjoyable, and satisfying the interaction proves.
-                This shifted focus from functionality to user experience, recognizing these as
-                distinct dimensions affecting adoption
-              </li>
-              <li>
-                <strong>Temporal sophistication:</strong> Earlier models treated adoption intentions
-                and behavior as relatively concurrent phenomena
-              </li>
-              <li>
-                <strong>The framework suggested that motivation types differ temporally:</strong>{' '}
-                extrinsic motivation may drive initial adoption but intrinsic motivation sustains
-                long-term usage. This temporal sophistication provided more nuanced understanding of
-                adoption dynamics across time
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>
-              What Barriers to Technology Adoption does the model identify?
-            </h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The Extrinsic and Intrinsic Motivation framework identifies barriers to technology
-              adoption organized around two distinct but interrelated motivation dimensions:
-              Extrinsic motivation barriers: The framework identifies that low perceived usefulness
-              creates adoption barriers when workers question whether technology will enhance
-              performance or productivity.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>These extrinsic barriers parallel those identified in TAM:</strong>{' '}
-                technologies perceived as offering minimal performance benefits face adoption
-                resistance. Workers accustomed to achieving adequate performance through existing
-                processes perceive limited motivation to adopt technologies offering marginal
-                improvement
-              </li>
-              <li>
-                <strong>
-                  Extrinsic barriers additionally include perceived ease of use concerns:
-                </strong>{' '}
-                technologies perceived as requiring excessive effort, extensive training, or
-                disrupting work processes encounter resistance even when usefulness is acknowledged.
-                The effort burden appears unwarranted relative to benefits, creating overall
-                extrinsic motivation deficiency
-              </li>
-              <li>
-                <strong>Intrinsic motivation barriers:</strong> The framework identifies a distinct
-                barrier category: technologies that users perceive as boring, unstimulating, or
-                unengaging create adoption barriers through intrinsic motivation deficit. Even if
-                technologies offer clear performance benefits (high extrinsic motivation) and
-                require manageable effort (favorable ease perception), users finding technology
-                inherently uninteresting experience reduced motivation for sustained adoption.
-                Technologies with poor user experiences - unattractive interfaces, unresponsive
-                interactions, or frustrating workflows - undermine intrinsic motivation. Tasks
-                involving repetitive, routine computer work might offer no novelty or engagement
-                opportunity, creating intrinsic motivation barriers regardless of instrumental
-                benefits. Intrinsic motivation barriers additionally include lack of autonomy and
-                choice in technology adoption. When organizations mandate adoption with no user
-                discretion about whether, when, or how to adopt, the loss of autonomy undermines
-                intrinsic motivation even if technology is otherwise engaging. Mandatory adoption
-                approaches can create resentment reducing intrinsic motivation. Intrinsic barriers
-                further include surveillance and monitoring implementation approaches: if technology
-                adoption occurs alongside increased monitoring, surveillance, or reduced autonomy,
-                the loss of independence undermines enjoyment even if technology itself is
-                interesting. Intrinsic motivation barriers include absence of mastery opportunities.
-                Technologies offering no opportunity for increasing competence, developing skills,
-                or advancing capability provide limited intrinsic motivation. Complex technologies
-                challenging users to develop competence can create engaging experiences; simple,
-                inflexible technologies providing no growth opportunity create boredom
-              </li>
-              <li>
-                <strong>Intrinsic barriers additionally include lack of social engagement:</strong>{' '}
-                if technology adoption isolates users from colleagues, reduces collaboration, or
-                eliminates social aspects of work, the loss of connection undermines intrinsic
-                motivation
-              </li>
-              <li>
-                <strong>Interaction of extrinsic and intrinsic barriers:</strong> The framework
-                recognizes that these barrier types combine in affecting adoption. Technology with
-                strong extrinsic motivation (clear usefulness, manageable effort) but weak intrinsic
-                motivation (boring, unengaging) might achieve initial adoption through instrumental
-                motivation but fail to sustain usage as the instrumental value becomes routine.
-                Technology with weak extrinsic motivation (unclear usefulness, effortful) but strong
-                intrinsic motivation (engaging, stimulating) might not achieve adoption despite
-                potential for enjoyment because inadequate instrumental value prevents trial
-              </li>
-              <li>
-                <strong>Organizational context barriers affecting intrinsic motivation:</strong> The
-                framework implies that organizational implementation choices substantially affect
-                intrinsic motivation. Organizations implementing technology through top-down
-                mandates with surveillance and monitoring create barriers through loss of autonomy.
-                Organizations implementing technology through empowered adoption enabling choice and
-                discretion enhance intrinsic motivation. Organizations providing engaging,
-                responsive support systems maintain intrinsic motivation better than those providing
-                minimal support. The broader organizational context creates conditions enabling or
-                constraining intrinsic motivation development
-              </li>
-            </ul>
-          </section>
-          <section className="mb-6">
-            <h3 className={H3_CLASSES}>
-              What does the model instruct leaders to do in order to reduce these barriers?
-            </h3>
-            <p className={PARAGRAPH_CLASSES}>
-              The extrinsic-intrinsic motivation framework provides explicit guidance for leaders
-              designing adoption approaches addressing both motivation types: Establish and
-              communicate extrinsic motivation through benefit clarity: Leaders instructed by the
-              framework should first ensure that technology adoption will produce genuine
-              performance benefits that users understand and value. Clear articulation of how
-              technology improves work quality, reduces effort, improves efficiency, or enables new
-              capabilities establishes extrinsic motivation foundation. Leaders should provide
-              evidence and demonstrations showing performance benefits. Benefits should be
-              communicated in user-relevant terms matching different job requirements.
-            </p>
-            <ul className={BODY_LIST_CLASSES}>
-              <li>
-                <strong>This extrinsic motivation foundation proves essential:</strong> without
-                clear instrumental value, users lack primary motivation for adoption effort
-              </li>
-              <li>
-                <strong>Enhance ease of use reducing effort barriers:</strong> Leaders should ensure
-                that technology adoption requires manageable effort through system design
-                emphasizing intuitive interfaces, comprehensive training enabling proficiency before
-                adoption demands intensify, and support systems enabling problem resolution.
-                Easy-to-use systems reduce effort barriers supporting extrinsic motivation. Leaders
-                should avoid assuming users can learn through trial-and-error; proactive training
-                ensures users possess confidence and capability before adoption pressure increases.
-                Reducing perceived difficulty barriers removes impediments to extrinsic motivation
-                realization
-              </li>
-              <li>
-                <strong>Design for intrinsic motivation through engaging user experiences:</strong>{' '}
-                Leaders should explicitly consider intrinsic motivation in technology selection,
-                system design, and implementation approaches. System design should emphasize user
-                experience quality-interface aesthetics, interactive responsiveness, engaging
-                interactions, and satisfying feedback. Leaders should select or adapt systems that
-                provide engagement opportunities where possible. For inherently routine systems
-                offering limited engagement (data entry, compliance monitoring), leaders might
-                enhance intrinsic motivation through gamification, progress visibility, or
-                accomplishment recognition
-              </li>
-              <li>
-                <strong>Provide mastery and skill development opportunities:</strong> Leaders should
-                ensure that technology adoption provides opportunities for users to develop
-                competence and mastery. Rather than providing minimal training ensuring only basic
-                functionality, leaders should offer extended learning enabling users to develop
-                advanced capabilities and expertise. Progressive challenges enabling skill
-                advancement create engagement. Recognition of increasing mastery (certifications,
-                proficiency levels, expert designations) supports intrinsic motivation. Leaders
-                should design technology rollout providing graduated complexity enabling skill
-                development over time rather than overwhelming users with full functionality
-                immediately
-              </li>
-              <li>
-                <strong>Maximize autonomy in adoption approaches:</strong> Rather than mandating
-                adoption with no user discretion, leaders should enable user choice and autonomy
-                where possible. Providing choice about adoption timing, implementation approach, or
-                system customization supports intrinsic motivation by preserving autonomy.
-                Participation in adoption planning and decision-making increases ownership and
-                intrinsic motivation. Leaders should minimize surveillance and monitoring
-                implemented alongside technology adoption, recognizing that loss of autonomy
-                undermines intrinsic motivation even when technology itself provides good extrinsic
-                and intrinsic benefits
-              </li>
-              <li>
-                <strong>Preserve and enhance social dimensions:</strong> Leaders should ensure
-                technology adoption does not eliminate beneficial social collaboration and
-                connection. Implementation approaches should emphasize how technology enables rather
-                than replaces interpersonal collaboration. Training and support should include peer
-                learning components maintaining social engagement. User communities and
-                collaboration systems should be established where possible, creating social
-                engagement alongside technology adoption. Leaders should resist implementation
-                approaches reducing collaboration in pursuit of efficiency; technology adoption
-                rarely justifies eliminating beneficial social dimensions
-              </li>
-              <li>
-                <strong>Implement multi-faceted motivation interventions:</strong> Leaders
-                instructed by the framework should recognize that comprehensive adoption approaches
-                address both extrinsic and intrinsic motivation simultaneously. Implementation
-                strategies should include extrinsic motivation components (benefit communication,
-                performance evidence, training ensuring manageable effort) alongside intrinsic
-                motivation components (engaging user experience, mastery opportunities, autonomy
-                support, social engagement). Different population segments may require different
-                motivation-focused intensity: populations already motivated extrinsically might
-                require primarily intrinsic motivation support; populations lacking instrumental
-                benefits require greater extrinsic motivation focus
-              </li>
-            </ul>
-          </section>
-          <p className="mt-8 text-sm italic text-gray-600">
-            Note: This article provides an overview based on the comprehensive literature review.
-            Readers are encouraged to consult the original publication for complete details.
+          <h2 className={H2_CLASSES}>Why Was the Model Created?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Davis, Bagozzi, and Warshaw extended the Technology Acceptance Model (TAM) to
+            incorporate motivational psychology, addressing a theoretical gap in understanding what
+            actually drives continued technology use. While earlier TAM research focused primarily
+            on perceived usefulness and perceived ease of use, this extension recognized that user
+            motivation operates on two distinct psychological dimensions: extrinsic motivation
+            (using technology as a means to achieve desired outcomes) and intrinsic motivation
+            (using technology because the activity itself is enjoyable).
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            The authors recognized that accepting a technology and actually using it are distinct
+            outcomes driven by different motivational structures. Particularly, they theorized that
+            perceived enjoyment - an intrinsic motivation factor - had been underemphasized in prior
+            acceptance research despite its importance in sustained usage patterns. Organizations
+            deploying expensive systems needed frameworks predicting not just initial adoption but
+            ongoing utilization and enthusiastic engagement.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            Building on motivational theories from psychology, the authors conducted empirical
+            research with 200 MBA students using two software applications to test whether intrinsic
+            motivation independently predicts usage intentions above and beyond extrinsic motivation
+            variables. Their findings demonstrated that enjoyment significantly predicts computer
+            usage intentions, opening new theoretical directions for understanding technology
+            adoption as a function of both practical utility and experiential pleasure.
           </p>
         </section>
 
-        {/* Navigation */}
-        <section className="mt-12 pt-6 border-t border-gray-200">
-          <Link
-            href="/article-bibliography-comprehensive-series-bibliography"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            ← Back to Complete Bibliography
-          </Link>
+        {/* 5. Core Concepts and Definitions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Core Concepts and Definitions</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The intrinsic-extrinsic motivation extension operationalizes five primary constructs:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Perceived Usefulness (Extrinsic):</strong> The degree to which users believe a
+              system enhances job performance and productivity. This extrinsic motivation reflects
+              instrumental value - using technology to accomplish work tasks effectively.
+            </li>
+            <li>
+              <strong>Perceived Ease of Use (Extrinsic):</strong> The degree to which users perceive
+              the system is easy to learn and operate. This reflects effort-minimization motivation
+              - reducing cognitive and behavioral burden in system interaction.
+            </li>
+            <li>
+              <strong>Perceived Enjoyment (Intrinsic):</strong> The extent to which users find the
+              activity of using the system to be inherently fun or pleasurable independent of
+              performance consequences. This intrinsic motivation reflects experience quality and
+              hedonic aspects.
+            </li>
+            <li>
+              <strong>Attitude Toward Using the System:</strong> Overall favorable or unfavorable
+              evaluations of using the technology, predicted by usefulness, ease of use, and
+              enjoyment beliefs.
+            </li>
+            <li>
+              <strong>Behavioral Intention to Use:</strong> User likelihood of continuing to use the
+              system, predicted by attitudes and perceived usefulness through both
+              intention-normative and intention-affective pathways.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Preceding Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Davis et al. extension built systematically upon multiple foundational frameworks:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Original Technology Acceptance Model (
+                <a
+                  id="cite-ref-davis-1989-1"
+                  href="#ref-davis-1989"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Davis, 1989
+                </a>
+                ):
+              </strong>{' '}
+              Established that perceived usefulness and perceived ease of use predict attitudes and
+              intentions to use information systems.
+            </li>
+            <li>
+              <strong>Intrinsic motivation theory (Deci &amp; Ryan):</strong> Provided psychological
+              foundations showing that intrinsic motivation is a distinct motivational force from
+              extrinsic reward structures.
+            </li>
+            <li>
+              <strong>Hedonic motivation research:</strong> Grounded the concept that pleasurable
+              experiences independently drive behavior separate from utilitarian outcomes.
+            </li>
+            <li>
+              <strong>Theory of reasoned action (Fishbein &amp; Ajzen):</strong> Provided the
+              attitudinal framework showing beliefs predict attitudes which predict behavioral
+              intentions.
+            </li>
+            <li>
+              <strong>Self-determination theory (Deci &amp; Ryan):</strong> Offered psychological
+              theorizing that humans have basic needs for autonomy, competence, and relatedness
+              driving behavior.
+            </li>
+          </ul>
+        </section>
+
+        {/* 7. Describe The Model */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Describe The Model</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The model proposes that usage intentions are determined by two distinct psychological
+            pathways operating simultaneously. The extrinsic pathway operates through perceived
+            usefulness, perceived ease of use, and attitudes - representing rational evaluation of
+            instrumental benefits. The intrinsic pathway operates through perceived enjoyment
+            influencing attitude and behavioral intentions - representing emotional and experiential
+            motivations. Both pathways have significant effects, with perceived enjoyment showing
+            direct effects on intentions even controlling for attitudes.
+          </p>
+
+          <h3 className={H3_CLASSES}>What does the model measure?</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Extrinsic motivation beliefs:</strong> Perceived usefulness and ease of use
+              capturing rational, instrumental motivations for technology adoption.
+            </li>
+            <li>
+              <strong>Intrinsic motivation beliefs:</strong> Perceived enjoyment capturing
+              emotional, hedonic, and experiential quality of technology interaction.
+            </li>
+            <li>
+              <strong>Affective responses:</strong> Attitudes toward the system reflecting combined
+              influence of usefulness, ease of use, and enjoyment beliefs.
+            </li>
+            <li>
+              <strong>Behavioral intentions:</strong> Direct intentions to use the system predicted
+              by both rational and emotional motivations.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Strengths</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Theoretical integration:</strong> Synthesizes information systems acceptance
+              frameworks with psychological motivation theory, bridging two literatures.
+            </li>
+            <li>
+              <strong>Motivation duality recognition:</strong> Acknowledges that technology adoption
+              is driven by both practical utility and experiential pleasure, not utility alone.
+            </li>
+            <li>
+              <strong>Empirical support for enjoyment:</strong> Provides robust evidence that
+              perceived enjoyment independently predicts intentions controlling for usefulness and
+              ease.
+            </li>
+            <li>
+              <strong>Dual-pathway structure:</strong> Shows that both extrinsic and intrinsic
+              motivation matter, with neither completely mediating the other.
+            </li>
+            <li>
+              <strong>Clean methodological design:</strong> Tested model with two software
+              applications (an information system and a word processor) demonstrating
+              generalizability across system types.
+            </li>
+            <li>
+              <strong>Student and professional validation:</strong> Used MBA student sample
+              representing business professionals with relevant work experience.
+            </li>
+            <li>
+              <strong>Mediation pathway analysis:</strong> Examined both direct and indirect effects
+              showing complex motivational structures.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Main Weaknesses</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Limited sample diversity:</strong> 200 MBA students from single university may
+              not represent diverse professions, industries, and organizational contexts.
+            </li>
+            <li>
+              <strong>Narrow application contexts:</strong> Two software systems (both
+              business-focused) limit generalization to other technology categories like
+              entertainment or social systems.
+            </li>
+            <li>
+              <strong>Measurement limitation:</strong> Enjoyment may be system-specific;
+              entertainment software might show stronger enjoyment effects than complex business
+              systems.
+            </li>
+            <li>
+              <strong>Short-term focus:</strong> Cross-sectional design captures intentions rather
+              than actual sustained usage over time or adoption trajectories.
+            </li>
+            <li>
+              <strong>Self-report bias:</strong> All measures relied on self-reported beliefs and
+              intentions rather than objective system usage logs or behavior tracking.
+            </li>
+            <li>
+              <strong>Unexplored moderators:</strong> Did not examine whether intrinsic-extrinsic
+              balance differs across user experience levels, task types, or organizational contexts.
+            </li>
+            <li>
+              <strong>Construct overlap concerns:</strong> Perceived ease of use and perceived
+              enjoyment may share variance not fully separated in measurement.
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Key Contributions */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Key Contributions</h2>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Hedonic motivation integration:</strong> Demonstrated that technology adoption
+              requires understanding both utility (extrinsic) and pleasure (intrinsic) motivations.
+            </li>
+            <li>
+              <strong>Enjoyment as adoption driver:</strong> Provided empirical evidence that
+              perceived enjoyment directly predicts usage intentions independent of usefulness.
+            </li>
+            <li>
+              <strong>Expanded TAM theoretical reach:</strong> Extended the Technology Acceptance
+              Model beyond rational decision-making to include emotional and affective dimensions.
+            </li>
+            <li>
+              <strong>Motivation psychology bridge:</strong> Connected established motivational
+              psychology literature (intrinsic-extrinsic distinction) to information systems
+              acceptance.
+            </li>
+            <li>
+              <strong>Dual-pathway conceptualization:</strong> Articulated how rational and
+              emotional motivations operate as distinct but related paths to usage intentions.
+            </li>
+            <li>
+              <strong>Practical implications:</strong> Provided guidance that system designers
+              should consider both utility and enjoyment in creating systems users will embrace.
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Internal Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Internal Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The researchers employed rigorous measurement and analysis procedures:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Multi-item scales:</strong> Operationalized each construct using multiple
+              survey items rather than single indicators, allowing measurement error assessment.
+            </li>
+            <li>
+              <strong>Reliability testing:</strong> Reported Cronbach&rsquo;s alpha coefficients for
+              all scales, with most exceeding .80 threshold, demonstrating internal consistency.
+            </li>
+            <li>
+              <strong>Discriminant validity:</strong> Provided correlation matrices and confidence
+              intervals showing constructs are distinct (e.g., enjoyment separate from usefulness).
+            </li>
+            <li>
+              <strong>Path analysis with SEM:</strong> Used structural equation modeling allowing
+              simultaneous testing of measurement and structural models.
+            </li>
+            <li>
+              <strong>Cross-system replication:</strong> Tested model with two different software
+              applications, showing consistent effects across contexts.
+            </li>
+            <li>
+              <strong>Significance testing:</strong> Reported standardized path coefficients,
+              standard errors, and t-statistics for hypothesis testing.
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. External Validity */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>External Validity</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            External validity claims and limitations require careful consideration:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Student sample limitation:</strong> MBA students may be more
+              computer-proficient and motivated than average workforce, potentially amplifying
+              enjoyment effects.
+            </li>
+            <li>
+              <strong>Business software focus:</strong> Two productivity applications may not
+              generalize to entertainment systems, social media, or specialized professional
+              software.
+            </li>
+            <li>
+              <strong>Laboratory-like contexts:</strong> University computing lab settings lack
+              organizational pressures, mandatory usage requirements, and real job integration.
+            </li>
+            <li>
+              <strong>Cross-system consistency:</strong> Replication across two applications
+              provides modest generalization evidence, though both remained business-focused
+              systems.
+            </li>
+            <li>
+              <strong>Theoretical generalizability:</strong> The intrinsic-extrinsic distinction is
+              grounded in well-established motivation psychology, suggesting broader applicability.
+            </li>
+            <li>
+              <strong>Temporal generalizability:</strong> Cross-sectional design at single time
+              point limits understanding of whether enjoyment effects persist over extended usage
+              periods.
+            </li>
+          </ul>
+        </section>
+
+        {/* 11. Relevance to Technology Adoption */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The intrinsic-extrinsic motivation framework is directly relevant to technology adoption
+            because it identifies distinct barriers rooted in different motivational deficits.
+            Organizations implementing systems that satisfy either extrinsic (practical utility) or
+            intrinsic (enjoyable experience) motivations show improved adoption outcomes.
+          </p>
+
+          <h3 className={H3_CLASSES}>Barriers to Technology Adoption Identified</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Low perceived usefulness:</strong> Users viewing systems as not improving job
+              performance or productivity show reduced usage intentions regardless of enjoyment.
+            </li>
+            <li>
+              <strong>High perceived complexity:</strong> Systems perceived as difficult to learn
+              and operate create ease-of-use barriers reducing both attitudes and intentions.
+            </li>
+            <li>
+              <strong>Lack of perceived enjoyment:</strong> Systems designed as purely functional
+              without any pleasurable interaction experience create adoption friction.
+            </li>
+            <li>
+              <strong>Negative user experience:</strong> Cumbersome interfaces, frustrating error
+              handling, and unintuitive workflows undermine intrinsic motivation.
+            </li>
+            <li>
+              <strong>Disconnection from job tasks:</strong> When users perceive systems as
+              tangential rather than central to their actual work, usefulness perceptions decline.
+            </li>
+            <li>
+              <strong>Absence of playfulness:</strong> Highly utilitarian systems without any
+              engaging, pleasant, or gamified elements lose the intrinsic motivation component.
+            </li>
+          </ul>
+
+          <h3 className={H3_CLASSES}>Leadership Actions the Model Prescribes</h3>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Establish clear use case fit:</strong> Communicate explicitly how systems
+              improve job performance, save time, or enhance effectiveness to build usefulness
+              perceptions.
+            </li>
+            <li>
+              <strong>Optimize user experience design:</strong> Ensure systems are intuitive,
+              responsive, and pleasant to interact with, reducing complexity barriers.
+            </li>
+            <li>
+              <strong>Incorporate engaging elements:</strong> Add gamification, visual appeal, or
+              pleasurable interaction patterns that build intrinsic motivation.
+            </li>
+            <li>
+              <strong>Provide comprehensive training:</strong> Reduce perceived ease-of-use barriers
+              through hands-on practice, clear documentation, and accessible support.
+            </li>
+            <li>
+              <strong>Demonstrate tangible benefits:</strong> Show real examples of productivity
+              gains, time savings, or improved outcomes to strengthen usefulness beliefs.
+            </li>
+            <li>
+              <strong>Create positive first experiences:</strong> Ensure initial interactions are
+              smooth and successful, building positive attitudes and enjoyment perceptions.
+            </li>
+            <li>
+              <strong>Balance utility and experience:</strong> Recognize that systems need both
+              practical value (extrinsic) and pleasant experiences (intrinsic) for strong adoption.
+            </li>
+          </ul>
+        </section>
+
+        {/* 12. Following Models or Theories */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Following Models or Theories</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Davis et al. motivation extension directly shaped subsequent technology adoption
+            research:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>
+                Task-Technology Fit extensions (Goodhue &amp;{' '}
+                <Link
+                  href="/bibliography-1-11-task-technology-fit-ttf-goodhue-thompson-1995"
+                  className="text-tabs-teal-deep hover:underline"
+                >
+                  Thompson, 1995
+                </Link>
+                ):
+              </strong>{' '}
+              Incorporated hedonic fit alongside utilitarian task-technology fit recognition.
+            </li>
+            <li>
+              <strong>TAM 2 and TAM 3 models (Venkatesh &amp; Bala):</strong> Expanded perceived
+              usefulness antecedents to include social influence and cognitive experience factors.
+            </li>
+            <li>
+              <strong>Unified Theory of Acceptance and Use of Technology (UTAUT):</strong> Included
+              both utilitarian (performance expectancy) and hedonic (hedonic motivation) dimensions.
+            </li>
+            <li>
+              <strong>Flow theory in technology (Csikszentmihalyi-based research):</strong> Extended
+              intrinsic motivation investigations to examine optimal experience in system use.
+            </li>
+            <li>
+              <strong>Gamification in technology adoption:</strong> Applied intrinsic motivation
+              principles to design game-like elements improving engagement and adoption.
+            </li>
+          </ul>
+        </section>
+
+        {/* 13. References */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>References</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-davis-1989">
+              Davis, F. D. (1989). Perceived usefulness, perceived ease of use, and user acceptance
+              of information technology. <em>MIS Quarterly</em>, 13(3), 319-340.
+              <span className="text-xs ml-1">
+                <a
+                  href="#cite-ref-davis-1989-1"
+                  className="text-tabs-teal-deep hover:underline"
+                  aria-label="Back to citation 1"
+                >
+                  ↩
+                </a>
+              </span>{' '}
+              https://doi.org/10.2307/249008
+            </li>
+            <li id="ref-davis-1992">
+              Davis, F. D., Bagozzi, R. P., &amp; Warshaw, P. R. (1992). Extrinsic and intrinsic
+              motivation to use computers in the workplace.{' '}
+              <em>Journal of Applied Social Psychology</em>, 22(14), 1111-1132.
+              https://doi.org/10.1111/j.1559-1816.1992.tb00945.x
+            </li>
+          </ol>
+        </section>
+
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Further Reading</h2>
+          <ol className={REFERENCES_OL_CLASSES}>
+            <li id="ref-deci-1985">
+              Deci, E. L., &amp; Ryan, R. M. (1985). Intrinsic motivation and self-determination in
+              human behavior. Plenum Press.
+            </li>
+            <li id="ref-fishbein-1975">
+              Fishbein, M., &amp; Ajzen, I. (1975). Belief, attitude, intention, and behavior: An
+              introduction to theory and research. Addison-Wesley.
+            </li>
+            <li id="ref-csikszentmihalyi-1990">
+              Csikszentmihalyi, M. (1990). Flow: The psychology of optimal experience. Harper &amp;
+              Row.
+            </li>
+            <li id="ref-venkatesh-2003">
+              Venkatesh, V., Morris, M. G., Davis, G. B., &amp; Davis, F. D. (2003). User acceptance
+              of information technology: Toward a unified view. <em>MIS Quarterly</em>, 27(3),
+              425-478. https://doi.org/10.2307/30036540
+            </li>
+            <li id="ref-goodhue-1995">
+              Goodhue, D. L., &amp; Thompson, R. L. (1995). Task-technology fit and individual
+              performance. <em>MIS Quarterly</em>, 19(2), 213-236. https://doi.org/10.2307/249689
+            </li>
+            <li id="ref-ryan-2000">
+              Ryan, R. M., &amp; Deci, E. L. (2000). Intrinsic and extrinsic motivations: Classic
+              definitions and new directions. <em>Contemporary Educational Psychology</em>, 25(1),
+              54-67.
+            </li>
+          </ol>
+        </section>
+
+        {/* 14. Series Navigation */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Series Navigation</h2>
+          <div className="space-y-4">
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-8-personal-computing-acceptance-thompson-1991"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                &larr; Previous: Personal Computing Utilization (Thompson et al.)
+              </Link>
+            </p>
+            <p className={PARAGRAPH_CLASSES}>
+              <Link
+                href="/bibliography-1-10-decomposed-tpb-taylor-todd-1995"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Next: Decomposed Theory of Planned Behavior (Taylor &amp; Todd) &rarr;
+              </Link>
+            </p>
+            <p className={`${PARAGRAPH_CLASSES} mt-6`}>
+              <Link
+                href="/article-bibliography-comprehensive-series-bibliography"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                Back to Complete Bibliography
+              </Link>
+            </p>
+          </div>
         </section>
       </article>
     </main>

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -538,9 +538,7 @@ const BibliographyArticlePage = () => {
                   href="#cite-ref-davis-1989-1"
                   className="text-tabs-teal-deep hover:underline"
                   aria-label="Back to citation 1"
-                >
-                  ↩
-                </a>
+                ></a>
               </span>{' '}
               https://doi.org/10.2307/249008
             </li>


### PR DESCRIPTION
## Summary

Source PDF-verified corrections and structural improvements to bibliography page 1-9 (Intrinsic & Extrinsic Motivation - Davis et al., 1992).

**Reviewed against:** Davis, Bagozzi & Warshaw (1992) JASP 22(14), 1111-1132. 22-page PDF read.

### Full scope of changes

**Content corrections (PDF-verified):**
- **WRONG DOI appearing TWICE** — Had `10.2307/249008` (Davis 1989 MIS Quarterly) in the Theory Publication Info section, duplicated. Replaced with correct DOI from Zotero: `10.1111/j.1559-1816.1992.tb00945.x`. Removed duplicate field.
- **PEOU misclassified as "(Extrinsic)"** — Paper treats PEOU as an antecedent whose effects are fully mediated by usefulness and enjoyment, not as extrinsic motivation itself.

**Page structure improvements:**
- Reworked page into standard H2 sections (Model Identification, Citation Information, etc.) matching the bibliography page template used across the series
- Added expanded citation formatting (APA + Chicago styles)
- Added References and Further Reading sections with properly linked DOIs
- Updated conceptual framing of PEOU throughout

**Accessibility / consistency fixes (from code review):**
- Fixed empty `<a>` back-link — added `↩︎` glyph and `focus-visible:underline` for keyboard accessibility
- Wrapped all reference and further-reading DOIs as external hyperlinks (`target="_blank" rel="noopener noreferrer"`) to match pattern on other bibliography pages
- Replaced non-standard `` {` `} `` whitespace JSX with standard `{' '}` pattern
- Updated `metadata.description` to use the consistent "Deep dive into …" format used across bibliography pages

### What passed PDF review
- Extrinsic (usefulness) vs intrinsic (enjoyment) distinction correct
- Two studies (word processing, business graphics) correct
- Publication metadata matches Zotero (JASP 22, 1111-1132)

## Test plan
- [x] Verify 1 file changed
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)