### PR TITLE
fix: 2-14 CMMI R1 - correct maturity/capability level names and PA categories from source PDF

### DIFF
--- a/src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx
+++ b/src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx
@@ -225,7 +225,10 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Preceding Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
-            CMMI built upon and integrated several prior approaches:
+            CMMI built upon and integrated several prior approaches. The specific preceding models
+            listed below (CMM, SECM, CMM-SW, SE-CMM, IPD-CMM, P-CMM, TQM, ISO 9000) are drawn from
+            secondary sources rather than the Chrissis et al. TOC itself; TOC-limited, full book
+            unavailable:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
@@ -308,9 +311,11 @@ const BibliographyArticlePage = () => {
           <h3 className={H3_CLASSES}>CMMI Process Areas</h3>
           <p className={PARAGRAPH_CLASSES}>
             The CMMI-SE/SW/IPPD/SS v1.1 edition documented by Chrissis, Konrad, and Shrum organizes
-            25 process areas into four categories. The book further groups process areas within each
-            category as &quot;Fundamental&quot; or &quot;Progressive&quot; to indicate prerequisite
-            relationships among them:
+            25 process areas into four categories. For Process Management, Project Management, and
+            Support, the book further groups process areas as &quot;Fundamental&quot; or
+            &quot;Progressive&quot; to indicate prerequisite relationships among them. For
+            Engineering, the book discusses process areas under &quot;Engineering Process Areas and
+            Recursion&quot; rather than a Fundamental/Progressive split.
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
@@ -700,7 +705,10 @@ const BibliographyArticlePage = () => {
           <h2 className={H2_CLASSES}>Following Models or Theories</h2>
           <p className={PARAGRAPH_CLASSES}>
             CMMI has evolved through multiple versions and is commonly discussed alongside related
-            process-improvement frameworks:
+            process-improvement frameworks. The specific successor constellations (CMMI-DEV,
+            CMMI-ACQ, CMMI-SVC) and adjacent frameworks (COBIT, ITIL, ISO/IEC 15504, Lean, Agile,
+            DevOps) listed below are drawn from secondary sources rather than the Chrissis et al.
+            TOC itself; TOC-limited, full book unavailable:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>

--- a/src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx
+++ b/src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx
@@ -190,8 +190,8 @@ const BibliographyArticlePage = () => {
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>Capability level (continuous representation):</strong> For each process area,
-              ratings ranging across levels (for example, Incomplete, Performed, Managed, Defined,
-              and, in some versions, Quantitatively Managed and Optimizing).
+              one of six levels: Incomplete (Level 0), Performed (Level 1), Managed (Level 2),
+              Defined (Level 3), Quantitatively Managed (Level 4), and Optimizing (Level 5).
             </li>
             <li>
               <strong>Maturity level (staged representation):</strong> An overall organizational
@@ -279,58 +279,65 @@ const BibliographyArticlePage = () => {
           <h3 className={H3_CLASSES}>CMMI Staged Representation - Five Maturity Levels</h3>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Level 1: Initial (Ad Hoc):</strong> Processes unpredictable, poorly
-              controlled, reactive. Success depends on individual efforts rather than established
-              processes. Organization lacks repeatable processes.
+              <strong>Level 1: Initial:</strong> Processes unpredictable, poorly controlled,
+              reactive. Success depends on individual efforts rather than established processes.
+              Organization lacks repeatable processes.
             </li>
             <li>
-              <strong>Level 2: Managed (Repeatable):</strong> Requirements managed, processes
-              planned and executed, work products monitored and controlled. Some processes
-              institutionalized but discipline variable across organization.
+              <strong>Level 2: Managed:</strong> Requirements managed, processes planned and
+              executed, work products monitored and controlled. Some processes institutionalized but
+              discipline variable across organization.
             </li>
             <li>
-              <strong>Level 3: Defined (Standardized):</strong> Standard processes documented and
-              communicated, processes tailored from organizational standards, integration across
-              functional groups. Processes are proactive with preventive mechanisms.
+              <strong>Level 3: Defined:</strong> Standard processes documented and communicated,
+              processes tailored from organizational standards, integration across functional
+              groups. Processes are proactive with preventive mechanisms.
             </li>
             <li>
-              <strong>Level 4: Managed (Quantitatively Managed):</strong> Processes measured and
-              controlled, quantitative objectives for quality and performance established.
-              Statistical techniques used to manage processes.
+              <strong>Level 4: Quantitatively Managed:</strong> Processes measured and controlled,
+              quantitative objectives for quality and performance established. Statistical
+              techniques used to manage processes.
             </li>
             <li>
-              <strong>Level 5: Optimizing (Innovating):</strong> Organization focuses on continuous
-              process improvement and innovation. Processes enable rapid adaption to changing
+              <strong>Level 5: Optimizing:</strong> Organization focuses on continuous process
+              improvement and innovation. Processes enable rapid adaptation to changing
               circumstances.
             </li>
           </ul>
 
-          <h3 className={H3_CLASSES}>CMMI Process Areas by Maturity Level</h3>
+          <h3 className={H3_CLASSES}>CMMI Process Areas</h3>
           <p className={PARAGRAPH_CLASSES}>
-            CMMI-DEV v1.3 (2010) organized into four categories of process areas distributed across
-            maturity levels:
+            The CMMI-SE/SW/IPPD/SS v1.1 edition documented by Chrissis, Konrad, and Shrum organizes
+            25 process areas into four categories. The book further groups process areas within each
+            category as &quot;Fundamental&quot; or &quot;Progressive&quot; to indicate prerequisite
+            relationships among them:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Process Management (6 areas):</strong> Organizational processes and standards:
-              Organizational Process Focus, Organizational Process Definition, Organizational
-              Training, Integrated Product and Process, Risk Management, Organizational Performance
-              Management.
+              <strong>Process Management:</strong> Organizational-level process areas addressing the
+              infrastructure needed to sustain process improvement across the enterprise.
             </li>
             <li>
-              <strong>Project Management (8 areas):</strong> Planning and executing projects:
-              Project Planning, Project Monitoring and Control, Supplier Agreement Management,
-              Integrated Teaming, Quantitative Project Management, Requirements Management.
+              <strong>Project Management:</strong> Process areas for planning, monitoring, and
+              controlling projects, including integrated product teams and supplier arrangements
+              where applicable.
             </li>
             <li>
-              <strong>Engineering (9 areas):</strong> Technical product development: Requirements
-              Development, Technical Solution, Product Integration, Verification, Validation.
+              <strong>Engineering:</strong> Process areas for the technical work of developing and
+              delivering products, spanning requirements, technical solution, product integration,
+              verification, and validation.
             </li>
             <li>
-              <strong>Support (3 areas):</strong> Cross-cutting support processes: Configuration
-              Management, Process and Product Quality Assurance, Measurement and Analysis.
+              <strong>Support:</strong> Cross-cutting process areas providing infrastructure and
+              analytical capabilities that support all other process areas.
             </li>
           </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            The 25 process areas in this edition span software engineering, systems engineering,
+            integrated product and process development (IPPD), and supplier sourcing disciplines.
+            Selected process areas are active only when particular disciplines are in scope for an
+            appraisal.
+          </p>
 
           <h3 className={H3_CLASSES}>CMMI Continuous Representation - Capability Levels</h3>
           <p className={PARAGRAPH_CLASSES}>
@@ -360,7 +367,7 @@ const BibliographyArticlePage = () => {
               with statistical process control. Performance targets established and managed.
             </li>
             <li>
-              <strong>Level 5: Optimized:</strong> Process area optimized for continuous
+              <strong>Level 5: Optimizing:</strong> Process area optimized for continuous
               improvement. Innovation and process optimization institutionalized.
             </li>
           </ul>

--- a/src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx
+++ b/src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx
@@ -214,10 +214,14 @@ const BibliographyArticlePage = () => {
             coefficients in the way measurement theories do.
           </p>
           <p className={PARAGRAPH_CLASSES}>
-            <strong>Source note:</strong> Claims below are drawn from the 2005 Chrissis, Konrad, and
-            Shrum textbook, the CMMI v1.1 and subsequent model documents published by SEI/CMMI
-            Institute/ISACA, and commonly cited secondary treatments. Direct page-level verification
-            has not been performed for every claim.
+            <strong>Source note:</strong> Claims below are drawn from the Chrissis, Konrad, and
+            Shrum textbook (CMMI-SE/SW/IPPD/SS v1.1 edition), the CMMI v1.1 and subsequent model
+            documents published by SEI/CMMI Institute/ISACA, and commonly cited secondary
+            treatments. The structural elements verified against the book&rsquo;s Table of Contents
+            include the four process area categories, the 25 process areas, capability levels 0-5,
+            maturity levels 1-5, and generic goals GG 1-5. Historical claims about precursor CMMs
+            and successor constellations, together with the year-to-year evolution narrative, are
+            drawn from secondary sources rather than direct body-text verification.
           </p>
         </section>
 


### PR DESCRIPTION
## Summary

R1 factual review of bibliography page 2-14 (CMMI - Chrissis, Konrad, Shrum). Compared structural claims on the page against the source PDF available in Zotero.

**Important constraint:** The Zotero attachment for this book (key `W62Y69C8`) contains only a 7-page scanned Table of Contents PDF (132KB, sourced from gbv.de library catalog), not the full 663-page book. R1 findings are therefore limited to claims verifiable from the TOC (maturity level names, capability level names, number of process areas, category structure, preface/acknowledgments, part titles).

Zotero metadata notes:
- Parsed date: 2003 (8th printing) - page cites 2005
- ISBN from Zotero: 978-0-321-15496-5 - page cites 978-0-321-71150-2 (the 2011 3rd edition ISBN)

## R1 Findings Addressed (6 factual corrections)

All fixes are traceable to the PDF TOC pages (Contents, pages v-xi):

1. **Maturity Level 4 name** - removed spurious "(Managed)" qualifier; PDF names this level "Quantitatively Managed" (Contents p. viii, p. 81)
2. **Maturity Level 5 name** - removed spurious "(Innovating)" qualifier; PDF names this level "Optimizing" (Contents p. viii, p. 81)
3. **Maturity Levels 1-3** - removed parenthetical aliases "(Ad Hoc)", "(Repeatable)", "(Standardized)" not used in the book
4. **Capability Level 5 name** - corrected "Optimized" to "Optimizing" per PDF (Contents p. vii, p. 78)
5. **Capability levels list** - all 6 levels (0-5) are present in this edition per PDF TOC; removed misleading "in some versions" qualifier
6. **Process Area Categories block** - removed incorrect reference to "CMMI-DEV v1.3 (2010)" in a section citing the 2005 Chrissis book; fixed count/list mismatches where section headings said "8 areas" but listed 6 items, etc.; stated 25 PAs across 4 categories (Process Management, Project Management, Engineering, Support) per PDF TOC Part Two listing

## Deferred (require user approval per skill rule 8)

- **Publication year** (2005 vs. Zotero 2003): appears in page title, metadata, body prose, and citations. Not changed in R1 because modifying body without citation creates internal inconsistency; modifying citation requires user approval.
- **ISBN 978-0-321-71150-2** (Theory Publication Information): This is the ISBN for the 2011 3rd edition, not the cited 2005 book. Zotero records 978-0-321-15496-5 for the 2003 1st edition. Defer until user resolves which edition to cite.
- **Non-verifiable detail claims**: Specific PA-to-category assignments (e.g., which PAs belong to "Process Management" vs. "Project Management") are not extractable from the TOC. Current page only asserts the 4 categories exist; specific per-PA membership deferred to a round that has access to book chapters beyond the TOC.

## Scope

- Single-file change: `src/app/bibliography-2-14-cmmi-chrissis-2005/page.tsx`
- No citation changes in this round
- No em-dashes or en-dashes introduced
- R1 of up-to-3 round review

## Test plan
- [ ] CI passes (format, lint, test, build, E2E)
- [ ] Human verification that deferred citation/ISBN issues are correctly scoped for a later pass