### PR TITLE
docs: 1-10 Decomposed TPB (Taylor & Todd, 1995) - upgrade to canonical 16-section template

### DIFF
--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -452,13 +452,13 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Theoretical integration model:</strong> Demonstrated how to combine
-              TPB&rsquo;s behavioral intention framework with TAM&rsquo;s IT-specific constructs
-              into unified model.
+              <strong>Theoretical integration model:</strong> Illustrated how to combine
+              TPB&rsquo;s behavioral-intention framework with TAM&rsquo;s IT-specific constructs
+              into a unified model.
             </li>
             <li>
-              <strong>Decomposition methodology:</strong> Established approach for making general
-              behavioral theories technology-specific through construct decomposition.
+              <strong>Decomposition methodology:</strong> Articulated an approach for making
+              general behavioral theories technology-specific through construct decomposition.
             </li>
             <li>
               <strong>Superior predictive framework:</strong> Provided empirical evidence that

--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -452,13 +452,13 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Theoretical integration model:</strong> Illustrated how to combine
-              TPB&rsquo;s behavioral-intention framework with TAM&rsquo;s IT-specific constructs
-              into a unified model.
+              <strong>Theoretical integration model:</strong> Illustrated how to combine TPB&rsquo;s
+              behavioral-intention framework with TAM&rsquo;s IT-specific constructs into a unified
+              model.
             </li>
             <li>
-              <strong>Decomposition methodology:</strong> Articulated an approach for making
-              general behavioral theories technology-specific through construct decomposition.
+              <strong>Decomposition methodology:</strong> Articulated an approach for making general
+              behavioral theories technology-specific through construct decomposition.
             </li>
             <li>
               <strong>Superior predictive framework:</strong> Provided empirical evidence that

--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -214,7 +214,70 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 6. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Taylor and Todd (1995) decompose each TPB belief structure into multiple
+            technology-specific constructs. The measured constructs are:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Attitude (from decomposed attitudinal beliefs):</strong>
+              <ul className={BODY_LIST_CLASSES}>
+                <li>
+                  <strong>Perceived Usefulness:</strong> Rogers-style relative advantage / TAM PU
+                  adapted to the technology context.
+                </li>
+                <li>
+                  <strong>Perceived Ease of Use:</strong> Davis 1989 PEOU.
+                </li>
+                <li>
+                  <strong>Compatibility:</strong> Rogers 1983 compatibility with values,
+                  experiences, and needs.
+                </li>
+              </ul>
+            </li>
+            <li>
+              <strong>Subjective Norm (from decomposed normative beliefs):</strong>
+              <ul className={BODY_LIST_CLASSES}>
+                <li>
+                  <strong>Peer Influence:</strong> Influence of colleagues.
+                </li>
+                <li>
+                  <strong>Superior&rsquo;s Influence:</strong> Influence of supervisors/managers.
+                </li>
+              </ul>
+            </li>
+            <li>
+              <strong>Perceived Behavioral Control (from decomposed control beliefs):</strong>
+              <ul className={BODY_LIST_CLASSES}>
+                <li>
+                  <strong>Self-Efficacy:</strong> Bandura-style belief in one&rsquo;s capability.
+                </li>
+                <li>
+                  <strong>Resource Facilitating Conditions:</strong> Access to money, time, and
+                  other resources.
+                </li>
+                <li>
+                  <strong>Technology Facilitating Conditions:</strong> Access to compatible
+                  technology and support.
+                </li>
+              </ul>
+            </li>
+            <li>
+              <strong>Behavioral Intention and Behavior:</strong> Standard TPB dependent
+              measures.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Taylor and Todd (1995) report a field study of information center users; they
+            provide reliability and validity evidence for the decomposed scales and compare the
+            decomposed TPB with TAM and pure TPB.
+          </p>
+        </section>
+
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -269,7 +332,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe the Model */}
+        {/* 8. Describe the Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe the Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -385,7 +448,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -419,7 +482,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -458,7 +521,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -494,7 +557,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -570,7 +633,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -608,7 +671,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -688,6 +751,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -719,7 +783,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
+++ b/src/app/bibliography-1-10-decomposed-tpb-taylor-todd-1995/page.tsx
@@ -266,14 +266,13 @@ const BibliographyArticlePage = () => {
               </ul>
             </li>
             <li>
-              <strong>Behavioral Intention and Behavior:</strong> Standard TPB dependent
-              measures.
+              <strong>Behavioral Intention and Behavior:</strong> Standard TPB dependent measures.
             </li>
           </ul>
           <p className={PARAGRAPH_CLASSES}>
-            Taylor and Todd (1995) report a field study of information center users; they
-            provide reliability and validity evidence for the decomposed scales and compare the
-            decomposed TPB with TAM and pure TPB.
+            Taylor and Todd (1995) report a field study of information center users; they provide
+            reliability and validity evidence for the decomposed scales and compare the decomposed
+            TPB with TAM and pure TPB.
           </p>
         </section>
 


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.

---

## Summary

Brings bibliography page 1-10 **Decomposed TPB (Taylor & Todd, 1995)** from the original 14-section canonical template up to the current 16-section canonical + full-review standard defined in umbrella #1553.

The original 14-section standardization was merged via PR #1622. That PR and its history are preserved at its original URL; this PR does not modify that history. Per discussion under the umbrella, the child issue was reopened for the 16-section upgrade scope, and this PR will close it on merge.

## R1 - Structural audit

- Added canonical **Section 6: What Does the Model Measure?** with article-specific measurement content (constructs, scales, reliability/validity evidence where applicable)
- Added canonical **Section 15: Further Reading** marker where the section existed but lacked the comment marker
- Renumbered sections 6-14 to 7-16 to accommodate the new §6; renumbered Series Navigation to §16
- Preserved existing body content and references

## R2 - Softening pass

- Scanned for overstatement language ("Demonstrated/Established/Spawned/Revolutionary/Pioneered/proven") and applied light softening where present
- Full softening/hedging pass will happen in a Grumpy follow-up before merge

## R3 - References + single-file diff

- Branched from current `origin/main` for a guaranteed single-file diff
- Verified in-body `#ref-*` citations resolve to matching `<li id="ref-*">` entries

## Status

**DRAFT** - awaiting full Grumpy pre-merge review before marking ready.

## Linked items

- Closes #1562
- Part of umbrella #1553

## Test plan

- [ ] Build succeeds
- [ ] Verify 16 canonical section markers in order
- [ ] Verify What Does the Model Measure? content is accurate for this framework
- [ ] Grumpy pre-merge review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
