### PR TITLE
docs: 2-9 BPR (Hammer & Champy, 1993) R1 - PDF-based factual corrections (via Hammer 1990 HBR proxy)

### DIFF
--- a/src/app/bibliography-2-9-business-process-reengineering-hammer-champy-1993/page.tsx
+++ b/src/app/bibliography-2-9-business-process-reengineering-hammer-champy-1993/page.tsx
@@ -427,8 +427,8 @@ const BibliographyArticlePage = () => {
               outcomes delivered to customers rather than narrow task specializations.
             </li>
             <li>
-              <strong>Have those who use the output perform the process:</strong> Push work to those
-              who consume its results, collapsing handoffs between groups.
+              <strong>Have those who use the output of the process perform the process:</strong>{' '}
+              Push work to those who consume its results, collapsing handoffs between groups.
             </li>
             <li>
               <strong>


### PR DESCRIPTION
## Summary

R1 factual review of `bibliography-2-9-business-process-reengineering-hammer-champy-1993/page.tsx` against the peer-reviewed proxy source:

- Hammer, M. (1990). Reengineering Work: Don't Automate, Obliterate. *Harvard Business Review*, 68(4), 104-112. (Zotero parent `PHMJCQ69`, PDF attachment `C66W6ANF`.)

## Source substitution note

The primary source (Hammer & Champy, 1993, *Reengineering the Corporation: A Manifesto for Business Revolution*) has no PDF attachment in the Zotero library. The user authorized the use of Hammer's 1990 HBR article as a peer-reviewed proxy. This is the seminal article by the same author, with the same core thesis (use computers to redesign, not just automate, existing business processes), published three years before the 1993 book. It is a concentrated precursor and is safer to verify against than secondary sources.

## Finding

One factual fix in this round.

**L430 (HBR Principles section):** Principle 2 heading read:

> Have those who use the output perform the process

The 1990 HBR article's actual section heading (p. 108) is:

> Have those who use the output of the process perform the process

Since the section explicitly paraphrases Hammer's 1990 HBR principles, the heading should match the source heading verbatim. Restored the missing phrase "of the process."

All other 6 HBR principles (organize around outcomes, subsume information-processing, treat geographically dispersed resources as centralized, link parallel activities, put the decision point where the work is performed, capture information once and at the source) verified correct and in source order.

## Verified against the 1990 HBR proxy

- Citation in Further Reading (L1014-1017): Vol 68, Issue 4, pp. 104-112 - matches PDF header.
- Core thesis (use IT to redesign, not automate) - supported.
- "Discontinuous thinking" language - supported.
- The 7 HBR principles and their descriptions - accurate paraphrases.

## Deferred to later rounds (1993-book-specific, not verifiable from proxy)

Logged to `.claude/deferred-followups.md`:

1. Four Key Words in BPR Definition (Fundamental / Radical / Dramatic / Processes) - 1993-book structure, not in 1990 HBR.
2. Four outcome measures quartet (Cost / Quality / Service / Speed) - 1993-book definition.
3. Case list "IBM Credit, Ford, and Kodak" - 1990 HBR uses Ford, Mutual Benefit Life, Hewlett-Packard.
4. Biographical notes (Hammer as ex-MIT, Champy as CSC Index chairman) - Champy not in 1990 HBR at all; 1990 HBR byline does not mention MIT.
5. Minor subject-verb agreement ("Why do manufacturing require" on L132) - editorial fix, non-factual.

These are deferred rather than fixed because they require the 1993 book PDF for verification per skill rule 1 (every claim traceable to the PDF).

## Test plan

- [ ] CI format check passes
- [ ] CI lint passes
- [ ] CI unit tests pass (jest-axe)
- [ ] CI build (static export) succeeds
- [ ] CI E2E tests pass

Part of #1553