### PR TITLE
fix(nav): update 2-20 navigation from Gartner HC Methodology to CMMC

### DIFF
--- a/src/app/article-bibliography-comprehensive-series-bibliography/page.tsx
+++ b/src/app/article-bibliography-comprehensive-series-bibliography/page.tsx
@@ -402,11 +402,13 @@ const BibliographyPage = () => {
               <div className="text-sm text-gray-600">Microsoft (2025)</div>
             </Link>
             <Link
-              href="/bibliography-2-20-gartner-hype-cycle-methodology-2025"
+              href="/bibliography-2-20-cmmc-dod-2020"
               className="block p-3 bg-white rounded border border-gray-300 hover:border-green-500 hover:shadow-md transition-all"
             >
-              <div className="font-semibold text-green-700">20. Gartner Hype Cycle Methodology</div>
-              <div className="text-sm text-gray-600">Gartner (2025)</div>
+              <div className="font-semibold text-green-700">
+                20. Cybersecurity Maturity Model Certification (CMMC)
+              </div>
+              <div className="text-sm text-gray-600">U.S. DoD (2020)</div>
             </Link>
             <Link
               href="/bibliography-2-21-diffusion-of-innovations-organizational-rogers-1962"

--- a/src/app/bibliography-2-19-microsoft-ai-adoption-framework-2025/page.tsx
+++ b/src/app/bibliography-2-19-microsoft-ai-adoption-framework-2025/page.tsx
@@ -834,10 +834,10 @@ const BibliographyArticlePage = () => {
             </p>
             <p className={PARAGRAPH_CLASSES}>
               <Link
-                href="/bibliography-2-20-gartner-hype-cycle-methodology-2025"
+                href="/bibliography-2-20-cmmc-dod-2020"
                 className="text-blue-600 hover:text-blue-800 underline"
               >
-                Next: Gartner Hype Cycle Methodology - Gartner (2025) &rarr;
+                Next: Cybersecurity Maturity Model Certification (CMMC) - U.S. DoD (2020) &rarr;
               </Link>
             </p>
             <p className={`${PARAGRAPH_CLASSES} mt-6`}>

--- a/src/data/technology-adoption-models-series.ts
+++ b/src/data/technology-adoption-models-series.ts
@@ -356,8 +356,8 @@ export const technologyAdoptionModelsSeries: SeriesStructure = {
       },
       {
         id: 'bib-2-20',
-        title: 'Gartner Hype Cycle Methodology',
-        slug: '/bibliography-2-20-gartner-hype-cycle-methodology-2025',
+        title: 'Cybersecurity Maturity Model Certification (CMMC)',
+        slug: '/bibliography-2-20-cmmc-dod-2020',
       },
       {
         id: 'bib-2-21',


### PR DESCRIPTION
## Summary

The 2-20 bibliography slot was renamed from "Gartner Hype Cycle Methodology (2025)" to "Cybersecurity Maturity Model Certification (CMMC) - U.S. DoD (2020)" on \`origin/main\` (commits \`ed4d78be\` + \`20ec3c2f\`, Apr 15). Gartner methodology content was consolidated into 2-11. However, three navigation references to the old slug were missed at rename time, leaving the nav out of sync with the actual folder on main.

## Changes

Three stale \`/bibliography-2-20-gartner-hype-cycle-methodology-2025\` references now point to \`/bibliography-2-20-cmmc-dod-2020\`:

1. [technology-adoption-models-series.ts:357-361](../blob/main/src/data/technology-adoption-models-series.ts#L357-L361) - primary series data file
2. [article-bibliography-comprehensive-series-bibliography/page.tsx:404-410](../blob/main/src/app/article-bibliography-comprehensive-series-bibliography/page.tsx#L404-L410) - comprehensive bibliography index card
3. [bibliography-2-19-microsoft-ai-adoption-framework-2025/page.tsx:836-841](../blob/main/src/app/bibliography-2-19-microsoft-ai-adoption-framework-2025/page.tsx#L836-L841) - 2-19's "Next" series-nav link

The 2-21 page already correctly links back to CMMC at 2-20, so that file is unchanged.

Titles and attributions updated to match the canonical ones on the CMMC page itself: "Cybersecurity Maturity Model Certification (CMMC)" with "U.S. DoD (2020)".

## Test plan

- [ ] CI passes (format, lint, test, build, E2E)
- [ ] Series navigation from 2-19 -> 2-20 -> 2-21 works end-to-end
- [ ] Comprehensive bibliography index links to CMMC at 2-20
- [ ] No remaining references to \`gartner-hype-cycle-methodology-2025\` slug

Part of #1553 umbrella bibliography standardization.