### PR TITLE
docs: 1-12 TRI (Parasuraman, 2000) - upgrade to canonical 16-section template

### DIFF
--- a/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
+++ b/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
@@ -396,7 +396,7 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Established categories of adopters (innovators, early adopters, early majority, late
+              Articulated categories of adopters (innovators, early adopters, early majority, late
               majority, laggards) based on individual characteristics and risk tolerance. TRI
               operationalizes these differences more precisely through multi-dimensional
               measurement.
@@ -429,7 +429,7 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Established perceived usefulness and perceived ease of use as adoption predictors, but
+              Proposed perceived usefulness and perceived ease of use as adoption predictors; the model
               did not fully explore underlying personality dispositions driving these perceptions.
             </li>
             <li>
@@ -459,7 +459,7 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Demonstrated that individual innovativeness toward information technology is a stable
+              Argued and reported evidence that individual innovativeness toward information technology can be a stable
               personality trait predicting adoption across systems.
             </li>
           </ul>
@@ -591,7 +591,7 @@ const BibliographyArticlePage = () => {
               dimensions with strong psychometric properties.
             </li>
             <li>
-              <strong>Multidimensional readiness concept:</strong> Demonstrated that technology
+              <strong>Multidimensional readiness concept:</strong> Proposed that technology
               readiness is not unidimensional (acceptance/resistance) but comprises distinct
               psychological components (optimism, innovativeness, discomfort, insecurity).
             </li>

--- a/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
+++ b/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
@@ -343,36 +343,36 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
           <p className={PARAGRAPH_CLASSES}>
             The Technology Readiness Index (TRI) is a psychometric scale. Parasuraman (2000)
-            develops a 36-item Likert instrument measuring a general personality-trait construct
-            of technology readiness, composed of four dimensions:
+            develops a 36-item Likert instrument measuring a general personality-trait construct of
+            technology readiness, composed of four dimensions:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Optimism (contributor):</strong> A positive view of technology and a
-              belief that it offers people increased control, flexibility, and efficiency.
-              Measured via multi-item scale.
+              <strong>Optimism (contributor):</strong> A positive view of technology and a belief
+              that it offers people increased control, flexibility, and efficiency. Measured via
+              multi-item scale.
             </li>
             <li>
-              <strong>Innovativeness (contributor):</strong> A tendency to be a technology
-              pioneer and thought leader.
+              <strong>Innovativeness (contributor):</strong> A tendency to be a technology pioneer
+              and thought leader.
             </li>
             <li>
-              <strong>Discomfort (inhibitor):</strong> A perceived lack of control over
-              technology and a feeling of being overwhelmed by it.
+              <strong>Discomfort (inhibitor):</strong> A perceived lack of control over technology
+              and a feeling of being overwhelmed by it.
             </li>
             <li>
-              <strong>Insecurity (inhibitor):</strong> Distrust of technology and skepticism
-              about its ability to work properly, often tied to privacy and transaction-integrity
+              <strong>Insecurity (inhibitor):</strong> Distrust of technology and skepticism about
+              its ability to work properly, often tied to privacy and transaction-integrity
               concerns.
             </li>
           </ul>
           <p className={PARAGRAPH_CLASSES}>
-            TRI produces a composite technology-readiness score and four subscale scores. The
-            2000 instrument was developed and validated with a nationally representative
-            US sample (&gt;1,000 consumers); Parasuraman &amp; Colby subsequently produced TRI 2.0
-            (2015, bibliography 1-21) - a shorter 16-item instrument. The original 36-item scale
-            reports Cronbach&rsquo;s alpha values above conventional thresholds for each subscale
-            in the validation sample.
+            TRI produces a composite technology-readiness score and four subscale scores. The 2000
+            instrument was developed and validated with a nationally representative US sample
+            (&gt;1,000 consumers); Parasuraman &amp; Colby subsequently produced TRI 2.0 (2015,
+            bibliography 1-21) - a shorter 16-item instrument. The original 36-item scale reports
+            Cronbach&rsquo;s alpha values above conventional thresholds for each subscale in the
+            validation sample.
           </p>
         </section>
 

--- a/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
+++ b/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
@@ -429,8 +429,9 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Proposed perceived usefulness and perceived ease of use as adoption predictors; the model
-              did not fully explore underlying personality dispositions driving these perceptions.
+              Proposed perceived usefulness and perceived ease of use as adoption predictors; the
+              model did not fully explore underlying personality dispositions driving these
+              perceptions.
             </li>
             <li>
               <strong>
@@ -459,8 +460,8 @@ const BibliographyArticlePage = () => {
                 </a>
                 ):
               </strong>{' '}
-              Argued and reported evidence that individual innovativeness toward information technology can be a stable
-              personality trait predicting adoption across systems.
+              Argued and reported evidence that individual innovativeness toward information
+              technology can be a stable personality trait predicting adoption across systems.
             </li>
           </ul>
         </section>

--- a/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
+++ b/src/app/bibliography-1-12-technology-readiness-index-tri-parasuraman-2000/page.tsx
@@ -338,7 +338,45 @@ const BibliographyArticlePage = () => {
           </p>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 6. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            The Technology Readiness Index (TRI) is a psychometric scale. Parasuraman (2000)
+            develops a 36-item Likert instrument measuring a general personality-trait construct
+            of technology readiness, composed of four dimensions:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Optimism (contributor):</strong> A positive view of technology and a
+              belief that it offers people increased control, flexibility, and efficiency.
+              Measured via multi-item scale.
+            </li>
+            <li>
+              <strong>Innovativeness (contributor):</strong> A tendency to be a technology
+              pioneer and thought leader.
+            </li>
+            <li>
+              <strong>Discomfort (inhibitor):</strong> A perceived lack of control over
+              technology and a feeling of being overwhelmed by it.
+            </li>
+            <li>
+              <strong>Insecurity (inhibitor):</strong> Distrust of technology and skepticism
+              about its ability to work properly, often tied to privacy and transaction-integrity
+              concerns.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            TRI produces a composite technology-readiness score and four subscale scores. The
+            2000 instrument was developed and validated with a nationally representative
+            US sample (&gt;1,000 consumers); Parasuraman &amp; Colby subsequently produced TRI 2.0
+            (2015, bibliography 1-21) - a shorter 16-item instrument. The original 36-item scale
+            reports Cronbach&rsquo;s alpha values above conventional thresholds for each subscale
+            in the validation sample.
+          </p>
+        </section>
+
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -427,7 +465,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -543,7 +581,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -580,7 +618,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -617,7 +655,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -660,7 +698,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -745,7 +783,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -789,7 +827,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -799,6 +837,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -808,7 +847,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.

---

## Summary

Brings bibliography page 1-12 **TRI (Parasuraman, 2000)** from the original 14-section canonical template up to the current 16-section canonical + full-review standard defined in umbrella #1553.

The original 14-section standardization was merged via PR #1624. That PR and its history are preserved at its original URL; this PR does not modify that history. Per discussion under the umbrella, the child issue was reopened for the 16-section upgrade scope, and this PR will close it on merge.

## R1 - Structural audit

- Added canonical **Section 6: What Does the Model Measure?** with article-specific measurement content (constructs, scales, reliability/validity evidence where applicable)
- Added canonical **Section 15: Further Reading** marker where the section existed but lacked the comment marker
- Renumbered sections 6-14 to 7-16 to accommodate the new §6; renumbered Series Navigation to §16
- Preserved existing body content and references

## R2 - Softening pass

- Scanned for overstatement language ("Demonstrated/Established/Spawned/Revolutionary/Pioneered/proven") and applied light softening where present
- Full softening/hedging pass will happen in a Grumpy follow-up before merge

## R3 - References + single-file diff

- Branched from current `origin/main` for a guaranteed single-file diff
- Verified in-body `#ref-*` citations resolve to matching `<li id="ref-*">` entries

## Status

**DRAFT** - awaiting full Grumpy pre-merge review before marking ready.

## Linked items

- Closes #1564
- Part of umbrella #1553

## Test plan

- [ ] Build succeeds
- [ ] Verify 16 canonical section markers in order
- [ ] Verify What Does the Model Measure? content is accurate for this framework
- [ ] Grumpy pre-merge review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
