### PR TITLE
docs: 2-16 AWS CAF for AI (2024) R1 - PDF-based factual corrections

### DIFF
--- a/src/app/bibliography-2-16-aws-caf-ai-2024/page.tsx
+++ b/src/app/bibliography-2-16-aws-caf-ai-2024/page.tsx
@@ -14,7 +14,7 @@ import {
 export const metadata: Metadata = {
   title: 'Bibliography: AWS Cloud Adoption Framework for AI/ML (CAF-AI) - AWS (2024)',
   description:
-    'Comprehensive overview of the AWS Cloud Adoption Framework specialization for Artificial Intelligence, Machine Learning, and Generative AI. Explains the six perspectives, capability building blocks, and AWS CAF AI role in guiding organizations through AI adoption journey.',
+    'Comprehensive overview of the AWS Cloud Adoption Framework specialization for Artificial Intelligence, Machine Learning, and Generative AI. Explains the six perspectives, foundational AI capabilities, and the role of CAF-AI in guiding organizations through the AI adoption journey.',
 }
 
 const BibliographyArticlePage = () => {
@@ -32,7 +32,8 @@ const BibliographyArticlePage = () => {
               Intelligence, Machine Learning, and Generative AI
             </p>
             <p>
-              <strong>Framework Abbreviation:</strong> AWS CAF-AI
+              <strong>Framework Abbreviation:</strong> CAF-AI (also referred to as AWS CAF-AI in the
+              whitepaper prose)
             </p>
             <p>
               <strong>Target of Framework:</strong> Guiding organizations through cloud-based
@@ -219,29 +220,28 @@ const BibliographyArticlePage = () => {
               challenges.
             </li>
             <li>
-              <strong>AWS Well-Architected Framework (2015):</strong> AWS framework emphasizing
-              operational excellence, security, reliability, performance efficiency, and cost
-              optimization. CAF for AI aligns with Well-Architected principles.
+              <strong>AWS Well-Architected Framework:</strong> AWS framework emphasizing operational
+              excellence, security, reliability, performance efficiency, and cost optimization.
+              CAF-AI references the Machine Learning Lens of the Well-Architected Framework for
+              deeper guidance on MLOps and AI system design.
             </li>
             <li>
-              <strong>AI/ML Maturity Models (2015-2020):</strong> Prior academic and industry
-              frameworks assessing AI/ML organizational maturity. AWS CAF for AI incorporates
-              maturity model concepts within capability building blocks.
+              <strong>MLOps Maturity Framework:</strong> AWS CAF-AI explicitly recommends reviewing
+              the MLOps Maturity Framework for deeper guidance on managing the AI lifecycle and
+              operations beyond what the CAF-AI Operations perspective covers.
             </li>
             <li>
-              <strong>MLOps Frameworks (2019-2023):</strong> Emerging MLOps frameworks addressing
-              machine learning operations challenges. AWS CAF for AI incorporates MLOps as core
-              capability building block.
+              <strong>Machine Learning Lens (AWS Well-Architected Framework):</strong> CAF-AI
+              directly references the Machine Learning Lens of the AWS Well-Architected Framework
+              for extensive documentation and best practices on ML incident management and
+              performance.
             </li>
             <li>
-              <strong>Responsible AI Frameworks (2018-2023):</strong> AI ethics and responsible AI
-              frameworks addressing fairness, transparency, and trustworthiness. AWS CAF for AI
-              incorporates responsible AI as core capability.
-            </li>
-            <li>
-              <strong>Digital Transformation Frameworks (2010-2020):</strong> General digital
-              transformation frameworks addressing organizational change. AWS CAF for AI applies
-              digital transformation principles to AI adoption.
+              <strong>AI governance and responsible AI guidance:</strong> CAF-AI introduces
+              Responsible use of AI as a new capability, positioned as a decisive element for future
+              competitive advantage and built on broader industry recognition of responsible AI
+              principles. The whitepaper notes an AWS Responsible Use of AI whitepaper as a
+              companion reference.
             </li>
           </ul>
         </section>
@@ -311,18 +311,18 @@ const BibliographyArticlePage = () => {
               Portfolio Management, Innovation Management, and the new Generative AI capability.
             </li>
             <li>
-              <strong>People:</strong> the new ML Fluency capability, Workforce Transformation,
-              Organizational Alignment, and Culture Evolution.
+              <strong>People:</strong> Workforce Transformation, Organizational Alignment, Culture
+              Evolution, and the new ML Fluency capability.
             </li>
             <li>
               <strong>Governance:</strong> Cloud Financial Management (CFM), Data Curation, Risk
               Management, and the new Responsible use of AI capability.
             </li>
             <li>
-              <strong>Platform:</strong> Platform Architecture, Modern Application Development, AI
-              Lifecycle Management and MLOps, Data Architecture, Platform Engineering, Data
-              Engineering, Provisioning and Orchestration, and Continuous Integration and Continuous
-              Delivery (CI/CD).
+              <strong>Platform:</strong> Platform Architecture, Modern Application Development, Data
+              Architecture, Platform Engineering, Data Engineering, Provisioning and Orchestration,
+              Continuous Integration and Continuous Delivery (CI/CD), and the new AI Lifecycle
+              Management and MLOps capability.
             </li>
             <li>
               <strong>Security:</strong> Vulnerability Management, Security Governance, Security
@@ -417,8 +417,8 @@ const BibliographyArticlePage = () => {
               simultaneously.
             </li>
             <li>
-              <strong>Clear capability focus:</strong> Seven capability building blocks provide
-              clear, achievable targets for AI implementation roadmaps.
+              <strong>Clear capability focus:</strong> Foundational AI capabilities organized under
+              six perspectives provide clear, achievable targets for AI implementation roadmaps.
             </li>
             <li>
               <strong>Outcome orientation:</strong> Framework emphasizes measurable business
@@ -519,9 +519,9 @@ const BibliographyArticlePage = () => {
               requires specialized capabilities distinct from cloud infrastructure.
             </li>
             <li>
-              <strong>Comprehensive capability coverage:</strong> Seven capability building blocks
-              comprehensively address AI implementation requirements from strategy through
-              operations.
+              <strong>Comprehensive capability coverage:</strong> Foundational AI capabilities under
+              the six perspectives comprehensively address AI implementation requirements from
+              strategy through operations.
             </li>
             <li>
               <strong>Clear capability progression:</strong> Framework provides logical progression

--- a/src/app/bibliography-2-16-aws-caf-ai-2024/page.tsx
+++ b/src/app/bibliography-2-16-aws-caf-ai-2024/page.tsx
@@ -32,7 +32,7 @@ const BibliographyArticlePage = () => {
               Intelligence, Machine Learning, and Generative AI
             </p>
             <p>
-              <strong>Framework Abbreviation:</strong> AWS CAF for AI
+              <strong>Framework Abbreviation:</strong> AWS CAF-AI
             </p>
             <p>
               <strong>Target of Framework:</strong> Guiding organizations through cloud-based
@@ -57,7 +57,7 @@ const BibliographyArticlePage = () => {
               <strong>Author/Organization:</strong> Amazon Web Services (AWS)
             </p>
             <p>
-              <strong>Formal Publication Date:</strong> 2024
+              <strong>Formal Publication Date:</strong> February 13, 2024
             </p>
             <p>
               <strong>Current Version:</strong> AWS Cloud Adoption Framework for Artificial
@@ -174,30 +174,33 @@ const BibliographyArticlePage = () => {
               organizational roles and concerns during AI adoption.
             </li>
             <li>
-              <strong>Capability Building Blocks:</strong> Seven foundational capabilities required
-              for successful AI implementation: Strategic Alignment, Use Case Identification, Data
-              Foundation, ML Operations, Model Risk Management, Responsible AI, and Talent
-              Development.
+              <strong>Foundational AI Capabilities:</strong> Organizational capabilities grouped
+              under the six perspectives. Each perspective enriches or adds specific capabilities
+              for AI adoption while reusing unchanged capabilities from the original AWS CAF.
+              Examples of new AI-specific capabilities introduced by CAF-AI include Generative AI
+              (Business), ML Fluency (People), Responsible use of AI (Governance), and AI Lifecycle
+              Management and MLOps (Platform).
             </li>
             <li>
-              <strong>Use Case Identification:</strong> Systematic process for identifying
-              high-value AI opportunities aligned with business objectives. Use case identification
-              focuses on realistic, achievable AI implementations.
+              <strong>AI Flywheel:</strong> A virtuous cycle where high-quality data (timely,
+              relevant, valuable, and valid) is used to train or tune an AI system that delivers
+              predictions, which positively impact business outcomes, leading to deeper customer
+              relationships and the creation of more or higher-quality data.
             </li>
             <li>
-              <strong>Data Foundation:</strong> Organizational infrastructure and practices for
-              collecting, managing, and preparing data for AI. Data foundation quality directly
-              determines AI model effectiveness.
+              <strong>Data Strategy:</strong> Described in the whitepaper as the element that keeps
+              the AI flywheel in motion. Data strategy and foundational capabilities are identified
+              as the primary drivers of success or failure when adopting AI.
             </li>
             <li>
-              <strong>MLOps (Machine Learning Operations):</strong> Operational practices for
-              continuously training, validating, deploying, and monitoring ML models in production.
-              MLOps enables sustainable AI implementations.
+              <strong>AI Lifecycle Management and MLOps:</strong> A new Platform-perspective
+              capability covering the operational practices for managing the lifecycle of machine
+              learning workloads, including training, deployment, and monitoring.
             </li>
             <li>
-              <strong>Responsible AI:</strong> Practices for ensuring AI systems are trustworthy,
-              fair, transparent, and aligned with organizational values. Responsible AI governance
-              mitigates AI risks.
+              <strong>Responsible use of AI:</strong> A new Governance-perspective capability
+              introduced by CAF-AI to foster continual AI innovation through responsible use,
+              described as a decisive element for future competitive advantage.
             </li>
           </ul>
         </section>
@@ -247,113 +250,123 @@ const BibliographyArticlePage = () => {
         <section className={SECTION_CLASSES}>
           <h2 className={H2_CLASSES}>Describe The Model</h2>
           <p className={PARAGRAPH_CLASSES}>
-            AWS CAF for AI provides outcome-driven framework for AI adoption through six
-            perspectives addressing different organizational stakeholder groups combined with seven
-            capability building blocks representing foundational requirements for successful AI
-            implementation.
+            AWS CAF-AI provides a mental model and prescriptive guidance for AI adoption through six
+            perspectives addressing different organizational stakeholder groups, each enriched with
+            a set of foundational capabilities tailored or newly introduced for AI, ML, and
+            generative AI adoption.
           </p>
 
           <h3 className={H3_CLASSES}>Six Perspectives</h3>
           <p className={PARAGRAPH_CLASSES}>
-            AWS CAF for AI organizes stakeholders and concerns into six perspectives, each
-            addressing distinct organizational viewpoint:
+            AWS CAF-AI organizes stakeholders and concerns into six perspectives inherited from the
+            original AWS CAF (Business, People, Governance, Platform, Security, Operations), each
+            enriched with AI-specific guidance:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Business Perspective:</strong> Addresses business executives, product
-              managers, and business stakeholders. Business perspective focuses on AI business case,
-              use case identification, outcome measurement, and business value realization.
+              <strong>Business Perspective:</strong> Helps ensure that AI investments accelerate
+              digital- and AI-transformation ambitions and business outcomes. Typical stakeholders
+              named in the whitepaper include CEO, CFO, COO, CIO, and CTO.
             </li>
             <li>
-              <strong>People Perspective:</strong> Addresses human resources, change management, and
-              organizational development. People perspective focuses on talent development, skill
-              building, change management, and organizational culture adaptation for AI.
+              <strong>People Perspective:</strong> Serves as a bridge between AI technology and
+              business and aims to evolve a culture of continual growth and learning. Typical
+              stakeholders include CHRO, CIO, COO, CTO, cloud director, and cross-functional
+              enterprise-wide leaders.
             </li>
             <li>
-              <strong>Governance Perspective:</strong> Addresses boards, compliance officers, and
-              enterprise governance. Governance perspective focuses on policies, standards, risk
-              management, compliance, and responsible AI governance.
+              <strong>Governance Perspective:</strong> Helps orchestrate AI initiatives while
+              maximizing organizational benefits and minimizing transformation-related risks, and
+              introduces Responsible use of AI as a new capability. Typical stakeholders include the
+              chief transformation officer, CIO, CTO, CFO, CDO, and CRO.
             </li>
             <li>
-              <strong>Platform Perspective:</strong> Addresses architects, infrastructure engineers,
-              and technology leaders. Platform perspective focuses on technology infrastructure,
-              data platforms, ML platforms, and AI services.
+              <strong>Platform Perspective:</strong> Helps build an enterprise-grade, scalable cloud
+              platform for operating AI-enabled services and developing custom AI solutions. Typical
+              stakeholders include CTO, technology leaders, ML operations engineers, and data
+              scientists.
             </li>
             <li>
-              <strong>Security Perspective:</strong> Addresses security officers and information
-              security professionals. Security perspective focuses on data security, model security,
-              AI-specific security risks, and compliance.
+              <strong>Security Perspective:</strong> Helps achieve the confidentiality, integrity,
+              and availability of data and cloud workloads and addresses attack vectors specific to
+              AI systems. Typical stakeholders include CISO, CCO, internal audit leaders, and
+              security architects and engineers.
             </li>
             <li>
-              <strong>Operations Perspective:</strong> Addresses operations teams, system
-              administrators, and IT operations. Operations perspective focuses on ML model
-              lifecycle management, MLOps, monitoring, and operational excellence.
+              <strong>Operations Perspective:</strong> Helps ensure cloud services, and in
+              particular AI workloads, are delivered at a level that meets the needs of the
+              business. Typical stakeholders include infrastructure and operations leaders.
             </li>
           </ul>
 
-          <h3 className={H3_CLASSES}>Seven Capability Building Blocks</h3>
+          <h3 className={H3_CLASSES}>Foundational AI Capabilities by Perspective</h3>
           <p className={PARAGRAPH_CLASSES}>
-            AWS CAF for AI identifies seven foundational capabilities required for successful AI
-            implementation:
+            AWS CAF-AI enriches existing AWS CAF capabilities and adds new ones under each
+            perspective. The capabilities that are enriched or newly introduced for AI in the 2024
+            whitepaper include:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Strategic Alignment:</strong> Alignment of AI initiatives with organizational
-              strategy and business objectives. Strategic alignment ensures AI investments support
-              business priorities.
+              <strong>Business:</strong> Strategy Management, Product Management, Business Insight,
+              Portfolio Management, Innovation Management, and the new Generative AI capability.
             </li>
             <li>
-              <strong>Use Case Identification:</strong> Systematic process for identifying
-              high-value AI opportunities within organization. Use case identification focuses on
-              realistic, achievable, measurable AI implementations.
+              <strong>People:</strong> the new ML Fluency capability, Workforce Transformation,
+              Organizational Alignment, and Culture Evolution.
             </li>
             <li>
-              <strong>Data Foundation:</strong> Organizational infrastructure for collecting,
-              managing, preparing, and governing data for AI. Data foundation quality determines AI
-              model quality and effectiveness.
+              <strong>Governance:</strong> Cloud Financial Management (CFM), Data Curation, Risk
+              Management, and the new Responsible use of AI capability.
             </li>
             <li>
-              <strong>ML Operations (MLOps):</strong> Operational practices for continuously
-              developing, training, validating, deploying, and monitoring ML models. MLOps enables
-              sustainable, scalable AI implementations.
+              <strong>Platform:</strong> Platform Architecture, Modern Application Development, AI
+              Lifecycle Management and MLOps, Data Architecture, Platform Engineering, Data
+              Engineering, Provisioning and Orchestration, and Continuous Integration and Continuous
+              Delivery (CI/CD).
             </li>
             <li>
-              <strong>Model Risk Management:</strong> Processes for identifying, assessing, and
-              mitigating AI model risks including model performance degradation, bias, security
-              vulnerabilities, and operational failures.
+              <strong>Security:</strong> Vulnerability Management, Security Governance, Security
+              Assurance, Threat Detection, Infrastructure Protection, Data Protection, and
+              Application Security.
             </li>
             <li>
-              <strong>Responsible AI:</strong> Practices for ensuring AI systems are trustworthy,
-              fair, transparent, explainable, and aligned with organizational values and societal
-              expectations.
-            </li>
-            <li>
-              <strong>Talent Development:</strong> Programs for developing AI expertise within
-              organization including data scientists, ML engineers, AI architects, and business
-              stakeholders with AI literacy.
+              <strong>Operations:</strong> Incident and Problem Management, and Performance and
+              Capacity.
             </li>
           </ul>
-
-          <h3 className={H3_CLASSES}>AI Adoption Journey</h3>
           <p className={PARAGRAPH_CLASSES}>
-            AWS CAF for AI frames AI adoption as structured journey progressing through stages:
+            Each perspective also lists several existing CAF capabilities that are not enriched for
+            AI and refer back to the original AWS CAF (for example, Identity and Access Management,
+            Incident Response, Data Governance, and Benefits Management).
+          </p>
+
+          <h3 className={H3_CLASSES}>AI Transformation Journey</h3>
+          <p className={PARAGRAPH_CLASSES}>
+            After an initial assessment, AWS CAF-AI frames AI adoption as an iterative cycle based
+            on four stages:
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Envision:</strong> Assess current organizational AI readiness and identify
-              high-value AI use cases aligned with business strategy.
+              <strong>Envision:</strong> Envision how AI can accelerate business outcomes by
+              identifying and prioritizing transformation opportunities in line with business
+              objectives, associating them with key stakeholders and measurable outcomes, and
+              identifying the data assets and sources these opportunities rely upon.
             </li>
             <li>
-              <strong>Align:</strong> Assess organizational readiness and gaps, develop
-              transformation roadmap, and establish cross-functional alignment.
+              <strong>Align:</strong> Focus on the foundational capabilities, identify
+              cross-organizational dependencies, and surface stakeholder concerns and challenges.
+              Align internally on the goals set in the Envision phase to improve cloud and AI
+              readiness and facilitate change management.
             </li>
             <li>
-              <strong>Launch:</strong> Deploy and iterate on initial use cases, validate outcomes,
-              and build operational capabilities.
+              <strong>Launch:</strong> Deliver pilot initiatives from early proofs of concept to
+              production and demonstrate incremental business value, learning from each pilot
+              regardless of its success before scaling.
             </li>
             <li>
-              <strong>Scale:</strong> Expand successful use cases across the organization, optimize
-              responsible AI practices, and maximize business value.
+              <strong>Scale:</strong> Scale pilots in production to achieve broad, sustained value,
+              where scaling can refer to the technical capabilities of solutions as well as their
+              reach through the business and to customers.
             </li>
           </ul>
 


### PR DESCRIPTION
## Summary

R1 factual review of TABS bibliography page 2-16 "AWS Cloud Adoption Framework for AI/ML (CAF-AI)" against the primary PDF (AWS whitepaper, publication date February 13, 2024; Zotero attachment `TAWG8GQD`) with the AWS CAF Overview whitepaper (Zotero `N4PBK462`) used as secondary context.

### Vendor framework (rule 5) note

The bibliography-review skill rule 5 normally flags "vendor frameworks with no authoritative text-based source" for human review. In this case AWS's own whitepaper is the authoritative source and was PDF-available, so R1 proceeded only on AWS-verifiable claims (perspective names and order, capability tables, transformation phases, publication date, abbreviation). Vendor marketing claims were intentionally not re-verified.

### Findings and fixes (Round 1)

All changes are PDF-traceable to the AWS CAF-AI 2024 whitepaper.

- **CRITICAL FACTUAL**: Removed fabricated "Seven Capability Building Blocks" taxonomy (Strategic Alignment / Use Case Identification / Data Foundation / ML Operations / Model Risk Management / Responsible AI / Talent Development). These names do not appear anywhere in the whitepaper. The actual framework organizes capabilities under the six perspectives with varying counts per perspective (not seven global blocks). Replaced with the actual per-perspective capabilities from the PDF tables.
- **FACTUAL**: Framework Abbreviation was "AWS CAF for AI"; the whitepaper uniformly uses **CAF-AI**.
- **FACTUAL**: Formal Publication Date was "2024"; whitepaper states "Publication date: February 13, 2024" on page 1.
- **FACTUAL**: Core Concepts list included the fabricated capability names; replaced with PDF-traceable concepts (AI Flywheel, Data Strategy, AI Lifecycle Management and MLOps, Responsible use of AI).
- **FACTUAL**: Six Perspectives stakeholder descriptions aligned to the whitepaper's explicit stakeholder callouts (e.g., Governance: "chief transformation officer, CIO, CTO, CFO, CDO, CRO").
- **FACTUAL**: Envision/Align/Launch/Scale descriptions tightened to match the whitepaper's wording (iterative cycle following an initial assessment).

### Deferred to cleanup pass (citation scope - requires user approval)

- Further Reading list (9 entries) not re-verified against sources; untouched per skill rules 7-8.
- Numerous prose references to "AWS CAF for AI" (vs "CAF-AI") are stylistic and not factually incorrect (both map to the full title), so they were left in place.

## Test plan

- [ ] CI passes (format, lint, test, build, E2E)
- [ ] Visual check of /bibliography-2-16-aws-caf-ai-2024 renders correctly
- [ ] No citation changes included (deferred per skill rules)

## Scope

R1 only (no R2 in this session). Part of #1553.

Single file changed: `src/app/bibliography-2-16-aws-caf-ai-2024/page.tsx`.