### PR TITLE
docs: 2-12 TOGAF (The Open Group, 1995) R1 - PDF-based factual corrections (via TOGAF 10th Edition PDFs)

### DIFF
--- a/src/app/bibliography-2-12-togaf-the-open-group-1995/page.tsx
+++ b/src/app/bibliography-2-12-togaf-the-open-group-1995/page.tsx
@@ -150,7 +150,7 @@ const BibliographyArticlePage = () => {
             <li>
               <strong>Enterprise Architecture:</strong> A comprehensive view of organization&rsquo;s
               structure supported through four architecture domains: Business, Data, Application,
-              and Technology. Architecture provides strategic blueprint aligning business and
+              and Technology. Architecture provides a strategic blueprint aligning business and
               technology decisions.
             </li>
             <li>
@@ -354,10 +354,10 @@ const BibliographyArticlePage = () => {
               relevant and effective.
             </li>
             <li>
-              <strong>Requirements Management:</strong> Cross-cutting activity operating throughout
-              ADM that manages architecture requirements throughout the cycle. Per the TOGAF
-              Standard, Requirements Management is not a numbered phase but a continuous activity at
-              the center of the ADM cycle.
+              <strong>Requirements Management:</strong> A cross-cutting activity operating
+              throughout the ADM that manages architecture requirements throughout the cycle. Per
+              the TOGAF Standard, Requirements Management is not a numbered phase but a continuous
+              activity at the center of the ADM cycle.
             </li>
           </ul>
 

--- a/src/app/bibliography-2-12-togaf-the-open-group-1995/page.tsx
+++ b/src/app/bibliography-2-12-togaf-the-open-group-1995/page.tsx
@@ -149,16 +149,18 @@ const BibliographyArticlePage = () => {
           <ul className={BODY_LIST_CLASSES}>
             <li>
               <strong>Enterprise Architecture:</strong> A comprehensive view of organization&rsquo;s
-              structure comprising business, information, applications, and technology architecture.
-              Architecture provides strategic blueprint aligning business and technology decisions.
+              structure supported through four architecture domains: Business, Data, Application,
+              and Technology. Architecture provides strategic blueprint aligning business and
+              technology decisions.
             </li>
             <li>
               <strong>Architecture Development Method (ADM):</strong> Iterative, cyclic process for
-              developing enterprise architecture. ADM comprises eight phases (Preliminary, A -
-              Vision, B - Business Architecture, C - Information Systems Architecture, D -
-              Technology Architecture, E - Opportunities &amp; Solutions, F - Migration Planning, G
-              - Implementation Governance, H - Architecture Change Management) plus architecture
-              requirements management.
+              developing enterprise architecture. ADM comprises a Preliminary Phase plus eight
+              lettered phases (A - Architecture Vision, B - Business Architecture, C - Information
+              Systems Architectures, D - Technology Architecture, E - Opportunities &amp; Solutions,
+              F - Migration Planning, G - Implementation Governance, H - Architecture Change
+              Management), with Requirements Management operating as a cross-cutting activity
+              throughout the cycle.
             </li>
             <li>
               <strong>Architecture Content Framework (ACF):</strong> Structured model describing
@@ -301,8 +303,10 @@ const BibliographyArticlePage = () => {
 
           <h3 className={H3_CLASSES}>Architecture Development Method (ADM)</h3>
           <p className={PARAGRAPH_CLASSES}>
-            TOGAF&rsquo;s core method is the Architecture Development Method, comprising nine phases
-            organized as iterative cycle:
+            TOGAF&rsquo;s core method is the Architecture Development Method, organized as an
+            iterative cycle comprising a Preliminary Phase and eight lettered phases (A through H),
+            plus Requirements Management as a cross-cutting activity that operates throughout the
+            ADM:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
@@ -320,9 +324,9 @@ const BibliographyArticlePage = () => {
               and business requirements.
             </li>
             <li>
-              <strong>Phase C - Information Systems Architecture:</strong> Develop applications and
-              data architecture describing information systems, applications, and data standards
-              required to support business.
+              <strong>Phase C - Information Systems Architectures:</strong> Develop Information
+              Systems Architectures (comprising Data Architecture and Application Architecture) to
+              support the agreed Architecture Vision.
             </li>
             <li>
               <strong>Phase D - Technology Architecture:</strong> Develop technology architecture
@@ -350,8 +354,10 @@ const BibliographyArticlePage = () => {
               relevant and effective.
             </li>
             <li>
-              <strong>Requirements Management:</strong> Cross-cutting activity throughout ADM
-              managing architecture requirements, traceability, and alignment.
+              <strong>Requirements Management:</strong> Cross-cutting activity operating throughout
+              ADM that manages architecture requirements throughout the cycle. Per the TOGAF
+              Standard, Requirements Management is not a numbered phase but a continuous activity at
+              the center of the ADM cycle.
             </li>
           </ul>
 
@@ -414,28 +420,38 @@ const BibliographyArticlePage = () => {
           </ul>
 
           <h3 className={H3_CLASSES}>Key Architectural Domains</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            The TOGAF Standard identifies four architecture domains that are commonly accepted as
+            subsets of an overall Enterprise Architecture:
+          </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Business Architecture:</strong> Organizational structure, business
-              capabilities, business processes, and business information requirements. Establishes
-              business context for technology architecture.
+              <strong>Business Architecture:</strong> Defines the business strategy, governance,
+              organization, and key business processes. Establishes business context for the other
+              architecture domains.
             </li>
             <li>
-              <strong>Information Systems Architecture:</strong> Applications and data architecture
-              describing information systems and data flows. Includes applications architecture and
-              data architecture domains.
+              <strong>Data Architecture:</strong> Describes the structure of an organization&rsquo;s
+              logical and physical data assets and data management resources.
             </li>
             <li>
-              <strong>Technology Architecture:</strong> Technology infrastructure, technology
-              standards, and technology platforms. Describes computing, networking, storage, and
-              infrastructure components.
+              <strong>Application Architecture:</strong> Provides a blueprint for the individual
+              applications to be deployed, their interactions, and their relationships to the core
+              business processes of the organization.
             </li>
             <li>
-              <strong>Architecture Governance:</strong> Processes, structures, and decision-making
-              frameworks guiding architecture implementation. Ensures architecture compliance and
-              drives organizational alignment.
+              <strong>Technology Architecture:</strong> Describes the logical software and hardware
+              infrastructure capabilities and standards required to support the deployment of
+              business, data, and application services, including IT infrastructure, middleware,
+              networks, communications, processing, and standards.
             </li>
           </ul>
+          <p className={PARAGRAPH_CLASSES}>
+            Within the ADM, Phase C (Information Systems Architectures) develops the Data
+            Architecture and Application Architecture domains together, while Architecture
+            Governance and stakeholder management are supporting capabilities exercised across all
+            domains rather than domains in their own right.
+          </p>
 
           <h3 className={H3_CLASSES}>Main Strengths</h3>
           <ul className={BODY_LIST_CLASSES}>


### PR DESCRIPTION
## Summary

R1 factual review of the TOGAF bibliography page (2-12) against The Open Group Standard PDFs in Zotero.

### Source substitution

The 1995 TOGAF 1.0 original has **no PDF attachment in Zotero** (parent \`F5QWECUF\` is a report with one child and no PDF). Per reviewer instruction, this review uses later-edition PDFs as source substitutes:

- **Primary**: TOGAF 10th Edition Introduction and Core Concepts (Zotero parent \`WYXZLFYJ\`, PDF \`ZJ9Q9QEI\`)
- **Secondary**: TOGAF Standard Version 9.2 (Zotero parent \`RHX43JE2\`, PDF \`TAW8H87E\`)

Both editions are backward-compatible evolutions of the framework first published in 1995. Claims specific to the 1995 original that are not addressed by later editions were left as-is and are noted as unverified in the existing Source Note within the page.

### Findings and fixes (FACTUAL)

1. **ADM phase count inconsistency (HIGH)** - Core Concepts section said "eight phases (Preliminary, A-H)" while the Describe-The-Model section called it "nine phases" and included Requirements Management in the numbered list. Per TOGAF 10th Edition section 3.4 and TOGAF 9.2 section 2.4, the ADM consists of a Preliminary Phase plus eight lettered phases A through H, with Requirements Management operating as a cross-cutting activity at the center of the cycle (not a numbered phase). Rewrote both sections to match the PDF wording.
2. **Four architecture domains wrong (HIGH)** - Page listed "Business, Information Systems, Technology, Architecture Governance" as the four domains. Per TOGAF 10th Edition section 3.3 and TOGAF 9.2 section 2.3, the four domains are **Business, Data, Application, and Technology**. Architecture Governance is not a domain. Rewrote the Key Architectural Domains section to match.
3. **Phase C naming (LOW)** - Page used singular "Information Systems Architecture"; both PDFs use plural "Information Systems Architectures". Corrected.
4. **Core Concepts Enterprise Architecture definition (LOW)** - Listed components as "business, information, applications, technology"; aligned to the four PDF-defined domains.

### Deferred (citation changes require user approval)

- References list currently contains only two entries (Zachman 1987, The Open Group 2022). The Further Reading list includes the TOGAF 9.1 2011 document and the TAFIM 1994 DoD source, but the 1995 original document citation is an unusual form: \`Group, T. O. (1995). The Open Group Architecture Framework (TOGAF).\` - author is parsed as \"Group, T. O.\" rather than \"The Open Group\". Not changed in this PR.

### Not verified (1995 original not in Zotero)

- Specific claims about the 1995 Version 1 document beyond what the 10th Edition Chapter 1 history paragraph states (which confirms only: Version 1 in 1995, based on TAFIM, DoD permission).

Part of #1553.

## Test plan

- [ ] CI format, lint, tests, build pass
- [ ] E2E tests pass
- [ ] Manual review of TOGAF bibliography page rendering

Generated with Claude Code