### PR TITLE
docs: 2-20 CMMC (DoD, 2020) R1 - PDF-based factual corrections

### DIFF
--- a/src/app/bibliography-2-20-cmmc-dod-2020/page.tsx
+++ b/src/app/bibliography-2-20-cmmc-dod-2020/page.tsx
@@ -60,8 +60,9 @@ const BibliographyArticlePage = () => {
               Secretary of Defense for Acquisition &amp; Sustainment
             </p>
             <p>
-              <strong>Formal Publication Date:</strong> January 2020 (CMMC 1.0); November 2021 (CMMC
-              2.0); October 2024 (Final Rule)
+              <strong>Formal Publication Date:</strong> September 2020 (48 CFR CMMC interim final
+              rule, effective 30 November 2020); November 2021 (announcement of revised CMMC
+              Program, CMMC 2.0); October 15, 2024 (32 CFR Part 170 final rule)
             </p>
             <p>
               <strong>Current Version:</strong> CMMC 2.0 (32 CFR Part 170, effective December 16,
@@ -177,14 +178,14 @@ const BibliographyArticlePage = () => {
               (Level 2), and Expert (Level 3).
             </li>
             <li>
-              <strong>Practices:</strong> Specific cybersecurity activities that contractors must
-              implement at each maturity level, drawn primarily from NIST SP 800-171 and NIST SP
-              800-172.
+              <strong>Security Requirements:</strong> Specific cybersecurity requirements that
+              contractors must implement at each CMMC level, drawn from FAR clause 52.204-21 (Level
+              1), NIST SP 800-171 Rev 2 (Level 2), and a subset of NIST SP 800-172 (Level 3).
             </li>
             <li>
               <strong>Assessment:</strong> The verification mechanism ranging from annual
-              self-assessment (Level 1) to third-party C3PAO assessment (Level 2) to government-led
-              assessment (Level 3).
+              self-assessment (Level 1) to either self-assessment or third-party C3PAO assessment
+              (Level 2, depending on the contract) to government-led DIBCAC assessment (Level 3).
             </li>
             <li>
               <strong>CMMC Third-Party Assessment Organization (C3PAO):</strong> Accredited
@@ -197,8 +198,10 @@ const BibliographyArticlePage = () => {
               POA&amp;Ms for Level 2 assessments with specific constraints.
             </li>
             <li>
-              <strong>Defense Industrial Base (DIB):</strong> The network of over 300,000 companies
-              and subcontractors that provide products and services to the Department of Defense.
+              <strong>Defense Industrial Base (DIB):</strong> The network of over 220,000 companies
+              that process, store, or transmit Controlled Unclassified Information or Federal
+              Contract Information in support of DoD systems, networks, installations, capabilities,
+              and services.
             </li>
           </ul>
         </section>
@@ -264,26 +267,32 @@ const BibliographyArticlePage = () => {
           </p>
           <ul className={BODY_LIST_CLASSES}>
             <li>
-              <strong>Level 1 - Foundational:</strong> Requires implementation of 17 practices
-              derived from FAR 52.204-21, addressing basic safeguarding of Federal Contract
-              Information. Assessment is conducted through annual self-assessment with affirmation
-              by a senior company official. Level 1 represents the minimum cybersecurity hygiene
-              expected of all DoD contractors.
+              <strong>Level 1 - Foundational:</strong> Requires implementation of the 15 basic
+              safeguarding requirements set forth in FAR clause 52.204-21(b)(1)(i) through
+              (b)(1)(xv), addressing basic safeguarding of Federal Contract Information. Assessment
+              is conducted through annual self-assessment by the Organization Seeking Assessment
+              (OSA) with results entered into the Supplier Performance Risk System (SPRS) and annual
+              affirmation by a senior company official. Level 1 represents the minimum cybersecurity
+              hygiene expected of contractors handling FCI.
             </li>
             <li>
-              <strong>Level 2 - Advanced:</strong> Requires implementation of 110 practices aligned
-              with NIST SP 800-171 Rev 2, providing comprehensive protection for Controlled
-              Unclassified Information. Assessment requires triennial third-party evaluation by an
-              accredited C3PAO, with some contracts permitting self-assessment based on information
-              sensitivity. Level 2 represents the standard expected for contractors handling CUI.
+              <strong>Level 2 - Advanced:</strong> Requires implementation of the 110 security
+              requirements in NIST SP 800-171 Rev 2, providing comprehensive protection for
+              Controlled Unclassified Information. CMMC 2.0 provides two Level 2 assessment
+              pathways: Level 2 (Self), conducted every three years by the OSA with results entered
+              into SPRS, and Level 2 (C3PAO), conducted every three years by an accredited CMMC
+              Third-Party Assessment Organization with results entered into eMASS. The assessment
+              pathway is determined by the contract and by the sensitivity of the CUI involved.
+              Level 2 represents the standard expected for contractors handling CUI.
             </li>
             <li>
-              <strong>Level 3 - Expert:</strong> Requires implementation of 110+ practices
-              incorporating selected requirements from NIST SP 800-172 in addition to all Level 2
-              controls. Assessment is conducted by the Defense Contract Management Agency (DCMA)
-              Defense Industrial Base Cybersecurity Assessment Center (DIBCAC). Level 3 is reserved
-              for contractors handling the most sensitive CUI requiring protection against advanced
-              persistent threats.
+              <strong>Level 3 - Expert:</strong> Requires implementation of all 110 Level 2
+              requirements plus 24 additional security requirements selected from NIST SP 800-172
+              (February 2021) with DoD-approved parameters. Assessment is conducted by the Defense
+              Contract Management Agency (DCMA) Defense Industrial Base Cybersecurity Assessment
+              Center (DIBCAC) and requires a prerequisite CMMC Status of Final Level 2 (C3PAO) for
+              the same CMMC Assessment Scope. Level 3 is reserved for contractors handling the most
+              sensitive CUI requiring protection against advanced persistent threats.
             </li>
           </ul>
 


### PR DESCRIPTION
## Summary

R1 factual review of the CMMC bibliography page against the authoritative PDFs in Zotero. All changes are PDF-traceable to either (a) the 32 CFR Part 170 final rule published in the Federal Register (Vol. 89, No. 199, October 15, 2024; effective December 16, 2024) or (b) the CMMC Model Overview v2.13 (DoD-CIO-00001, ZRIN 0790-ZA17, September 2024).

## R1 scope

Factual claim verification only. No citation changes (deferred). Single-file change (`src/app/bibliography-2-20-cmmc-dod-2020/page.tsx`). No em/en-dashes.

## Findings corrected

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | FACTUAL | Level 1: claimed 17 practices | Corrected to 15 basic safeguarding requirements per FAR 52.204-21(b)(1)(i)-(xv) (Final Rule Table 1; Model Overview 2.2.3) |
| 2 | FACTUAL | Level 2: claimed mandatory triennial C3PAO with "some contracts" permitting self-assessment | Clarified two distinct pathways: Level 2 (Self) and Level 2 (C3PAO), both triennial. SPRS for Self, eMASS for C3PAO (Final Rule Table 1) |
| 3 | FACTUAL | Level 3: claimed "110+ practices" without numeric detail | Corrected to 110 Level 2 requirements plus 24 additional requirements selected from NIST SP 800-172 (February 2021). Added Level 2 (C3PAO) prerequisite (Final Rule Table 1) |
| 4 | FACTUAL | DIB described as "over 300,000 companies and subcontractors" | Corrected to "over 220,000 companies" per both source documents (Final Rule p. 78 footnote; Model Overview Section 1) |
| 5 | FACTUAL | Formal Publication Date "January 2020 (CMMC 1.0)" not supported by either PDF | Replaced with PDF-supported milestones (Sep 2020 interim rule, Nov 2020 effective, Nov 2021 CMMC 2.0 announcement, Oct 15 2024 final rule, Dec 16 2024 effective) |
| 6 | FACTUAL | Core Concepts entry "Practices ... drawn primarily from NIST SP 800-171 and NIST SP 800-172" understated FAR source | Refined to "Security Requirements" with per-level source standards (FAR 52.204-21 / SP 800-171 Rev 2 / subset of SP 800-172) |
| 7 | FACTUAL | Core Concepts Assessment entry implied Level 2 is always C3PAO | Updated to reflect self-or-C3PAO pathway structure |

## Deferred items

- Citations/References section not modified in this round (citation changes require direct user approval per skill rule 8). Reference entries and Further Reading remain as-is.
- R2/R3 rounds (e.g., domain descriptions, Preceding/Following Models accuracy, prose audit) not run; available for a follow-up session.

## Test plan

- [ ] CI format/lint/test/build pass
- [ ] Visual review of rendered page
- [ ] Confirm no em/en-dashes introduced

Part of #1553