### PR TITLE
docs: 1-7 TPB (Ajzen, 1991) - upgrade to canonical 16-section template

### DIFF
--- a/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
+++ b/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
@@ -179,7 +179,55 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 6. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Theory of Planned Behavior is a measurement model. Ajzen (1991) and Ajzen&rsquo;s
+            subsequent TPB measurement guidance specify how each construct is operationalized:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Attitude Toward the Behavior (AB):</strong> Overall favorable/unfavorable
+              evaluation of performing the behavior; typically measured via semantic-differential
+              items (good-bad, pleasant-unpleasant, beneficial-harmful, wise-foolish).
+            </li>
+            <li>
+              <strong>Subjective Norm (SN):</strong> Perceived social pressure from important
+              referents; measured via direct perception items and underlying normative-belief
+              &times; motivation-to-comply products.
+            </li>
+            <li>
+              <strong>Perceived Behavioral Control (PBC):</strong> Perceived ease/difficulty of
+              performing the behavior, including both self-efficacy and controllability
+              facets. Measured via direct items (e.g., &ldquo;For me to perform X is easy/hard&rdquo;)
+              and underlying control-belief &times; power-of-factor products.
+            </li>
+            <li>
+              <strong>Behavioral Intention (BI):</strong> Self-reported plan or willingness to
+              perform the behavior.
+            </li>
+            <li>
+              <strong>Behavior (B):</strong> Observed action, ideally matched to intent on
+              action, target, context, and time (principle of compatibility inherited from TRA).
+            </li>
+            <li>
+              <strong>Underlying Beliefs:</strong> Behavioral beliefs (bi) &times; outcome
+              evaluations (ei), normative beliefs (nj) &times; motivation to comply (mj), and
+              control beliefs (ck) &times; power factors (pk) - typically elicited through
+              open-ended belief elicitation before scale construction.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Ajzen (1991) and the accompanying construction guidance (Ajzen, 2006) describe belief
+            elicitation, pilot testing, and scale construction procedures. TPB has an extensive
+            validation record across health, consumer, and technology adoption behaviors;
+            meta-analyses commonly report that TPB variables explain a substantial portion of
+            variance in intention and a smaller but meaningful portion of variance in behavior.
+          </p>
+        </section>
+
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -229,7 +277,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe the Model */}
+        {/* 8. Describe the Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe the Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -331,7 +379,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -363,7 +411,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -396,7 +444,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -427,7 +475,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -494,7 +542,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -532,7 +580,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -557,7 +605,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Further Reading */}
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -580,7 +628,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 15. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
+++ b/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
@@ -260,8 +260,8 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Developed the self-efficacy construct - beliefs about personal capability to
-              perform actions - which TPB draws on via perceived behavioral control.
+              Developed the self-efficacy construct - beliefs about personal capability to perform
+              actions - which TPB draws on via perceived behavioral control.
             </li>
             <li>
               <strong>Locus of control research:</strong> Documented how individuals&rsquo; beliefs
@@ -402,8 +402,8 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>General behavior prediction template:</strong> Provides a general framework
-              that has been applied across health, education, environment, workplace, and
-              consumer domains.
+              that has been applied across health, education, environment, workplace, and consumer
+              domains.
             </li>
             <li>
               <strong>Practical intervention specification:</strong> Explicitly specified
@@ -456,8 +456,8 @@ const BibliographyArticlePage = () => {
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>Cross-domain applicability:</strong> Applied across health, occupational,
-              educational, environmental, and consumer behaviors, with reported effect sizes
-              varying by domain.
+              educational, environmental, and consumer behaviors, with reported effect sizes varying
+              by domain.
             </li>
             <li>
               <strong>Population diversity:</strong> Found consistent relationships across

--- a/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
+++ b/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
@@ -199,17 +199,17 @@ const BibliographyArticlePage = () => {
             </li>
             <li>
               <strong>Perceived Behavioral Control (PBC):</strong> Perceived ease/difficulty of
-              performing the behavior, including both self-efficacy and controllability
-              facets. Measured via direct items (e.g., &ldquo;For me to perform X is easy/hard&rdquo;)
-              and underlying control-belief &times; power-of-factor products.
+              performing the behavior, including both self-efficacy and controllability facets.
+              Measured via direct items (e.g., &ldquo;For me to perform X is easy/hard&rdquo;) and
+              underlying control-belief &times; power-of-factor products.
             </li>
             <li>
               <strong>Behavioral Intention (BI):</strong> Self-reported plan or willingness to
               perform the behavior.
             </li>
             <li>
-              <strong>Behavior (B):</strong> Observed action, ideally matched to intent on
-              action, target, context, and time (principle of compatibility inherited from TRA).
+              <strong>Behavior (B):</strong> Observed action, ideally matched to intent on action,
+              target, context, and time (principle of compatibility inherited from TRA).
             </li>
             <li>
               <strong>Underlying Beliefs:</strong> Behavioral beliefs (bi) &times; outcome

--- a/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
+++ b/src/app/bibliography-1-7-theory-of-planned-behavior-tpb-ajzen-1991/page.tsx
@@ -260,7 +260,8 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Established the importance of beliefs about personal capability to perform actions.
+              Developed the self-efficacy construct - beliefs about personal capability to
+              perform actions - which TPB draws on via perceived behavioral control.
             </li>
             <li>
               <strong>Locus of control research:</strong> Documented how individuals&rsquo; beliefs
@@ -400,8 +401,9 @@ const BibliographyArticlePage = () => {
               understanding them as built from specific belief systems.
             </li>
             <li>
-              <strong>General behavior prediction template:</strong> Established general framework
-              applicable across health, education, environment, workplace, and consumer domains.
+              <strong>General behavior prediction template:</strong> Provides a general framework
+              that has been applied across health, education, environment, workplace, and
+              consumer domains.
             </li>
             <li>
               <strong>Practical intervention specification:</strong> Explicitly specified
@@ -453,8 +455,9 @@ const BibliographyArticlePage = () => {
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Cross-domain applicability:</strong> Demonstrated applicability across health,
-              occupational, educational, environmental, and consumer behaviors.
+              <strong>Cross-domain applicability:</strong> Applied across health, occupational,
+              educational, environmental, and consumer behaviors, with reported effect sizes
+              varying by domain.
             </li>
             <li>
               <strong>Population diversity:</strong> Found consistent relationships across


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.

---

## Summary

Brings bibliography page 1-7 **TPB (Ajzen, 1991)** from the original 14-section canonical template up to the current 16-section canonical + full-review standard defined in umbrella #1553.

The original 14-section standardization was merged via PR #1618. That PR and its history are preserved at its original URL; this PR does not modify that history. Per discussion under the umbrella, the child issue was reopened for the 16-section upgrade scope, and this PR will close it on merge.

## R1 - Structural audit

- Added canonical **Section 6: What Does the Model Measure?** with article-specific measurement content (constructs, scales, reliability/validity evidence where applicable)
- Added canonical **Section 15: Further Reading** marker where the section existed but lacked the comment marker
- Renumbered sections 6-14 to 7-16 to accommodate the new §6; renumbered Series Navigation to §16
- Preserved existing body content and references

## R2 - Softening pass

- Scanned for overstatement language ("Demonstrated/Established/Spawned/Revolutionary/Pioneered/proven") and applied light softening where present
- Full softening/hedging pass will happen in a Grumpy follow-up before merge

## R3 - References + single-file diff

- Branched from current `origin/main` for a guaranteed single-file diff
- Verified in-body `#ref-*` citations resolve to matching `<li id="ref-*">` entries

## Status

**DRAFT** - awaiting full Grumpy pre-merge review before marking ready.

## Linked items

- Closes #1559
- Part of umbrella #1553

## Test plan

- [ ] Build succeeds
- [ ] Verify 16 canonical section markers in order
- [ ] Verify What Does the Model Measure? content is accurate for this framework
- [ ] Grumpy pre-merge review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
