### PR TITLE
docs: 1-9 Intrinsic/Extrinsic Motivation (Davis et al., 1992) - upgrade to canonical 16-section template

### DIFF
--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -230,8 +230,9 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Established that perceived usefulness and perceived ease of use predict attitudes and
-              intentions to use information systems.
+              Proposed that perceived usefulness and perceived ease of use predict attitudes and
+              intentions to use information systems, with supporting evidence in the original
+              TAM study.
             </li>
             <li>
               <strong>Intrinsic motivation theory (Deci &amp; Ryan):</strong> Provided psychological
@@ -362,8 +363,9 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Hedonic motivation integration:</strong> Demonstrated that technology adoption
-              requires understanding both utility (extrinsic) and pleasure (intrinsic) motivations.
+              <strong>Hedonic motivation integration:</strong> Argued and reported evidence that
+              technology adoption involves both utility (extrinsic) and pleasure (intrinsic)
+              motivations rather than utility alone.
             </li>
             <li>
               <strong>Enjoyment as adoption driver:</strong> Provided empirical evidence that

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -175,7 +175,43 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 6. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Davis, Bagozzi, and Warshaw (1992) extend TAM by adding an intrinsic-motivation
+            construct. Core measured constructs:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Perceived Usefulness (PU) - extrinsic motivator:</strong> Degree to which
+              a person believes using the system will enhance job performance. Standard TAM
+              Davis (1989) 6-item Likert scale.
+            </li>
+            <li>
+              <strong>Perceived Enjoyment (PE) - intrinsic motivator:</strong> Extent to which
+              using the system is perceived to be enjoyable in its own right, apart from
+              instrumental consequences. Typically measured via items assessing fun,
+              entertainment, or enjoyment of the activity itself.
+            </li>
+            <li>
+              <strong>Perceived Ease of Use (PEOU):</strong> Standard TAM belief construct.
+            </li>
+            <li>
+              <strong>Behavioral Intention / Future Usage Intent:</strong> Self-reported intent
+              to use the system.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Davis, Bagozzi, and Warshaw (1992) report a workplace field study distinguishing
+            workplace task performance (driven by PU) from workplace enjoyment (driven by PE).
+            The Perceived Enjoyment scale has been adopted widely in subsequent research on
+            hedonic information systems (e.g., Van der Heijden, 2004) and in TAM3
+            (Venkatesh &amp; Bala, 2008) as a determinant of perceived ease of use.
+          </p>
+        </section>
+
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -219,7 +255,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -321,7 +357,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -353,7 +389,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -387,7 +423,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -425,7 +461,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -497,7 +533,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -537,7 +573,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -578,6 +614,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -626,7 +663,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -231,8 +231,8 @@ const BibliographyArticlePage = () => {
                 ):
               </strong>{' '}
               Proposed that perceived usefulness and perceived ease of use predict attitudes and
-              intentions to use information systems, with supporting evidence in the original
-              TAM study.
+              intentions to use information systems, with supporting evidence in the original TAM
+              study.
             </li>
             <li>
               <strong>Intrinsic motivation theory (Deci &amp; Ryan):</strong> Provided psychological

--- a/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
+++ b/src/app/bibliography-1-9-intrinsic-extrinsic-motivation-davis-1992/page.tsx
@@ -184,30 +184,30 @@ const BibliographyArticlePage = () => {
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Perceived Usefulness (PU) - extrinsic motivator:</strong> Degree to which
-              a person believes using the system will enhance job performance. Standard TAM
-              Davis (1989) 6-item Likert scale.
+              <strong>Perceived Usefulness (PU) - extrinsic motivator:</strong> Degree to which a
+              person believes using the system will enhance job performance. Standard TAM Davis
+              (1989) 6-item Likert scale.
             </li>
             <li>
-              <strong>Perceived Enjoyment (PE) - intrinsic motivator:</strong> Extent to which
-              using the system is perceived to be enjoyable in its own right, apart from
-              instrumental consequences. Typically measured via items assessing fun,
-              entertainment, or enjoyment of the activity itself.
+              <strong>Perceived Enjoyment (PE) - intrinsic motivator:</strong> Extent to which using
+              the system is perceived to be enjoyable in its own right, apart from instrumental
+              consequences. Typically measured via items assessing fun, entertainment, or enjoyment
+              of the activity itself.
             </li>
             <li>
               <strong>Perceived Ease of Use (PEOU):</strong> Standard TAM belief construct.
             </li>
             <li>
-              <strong>Behavioral Intention / Future Usage Intent:</strong> Self-reported intent
-              to use the system.
+              <strong>Behavioral Intention / Future Usage Intent:</strong> Self-reported intent to
+              use the system.
             </li>
           </ul>
           <p className={PARAGRAPH_CLASSES}>
             Davis, Bagozzi, and Warshaw (1992) report a workplace field study distinguishing
-            workplace task performance (driven by PU) from workplace enjoyment (driven by PE).
-            The Perceived Enjoyment scale has been adopted widely in subsequent research on
-            hedonic information systems (e.g., Van der Heijden, 2004) and in TAM3
-            (Venkatesh &amp; Bala, 2008) as a determinant of perceived ease of use.
+            workplace task performance (driven by PU) from workplace enjoyment (driven by PE). The
+            Perceived Enjoyment scale has been adopted widely in subsequent research on hedonic
+            information systems (e.g., Van der Heijden, 2004) and in TAM3 (Venkatesh &amp; Bala,
+            2008) as a determinant of perceived ease of use.
           </p>
         </section>
 


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.

---

## Summary

Brings bibliography page 1-9 **Intrinsic/Extrinsic Motivation (Davis et al., 1992)** from the original 14-section canonical template up to the current 16-section canonical + full-review standard defined in umbrella #1553.

The original 14-section standardization was merged via PR #1620. That PR and its history are preserved at its original URL; this PR does not modify that history. Per discussion under the umbrella, the child issue was reopened for the 16-section upgrade scope, and this PR will close it on merge.

## R1 - Structural audit

- Added canonical **Section 6: What Does the Model Measure?** with article-specific measurement content (constructs, scales, reliability/validity evidence where applicable)
- Added canonical **Section 15: Further Reading** marker where the section existed but lacked the comment marker
- Renumbered sections 6-14 to 7-16 to accommodate the new §6; renumbered Series Navigation to §16
- Preserved existing body content and references

## R2 - Softening pass

- Scanned for overstatement language ("Demonstrated/Established/Spawned/Revolutionary/Pioneered/proven") and applied light softening where present
- Full softening/hedging pass will happen in a Grumpy follow-up before merge

## R3 - References + single-file diff

- Branched from current `origin/main` for a guaranteed single-file diff
- Verified in-body `#ref-*` citations resolve to matching `<li id="ref-*">` entries

## Status

**DRAFT** - awaiting full Grumpy pre-merge review before marking ready.

## Linked items

- Closes #1561
- Part of umbrella #1553

## Test plan

- [ ] Build succeeds
- [ ] Verify 16 canonical section markers in order
- [ ] Verify What Does the Model Measure? content is accurate for this framework
- [ ] Grumpy pre-merge review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
