### PR TITLE
fix(crp-2026/top-barriers): only show omission note when an item is actually omitted

### DIFF
--- a/src/app/results/crp-2026/top-barriers/page.tsx
+++ b/src/app/results/crp-2026/top-barriers/page.tsx
@@ -62,7 +62,7 @@ const pickRankOf: Record<string, number> = {}
 pickSorted.forEach((r, i) => {
   pickRankOf[r.item] = i + 1
 })
-const meanRankOf: Record<string, number> = {}
+const meanRankOf: Partial<Record<string, number>> = {}
 meanSorted.forEach((r, i) => {
   meanRankOf[r.item] = i + 1
 })
@@ -372,8 +372,8 @@ const TopBarriersPage = () => {
             participants must prioritize), and a positive Delta means the opposite (it falls under
             forced choice relative to continuous rating).
             {hasOmittedMeanRank
-              ? ' Barriers missing a Mean Rank value above are those with no valid continuous-rating mean in this dataset (all responses missing for that item).'
-              : ''}
+              ? ' Barriers missing a Mean Rank value above are those with no valid continuous-rating responses for that item in this dataset.'
+              : null}
           </p>
         </section>
 

--- a/src/app/results/crp-2026/top-barriers/page.tsx
+++ b/src/app/results/crp-2026/top-barriers/page.tsx
@@ -157,16 +157,18 @@ const positiveMovers = [...moversAll].filter((r) => r.delta > 0).sort((a, b) => 
 const topNegative = negativeMovers.slice(0, 2)
 const topPositive = positiveMovers.slice(0, 2)
 
-// An "omitted" barrier is one that appears in the pick list but has no continuous-rating mean,
-// so it receives no Mean Rank. In the frozen CRP N=200 dataset this never happens, but the guard
-// stays in place so the page renders correctly if a future pipeline run surfaces an item where
-// every response is missing. Only show the explanatory sentence when mean-rank data exists and
-// there is an actual omission for at least one picked item.
+// The Pick-vs-Mean comparison table below only renders the top 10 items from the pick ranking.
+// Gate the "omitted Mean Rank" explanatory sentence on whether any of those rendered rows is
+// actually missing a Mean Rank value, not on whether the full 18-item pick list has one. This
+// keeps the prose consistent with what the reader can see. In the frozen CRP N=200 dataset no
+// omission occurs, but the guard stays in place so the page renders correctly if a future
+// pipeline run surfaces an item where every response is missing.
+const displayedPick: PickItem[] = pickSorted.slice(0, 10)
 const hasOmittedMeanRank =
-  meanRankable.length > 0 && pickSorted.some((r) => meanRankOf[r.item] === undefined)
+  meanRankable.length > 0 && displayedPick.some((r) => meanRankOf[r.item] === undefined)
 
 const TopBarriersPage = () => {
-  const topPick = pickSorted.slice(0, 10)
+  const topPick = displayedPick
   const topMean = meanSorted.slice(0, 10)
   const maxPick = topPick.length > 0 ? Math.max(...topPick.map((r) => r.count)) : 0
 

--- a/src/app/results/crp-2026/top-barriers/page.tsx
+++ b/src/app/results/crp-2026/top-barriers/page.tsx
@@ -160,8 +160,10 @@ const topPositive = positiveMovers.slice(0, 2)
 // An "omitted" barrier is one that appears in the pick list but has no continuous-rating mean,
 // so it receives no Mean Rank. In the frozen CRP N=200 dataset this never happens, but the guard
 // stays in place so the page renders correctly if a future pipeline run surfaces an item where
-// every response is missing. Only show the explanatory sentence when there is an actual omission.
-const hasOmittedMeanRank = pickSorted.some((r) => meanRankOf[r.item] === undefined)
+// every response is missing. Only show the explanatory sentence when mean-rank data exists and
+// there is an actual omission for at least one picked item.
+const hasOmittedMeanRank =
+  meanRankable.length > 0 && pickSorted.some((r) => meanRankOf[r.item] === undefined)
 
 const TopBarriersPage = () => {
   const topPick = pickSorted.slice(0, 10)

--- a/src/app/results/crp-2026/top-barriers/page.tsx
+++ b/src/app/results/crp-2026/top-barriers/page.tsx
@@ -157,6 +157,12 @@ const positiveMovers = [...moversAll].filter((r) => r.delta > 0).sort((a, b) => 
 const topNegative = negativeMovers.slice(0, 2)
 const topPositive = positiveMovers.slice(0, 2)
 
+// An "omitted" barrier is one that appears in the pick list but has no continuous-rating mean,
+// so it receives no Mean Rank. In the frozen CRP N=200 dataset this never happens, but the guard
+// stays in place so the page renders correctly if a future pipeline run surfaces an item where
+// every response is missing. Only show the explanatory sentence when there is an actual omission.
+const hasOmittedMeanRank = pickSorted.some((r) => meanRankOf[r.item] === undefined)
+
 const TopBarriersPage = () => {
   const topPick = pickSorted.slice(0, 10)
   const topMean = meanSorted.slice(0, 10)
@@ -362,8 +368,10 @@ const TopBarriersPage = () => {
             Interpretation: Delta = Pick Rank - Mean Rank. A negative Delta means the barrier is
             more salient under the forced-choice task than under continuous rating (it rises when
             participants must prioritize), and a positive Delta means the opposite (it falls under
-            forced choice relative to continuous rating). Barriers omitted from the Mean Rank column
-            are those with no valid continuous-rating mean in the frozen dataset.
+            forced choice relative to continuous rating).
+            {hasOmittedMeanRank
+              ? ' Barriers missing a Mean Rank value above are those with no valid continuous-rating mean in this dataset (all responses missing for that item).'
+              : ''}
           </p>
         </section>
 


### PR DESCRIPTION
## Problem

On `/results/crp-2026/top-barriers` the interpretation paragraph below the Pick-vs-Mean table ended with:

> Barriers omitted from the Mean Rank column are those with no valid continuous-rating mean in the frozen dataset.

Readers look for an omission that never happens. In the frozen CRP N=200 dataset every one of the 18 substantive barriers has a valid continuous-rating mean (per-item N range 198 to 200), so zero barriers are ever missing from the Mean Rank column.

## Fix

- Keep the defensive `filter` that excludes items with null means (so a future partial-response case would still render correctly).
- Compute `hasOmittedMeanRank = pickSorted.some((r) => meanRankOf[r.item] === undefined)` at module scope.
- Only render the omission sentence when `hasOmittedMeanRank` is true.

With the current frozen data, readers now see only the Delta interpretation, without the dangling reference to an omission that does not exist.

## Verification

All 18 barriers have valid means in `src/data/crp-sensitivity-analysis.json` (verified via the pipeline-generated JSON). `npx tsc --noEmit` and `npx eslint` both pass clean.