### PR TITLE
docs: 1-8 PC Utilization (Thompson et al., 1991) - upgrade to canonical 16-section template

### DIFF
--- a/src/app/bibliography-1-8-personal-computing-utilization-thompson-1991/page.tsx
+++ b/src/app/bibliography-1-8-personal-computing-utilization-thompson-1991/page.tsx
@@ -189,21 +189,21 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
           <p className={PARAGRAPH_CLASSES}>
-            Thompson, Higgins, and Howell (1991) adapt Triandis&rsquo; theoretical framework into
-            a measurement model of personal computing utilization. Core measured constructs:
+            Thompson, Higgins, and Howell (1991) adapt Triandis&rsquo; theoretical framework into a
+            measurement model of personal computing utilization. Core measured constructs:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Utilization:</strong> Frequency, duration, and diversity of personal
-              computer use; measured via self-report usage items.
+              <strong>Utilization:</strong> Frequency, duration, and diversity of personal computer
+              use; measured via self-report usage items.
             </li>
             <li>
               <strong>Perceived Near-Term Consequences (job fit):</strong> Beliefs about how
               computer use fits and improves specific job tasks.
             </li>
             <li>
-              <strong>Perceived Long-Term Consequences:</strong> Beliefs about how computer use
-              will affect career, knowledge, and future opportunities.
+              <strong>Perceived Long-Term Consequences:</strong> Beliefs about how computer use will
+              affect career, knowledge, and future opportunities.
             </li>
             <li>
               <strong>Complexity:</strong> Perceived difficulty of understanding and using the
@@ -223,14 +223,14 @@ const BibliographyArticlePage = () => {
               make computer use easier (support, infrastructure, availability).
             </li>
             <li>
-              <strong>Habit:</strong> Automaticity of behavior; operationalized through
-              self-report of habitual patterns.
+              <strong>Habit:</strong> Automaticity of behavior; operationalized through self-report
+              of habitual patterns.
             </li>
           </ul>
           <p className={PARAGRAPH_CLASSES}>
             Thompson et al. (1991) report survey-based scale development with participants in a
-            large organization and provide reliability estimates for each construct. Construct
-            sets from this model were later partly absorbed into UTAUT (Venkatesh et al., 2003).
+            large organization and provide reliability estimates for each construct. Construct sets
+            from this model were later partly absorbed into UTAUT (Venkatesh et al., 2003).
           </p>
         </section>
 

--- a/src/app/bibliography-1-8-personal-computing-utilization-thompson-1991/page.tsx
+++ b/src/app/bibliography-1-8-personal-computing-utilization-thompson-1991/page.tsx
@@ -185,7 +185,56 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 6. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Thompson, Higgins, and Howell (1991) adapt Triandis&rsquo; theoretical framework into
+            a measurement model of personal computing utilization. Core measured constructs:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Utilization:</strong> Frequency, duration, and diversity of personal
+              computer use; measured via self-report usage items.
+            </li>
+            <li>
+              <strong>Perceived Near-Term Consequences (job fit):</strong> Beliefs about how
+              computer use fits and improves specific job tasks.
+            </li>
+            <li>
+              <strong>Perceived Long-Term Consequences:</strong> Beliefs about how computer use
+              will affect career, knowledge, and future opportunities.
+            </li>
+            <li>
+              <strong>Complexity:</strong> Perceived difficulty of understanding and using the
+              technology.
+            </li>
+            <li>
+              <strong>Affect Toward Use:</strong> Feelings of joy, pleasure, or
+              displeasure/depression associated with computer use.
+            </li>
+            <li>
+              <strong>Social Factors:</strong> Internalized subjective culture and specific
+              interpersonal agreements - perceptions of how referents think one should use the
+              computer.
+            </li>
+            <li>
+              <strong>Facilitating Conditions:</strong> Objective factors in the environment that
+              make computer use easier (support, infrastructure, availability).
+            </li>
+            <li>
+              <strong>Habit:</strong> Automaticity of behavior; operationalized through
+              self-report of habitual patterns.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Thompson et al. (1991) report survey-based scale development with participants in a
+            large organization and provide reliability estimates for each construct. Construct
+            sets from this model were later partly absorbed into UTAUT (Venkatesh et al., 2003).
+          </p>
+        </section>
+
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -227,7 +276,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -327,7 +376,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -358,7 +407,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -389,7 +438,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -416,7 +465,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -495,7 +544,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -545,7 +594,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -556,6 +605,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -589,7 +639,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.

---

## Summary

Brings bibliography page 1-8 **PC Utilization (Thompson et al., 1991)** from the original 14-section canonical template up to the current 16-section canonical + full-review standard defined in umbrella #1553.

The original 14-section standardization was merged via PR #1619. That PR and its history are preserved at its original URL; this PR does not modify that history. Per discussion under the umbrella, the child issue was reopened for the 16-section upgrade scope, and this PR will close it on merge.

## R1 - Structural audit

- Added canonical **Section 6: What Does the Model Measure?** with article-specific measurement content (constructs, scales, reliability/validity evidence where applicable)
- Added canonical **Section 15: Further Reading** marker where the section existed but lacked the comment marker
- Renumbered sections 6-14 to 7-16 to accommodate the new §6; renumbered Series Navigation to §16
- Preserved existing body content and references

## R2 - Softening pass

- Scanned for overstatement language ("Demonstrated/Established/Spawned/Revolutionary/Pioneered/proven") and applied light softening where present
- Full softening/hedging pass will happen in a Grumpy follow-up before merge

## R3 - References + single-file diff

- Branched from current `origin/main` for a guaranteed single-file diff
- Verified in-body `#ref-*` citations resolve to matching `<li id="ref-*">` entries

## Status

**DRAFT** - awaiting full Grumpy pre-merge review before marking ready.

## Linked items

- Closes #1560
- Part of umbrella #1553

## Test plan

- [ ] Build succeeds
- [ ] Verify 16 canonical section markers in order
- [ ] Verify What Does the Model Measure? content is accurate for this framework
- [ ] Grumpy pre-merge review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
