### PR TITLE
docs: 1-16 MATH (Brown & Venkatesh, 2005) - upgrade to canonical 16-section template

### DIFF
--- a/src/app/bibliography-1-16-math-brown-venkatesh-2005/page.tsx
+++ b/src/app/bibliography-1-16-math-brown-venkatesh-2005/page.tsx
@@ -550,20 +550,19 @@ const BibliographyArticlePage = () => {
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>Early household-specific adoption model:</strong> Argued that household
-              technology adoption benefits from a distinct theoretical framework from
-              organizational adoption, challenging assumptions that single models apply
-              universally.
+              technology adoption benefits from a distinct theoretical framework from organizational
+              adoption, challenging assumptions that single models apply universally.
             </li>
             <li>
-              <strong>Multiple benefit dimensions in consumer adoption:</strong> Argued and
-              reported evidence that household adoption decisions involve evaluating multiple
-              benefit dimensions (work, education, entertainment, family) rather than a single
-              performance criterion as is typical in organizational-adoption research.
+              <strong>Multiple benefit dimensions in consumer adoption:</strong> Argued and reported
+              evidence that household adoption decisions involve evaluating multiple benefit
+              dimensions (work, education, entertainment, family) rather than a single performance
+              criterion as is typical in organizational-adoption research.
             </li>
             <li>
               <strong>Collective household decision-making framework:</strong> Frames household
-              adoption as a collective family decision rather than an individual choice,
-              requiring attention to preference negotiation and family influence dynamics.
+              adoption as a collective family decision rather than an individual choice, requiring
+              attention to preference negotiation and family influence dynamics.
             </li>
             <li>
               <strong>Cost as primary household adoption barrier:</strong> Empirically demonstrated

--- a/src/app/bibliography-1-16-math-brown-venkatesh-2005/page.tsx
+++ b/src/app/bibliography-1-16-math-brown-venkatesh-2005/page.tsx
@@ -549,20 +549,21 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>First household-specific adoption model:</strong> Established that household
-              technology adoption required distinct theoretical framework from organizational
-              adoption, challenging assumptions that single models apply universally.
+              <strong>Early household-specific adoption model:</strong> Argued that household
+              technology adoption benefits from a distinct theoretical framework from
+              organizational adoption, challenging assumptions that single models apply
+              universally.
             </li>
             <li>
-              <strong>Multiple benefit dimensions in consumer adoption:</strong> Demonstrated that
-              household adoption decisions involve evaluating multiple benefit dimensions (work,
-              education, entertainment, family) rather than single performance criterion in
-              organizational adoption.
+              <strong>Multiple benefit dimensions in consumer adoption:</strong> Argued and
+              reported evidence that household adoption decisions involve evaluating multiple
+              benefit dimensions (work, education, entertainment, family) rather than a single
+              performance criterion as is typical in organizational-adoption research.
             </li>
             <li>
-              <strong>Collective household decision-making framework:</strong> Established household
-              adoption as collective family decision rather than individual choice, requiring
-              understanding of preference negotiation and family influence dynamics.
+              <strong>Collective household decision-making framework:</strong> Frames household
+              adoption as a collective family decision rather than an individual choice,
+              requiring attention to preference negotiation and family influence dynamics.
             </li>
             <li>
               <strong>Cost as primary household adoption barrier:</strong> Empirically demonstrated

--- a/src/app/bibliography-1-16-math-brown-venkatesh-2005/page.tsx
+++ b/src/app/bibliography-1-16-math-brown-venkatesh-2005/page.tsx
@@ -215,7 +215,67 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 6. Preceding Models or Theories */}
+        {/* 6. What Does the Model Measure? */}
+        <section className={SECTION_CLASSES}>
+          <h2 className={H2_CLASSES}>What Does the Model Measure?</h2>
+          <p className={PARAGRAPH_CLASSES}>
+            Brown and Venkatesh (2005) develop MATH as a decomposed belief-structure measurement
+            model for household technology adoption. The framework adapts TPB and extends it with
+            household-specific belief decompositions:
+          </p>
+          <ul className={BODY_LIST_CLASSES}>
+            <li>
+              <strong>Utilitarian Outcomes (attitudinal):</strong>
+              <ul className={BODY_LIST_CLASSES}>
+                <li>Utility for Children (e.g., educational use)</li>
+                <li>Utility for Work-Related Use</li>
+                <li>Applications for Personal Use</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Hedonic Outcomes (attitudinal):</strong> Fun, enjoyment, and excitement of
+              using the technology at home.
+            </li>
+            <li>
+              <strong>Social Outcomes (attitudinal):</strong> Status gains from being seen as
+              technologically savvy within one&rsquo;s household/social network.
+            </li>
+            <li>
+              <strong>Normative Beliefs:</strong>
+              <ul className={BODY_LIST_CLASSES}>
+                <li>Friends and Family Influences</li>
+                <li>Secondary Sources&rsquo; Influences (e.g., media, vendors)</li>
+                <li>Workplace Referents&rsquo; Influences</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Control Beliefs:</strong>
+              <ul className={BODY_LIST_CLASSES}>
+                <li>Fear of Technological Advances (Rapid Change)</li>
+                <li>Declining Cost / Cost</li>
+                <li>Perceived Ease of Use / Self-Efficacy</li>
+                <li>Requisite Knowledge for Use</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Attitude, Subjective Norm, Perceived Behavioral Control, and Behavioral
+              Intention:</strong> Standard TPB dependent constructs.
+            </li>
+            <li>
+              <strong>Moderators:</strong> Age, Income, Marital Status, Life-Stage, and Presence
+              of Children - proposed to moderate relationships between specific beliefs and the
+              TPB second-order constructs.
+            </li>
+          </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Brown and Venkatesh (2005) report a survey-based study with &gt;700 US household
+            respondents and provide validity evidence and path-coefficient estimates for the
+            decomposed belief structure. The household framing distinguishes MATH from UTAUT and
+            other workplace-oriented models.
+          </p>
+        </section>
+
+        {/* 7. Preceding Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -315,7 +375,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 7. Describe The Model */}
+        {/* 8. Describe The Model */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -482,7 +542,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 8. Key Contributions */}
+        {/* 9. Key Contributions */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Key Contributions</h2>
           <ul className={BODY_LIST_CLASSES}>
@@ -535,7 +595,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 9. Internal Validity */}
+        {/* 10. Internal Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Internal Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -584,7 +644,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 10. External Validity */}
+        {/* 11. External Validity */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>External Validity</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -642,7 +702,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 11. Relevance to Technology Adoption */}
+        {/* 12. Relevance to Technology Adoption */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Relevance to Technology Adoption</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -752,7 +812,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 12. Following Models or Theories */}
+        {/* 13. Following Models or Theories */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
@@ -815,7 +875,7 @@ const BibliographyArticlePage = () => {
           </ul>
         </section>
 
-        {/* 13. References */}
+        {/* 14. References */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>References</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -877,6 +937,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
+        {/* 15. Further Reading */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Further Reading</h2>
           <ol className={REFERENCES_OL_CLASSES}>
@@ -909,7 +970,7 @@ const BibliographyArticlePage = () => {
           </ol>
         </section>
 
-        {/* 14. Series Navigation */}
+        {/* 16. Series Navigation */}
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Series Navigation</h2>
           <div className="space-y-4">

--- a/src/app/bibliography-1-16-math-brown-venkatesh-2005/page.tsx
+++ b/src/app/bibliography-1-16-math-brown-venkatesh-2005/page.tsx
@@ -258,13 +258,15 @@ const BibliographyArticlePage = () => {
               </ul>
             </li>
             <li>
-              <strong>Attitude, Subjective Norm, Perceived Behavioral Control, and Behavioral
-              Intention:</strong> Standard TPB dependent constructs.
+              <strong>
+                Attitude, Subjective Norm, Perceived Behavioral Control, and Behavioral Intention:
+              </strong>{' '}
+              Standard TPB dependent constructs.
             </li>
             <li>
-              <strong>Moderators:</strong> Age, Income, Marital Status, Life-Stage, and Presence
-              of Children - proposed to moderate relationships between specific beliefs and the
-              TPB second-order constructs.
+              <strong>Moderators:</strong> Age, Income, Marital Status, Life-Stage, and Presence of
+              Children - proposed to moderate relationships between specific beliefs and the TPB
+              second-order constructs.
             </li>
           </ul>
           <p className={PARAGRAPH_CLASSES}>


### PR DESCRIPTION
> **SCOPE UPDATE 2026-04-17: Canonical template expanded from 14 to 16 sections.** Per umbrella #1553:
> - **New Section 6: "What Does the Model Measure?"** (codifies measurement-model vs prescriptive-framework distinction)
> - **New Section 15: "Further Reading"** (split from References; References is now body-cited-only)
>
> Additionally, every page must now pass a **full R1-R3 + Grumpy pre-merge review cycle** (structural audit / softening pass / references-and-rebase polish / adversarial final audit) before the associated child issue is fully complete.

---

## Summary

Brings bibliography page 1-16 **MATH (Brown & Venkatesh, 2005)** from the original 14-section canonical template up to the current 16-section canonical + full-review standard defined in umbrella #1553.

The original 14-section standardization was merged via PR #1630. That PR and its history are preserved at its original URL; this PR does not modify that history. Per discussion under the umbrella, the child issue was reopened for the 16-section upgrade scope, and this PR will close it on merge.

## R1 - Structural audit

- Added canonical **Section 6: What Does the Model Measure?** with article-specific measurement content (constructs, scales, reliability/validity evidence where applicable)
- Added canonical **Section 15: Further Reading** marker where the section existed but lacked the comment marker
- Renumbered sections 6-14 to 7-16 to accommodate the new §6; renumbered Series Navigation to §16
- Preserved existing body content and references

## R2 - Softening pass

- Scanned for overstatement language ("Demonstrated/Established/Spawned/Revolutionary/Pioneered/proven") and applied light softening where present
- Full softening/hedging pass will happen in a Grumpy follow-up before merge

## R3 - References + single-file diff

- Branched from current `origin/main` for a guaranteed single-file diff
- Verified in-body `#ref-*` citations resolve to matching `<li id="ref-*">` entries

## Status

**DRAFT** - awaiting full Grumpy pre-merge review before marking ready.

## Linked items

- Closes #1569
- Part of umbrella #1553

## Test plan

- [ ] Build succeeds
- [ ] Verify 16 canonical section markers in order
- [ ] Verify What Does the Model Measure? content is accurate for this framework
- [ ] Grumpy pre-merge review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
