### PR TITLE
fix(nav): update 3 stale references to 1-16 MATH slug

### DIFF
--- a/src/app/article-bibliography-comprehensive-series-bibliography/page.tsx
+++ b/src/app/article-bibliography-comprehensive-series-bibliography/page.tsx
@@ -195,11 +195,11 @@ const BibliographyPage = () => {
               <div className="text-sm text-gray-600">Venkatesh et al. (2003)</div>
             </Link>
             <Link
-              href="/bibliography-1-16-math-venkatesh-brown-2001"
+              href="/bibliography-1-16-math-brown-venkatesh-2005"
               className="block p-3 bg-white rounded border border-gray-300 hover:border-blue-500 hover:shadow-md transition-all"
             >
               <div className="font-semibold text-blue-600">16. MATH</div>
-              <div className="text-sm text-gray-600">Venkatesh &amp; Brown (2001)</div>
+              <div className="text-sm text-gray-600">Brown &amp; Venkatesh (2005)</div>
             </Link>
             <Link
               href="/bibliography-1-17-value-based-adoption-kim-2007"

--- a/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
+++ b/src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx
@@ -896,11 +896,11 @@ const BibliographyArticlePage = () => {
           <div className="space-y-4">
             <p className={PARAGRAPH_CLASSES}>
               <Link
-                href="/bibliography-1-16-math-venkatesh-brown-2001"
+                href="/bibliography-1-16-math-brown-venkatesh-2005"
                 className="text-blue-600 hover:text-blue-800 underline"
               >
-                &larr; Previous: Model of Adoption of Technology in Households (Venkatesh &amp;
-                Brown)
+                &larr; Previous: Model of Adoption of Technology in Households (Brown &amp;
+                Venkatesh)
               </Link>
             </p>
             <p className={PARAGRAPH_CLASSES}>

--- a/src/data/technology-adoption-models-series.ts
+++ b/src/data/technology-adoption-models-series.ts
@@ -238,7 +238,7 @@ export const technologyAdoptionModelsSeries: SeriesStructure = {
       {
         id: 'bib-1-16',
         title: 'Model of Adoption of Technology in Households (MATH)',
-        slug: '/bibliography-1-16-math-venkatesh-brown-2001',
+        slug: '/bibliography-1-16-math-brown-venkatesh-2005',
       },
       {
         id: 'bib-1-17',


### PR DESCRIPTION
## Summary

After the 1-16 MATH page was renamed from `bibliography-1-16-math-venkatesh-brown-2001` to `bibliography-1-16-math-brown-venkatesh-2005` (reflecting correct authorship: Brown and Venkatesh 2005), 3 stale references to the old slug remained on main. The live URL at the old slug returns 404; this PR updates the dead-link referrers.

## Changes (3 files, 6 line changes)

1. \`src/app/article-bibliography-comprehensive-series-bibliography/page.tsx\` - comprehensive index link card
2. \`src/app/bibliography-1-17-value-based-adoption-kim-2007/page.tsx\` - 1-17 Series Navigation Previous link
3. \`src/data/technology-adoption-models-series.ts\` - primary series data (drives sitemap)

All now point to \`/bibliography-1-16-math-brown-venkatesh-2005\` with corrected attribution.

## Relationship to #1659

Supersedes #1659 which only fixed the first of the three stale references. Closing #1659 with pointer to this PR.

## Test plan

- [ ] CI passes
- [ ] \`curl -sI https://technologyadoptionbarriers.org/bibliography-1-16-math-brown-venkatesh-2005/\` returns 200 (already true)
- [ ] Sitemap regenerated with new slug after deploy
- [ ] Link from comprehensive bibliography + from 1-17's previous-nav both resolve

Part of #1553 umbrella bibliography standardization.