### PR TITLE
CRP convergence: top-3 salience ranking page + pipeline/JSON updates

### DIFF
--- a/scripts/analysis/tabs_v2_unified_data_analysis.py
+++ b/scripts/analysis/tabs_v2_unified_data_analysis.py
@@ -1784,10 +1784,182 @@ def sensitivity_to_json(cuts, idx):
         for cat, _ in OTHER_ROLE_CATEGORIES_PATTERNS
     ] + [{"label": "Uncategorized", "description": "Responses that did not match any keyword pattern", "examples": ""}]
 
+    # ------------------------------------------------------------------
+    # Extended blocks (added 2026-04-16): top-3 pick counts, item-level
+    # descriptives, construct grand means/SDs, demographic detail. These
+    # feed the /results/crp-2026/top-barriers page and validator v5.
+    # ------------------------------------------------------------------
+    primary_rows = None
+    for label, rows in cuts:
+        if label == "Prolific Accepted":
+            primary_rows = rows
+            break
+    if primary_rows is None and cuts:
+        primary_rows = cuts[-1][1]
+
+    if primary_rows:
+        result["top3_pick_counts"] = _build_top3_pick_counts(primary_rows, idx)
+        result["item_descriptives"] = _build_item_descriptives(primary_rows, idx)
+        result["construct_grand"] = _build_construct_grand(primary_rows, idx)
+        result["demographics_detailed"] = _build_demographics_detailed(primary_rows, idx)
+
     # Timestamp - consumed by 10+ results pages via utcTimestamp component
     result["last_updated"] = datetime.utcnow().isoformat() + "Z"
 
     return result
+
+
+# ============================================================================
+# SECTION 1B: Extended block builders (top-3, item descriptives, demographics)
+# ============================================================================
+
+# Item 19 in barriers, item 18 in readiness, item 9 in maturity are IRI attention
+# checks and are excluded from substantive analysis. CLAUDE.md documents this.
+TOP3_COLS = [f"Q29-46_Top3Barriers_{i}" for i in range(1, 19)]
+
+BARRIER_ITEM_TEXT = {
+    1: "Resistance to change among employees or middle management",
+    2: "Lack of skilled personnel or in-house expertise to implement new technologies",
+    3: "Insufficient leadership commitment or unclear strategic direction",
+    4: "Inadequate training or support for new technology users",
+    5: "Cultural or organizational inertia favoring established practices",
+    6: "High cost associated with acquiring or implementing new technologies",
+    7: "Difficulty integrating new technologies with existing legacy systems",
+    8: "Limited access to reliable vendor support or third-party expertise",
+    9: "Poor communication about the purpose or benefits of new technology",
+    10: "Fear of failure or adverse impact on daily operations",
+    11: "Lack of alignment between technology and business strategy",
+    12: "Insufficient budget or financial resources",
+    13: "Cybersecurity concerns or regulatory compliance barriers",
+    14: "Legal, contractual, or privacy restrictions",
+    15: "Uncertainty about return on investment (ROI) or measurable benefits",
+    16: "Supplier or vendor lock-in or compatibility limitations",
+    17: "Difficulty scaling pilot projects to organization-wide adoption",
+    18: "Economic, geopolitical, or market-level disruptions",
+}
+
+READINESS_ITEM_TEXT = {
+    1: "Formal digital or technology strategy",
+    2: "Dedicated IT leadership role",
+    3: "Skilled in-house technology staff",
+    4: "Adequate financial resources for technology",
+    5: "Willingness to invest in new technologies",
+    6: "Data and analytics capabilities",
+    7: "Cybersecurity and risk management capabilities",
+    8: "Change management capabilities",
+    9: "Vendor and partner management capabilities",
+    10: "Digital infrastructure (cloud, network, devices)",
+    11: "Alignment between IT and business strategy",
+    12: "Cross-functional collaboration on technology",
+    13: "Employee digital skills",
+    14: "Leadership digital literacy",
+    15: "Innovation culture",
+    16: "Willingness to experiment with new technologies",
+    17: "Customer or stakeholder demand for technology",
+}
+
+MATURITY_ITEM_TEXT = {
+    1: "IT Investment & Value Mgmt",
+    2: "IT-Enabled Innovation",
+    3: "Process Mgmt & Standardization",
+    4: "Data Governance & Analytics",
+    5: "Tech Risk & Resilience",
+    6: "Strategic IT Planning",
+    7: "Workforce Capability",
+    8: "Change Leadership",
+}
+
+
+def _build_top3_pick_counts(rows, idx):
+    total = len(rows)
+    items = []
+    for i, col in enumerate(TOP3_COLS, start=1):
+        if col not in idx:
+            items.append({"item": f"B{i}", "text": BARRIER_ITEM_TEXT[i], "count": 0, "pct": 0.0})
+            continue
+        col_idx = idx[col]
+        cnt = sum(1 for r in rows if col_idx < len(r) and str(r[col_idx]).strip() not in ("", "nan", "None"))
+        pct = round(100.0 * cnt / total, 2) if total else 0.0
+        items.append({"item": f"B{i}", "text": BARRIER_ITEM_TEXT[i], "count": cnt, "pct": pct})
+    items_sorted = sorted(items, key=lambda r: -r["count"])
+    return {"total_n": total, "items": items, "items_sorted_desc": items_sorted}
+
+
+def _build_item_descriptives(rows, idx):
+    def compute(cols, scale, labels, prefix):
+        out = []
+        for i, col in enumerate(cols, start=1):
+            if col not in idx:
+                continue
+            col_idx = idx[col]
+            vals = []
+            for r in rows:
+                if col_idx >= len(r):
+                    continue
+                v = str(r[col_idx]).strip()
+                if v in ("", "nan", "None"):
+                    continue
+                mapped = scale.get(v)
+                if mapped is None:
+                    continue
+                vals.append(mapped)
+            if not vals:
+                out.append({"item": f"{prefix}{i}", "text": labels[i], "mean": None, "sd": None, "n": 0})
+                continue
+            m = sum(vals) / len(vals)
+            if len(vals) > 1:
+                var = sum((x - m) ** 2 for x in vals) / (len(vals) - 1)
+                sd = var ** 0.5
+            else:
+                sd = 0.0
+            out.append({"item": f"{prefix}{i}", "text": labels[i], "mean": round(m, 4), "sd": round(sd, 4), "n": len(vals)})
+        return out
+
+    return {
+        "barriers":  compute(BARRIER_COLS,  BARRIER_SCALE,  BARRIER_ITEM_TEXT,  "B"),
+        "readiness": compute(READINESS_COLS, READINESS_SCALE, READINESS_ITEM_TEXT, "R"),
+        "maturity":  compute(MATURITY_COLS, MATURITY_SCALE, MATURITY_ITEM_TEXT, "M"),
+    }
+
+
+def _build_construct_grand(rows, idx):
+    def gm(cols, scale):
+        vals = _person_means_rows(rows, cols, scale, idx)
+        if not vals:
+            return {"mean": None, "sd": None, "n": 0}
+        m, sd = mean_sd(vals)
+        return {"mean": round(m, 4) if m is not None else None,
+                "sd": round(sd, 4) if sd is not None else None,
+                "n": len(vals)}
+
+    return {
+        "barriers":  gm(BARRIER_COLS,  BARRIER_SCALE),
+        "readiness": gm(READINESS_COLS, READINESS_SCALE),
+        "maturity":  gm(MATURITY_COLS, MATURITY_SCALE),
+    }
+
+
+def _build_demographics_detailed(rows, idx):
+    total = len(rows)
+    def tabulate(col_name):
+        if col_name not in idx:
+            return []
+        col_idx = idx[col_name]
+        counter = Counter()
+        for r in rows:
+            if col_idx < len(r):
+                v = str(r[col_idx]).strip()
+                if v not in ("", "nan", "None"):
+                    counter[v] += 1
+        return [{"label": k, "count": v, "pct": round(100.0 * v / total, 2) if total else 0.0}
+                for k, v in counter.most_common()]
+
+    return {
+        "roles": tabulate("Q1_Role"),
+        "org_sizes": tabulate("Q4_OrgSize"),
+        "profit_models": tabulate("Q5_ProfitModel"),
+        "decision_authority": tabulate("Q2_DecisionAuth"),
+    }
 
 
 # ============================================================================

--- a/src/app/results/crp-2026/page.tsx
+++ b/src/app/results/crp-2026/page.tsx
@@ -270,6 +270,12 @@ const CRP2026Page = () => {
               - hierarchical barrier factor structure
             </li>
             <li>
+              <Link href="/results/crp-2026/top-barriers" className="text-blue-600 hover:underline">
+                Top 3 Barriers
+              </Link>{' '}
+              - forced-choice salience ranking vs continuous-rating ranking
+            </li>
+            <li>
               <Link href="/results/crp-2026/glossary" className="text-blue-600 hover:underline">
                 Statistics Glossary
               </Link>{' '}

--- a/src/app/results/crp-2026/top-barriers/page.tsx
+++ b/src/app/results/crp-2026/top-barriers/page.tsx
@@ -1,0 +1,245 @@
+import type { Metadata } from 'next'
+import {
+  ARTICLE_CLASSES,
+  H1_CLASSES,
+  H2_CLASSES,
+  H3_CLASSES,
+  SECTION_CLASSES,
+  PARAGRAPH_CLASSES,
+} from '@/lib/articleStyles'
+import Link from 'next/link'
+import crpData from '@/data/crp-sensitivity-analysis.json'
+import { DATA_UNAVAILABLE } from '@/lib/sentinelMarker'
+
+export const metadata: Metadata = {
+  title: 'CRP 2026 Top 3 Barriers - TABS',
+  description:
+    'Top-3 barrier salience ranking for the TABS CRP 2026 frozen dataset (N=200). Compares forced-choice pick counts with mean-based ranking and highlights the position-3 divergence between cultural and cybersecurity barriers.',
+  alternates: {
+    canonical: '/results/crp-2026/top-barriers',
+  },
+}
+
+type PickItem = { item: string; text: string; count: number; pct: number }
+type ItemDescriptive = { item: string; text: string; mean: number | null; sd: number | null; n: number }
+
+type Top3Block = {
+  total_n?: number
+  items?: PickItem[]
+  items_sorted_desc?: PickItem[]
+}
+
+type ItemBlock = {
+  barriers?: ItemDescriptive[]
+}
+
+const top3: Top3Block =
+  (crpData as { top3_pick_counts?: Top3Block }).top3_pick_counts ?? {}
+
+const items: ItemBlock =
+  (crpData as { item_descriptives?: ItemBlock }).item_descriptives ?? {}
+
+const pickSorted: PickItem[] = Array.isArray(top3.items_sorted_desc)
+  ? top3.items_sorted_desc
+  : []
+const meanSorted: ItemDescriptive[] = Array.isArray(items.barriers)
+  ? [...items.barriers].sort((a, b) => (b.mean ?? -Infinity) - (a.mean ?? -Infinity))
+  : []
+
+const TOTAL_N: number | null = typeof top3.total_n === 'number' ? top3.total_n : null
+
+const pickRankOf: Record<string, number> = {}
+pickSorted.forEach((r, i) => {
+  pickRankOf[r.item] = i + 1
+})
+const meanRankOf: Record<string, number> = {}
+meanSorted.forEach((r, i) => {
+  meanRankOf[r.item] = i + 1
+})
+
+const fmt = (val: number | null, decimals: number = 2): string => {
+  if (val === null || val === undefined || Number.isNaN(val)) return DATA_UNAVAILABLE
+  return val.toFixed(decimals)
+}
+
+const TopBarriersPage = () => {
+  const topPick = pickSorted.slice(0, 10)
+  const topMean = meanSorted.slice(0, 10)
+  const maxPick = topPick.length > 0 ? Math.max(...topPick.map((r) => r.count)) : 1
+
+  return (
+    <div className="pt-20 sm:pt-[120px] bg-white">
+      <article className={ARTICLE_CLASSES}>
+        <h1 className={H1_CLASSES}>CRP 2026: Top 3 Barriers</h1>
+
+        <div className="mb-6">
+          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800 border border-green-200">
+            Published: April 2026
+          </span>
+        </div>
+
+        <section className={SECTION_CLASSES}>
+          <p className={PARAGRAPH_CLASSES}>
+            This page presents the forced-choice Top 3 barriers ranking from the TABS CRP 2026
+            frozen dataset (N={TOTAL_N !== null ? TOTAL_N : DATA_UNAVAILABLE}). Each participant
+            selected up to three barriers from the full list of 18. Counts below reflect the number
+            of participants who included each barrier in their top 3.
+          </p>
+          <p className={PARAGRAPH_CLASSES}>
+            The forced-choice ranking complements the continuous Likert-based ranking shown on the{' '}
+            <Link href="/results/crp-2026/descriptive" className="text-blue-600 hover:underline font-medium">
+              Descriptive Statistics
+            </Link>{' '}
+            page. When a participant is forced to pick only the 3 most salient barriers, cultural
+            and people-centric barriers (B1: Resistance to Change) rise in salience relative to
+            their continuous-rating position.
+          </p>
+        </section>
+
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Top 10 by Pick Count</h2>
+          <div className="space-y-2">
+            {topPick.map((r) => {
+              const width = Math.max(2, Math.round((r.count / maxPick) * 100))
+              return (
+                <div key={r.item} className="border border-gray-200 rounded-lg p-3 bg-gray-50">
+                  <div className="flex items-baseline justify-between gap-4">
+                    <div className="font-semibold text-tabs-teal-deep">
+                      {r.item}. {r.text}
+                    </div>
+                    <div className="font-mono text-sm text-gray-700 whitespace-nowrap">
+                      N={r.count} ({fmt(r.pct, 1)}%)
+                    </div>
+                  </div>
+                  <div className="mt-2 h-2 bg-gray-200 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-tabs-teal-deep"
+                      style={{ width: `${width}%` }}
+                      aria-hidden="true"
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Pick-Based vs Mean-Based Ranking</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The two rankings agree at the top two positions (B6: High Cost; B7: Legacy Integration)
+            but diverge at position 3. Continuous Likert means place cybersecurity and compliance
+            (B13, B14) above cultural barriers, while the forced-choice task places B1: Resistance
+            to Change at position 3.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border border-gray-200 rounded-lg">
+              <thead className="bg-gray-100 text-gray-700">
+                <tr>
+                  <th className="px-3 py-2 text-left">Barrier</th>
+                  <th className="px-3 py-2 text-right">Pick N</th>
+                  <th className="px-3 py-2 text-right">Pick %</th>
+                  <th className="px-3 py-2 text-right">Pick Rank</th>
+                  <th className="px-3 py-2 text-right">Mean</th>
+                  <th className="px-3 py-2 text-right">Mean Rank</th>
+                  <th className="px-3 py-2 text-right">Delta</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topPick.map((r) => {
+                  const meanEntry = (items.barriers ?? []).find((m) => m.item === r.item)
+                  const pr = pickRankOf[r.item] ?? null
+                  const mr = meanRankOf[r.item] ?? null
+                  const delta = pr !== null && mr !== null ? pr - mr : null
+                  return (
+                    <tr key={r.item} className="border-t border-gray-200">
+                      <td className="px-3 py-2">
+                        <span className="font-semibold">{r.item}</span> {r.text}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono">{r.count}</td>
+                      <td className="px-3 py-2 text-right font-mono">{fmt(r.pct, 1)}</td>
+                      <td className="px-3 py-2 text-right font-mono">{pr ?? DATA_UNAVAILABLE}</td>
+                      <td className="px-3 py-2 text-right font-mono">{fmt(meanEntry?.mean ?? null, 4)}</td>
+                      <td className="px-3 py-2 text-right font-mono">{mr ?? DATA_UNAVAILABLE}</td>
+                      <td className="px-3 py-2 text-right font-mono">
+                        {delta !== null ? (delta > 0 ? `+${delta}` : String(delta)) : DATA_UNAVAILABLE}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          <p className={PARAGRAPH_CLASSES}>
+            Interpretation: a negative Delta means the barrier is more salient under the
+            forced-choice task than under continuous rating; a positive Delta means the opposite.
+            B1 has Delta = -2 (forced choice pushes it up from rank 5 to rank 3), while B13 has
+            Delta = +2 (mean rating pushes it up from pick-rank 5 to mean-rank 3).
+          </p>
+        </section>
+
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Top 10 by Continuous Mean</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border border-gray-200 rounded-lg">
+              <thead className="bg-gray-100 text-gray-700">
+                <tr>
+                  <th className="px-3 py-2 text-left">Barrier</th>
+                  <th className="px-3 py-2 text-right">Mean</th>
+                  <th className="px-3 py-2 text-right">SD</th>
+                  <th className="px-3 py-2 text-right">N</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topMean.map((r) => (
+                  <tr key={r.item} className="border-t border-gray-200">
+                    <td className="px-3 py-2">
+                      <span className="font-semibold">{r.item}</span> {r.text}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono">{fmt(r.mean, 4)}</td>
+                    <td className="px-3 py-2 text-right font-mono">{fmt(r.sd, 4)}</td>
+                    <td className="px-3 py-2 text-right font-mono">{r.n}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>Methodology</h2>
+          <h3 className={H3_CLASSES}>Forced-Choice Top 3 Pick Task</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            Participants were shown all 18 substantive barriers (IRI attention check excluded) and
+            asked to select the three most salient barriers in their organizational context. The
+            counts above reflect the number of participants who selected each barrier, so the
+            column sums to at most 3N (here 3 x{' '}
+            {TOTAL_N !== null ? TOTAL_N : DATA_UNAVAILABLE} = {TOTAL_N !== null ? TOTAL_N * 3 : DATA_UNAVAILABLE}).
+          </p>
+          <h3 className={H3_CLASSES}>Continuous-Rating Mean</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            The continuous-rating mean is computed from the 5-point barrier Likert scale (Not a
+            Barrier = 1 through Major Barrier = 5) across the same 18 substantive items, averaging
+            across participants rather than summing selection counts. The sample-size column
+            reflects the number of non-missing responses per item.
+          </p>
+          <h3 className={H3_CLASSES}>Source Data</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            All numbers on this page are read from{' '}
+            <code className="text-sm bg-gray-100 px-1 py-0.5 rounded">
+              src/data/crp-sensitivity-analysis.json
+            </code>
+            , which is regenerated daily by the TABS analysis pipeline from the frozen
+            CRP N=200 CSV. The pipeline script is{' '}
+            <code className="text-sm bg-gray-100 px-1 py-0.5 rounded">
+              scripts/analysis/tabs_v2_unified_data_analysis.py
+            </code>
+            .
+          </p>
+        </section>
+      </article>
+    </div>
+  )
+}
+
+export default TopBarriersPage

--- a/src/app/results/crp-2026/top-barriers/page.tsx
+++ b/src/app/results/crp-2026/top-barriers/page.tsx
@@ -21,7 +21,13 @@ export const metadata: Metadata = {
 }
 
 type PickItem = { item: string; text: string; count: number; pct: number }
-type ItemDescriptive = { item: string; text: string; mean: number | null; sd: number | null; n: number }
+type ItemDescriptive = {
+  item: string
+  text: string
+  mean: number | null
+  sd: number | null
+  n: number
+}
 
 type Top3Block = {
   total_n?: number
@@ -33,15 +39,11 @@ type ItemBlock = {
   barriers?: ItemDescriptive[]
 }
 
-const top3: Top3Block =
-  (crpData as { top3_pick_counts?: Top3Block }).top3_pick_counts ?? {}
+const top3: Top3Block = (crpData as { top3_pick_counts?: Top3Block }).top3_pick_counts ?? {}
 
-const items: ItemBlock =
-  (crpData as { item_descriptives?: ItemBlock }).item_descriptives ?? {}
+const items: ItemBlock = (crpData as { item_descriptives?: ItemBlock }).item_descriptives ?? {}
 
-const pickSorted: PickItem[] = Array.isArray(top3.items_sorted_desc)
-  ? top3.items_sorted_desc
-  : []
+const pickSorted: PickItem[] = Array.isArray(top3.items_sorted_desc) ? top3.items_sorted_desc : []
 const meanSorted: ItemDescriptive[] = Array.isArray(items.barriers)
   ? [...items.barriers].sort((a, b) => (b.mean ?? -Infinity) - (a.mean ?? -Infinity))
   : []
@@ -87,7 +89,10 @@ const TopBarriersPage = () => {
           </p>
           <p className={PARAGRAPH_CLASSES}>
             The forced-choice ranking complements the continuous Likert-based ranking shown on the{' '}
-            <Link href="/results/crp-2026/descriptive" className="text-blue-600 hover:underline font-medium">
+            <Link
+              href="/results/crp-2026/descriptive"
+              className="text-blue-600 hover:underline font-medium"
+            >
               Descriptive Statistics
             </Link>{' '}
             page. When a participant is forced to pick only the 3 most salient barriers, cultural
@@ -159,10 +164,16 @@ const TopBarriersPage = () => {
                       <td className="px-3 py-2 text-right font-mono">{r.count}</td>
                       <td className="px-3 py-2 text-right font-mono">{fmt(r.pct, 1)}</td>
                       <td className="px-3 py-2 text-right font-mono">{pr ?? DATA_UNAVAILABLE}</td>
-                      <td className="px-3 py-2 text-right font-mono">{fmt(meanEntry?.mean ?? null, 4)}</td>
+                      <td className="px-3 py-2 text-right font-mono">
+                        {fmt(meanEntry?.mean ?? null, 4)}
+                      </td>
                       <td className="px-3 py-2 text-right font-mono">{mr ?? DATA_UNAVAILABLE}</td>
                       <td className="px-3 py-2 text-right font-mono">
-                        {delta !== null ? (delta > 0 ? `+${delta}` : String(delta)) : DATA_UNAVAILABLE}
+                        {delta !== null
+                          ? delta > 0
+                            ? `+${delta}`
+                            : String(delta)
+                          : DATA_UNAVAILABLE}
                       </td>
                     </tr>
                   )
@@ -172,9 +183,9 @@ const TopBarriersPage = () => {
           </div>
           <p className={PARAGRAPH_CLASSES}>
             Interpretation: a negative Delta means the barrier is more salient under the
-            forced-choice task than under continuous rating; a positive Delta means the opposite.
-            B1 has Delta = -2 (forced choice pushes it up from rank 5 to rank 3), while B13 has
-            Delta = +2 (mean rating pushes it up from pick-rank 5 to mean-rank 3).
+            forced-choice task than under continuous rating; a positive Delta means the opposite. B1
+            has Delta = -2 (forced choice pushes it up from rank 5 to rank 3), while B13 has Delta =
+            +2 (mean rating pushes it up from pick-rank 5 to mean-rank 3).
           </p>
         </section>
 
@@ -212,9 +223,9 @@ const TopBarriersPage = () => {
           <p className={PARAGRAPH_CLASSES}>
             Participants were shown all 18 substantive barriers (IRI attention check excluded) and
             asked to select the three most salient barriers in their organizational context. The
-            counts above reflect the number of participants who selected each barrier, so the
-            column sums to at most 3N (here 3 x{' '}
-            {TOTAL_N !== null ? TOTAL_N : DATA_UNAVAILABLE} = {TOTAL_N !== null ? TOTAL_N * 3 : DATA_UNAVAILABLE}).
+            counts above reflect the number of participants who selected each barrier, so the column
+            sums to at most 3N (here 3 x {TOTAL_N !== null ? TOTAL_N : DATA_UNAVAILABLE} ={' '}
+            {TOTAL_N !== null ? TOTAL_N * 3 : DATA_UNAVAILABLE}).
           </p>
           <h3 className={H3_CLASSES}>Continuous-Rating Mean</h3>
           <p className={PARAGRAPH_CLASSES}>
@@ -229,8 +240,8 @@ const TopBarriersPage = () => {
             <code className="text-sm bg-gray-100 px-1 py-0.5 rounded">
               src/data/crp-sensitivity-analysis.json
             </code>
-            , which is regenerated daily by the TABS analysis pipeline from the frozen
-            CRP N=200 CSV. The pipeline script is{' '}
+            , which is regenerated daily by the TABS analysis pipeline from the frozen CRP N=200
+            CSV. The pipeline script is{' '}
             <code className="text-sm bg-gray-100 px-1 py-0.5 rounded">
               scripts/analysis/tabs_v2_unified_data_analysis.py
             </code>

--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -210,13 +210,17 @@
         {
           "filter_id": "current_country_of_residence",
           "label": "Current Country of Residence",
-          "selected_values": ["United States"],
+          "selected_values": [
+            "United States"
+          ],
           "base_field": true
         },
         {
           "filter_id": "employment_status",
           "label": "Employment Status",
-          "selected_values": ["Full-Time"],
+          "selected_values": [
+            "Full-Time"
+          ],
           "base_field": true
         },
         {
@@ -237,7 +241,11 @@
         {
           "filter_id": "company_size",
           "label": "Company Size",
-          "selected_values": ["50-249", "250-999", "1000+"],
+          "selected_values": [
+            "50-249",
+            "250-999",
+            "1000+"
+          ],
           "base_field": false
         },
         {
@@ -510,8 +518,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [18, 61],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            18,
+            61
+          ],
           "constructs": {
             "barriers": {
               "f": 0.2849,
@@ -537,8 +551,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [37, 25, 17],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            37,
+            25,
+            17
+          ],
           "constructs": {
             "barriers": {
               "f": 2.3884,
@@ -774,8 +796,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [32, 84],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            32,
+            84
+          ],
           "constructs": {
             "barriers": {
               "f": 1.523,
@@ -801,8 +829,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [52, 42, 22],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            52,
+            42,
+            22
+          ],
           "constructs": {
             "barriers": {
               "f": 6.4834,
@@ -1039,8 +1075,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [53, 147],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            53,
+            147
+          ],
           "constructs": {
             "barriers": {
               "f": 0.0785,
@@ -1066,8 +1108,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [85, 70, 45],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            85,
+            70,
+            45
+          ],
           "constructs": {
             "barriers": {
               "f": 2.5541,
@@ -1304,8 +1354,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [53, 147],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            53,
+            147
+          ],
           "constructs": {
             "barriers": {
               "f": 0.0785,
@@ -1331,8 +1387,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [85, 70, 45],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            85,
+            70,
+            45
+          ],
           "constructs": {
             "barriers": {
               "f": 2.5541,
@@ -1569,8 +1633,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [53, 147],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            53,
+            147
+          ],
           "constructs": {
             "barriers": {
               "f": 0.0785,
@@ -1596,8 +1666,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [85, 70, 45],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            85,
+            70,
+            45
+          ],
           "constructs": {
             "barriers": {
               "f": 2.5541,
@@ -1648,7 +1726,11 @@
       "error": null
     },
     "profit_model_distribution": {
-      "labels": ["For-Profit", "Non-Profit", "Government/Public Sector"],
+      "labels": [
+        "For-Profit",
+        "Non-Profit",
+        "Government/Public Sector"
+      ],
       "groups": {
         "Conservative Clean": {
           "For-Profit": 56,
@@ -1710,5 +1792,704 @@
       "examples": ""
     }
   ],
-  "last_updated": "2026-04-16T11:02:38.149828Z"
+  "last_updated": "2026-04-16T11:02:38.149828Z",
+  "top3_pick_counts": {
+    "total_n": 200,
+    "items": [
+      {
+        "item": "B1",
+        "text": "Resistance to change among employees or middle management",
+        "count": 56,
+        "pct": 28.0
+      },
+      {
+        "item": "B2",
+        "text": "Lack of skilled personnel or in-house expertise to implement new technologies",
+        "count": 21,
+        "pct": 10.5
+      },
+      {
+        "item": "B3",
+        "text": "Insufficient leadership commitment or unclear strategic direction",
+        "count": 19,
+        "pct": 9.5
+      },
+      {
+        "item": "B4",
+        "text": "Inadequate training or support for new technology users",
+        "count": 30,
+        "pct": 15.0
+      },
+      {
+        "item": "B5",
+        "text": "Cultural or organizational inertia favoring established practices",
+        "count": 13,
+        "pct": 6.5
+      },
+      {
+        "item": "B6",
+        "text": "High cost associated with acquiring or implementing new technologies",
+        "count": 75,
+        "pct": 37.5
+      },
+      {
+        "item": "B7",
+        "text": "Difficulty integrating new technologies with existing legacy systems",
+        "count": 73,
+        "pct": 36.5
+      },
+      {
+        "item": "B8",
+        "text": "Limited access to reliable vendor support or third-party expertise",
+        "count": 21,
+        "pct": 10.5
+      },
+      {
+        "item": "B9",
+        "text": "Poor communication about the purpose or benefits of new technology",
+        "count": 28,
+        "pct": 14.0
+      },
+      {
+        "item": "B10",
+        "text": "Fear of failure or adverse impact on daily operations",
+        "count": 29,
+        "pct": 14.5
+      },
+      {
+        "item": "B11",
+        "text": "Lack of alignment between technology and business strategy",
+        "count": 6,
+        "pct": 3.0
+      },
+      {
+        "item": "B12",
+        "text": "Insufficient budget or financial resources",
+        "count": 44,
+        "pct": 22.0
+      },
+      {
+        "item": "B13",
+        "text": "Cybersecurity concerns or regulatory compliance barriers",
+        "count": 52,
+        "pct": 26.0
+      },
+      {
+        "item": "B14",
+        "text": "Legal, contractual, or privacy restrictions",
+        "count": 54,
+        "pct": 27.0
+      },
+      {
+        "item": "B15",
+        "text": "Uncertainty about return on investment (ROI) or measurable benefits",
+        "count": 18,
+        "pct": 9.0
+      },
+      {
+        "item": "B16",
+        "text": "Supplier or vendor lock-in or compatibility limitations",
+        "count": 20,
+        "pct": 10.0
+      },
+      {
+        "item": "B17",
+        "text": "Difficulty scaling pilot projects to organization-wide adoption",
+        "count": 19,
+        "pct": 9.5
+      },
+      {
+        "item": "B18",
+        "text": "Economic, geopolitical, or market-level disruptions",
+        "count": 22,
+        "pct": 11.0
+      }
+    ],
+    "items_sorted_desc": [
+      {
+        "item": "B6",
+        "text": "High cost associated with acquiring or implementing new technologies",
+        "count": 75,
+        "pct": 37.5
+      },
+      {
+        "item": "B7",
+        "text": "Difficulty integrating new technologies with existing legacy systems",
+        "count": 73,
+        "pct": 36.5
+      },
+      {
+        "item": "B1",
+        "text": "Resistance to change among employees or middle management",
+        "count": 56,
+        "pct": 28.0
+      },
+      {
+        "item": "B14",
+        "text": "Legal, contractual, or privacy restrictions",
+        "count": 54,
+        "pct": 27.0
+      },
+      {
+        "item": "B13",
+        "text": "Cybersecurity concerns or regulatory compliance barriers",
+        "count": 52,
+        "pct": 26.0
+      },
+      {
+        "item": "B12",
+        "text": "Insufficient budget or financial resources",
+        "count": 44,
+        "pct": 22.0
+      },
+      {
+        "item": "B4",
+        "text": "Inadequate training or support for new technology users",
+        "count": 30,
+        "pct": 15.0
+      },
+      {
+        "item": "B10",
+        "text": "Fear of failure or adverse impact on daily operations",
+        "count": 29,
+        "pct": 14.5
+      },
+      {
+        "item": "B9",
+        "text": "Poor communication about the purpose or benefits of new technology",
+        "count": 28,
+        "pct": 14.0
+      },
+      {
+        "item": "B18",
+        "text": "Economic, geopolitical, or market-level disruptions",
+        "count": 22,
+        "pct": 11.0
+      },
+      {
+        "item": "B2",
+        "text": "Lack of skilled personnel or in-house expertise to implement new technologies",
+        "count": 21,
+        "pct": 10.5
+      },
+      {
+        "item": "B8",
+        "text": "Limited access to reliable vendor support or third-party expertise",
+        "count": 21,
+        "pct": 10.5
+      },
+      {
+        "item": "B16",
+        "text": "Supplier or vendor lock-in or compatibility limitations",
+        "count": 20,
+        "pct": 10.0
+      },
+      {
+        "item": "B3",
+        "text": "Insufficient leadership commitment or unclear strategic direction",
+        "count": 19,
+        "pct": 9.5
+      },
+      {
+        "item": "B17",
+        "text": "Difficulty scaling pilot projects to organization-wide adoption",
+        "count": 19,
+        "pct": 9.5
+      },
+      {
+        "item": "B15",
+        "text": "Uncertainty about return on investment (ROI) or measurable benefits",
+        "count": 18,
+        "pct": 9.0
+      },
+      {
+        "item": "B5",
+        "text": "Cultural or organizational inertia favoring established practices",
+        "count": 13,
+        "pct": 6.5
+      },
+      {
+        "item": "B11",
+        "text": "Lack of alignment between technology and business strategy",
+        "count": 6,
+        "pct": 3.0
+      }
+    ]
+  },
+  "item_descriptives": {
+    "barriers": [
+      {
+        "item": "B1",
+        "text": "Resistance to change among employees or middle management",
+        "mean": 2.9698,
+        "sd": 1.3443,
+        "n": 199
+      },
+      {
+        "item": "B2",
+        "text": "Lack of skilled personnel or in-house expertise to implement new technologies",
+        "mean": 2.4798,
+        "sd": 1.2813,
+        "n": 198
+      },
+      {
+        "item": "B3",
+        "text": "Insufficient leadership commitment or unclear strategic direction",
+        "mean": 2.35,
+        "sd": 1.3626,
+        "n": 200
+      },
+      {
+        "item": "B4",
+        "text": "Inadequate training or support for new technology users",
+        "mean": 2.8,
+        "sd": 1.2155,
+        "n": 200
+      },
+      {
+        "item": "B5",
+        "text": "Cultural or organizational inertia favoring established practices",
+        "mean": 2.603,
+        "sd": 1.1273,
+        "n": 199
+      },
+      {
+        "item": "B6",
+        "text": "High cost associated with acquiring or implementing new technologies",
+        "mean": 3.4596,
+        "sd": 1.1776,
+        "n": 198
+      },
+      {
+        "item": "B7",
+        "text": "Difficulty integrating new technologies with existing legacy systems",
+        "mean": 3.3769,
+        "sd": 1.1822,
+        "n": 199
+      },
+      {
+        "item": "B8",
+        "text": "Limited access to reliable vendor support or third-party expertise",
+        "mean": 2.5327,
+        "sd": 1.2341,
+        "n": 199
+      },
+      {
+        "item": "B9",
+        "text": "Poor communication about the purpose or benefits of new technology",
+        "mean": 2.605,
+        "sd": 1.1338,
+        "n": 200
+      },
+      {
+        "item": "B10",
+        "text": "Fear of failure or adverse impact on daily operations",
+        "mean": 2.7286,
+        "sd": 1.1963,
+        "n": 199
+      },
+      {
+        "item": "B11",
+        "text": "Lack of alignment between technology and business strategy",
+        "mean": 2.3687,
+        "sd": 1.1446,
+        "n": 198
+      },
+      {
+        "item": "B12",
+        "text": "Insufficient budget or financial resources",
+        "mean": 2.905,
+        "sd": 1.2425,
+        "n": 200
+      },
+      {
+        "item": "B13",
+        "text": "Cybersecurity concerns or regulatory compliance barriers",
+        "mean": 3.26,
+        "sd": 1.2651,
+        "n": 200
+      },
+      {
+        "item": "B14",
+        "text": "Legal, contractual, or privacy restrictions",
+        "mean": 3.175,
+        "sd": 1.2816,
+        "n": 200
+      },
+      {
+        "item": "B15",
+        "text": "Uncertainty about return on investment (ROI) or measurable benefits",
+        "mean": 2.6,
+        "sd": 1.0797,
+        "n": 200
+      },
+      {
+        "item": "B16",
+        "text": "Supplier or vendor lock-in or compatibility limitations",
+        "mean": 2.5829,
+        "sd": 1.2317,
+        "n": 199
+      },
+      {
+        "item": "B17",
+        "text": "Difficulty scaling pilot projects to organization-wide adoption",
+        "mean": 2.57,
+        "sd": 1.1841,
+        "n": 200
+      },
+      {
+        "item": "B18",
+        "text": "Economic, geopolitical, or market-level disruptions",
+        "mean": 2.3333,
+        "sd": 1.1129,
+        "n": 198
+      }
+    ],
+    "readiness": [
+      {
+        "item": "R1",
+        "text": "Formal digital or technology strategy",
+        "mean": 3.23,
+        "sd": 1.1014,
+        "n": 200
+      },
+      {
+        "item": "R2",
+        "text": "Dedicated IT leadership role",
+        "mean": 3.27,
+        "sd": 1.016,
+        "n": 200
+      },
+      {
+        "item": "R3",
+        "text": "Skilled in-house technology staff",
+        "mean": 3.1186,
+        "sd": 0.9665,
+        "n": 194
+      },
+      {
+        "item": "R4",
+        "text": "Adequate financial resources for technology",
+        "mean": 3.1111,
+        "sd": 1.0888,
+        "n": 198
+      },
+      {
+        "item": "R5",
+        "text": "Willingness to invest in new technologies",
+        "mean": 3.46,
+        "sd": 1.0166,
+        "n": 200
+      },
+      {
+        "item": "R6",
+        "text": "Data and analytics capabilities",
+        "mean": 3.1212,
+        "sd": 1.0831,
+        "n": 198
+      },
+      {
+        "item": "R7",
+        "text": "Cybersecurity and risk management capabilities",
+        "mean": 2.9698,
+        "sd": 1.0679,
+        "n": 199
+      },
+      {
+        "item": "R8",
+        "text": "Change management capabilities",
+        "mean": 3.0251,
+        "sd": 0.9125,
+        "n": 199
+      },
+      {
+        "item": "R9",
+        "text": "Vendor and partner management capabilities",
+        "mean": 3.1859,
+        "sd": 1.0302,
+        "n": 199
+      },
+      {
+        "item": "R10",
+        "text": "Digital infrastructure (cloud, network, devices)",
+        "mean": 2.7538,
+        "sd": 1.0024,
+        "n": 199
+      },
+      {
+        "item": "R11",
+        "text": "Alignment between IT and business strategy",
+        "mean": 3.245,
+        "sd": 1.0913,
+        "n": 200
+      },
+      {
+        "item": "R12",
+        "text": "Cross-functional collaboration on technology",
+        "mean": 3.1224,
+        "sd": 1.0104,
+        "n": 196
+      },
+      {
+        "item": "R13",
+        "text": "Employee digital skills",
+        "mean": 3.132,
+        "sd": 0.9912,
+        "n": 197
+      },
+      {
+        "item": "R14",
+        "text": "Leadership digital literacy",
+        "mean": 3.3163,
+        "sd": 1.1241,
+        "n": 196
+      },
+      {
+        "item": "R15",
+        "text": "Innovation culture",
+        "mean": 3.1122,
+        "sd": 0.9158,
+        "n": 196
+      },
+      {
+        "item": "R16",
+        "text": "Willingness to experiment with new technologies",
+        "mean": 3.0653,
+        "sd": 0.9644,
+        "n": 199
+      },
+      {
+        "item": "R17",
+        "text": "Customer or stakeholder demand for technology",
+        "mean": 3.0704,
+        "sd": 1.0941,
+        "n": 199
+      }
+    ],
+    "maturity": [
+      {
+        "item": "M1",
+        "text": "IT Investment & Value Mgmt",
+        "mean": 3.1667,
+        "sd": 1.0556,
+        "n": 198
+      },
+      {
+        "item": "M2",
+        "text": "IT-Enabled Innovation",
+        "mean": 3.06,
+        "sd": 1.1192,
+        "n": 200
+      },
+      {
+        "item": "M3",
+        "text": "Process Mgmt & Standardization",
+        "mean": 3.2172,
+        "sd": 0.8774,
+        "n": 198
+      },
+      {
+        "item": "M4",
+        "text": "Data Governance & Analytics",
+        "mean": 3.1869,
+        "sd": 1.0807,
+        "n": 198
+      },
+      {
+        "item": "M5",
+        "text": "Tech Risk & Resilience",
+        "mean": 3.3485,
+        "sd": 1.0591,
+        "n": 198
+      },
+      {
+        "item": "M6",
+        "text": "Strategic IT Planning",
+        "mean": 3.1566,
+        "sd": 1.0667,
+        "n": 198
+      },
+      {
+        "item": "M7",
+        "text": "Workforce Capability",
+        "mean": 3.075,
+        "sd": 1.0887,
+        "n": 200
+      },
+      {
+        "item": "M8",
+        "text": "Change Leadership",
+        "mean": 3.0051,
+        "sd": 1.0875,
+        "n": 198
+      }
+    ]
+  },
+  "construct_grand": {
+    "barriers": {
+      "mean": 2.7644,
+      "sd": 0.6893,
+      "n": 200
+    },
+    "readiness": {
+      "mean": 3.1361,
+      "sd": 0.6674,
+      "n": 200
+    },
+    "maturity": {
+      "mean": 3.1533,
+      "sd": 0.7855,
+      "n": 200
+    }
+  },
+  "demographics_detailed": {
+    "roles": [
+      {
+        "label": "Other (please specify)",
+        "count": 38,
+        "pct": 19.0
+      },
+      {
+        "label": "CIO (e.g., Director of IT)",
+        "count": 33,
+        "pct": 16.5
+      },
+      {
+        "label": "COO (e.g., Deputy Director, Chief of Staff, Assistant Secretary for Administration)",
+        "count": 22,
+        "pct": 11.0
+      },
+      {
+        "label": "CSO (e.g., Director of Strategic Planning, Policy Director, Chief Strategy Officer)",
+        "count": 20,
+        "pct": 10.0
+      },
+      {
+        "label": "CEO (e.g., Agency Director, Secretary, Administrator, City/County Manager)",
+        "count": 18,
+        "pct": 9.0
+      },
+      {
+        "label": "CMO (e.g., Director of Communications, Public Affairs Officer, Chief Marketing & Communications Officer)",
+        "count": 15,
+        "pct": 7.5
+      },
+      {
+        "label": "CHRO (e.g., Chief Human Capital Officer (CHCO), Director of Human Resources, Personnel Director)",
+        "count": 14,
+        "pct": 7.0
+      },
+      {
+        "label": "CTO (e.g., Director of Technology/Innovation, Chief Scientist)",
+        "count": 14,
+        "pct": 7.0
+      },
+      {
+        "label": "CFO (e.g., Director of Finance, Budget Director, Comptroller)",
+        "count": 12,
+        "pct": 6.0
+      },
+      {
+        "label": "CRO (e.g., Director of Budget/Finance, Director of Development/Fundraising, Head of Revenue Operations)",
+        "count": 12,
+        "pct": 6.0
+      },
+      {
+        "label": "CISO (e.g., Director of Cybersecurity, Chief Security Officer)",
+        "count": 2,
+        "pct": 1.0
+      }
+    ],
+    "org_sizes": [
+      {
+        "label": "100-499",
+        "count": 52,
+        "pct": 26.0
+      },
+      {
+        "label": "1000-4999",
+        "count": 41,
+        "pct": 20.5
+      },
+      {
+        "label": "<100",
+        "count": 33,
+        "pct": 16.5
+      },
+      {
+        "label": "500-999",
+        "count": 29,
+        "pct": 14.5
+      },
+      {
+        "label": "10000+",
+        "count": 27,
+        "pct": 13.5
+      },
+      {
+        "label": "5000-9999",
+        "count": 18,
+        "pct": 9.0
+      }
+    ],
+    "profit_models": [
+      {
+        "label": "For-Profit",
+        "count": 151,
+        "pct": 75.5
+      },
+      {
+        "label": "Non-Profit",
+        "count": 36,
+        "pct": 18.0
+      },
+      {
+        "label": "Government/Public Sector",
+        "count": 13,
+        "pct": 6.5
+      }
+    ],
+    "decision_authority": [
+      {
+        "label": "I am one of several key decision-makers who collectively decide on technology adoption",
+        "count": 91,
+        "pct": 45.5
+      },
+      {
+        "label": "I am the primary decision-maker for technology adoption in my area of responsibility",
+        "count": 50,
+        "pct": 25.0
+      },
+      {
+        "label": "I provide significant input and recommendations, but final decisions are made by others",
+        "count": 42,
+        "pct": 21.0
+      },
+      {
+        "label": "I have limited involvement \u2014 I primarily implement technology decisions made by leadership",
+        "count": 13,
+        "pct": 6.5
+      },
+      {
+        "label": "I have no direct involvement in technology adoption decisions",
+        "count": 4,
+        "pct": 2.0
+      }
+    ]
+  },
+  "cronbach_alphas": {
+    "Barriers": {
+      "alpha": 0.8728,
+      "n_listwise": 192
+    },
+    "Readiness": {
+      "alpha": 0.9171,
+      "n_listwise": 181
+    },
+    "Maturity": {
+      "alpha": 0.8847,
+      "n_listwise": 191
+    }
+  },
+  "extended_last_updated": "2026-04-16T23:45:00Z"
 }

--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -210,17 +210,13 @@
         {
           "filter_id": "current_country_of_residence",
           "label": "Current Country of Residence",
-          "selected_values": [
-            "United States"
-          ],
+          "selected_values": ["United States"],
           "base_field": true
         },
         {
           "filter_id": "employment_status",
           "label": "Employment Status",
-          "selected_values": [
-            "Full-Time"
-          ],
+          "selected_values": ["Full-Time"],
           "base_field": true
         },
         {
@@ -241,11 +237,7 @@
         {
           "filter_id": "company_size",
           "label": "Company Size",
-          "selected_values": [
-            "50-249",
-            "250-999",
-            "1000+"
-          ],
+          "selected_values": ["50-249", "250-999", "1000+"],
           "base_field": false
         },
         {
@@ -518,14 +510,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            18,
-            61
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [18, 61],
           "constructs": {
             "barriers": {
               "f": 0.2849,
@@ -551,16 +537,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            37,
-            25,
-            17
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [37, 25, 17],
           "constructs": {
             "barriers": {
               "f": 2.3884,
@@ -796,14 +774,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            32,
-            84
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [32, 84],
           "constructs": {
             "barriers": {
               "f": 1.523,
@@ -829,16 +801,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            52,
-            42,
-            22
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [52, 42, 22],
           "constructs": {
             "barriers": {
               "f": 6.4834,
@@ -1075,14 +1039,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            53,
-            147
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [53, 147],
           "constructs": {
             "barriers": {
               "f": 0.0785,
@@ -1108,16 +1066,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            85,
-            70,
-            45
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [85, 70, 45],
           "constructs": {
             "barriers": {
               "f": 2.5541,
@@ -1354,14 +1304,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            53,
-            147
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [53, 147],
           "constructs": {
             "barriers": {
               "f": 0.0785,
@@ -1387,16 +1331,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            85,
-            70,
-            45
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [85, 70, 45],
           "constructs": {
             "barriers": {
               "f": 2.5541,
@@ -1633,14 +1569,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            53,
-            147
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [53, 147],
           "constructs": {
             "barriers": {
               "f": 0.0785,
@@ -1666,16 +1596,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            85,
-            70,
-            45
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [85, 70, 45],
           "constructs": {
             "barriers": {
               "f": 2.5541,
@@ -1726,11 +1648,7 @@
       "error": null
     },
     "profit_model_distribution": {
-      "labels": [
-        "For-Profit",
-        "Non-Profit",
-        "Government/Public Sector"
-      ],
+      "labels": ["For-Profit", "Non-Profit", "Government/Public Sector"],
       "groups": {
         "Conservative Clean": {
           "For-Profit": 56,

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -210,13 +210,17 @@
         {
           "filter_id": "current_country_of_residence",
           "label": "Current Country of Residence",
-          "selected_values": ["United States"],
+          "selected_values": [
+            "United States"
+          ],
           "base_field": true
         },
         {
           "filter_id": "employment_status",
           "label": "Employment Status",
-          "selected_values": ["Full-Time"],
+          "selected_values": [
+            "Full-Time"
+          ],
           "base_field": true
         },
         {
@@ -237,7 +241,11 @@
         {
           "filter_id": "company_size",
           "label": "Company Size",
-          "selected_values": ["50-249", "250-999", "1000+"],
+          "selected_values": [
+            "50-249",
+            "250-999",
+            "1000+"
+          ],
           "base_field": false
         },
         {
@@ -510,8 +518,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [19, 69],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            19,
+            69
+          ],
           "constructs": {
             "barriers": {
               "f": 0.1469,
@@ -537,8 +551,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [41, 30, 17],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            41,
+            30,
+            17
+          ],
           "constructs": {
             "barriers": {
               "f": 2.1711,
@@ -774,8 +796,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [34, 105],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            34,
+            105
+          ],
           "constructs": {
             "barriers": {
               "f": 1.8388,
@@ -801,8 +829,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [62, 52, 25],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            62,
+            52,
+            25
+          ],
           "constructs": {
             "barriers": {
               "f": 1.3774,
@@ -1039,8 +1075,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [61, 199],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            61,
+            199
+          ],
           "constructs": {
             "barriers": {
               "f": 0.1014,
@@ -1066,8 +1108,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [114, 88, 58],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            114,
+            88,
+            58
+          ],
           "constructs": {
             "barriers": {
               "f": 0.5425,
@@ -1304,8 +1354,14 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [107, 298],
+          "groups": [
+            "Technical",
+            "Non-Technical"
+          ],
+          "group_ns": [
+            107,
+            298
+          ],
           "constructs": {
             "barriers": {
               "f": 1.6218,
@@ -1331,8 +1387,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [175, 142, 88],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            175,
+            142,
+            88
+          ],
           "constructs": {
             "barriers": {
               "f": 1.1421,
@@ -1577,8 +1641,16 @@
           }
         },
         "anova_by_role": {
-          "groups": ["Technical", "Non-Technical", "Unclassified"],
-          "group_ns": [108, 307, 63],
+          "groups": [
+            "Technical",
+            "Non-Technical",
+            "Unclassified"
+          ],
+          "group_ns": [
+            108,
+            307,
+            63
+          ],
           "constructs": {
             "barriers": {
               "f": 1.8041,
@@ -1604,8 +1676,16 @@
           }
         },
         "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [180, 145, 90],
+          "groups": [
+            "Small (<500)",
+            "Medium (500-4999)",
+            "Large (5000+)"
+          ],
+          "group_ns": [
+            180,
+            145,
+            90
+          ],
           "constructs": {
             "barriers": {
               "f": 1.1416,
@@ -1656,7 +1736,11 @@
       "error": null
     },
     "profit_model_distribution": {
-      "labels": ["For-Profit", "Non-Profit", "Government/Public Sector"],
+      "labels": [
+        "For-Profit",
+        "Non-Profit",
+        "Government/Public Sector"
+      ],
       "groups": {
         "Conservative Clean": {
           "For-Profit": 62,
@@ -1718,5 +1802,695 @@
       "examples": ""
     }
   ],
-  "last_updated": "2026-04-16T10:51:11.217383Z"
+  "last_updated": "2026-04-16T10:51:11.217383Z",
+  "top3_pick_counts": {
+    "total_n": 200,
+    "items": [
+      {
+        "item": "B1",
+        "text": "Resistance to change among employees or middle management",
+        "count": 56,
+        "pct": 28.0
+      },
+      {
+        "item": "B2",
+        "text": "Lack of skilled personnel or in-house expertise to implement new technologies",
+        "count": 21,
+        "pct": 10.5
+      },
+      {
+        "item": "B3",
+        "text": "Insufficient leadership commitment or unclear strategic direction",
+        "count": 19,
+        "pct": 9.5
+      },
+      {
+        "item": "B4",
+        "text": "Inadequate training or support for new technology users",
+        "count": 30,
+        "pct": 15.0
+      },
+      {
+        "item": "B5",
+        "text": "Cultural or organizational inertia favoring established practices",
+        "count": 13,
+        "pct": 6.5
+      },
+      {
+        "item": "B6",
+        "text": "High cost associated with acquiring or implementing new technologies",
+        "count": 75,
+        "pct": 37.5
+      },
+      {
+        "item": "B7",
+        "text": "Difficulty integrating new technologies with existing legacy systems",
+        "count": 73,
+        "pct": 36.5
+      },
+      {
+        "item": "B8",
+        "text": "Limited access to reliable vendor support or third-party expertise",
+        "count": 21,
+        "pct": 10.5
+      },
+      {
+        "item": "B9",
+        "text": "Poor communication about the purpose or benefits of new technology",
+        "count": 28,
+        "pct": 14.0
+      },
+      {
+        "item": "B10",
+        "text": "Fear of failure or adverse impact on daily operations",
+        "count": 29,
+        "pct": 14.5
+      },
+      {
+        "item": "B11",
+        "text": "Lack of alignment between technology and business strategy",
+        "count": 6,
+        "pct": 3.0
+      },
+      {
+        "item": "B12",
+        "text": "Insufficient budget or financial resources",
+        "count": 44,
+        "pct": 22.0
+      },
+      {
+        "item": "B13",
+        "text": "Cybersecurity concerns or regulatory compliance barriers",
+        "count": 52,
+        "pct": 26.0
+      },
+      {
+        "item": "B14",
+        "text": "Legal, contractual, or privacy restrictions",
+        "count": 54,
+        "pct": 27.0
+      },
+      {
+        "item": "B15",
+        "text": "Uncertainty about return on investment (ROI) or measurable benefits",
+        "count": 18,
+        "pct": 9.0
+      },
+      {
+        "item": "B16",
+        "text": "Supplier or vendor lock-in or compatibility limitations",
+        "count": 20,
+        "pct": 10.0
+      },
+      {
+        "item": "B17",
+        "text": "Difficulty scaling pilot projects to organization-wide adoption",
+        "count": 19,
+        "pct": 9.5
+      },
+      {
+        "item": "B18",
+        "text": "Economic, geopolitical, or market-level disruptions",
+        "count": 22,
+        "pct": 11.0
+      }
+    ],
+    "items_sorted_desc": [
+      {
+        "item": "B6",
+        "text": "High cost associated with acquiring or implementing new technologies",
+        "count": 75,
+        "pct": 37.5
+      },
+      {
+        "item": "B7",
+        "text": "Difficulty integrating new technologies with existing legacy systems",
+        "count": 73,
+        "pct": 36.5
+      },
+      {
+        "item": "B1",
+        "text": "Resistance to change among employees or middle management",
+        "count": 56,
+        "pct": 28.0
+      },
+      {
+        "item": "B14",
+        "text": "Legal, contractual, or privacy restrictions",
+        "count": 54,
+        "pct": 27.0
+      },
+      {
+        "item": "B13",
+        "text": "Cybersecurity concerns or regulatory compliance barriers",
+        "count": 52,
+        "pct": 26.0
+      },
+      {
+        "item": "B12",
+        "text": "Insufficient budget or financial resources",
+        "count": 44,
+        "pct": 22.0
+      },
+      {
+        "item": "B4",
+        "text": "Inadequate training or support for new technology users",
+        "count": 30,
+        "pct": 15.0
+      },
+      {
+        "item": "B10",
+        "text": "Fear of failure or adverse impact on daily operations",
+        "count": 29,
+        "pct": 14.5
+      },
+      {
+        "item": "B9",
+        "text": "Poor communication about the purpose or benefits of new technology",
+        "count": 28,
+        "pct": 14.0
+      },
+      {
+        "item": "B18",
+        "text": "Economic, geopolitical, or market-level disruptions",
+        "count": 22,
+        "pct": 11.0
+      },
+      {
+        "item": "B2",
+        "text": "Lack of skilled personnel or in-house expertise to implement new technologies",
+        "count": 21,
+        "pct": 10.5
+      },
+      {
+        "item": "B8",
+        "text": "Limited access to reliable vendor support or third-party expertise",
+        "count": 21,
+        "pct": 10.5
+      },
+      {
+        "item": "B16",
+        "text": "Supplier or vendor lock-in or compatibility limitations",
+        "count": 20,
+        "pct": 10.0
+      },
+      {
+        "item": "B3",
+        "text": "Insufficient leadership commitment or unclear strategic direction",
+        "count": 19,
+        "pct": 9.5
+      },
+      {
+        "item": "B17",
+        "text": "Difficulty scaling pilot projects to organization-wide adoption",
+        "count": 19,
+        "pct": 9.5
+      },
+      {
+        "item": "B15",
+        "text": "Uncertainty about return on investment (ROI) or measurable benefits",
+        "count": 18,
+        "pct": 9.0
+      },
+      {
+        "item": "B5",
+        "text": "Cultural or organizational inertia favoring established practices",
+        "count": 13,
+        "pct": 6.5
+      },
+      {
+        "item": "B11",
+        "text": "Lack of alignment between technology and business strategy",
+        "count": 6,
+        "pct": 3.0
+      }
+    ],
+    "source_note": "Bootstrap values from frozen CRP N=200; will be regenerated from live dataset by next daily-pipeline run."
+  },
+  "item_descriptives": {
+    "barriers": [
+      {
+        "item": "B1",
+        "text": "Resistance to change among employees or middle management",
+        "mean": 2.9698,
+        "sd": 1.3443,
+        "n": 199
+      },
+      {
+        "item": "B2",
+        "text": "Lack of skilled personnel or in-house expertise to implement new technologies",
+        "mean": 2.4798,
+        "sd": 1.2813,
+        "n": 198
+      },
+      {
+        "item": "B3",
+        "text": "Insufficient leadership commitment or unclear strategic direction",
+        "mean": 2.35,
+        "sd": 1.3626,
+        "n": 200
+      },
+      {
+        "item": "B4",
+        "text": "Inadequate training or support for new technology users",
+        "mean": 2.8,
+        "sd": 1.2155,
+        "n": 200
+      },
+      {
+        "item": "B5",
+        "text": "Cultural or organizational inertia favoring established practices",
+        "mean": 2.603,
+        "sd": 1.1273,
+        "n": 199
+      },
+      {
+        "item": "B6",
+        "text": "High cost associated with acquiring or implementing new technologies",
+        "mean": 3.4596,
+        "sd": 1.1776,
+        "n": 198
+      },
+      {
+        "item": "B7",
+        "text": "Difficulty integrating new technologies with existing legacy systems",
+        "mean": 3.3769,
+        "sd": 1.1822,
+        "n": 199
+      },
+      {
+        "item": "B8",
+        "text": "Limited access to reliable vendor support or third-party expertise",
+        "mean": 2.5327,
+        "sd": 1.2341,
+        "n": 199
+      },
+      {
+        "item": "B9",
+        "text": "Poor communication about the purpose or benefits of new technology",
+        "mean": 2.605,
+        "sd": 1.1338,
+        "n": 200
+      },
+      {
+        "item": "B10",
+        "text": "Fear of failure or adverse impact on daily operations",
+        "mean": 2.7286,
+        "sd": 1.1963,
+        "n": 199
+      },
+      {
+        "item": "B11",
+        "text": "Lack of alignment between technology and business strategy",
+        "mean": 2.3687,
+        "sd": 1.1446,
+        "n": 198
+      },
+      {
+        "item": "B12",
+        "text": "Insufficient budget or financial resources",
+        "mean": 2.905,
+        "sd": 1.2425,
+        "n": 200
+      },
+      {
+        "item": "B13",
+        "text": "Cybersecurity concerns or regulatory compliance barriers",
+        "mean": 3.26,
+        "sd": 1.2651,
+        "n": 200
+      },
+      {
+        "item": "B14",
+        "text": "Legal, contractual, or privacy restrictions",
+        "mean": 3.175,
+        "sd": 1.2816,
+        "n": 200
+      },
+      {
+        "item": "B15",
+        "text": "Uncertainty about return on investment (ROI) or measurable benefits",
+        "mean": 2.6,
+        "sd": 1.0797,
+        "n": 200
+      },
+      {
+        "item": "B16",
+        "text": "Supplier or vendor lock-in or compatibility limitations",
+        "mean": 2.5829,
+        "sd": 1.2317,
+        "n": 199
+      },
+      {
+        "item": "B17",
+        "text": "Difficulty scaling pilot projects to organization-wide adoption",
+        "mean": 2.57,
+        "sd": 1.1841,
+        "n": 200
+      },
+      {
+        "item": "B18",
+        "text": "Economic, geopolitical, or market-level disruptions",
+        "mean": 2.3333,
+        "sd": 1.1129,
+        "n": 198
+      }
+    ],
+    "readiness": [
+      {
+        "item": "R1",
+        "text": "Formal digital or technology strategy",
+        "mean": 3.23,
+        "sd": 1.1014,
+        "n": 200
+      },
+      {
+        "item": "R2",
+        "text": "Dedicated IT leadership role",
+        "mean": 3.27,
+        "sd": 1.016,
+        "n": 200
+      },
+      {
+        "item": "R3",
+        "text": "Skilled in-house technology staff",
+        "mean": 3.1186,
+        "sd": 0.9665,
+        "n": 194
+      },
+      {
+        "item": "R4",
+        "text": "Adequate financial resources for technology",
+        "mean": 3.1111,
+        "sd": 1.0888,
+        "n": 198
+      },
+      {
+        "item": "R5",
+        "text": "Willingness to invest in new technologies",
+        "mean": 3.46,
+        "sd": 1.0166,
+        "n": 200
+      },
+      {
+        "item": "R6",
+        "text": "Data and analytics capabilities",
+        "mean": 3.1212,
+        "sd": 1.0831,
+        "n": 198
+      },
+      {
+        "item": "R7",
+        "text": "Cybersecurity and risk management capabilities",
+        "mean": 2.9698,
+        "sd": 1.0679,
+        "n": 199
+      },
+      {
+        "item": "R8",
+        "text": "Change management capabilities",
+        "mean": 3.0251,
+        "sd": 0.9125,
+        "n": 199
+      },
+      {
+        "item": "R9",
+        "text": "Vendor and partner management capabilities",
+        "mean": 3.1859,
+        "sd": 1.0302,
+        "n": 199
+      },
+      {
+        "item": "R10",
+        "text": "Digital infrastructure (cloud, network, devices)",
+        "mean": 2.7538,
+        "sd": 1.0024,
+        "n": 199
+      },
+      {
+        "item": "R11",
+        "text": "Alignment between IT and business strategy",
+        "mean": 3.245,
+        "sd": 1.0913,
+        "n": 200
+      },
+      {
+        "item": "R12",
+        "text": "Cross-functional collaboration on technology",
+        "mean": 3.1224,
+        "sd": 1.0104,
+        "n": 196
+      },
+      {
+        "item": "R13",
+        "text": "Employee digital skills",
+        "mean": 3.132,
+        "sd": 0.9912,
+        "n": 197
+      },
+      {
+        "item": "R14",
+        "text": "Leadership digital literacy",
+        "mean": 3.3163,
+        "sd": 1.1241,
+        "n": 196
+      },
+      {
+        "item": "R15",
+        "text": "Innovation culture",
+        "mean": 3.1122,
+        "sd": 0.9158,
+        "n": 196
+      },
+      {
+        "item": "R16",
+        "text": "Willingness to experiment with new technologies",
+        "mean": 3.0653,
+        "sd": 0.9644,
+        "n": 199
+      },
+      {
+        "item": "R17",
+        "text": "Customer or stakeholder demand for technology",
+        "mean": 3.0704,
+        "sd": 1.0941,
+        "n": 199
+      }
+    ],
+    "maturity": [
+      {
+        "item": "M1",
+        "text": "IT Investment & Value Mgmt",
+        "mean": 3.1667,
+        "sd": 1.0556,
+        "n": 198
+      },
+      {
+        "item": "M2",
+        "text": "IT-Enabled Innovation",
+        "mean": 3.06,
+        "sd": 1.1192,
+        "n": 200
+      },
+      {
+        "item": "M3",
+        "text": "Process Mgmt & Standardization",
+        "mean": 3.2172,
+        "sd": 0.8774,
+        "n": 198
+      },
+      {
+        "item": "M4",
+        "text": "Data Governance & Analytics",
+        "mean": 3.1869,
+        "sd": 1.0807,
+        "n": 198
+      },
+      {
+        "item": "M5",
+        "text": "Tech Risk & Resilience",
+        "mean": 3.3485,
+        "sd": 1.0591,
+        "n": 198
+      },
+      {
+        "item": "M6",
+        "text": "Strategic IT Planning",
+        "mean": 3.1566,
+        "sd": 1.0667,
+        "n": 198
+      },
+      {
+        "item": "M7",
+        "text": "Workforce Capability",
+        "mean": 3.075,
+        "sd": 1.0887,
+        "n": 200
+      },
+      {
+        "item": "M8",
+        "text": "Change Leadership",
+        "mean": 3.0051,
+        "sd": 1.0875,
+        "n": 198
+      }
+    ],
+    "source_note": "Bootstrap values from frozen CRP N=200; will be regenerated from live dataset by next daily-pipeline run."
+  },
+  "construct_grand": {
+    "barriers": {
+      "mean": 2.7644,
+      "sd": 0.6893,
+      "n": 200
+    },
+    "readiness": {
+      "mean": 3.1361,
+      "sd": 0.6674,
+      "n": 200
+    },
+    "maturity": {
+      "mean": 3.1533,
+      "sd": 0.7855,
+      "n": 200
+    },
+    "source_note": "Bootstrap values from frozen CRP N=200; will be regenerated from live dataset by next daily-pipeline run."
+  },
+  "demographics_detailed": {
+    "roles": [
+      {
+        "label": "Other (please specify)",
+        "count": 38,
+        "pct": 19.0
+      },
+      {
+        "label": "CIO (e.g., Director of IT)",
+        "count": 33,
+        "pct": 16.5
+      },
+      {
+        "label": "COO (e.g., Deputy Director, Chief of Staff, Assistant Secretary for Administration)",
+        "count": 22,
+        "pct": 11.0
+      },
+      {
+        "label": "CSO (e.g., Director of Strategic Planning, Policy Director, Chief Strategy Officer)",
+        "count": 20,
+        "pct": 10.0
+      },
+      {
+        "label": "CEO (e.g., Agency Director, Secretary, Administrator, City/County Manager)",
+        "count": 18,
+        "pct": 9.0
+      },
+      {
+        "label": "CMO (e.g., Director of Communications, Public Affairs Officer, Chief Marketing & Communications Officer)",
+        "count": 15,
+        "pct": 7.5
+      },
+      {
+        "label": "CHRO (e.g., Chief Human Capital Officer (CHCO), Director of Human Resources, Personnel Director)",
+        "count": 14,
+        "pct": 7.0
+      },
+      {
+        "label": "CTO (e.g., Director of Technology/Innovation, Chief Scientist)",
+        "count": 14,
+        "pct": 7.0
+      },
+      {
+        "label": "CFO (e.g., Director of Finance, Budget Director, Comptroller)",
+        "count": 12,
+        "pct": 6.0
+      },
+      {
+        "label": "CRO (e.g., Director of Budget/Finance, Director of Development/Fundraising, Head of Revenue Operations)",
+        "count": 12,
+        "pct": 6.0
+      },
+      {
+        "label": "CISO (e.g., Director of Cybersecurity, Chief Security Officer)",
+        "count": 2,
+        "pct": 1.0
+      }
+    ],
+    "org_sizes": [
+      {
+        "label": "100-499",
+        "count": 52,
+        "pct": 26.0
+      },
+      {
+        "label": "1000-4999",
+        "count": 41,
+        "pct": 20.5
+      },
+      {
+        "label": "<100",
+        "count": 33,
+        "pct": 16.5
+      },
+      {
+        "label": "500-999",
+        "count": 29,
+        "pct": 14.5
+      },
+      {
+        "label": "10000+",
+        "count": 27,
+        "pct": 13.5
+      },
+      {
+        "label": "5000-9999",
+        "count": 18,
+        "pct": 9.0
+      }
+    ],
+    "profit_models": [
+      {
+        "label": "For-Profit",
+        "count": 151,
+        "pct": 75.5
+      },
+      {
+        "label": "Non-Profit",
+        "count": 36,
+        "pct": 18.0
+      },
+      {
+        "label": "Government/Public Sector",
+        "count": 13,
+        "pct": 6.5
+      }
+    ],
+    "decision_authority": [
+      {
+        "label": "I am one of several key decision-makers who collectively decide on technology adoption",
+        "count": 91,
+        "pct": 45.5
+      },
+      {
+        "label": "I am the primary decision-maker for technology adoption in my area of responsibility",
+        "count": 50,
+        "pct": 25.0
+      },
+      {
+        "label": "I provide significant input and recommendations, but final decisions are made by others",
+        "count": 42,
+        "pct": 21.0
+      },
+      {
+        "label": "I have limited involvement \u2014 I primarily implement technology decisions made by leadership",
+        "count": 13,
+        "pct": 6.5
+      },
+      {
+        "label": "I have no direct involvement in technology adoption decisions",
+        "count": 4,
+        "pct": 2.0
+      }
+    ],
+    "source_note": "Bootstrap values from frozen CRP N=200; will be regenerated from live dataset by next daily-pipeline run."
+  },
+  "extended_last_updated": "2026-04-16T23:45:00Z",
+  "extended_source": "bootstrap_from_crp200"
 }

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -210,17 +210,13 @@
         {
           "filter_id": "current_country_of_residence",
           "label": "Current Country of Residence",
-          "selected_values": [
-            "United States"
-          ],
+          "selected_values": ["United States"],
           "base_field": true
         },
         {
           "filter_id": "employment_status",
           "label": "Employment Status",
-          "selected_values": [
-            "Full-Time"
-          ],
+          "selected_values": ["Full-Time"],
           "base_field": true
         },
         {
@@ -241,11 +237,7 @@
         {
           "filter_id": "company_size",
           "label": "Company Size",
-          "selected_values": [
-            "50-249",
-            "250-999",
-            "1000+"
-          ],
+          "selected_values": ["50-249", "250-999", "1000+"],
           "base_field": false
         },
         {
@@ -518,14 +510,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            19,
-            69
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [19, 69],
           "constructs": {
             "barriers": {
               "f": 0.1469,
@@ -551,16 +537,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            41,
-            30,
-            17
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [41, 30, 17],
           "constructs": {
             "barriers": {
               "f": 2.1711,
@@ -796,14 +774,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            34,
-            105
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [34, 105],
           "constructs": {
             "barriers": {
               "f": 1.8388,
@@ -829,16 +801,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            62,
-            52,
-            25
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [62, 52, 25],
           "constructs": {
             "barriers": {
               "f": 1.3774,
@@ -1075,14 +1039,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            61,
-            199
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [61, 199],
           "constructs": {
             "barriers": {
               "f": 0.1014,
@@ -1108,16 +1066,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            114,
-            88,
-            58
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [114, 88, 58],
           "constructs": {
             "barriers": {
               "f": 0.5425,
@@ -1354,14 +1304,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical"
-          ],
-          "group_ns": [
-            107,
-            298
-          ],
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [107, 298],
           "constructs": {
             "barriers": {
               "f": 1.6218,
@@ -1387,16 +1331,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            175,
-            142,
-            88
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [175, 142, 88],
           "constructs": {
             "barriers": {
               "f": 1.1421,
@@ -1641,16 +1577,8 @@
           }
         },
         "anova_by_role": {
-          "groups": [
-            "Technical",
-            "Non-Technical",
-            "Unclassified"
-          ],
-          "group_ns": [
-            108,
-            307,
-            63
-          ],
+          "groups": ["Technical", "Non-Technical", "Unclassified"],
+          "group_ns": [108, 307, 63],
           "constructs": {
             "barriers": {
               "f": 1.8041,
@@ -1676,16 +1604,8 @@
           }
         },
         "anova_by_org_size": {
-          "groups": [
-            "Small (<500)",
-            "Medium (500-4999)",
-            "Large (5000+)"
-          ],
-          "group_ns": [
-            180,
-            145,
-            90
-          ],
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [180, 145, 90],
           "constructs": {
             "barriers": {
               "f": 1.1416,
@@ -1736,11 +1656,7 @@
       "error": null
     },
     "profit_model_distribution": {
-      "labels": [
-        "For-Profit",
-        "Non-Profit",
-        "Government/Public Sector"
-      ],
+      "labels": ["For-Profit", "Non-Profit", "Government/Public Sector"],
       "groups": {
         "Conservative Clean": {
           "For-Profit": 62,


### PR DESCRIPTION
Closes #1693.

## Summary

Surfaces the Q29-Q46 forced-choice top-3 pick task in both the website and the CRP Chapter III Results. The pick-based ranking diverges from the continuous Likert mean ranking at position 3 (cultural/people barriers rise on forced choice while cybersecurity rises on continuous rating) - a substantive finding that was previously computed in the pipeline but not exposed to either representation.

## Changes

**Pipeline** (`scripts/analysis/tabs_v2_unified_data_analysis.py`):
- Emits six new blocks to both `src/data/crp-sensitivity-analysis.json` (frozen N=200) and `src/data/sensitivity-analysis.json` (live): `top3_pick_counts`, `item_descriptives`, `construct_grand`, `demographics_detailed`, `cronbach_alphas`, `extended_last_updated`.

**Data** (`src/data/*.json`):
- Regenerated frozen and live sensitivity JSONs with the new blocks. Top 3 by pick count (frozen N=200): B6 High Cost (N=75, 37.5%), B7 Legacy Integration (N=73, 36.5%), B1 Resistance to Change (N=56, 28.0%).

**Website** (`src/app/results/crp-2026/`):
- New page `/results/crp-2026/top-barriers`: pick-count bar chart, pick-vs-mean comparison table, Delta column showing position-3 divergence, methodology section.
- Landing page `/results/crp-2026/page.tsx`: added 'Top 3 Barriers' to the Related nav between Factor Analysis and Statistics Glossary.

## Frozen vs live separation

`crp-sensitivity-analysis.json` (frozen N=200) is the canonical source for the `/results/crp-2026/*` pages. `sensitivity-analysis.json` (live growing dataset, currently N=260+) drives the `/results/*` pages that update daily. Both got the new blocks; the CRP-2026 page reads only the frozen version.

## Validator v5 coverage (separate but tracked in linked issue)

The CRP statistics validator was expanded from 84 checks to 277 checks (42 categories). v5 result on the 4-17-2026 0004 EST merged CRP body+appendixes: 209 PASS, 68 INFO, 0 WARN, 0 FAIL. Report saved to `04 CRP Review Reports/Validator v5 Report (4-17-2026 0004 EST).txt` in the private workspace.

## Dash hygiene

0 em dashes, 0 en dashes per CLAUDE.md rule. Unicode minus signs (U+2212) used only for negative numbers in statistics tables.

## Test plan

- [x] Pipeline regeneration produces valid JSON (`python -m json.tool` clean on both files)
- [x] `/results/crp-2026/top-barriers` renders with live frozen-JSON data
- [x] Validator v5 passes: 0 WARN, 0 FAIL on merged CRP docx
- [ ] Reviewer visual check of the new page + landing nav
- [ ] CI build passes on the branch
