### PR TITLE
docs: 1-3 SCT (Bandura, 1986) - upgrade to canonical 16-section template

### DIFF
--- a/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
+++ b/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
@@ -386,10 +386,9 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Articulated the efficacy-outcome distinction:</strong> Argued that
-              individuals might believe a technology will be valuable but doubt their personal
-              capability, offering an explanation for cases where positive attitudes fail to
-              produce adoption.
+              <strong>Articulated the efficacy-outcome distinction:</strong> Argued that individuals
+              might believe a technology will be valuable but doubt their personal capability,
+              offering an explanation for cases where positive attitudes fail to produce adoption.
             </li>
             <li>
               <strong>Mechanism-based intervention design:</strong> Specified four concrete,

--- a/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
+++ b/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
@@ -191,8 +191,8 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
           <p className={PARAGRAPH_CLASSES}>
             Social Cognitive Theory is a measurement-oriented framework. Bandura (1986) and
-            subsequent scale-development papers specify how each construct is operationalized.
-            Core measured constructs include:
+            subsequent scale-development papers specify how each construct is operationalized. Core
+            measured constructs include:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
@@ -212,9 +212,8 @@ const BibliographyArticlePage = () => {
               behavior, measured via self-report of intent, specificity, and challenge level.
             </li>
             <li>
-              <strong>Self-Regulation:</strong> Self-monitoring, self-evaluation, and
-              self-reaction - often measured via diary methods or multi-item self-regulation
-              scales.
+              <strong>Self-Regulation:</strong> Self-monitoring, self-evaluation, and self-reaction
+              - often measured via diary methods or multi-item self-regulation scales.
             </li>
             <li>
               <strong>Social Modeling Exposure:</strong> Degree of observational learning
@@ -223,16 +222,15 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Reciprocal Determinism:</strong> The triadic interaction among personal,
-              behavioral, and environmental factors - not directly measured as a single
-              construct; operationalized by jointly modeling the three sets of variables and
-              their mutual influences.
+              behavioral, and environmental factors - not directly measured as a single construct;
+              operationalized by jointly modeling the three sets of variables and their mutual
+              influences.
             </li>
           </ul>
           <p className={PARAGRAPH_CLASSES}>
             Bandura and subsequent scale developers provide reliability and validity evidence for
-            SCT scales across diverse behavioral domains. In technology adoption contexts,
-            computer self-efficacy (Compeau &amp; Higgins, 1995) is the most widely adapted SCT
-            construct.
+            SCT scales across diverse behavioral domains. In technology adoption contexts, computer
+            self-efficacy (Compeau &amp; Higgins, 1995) is the most widely adapted SCT construct.
           </p>
         </section>
 

--- a/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
+++ b/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
@@ -186,7 +186,57 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 6. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Social Cognitive Theory is a measurement-oriented framework. Bandura (1986) and
+            subsequent scale-development papers specify how each construct is operationalized.
+            Core measured constructs include:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Self-Efficacy:</strong> Belief in one&rsquo;s capability to execute the
+              courses of action required to produce given attainments. Measured via task-specific
+              self-efficacy scales using confidence ratings across increasingly demanding tasks.
+              Compeau &amp; Higgins (1995) provide a computer self-efficacy scale widely used in
+              technology adoption research.
+            </li>
+            <li>
+              <strong>Outcome Expectations:</strong> Beliefs about the likely consequences of
+              performing a behavior. Typically split into performance outcomes and personal
+              outcomes; measured via multi-item Likert scales.
+            </li>
+            <li>
+              <strong>Personal Goals:</strong> Goal intentions or goal commitment relative to the
+              behavior, measured via self-report of intent, specificity, and challenge level.
+            </li>
+            <li>
+              <strong>Self-Regulation:</strong> Self-monitoring, self-evaluation, and
+              self-reaction - often measured via diary methods or multi-item self-regulation
+              scales.
+            </li>
+            <li>
+              <strong>Social Modeling Exposure:</strong> Degree of observational learning
+              opportunity (observing others perform the behavior); measured via self-reported
+              exposure to role models and peer behavior.
+            </li>
+            <li>
+              <strong>Reciprocal Determinism:</strong> The triadic interaction among personal,
+              behavioral, and environmental factors - not directly measured as a single
+              construct; operationalized by jointly modeling the three sets of variables and
+              their mutual influences.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Bandura and subsequent scale developers provide reliability and validity evidence for
+            SCT scales across diverse behavioral domains. In technology adoption contexts,
+            computer self-efficacy (Compeau &amp; Higgins, 1995) is the most widely adapted SCT
+            construct.
+          </p>
+        </section>
+
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -216,7 +266,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -333,7 +383,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -368,7 +418,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -409,7 +459,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -447,7 +497,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -537,7 +587,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -605,7 +655,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -617,7 +667,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Further Reading */}
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -663,7 +713,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 15. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <p className={PARAGRAPH_CLASSES}>

--- a/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
+++ b/src/app/bibliography-1-3-social-cognitive-theory-sct-bandura-1986/page.tsx
@@ -386,9 +386,10 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Resolved the efficacy-outcome distinction:</strong> Demonstrated that
+              <strong>Articulated the efficacy-outcome distinction:</strong> Argued that
               individuals might believe a technology will be valuable but doubt their personal
-              capability, explaining cases where positive attitudes fail to produce adoption.
+              capability, offering an explanation for cases where positive attitudes fail to
+              produce adoption.
             </li>
             <li>
               <strong>Mechanism-based intervention design:</strong> Specified four concrete,


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.

---

## Summary

Brings bibliography page 1-3 **SCT (Bandura, 1986)** from the original 14-section canonical template up to the current 16-section canonical + full-review standard defined in umbrella #1553.

No prior standardization PR successfully merged for this page. Prior PR attempts were closed without merge; this PR supersedes them and will close #1555 on merge.

## R1 - Structural audit

- Added canonical **Section 6: What Does the Model Measure?** with article-specific measurement content (constructs, scales, reliability/validity evidence where applicable)
- Added canonical **Section 15: Further Reading** marker where the section existed but lacked the comment marker
- Renumbered sections 6-14 to 7-16 to accommodate the new §6; renumbered Series Navigation to §16
- Preserved existing body content and references

## R2 - Softening pass

- Scanned for overstatement language ("Demonstrated/Established/Spawned/Revolutionary/Pioneered/proven") and applied light softening where present
- Full softening/hedging pass will happen in a Grumpy follow-up before merge

## R3 - References + single-file diff

- Branched from current `origin/main` for a guaranteed single-file diff
- Verified in-body `#ref-*` citations resolve to matching `<li id="ref-*">` entries

## Status

**DRAFT** - awaiting full Grumpy pre-merge review before marking ready.

## Linked items

- Closes #1555
- Part of umbrella #1553

## Test plan

- [ ] Build succeeds
- [ ] Verify 16 canonical section markers in order
- [ ] Verify What Does the Model Measure? content is accurate for this framework
- [ ] Grumpy pre-merge review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
