### PR TITLE
feat(ops): add stale AWAITING REVIEW triage to daily pipeline and report

### DIFF
--- a/.github/workflows/check-participant.yml
+++ b/.github/workflows/check-participant.yml
@@ -15,6 +15,7 @@ on:
           - send-custom
           - awaiting-report
           - request-return
+          - stale-return-requested
           - search-messages
           - find-url-replies
           - demographics
@@ -73,6 +74,14 @@ jobs:
           PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
           STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
         run: python3 scripts/analysis/prolific_tools.py url-replies
+
+      - name: Find stale return-requested submissions
+        if: inputs.mode == 'stale-return-requested'
+        env:
+          PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+          STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
+          STALE_HOURS: '48'
+        run: python3 scripts/analysis/find_stale_return_requested.py
 
       - name: Search messages
         if: inputs.mode == 'search-messages'

--- a/.github/workflows/check-participant.yml
+++ b/.github/workflows/check-participant.yml
@@ -53,11 +53,11 @@ jobs:
           python-version: '3.12'
       # Node.js only needed for modes that still run TS (single, search-messages, request-return, awaiting-report, verify-iri)
       - uses: actions/setup-node@v6
-        if: ${{ !contains(fromJSON('["demographics","find-url-replies","all-replies","send-custom","unreject","send-thank-you"]'), inputs.mode) }}
+        if: ${{ !contains(fromJSON('["demographics","find-url-replies","all-replies","send-custom","unreject","send-thank-you","stale-return-requested"]'), inputs.mode) }}
         with:
           node-version: '20'
           cache: 'npm'
-      - if: ${{ !contains(fromJSON('["demographics","find-url-replies","all-replies","send-custom","unreject","send-thank-you"]'), inputs.mode) }}
+      - if: ${{ !contains(fromJSON('["demographics","find-url-replies","all-replies","send-custom","unreject","send-thank-you","stale-return-requested"]'), inputs.mode) }}
         run: npm ci
 
       - name: Fetch Prolific demographics

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -602,6 +602,23 @@ jobs:
           path: ${{ runner.temp }}/disposition-summary.json
           retention-days: 1
 
+      - name: Find stale AWAITING REVIEW submissions
+        # Outputs two buckets used by the daily report:
+        # - stale no reply to return request (reject candidates)
+        # - stale no reply to TABS message  (request-return candidates)
+        run: python3 scripts/analysis/find_stale_return_requested.py
+        env:
+          PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+          STUDY_ID: ${{ vars.PROLIFIC_STUDY_ID }}
+          STALE_HOURS: '48'
+          OUTPUT_JSON_PATH: ${{ runner.temp }}/stale-triage.json
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: stale-triage
+          path: ${{ runner.temp }}/stale-triage.json
+          retention-days: 1
+
   # ── Phase 4: Commit all data (single PR) ─────────────────────
   commit-results:
     name: 'Phase 4: Commit All Data'

--- a/.github/workflows/prolific-reject-by-pid.yml
+++ b/.github/workflows/prolific-reject-by-pid.yml
@@ -1,13 +1,16 @@
 # ╔══════════════════════════════════════════════════════════════════════╗
-# ║  DESTRUCTIVE WORKFLOW: Reject submissions by PID (any disposition)  ║
+# ║  DESTRUCTIVE WORKFLOW: Reject submissions by PID                     ║
 # ║                                                                      ║
-# ║  Generalises prolific-reject-auto-exclude.yml to cover FLAG-* and    ║
-# ║  any other disposition. Targets the "stale no response to return     ║
-# ║  request" bucket produced by find_stale_return_requested.py.         ║
+# ║  Uses reject_by_pid.py to reject selected submissions whose          ║
+# ║  dispositions are explicitly handled by that script (currently       ║
+# ║  AUTO-EXCLUDE and the modelled FLAG-* variants). Commonly used for   ║
+# ║  the "stale no response to return request" bucket produced by        ║
+# ║  find_stale_return_requested.py. Unsupported dispositions will       ║
+# ║  abort the run rather than inventing an unmodelled reason.           ║
 # ║                                                                      ║
 # ║  Rejection messages and Prolific rejection categories are chosen     ║
-# ║  per-PID from the disposition CSV, so each participant gets a fair  ║
-# ║  reason tied to their actual flag.                                   ║
+# ║  per-PID from the disposition CSV for supported dispositions only,   ║
+# ║  so each participant gets a reason tied to their actual flag.        ║
 # ║                                                                      ║
 # ║  SAFETY REQUIREMENTS:                                                ║
 # ║    1. Manual trigger only (workflow_dispatch)                        ║

--- a/.github/workflows/prolific-reject-by-pid.yml
+++ b/.github/workflows/prolific-reject-by-pid.yml
@@ -1,0 +1,127 @@
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║  DESTRUCTIVE WORKFLOW: Reject submissions by PID (any disposition)  ║
+# ║                                                                      ║
+# ║  Generalises prolific-reject-auto-exclude.yml to cover FLAG-* and    ║
+# ║  any other disposition. Targets the "stale no response to return     ║
+# ║  request" bucket produced by find_stale_return_requested.py.         ║
+# ║                                                                      ║
+# ║  Rejection messages and Prolific rejection categories are chosen     ║
+# ║  per-PID from the disposition CSV, so each participant gets a fair  ║
+# ║  reason tied to their actual flag.                                   ║
+# ║                                                                      ║
+# ║  SAFETY REQUIREMENTS:                                                ║
+# ║    1. Manual trigger only (workflow_dispatch)                        ║
+# ║    2. Defaults to dry-run (safe preview)                             ║
+# ║    3. Live rejection requires typing "REJECT" in confirmation field  ║
+# ║    4. PID_LIST is required — no "reject all" shortcut                ║
+# ║    5. Unknown PIDs abort the run (no guessing reasons)               ║
+# ║    6. Full audit trail in workflow logs                              ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+name: 'DESTRUCTIVE: Reject Submissions by PID'
+
+on:
+  workflow_dispatch:
+    inputs:
+      study_id:
+        description: 'Prolific Study ID (defaults to PROLIFIC_STUDY_ID)'
+        required: false
+        type: string
+      pid_list:
+        description: 'Comma-separated PIDs to reject (required)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run - preview rejections without executing'
+        required: true
+        type: boolean
+        default: true
+      confirm_reject:
+        description: 'Type REJECT to confirm live rejection (required when dry_run is false)'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: 'prolific-reject-submissions'
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  triage:
+    name: Export & Triage
+    runs-on: ubuntu-latest
+    environment: qualtrics-prod
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Export Qualtrics responses
+        run: python3 scripts/analysis/export_qualtrics.py
+        env:
+          QUALTRICS_API_TOKEN: ${{ secrets.QUALTRICS_API_TOKEN }}
+          QUALTRICS_BASE_URL: ${{ vars.QUALTRICS_BASE_URL }}
+          QUALTRICS_SURVEY_ID: ${{ vars.QUALTRICS_SURVEY_ID }}
+          OUTPUT_PATH: ${{ runner.temp }}/qualtrics-export.csv
+
+      - name: Run disposition triage
+        run: python3 scripts/analysis/disposition_triage.py
+        env:
+          INPUT_PATH: ${{ runner.temp }}/qualtrics-export.csv
+          OUTPUT_PATH: ${{ runner.temp }}/disposition.csv
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: disposition-csv
+          path: ${{ runner.temp }}/disposition.csv
+          retention-days: 1
+
+  reject:
+    name: 'DESTRUCTIVE: Reject by PID'
+    needs: triage
+    runs-on: ubuntu-latest
+    environment: prolific-prod
+    steps:
+      - name: 'Safety check: validate confirmation'
+        if: inputs.dry_run == false
+        env:
+          CONFIRM: ${{ inputs.confirm_reject }}
+        run: |
+          echo "================================================================"
+          echo "  DESTRUCTIVE OPERATION: Prolific Submission Rejection"
+          echo "  This will REJECT the PIDs in the provided list."
+          echo "  They will NOT be paid."
+          echo "================================================================"
+          if [ "$CONFIRM" != "REJECT" ]; then
+            echo "SAFETY STOP: You must type REJECT in the confirmation field."
+            echo "Received: '$CONFIRM'"
+            exit 1
+          fi
+          echo "Confirmation accepted: '$CONFIRM'"
+
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: disposition-csv
+          path: ${{ runner.temp }}
+
+      - name: Reject by PID
+        env:
+          PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+          STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
+          CSV_FILE_PATH: ${{ runner.temp }}/disposition.csv
+          PID_LIST: ${{ inputs.pid_list }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          CONFIRM_REJECT: ${{ inputs.confirm_reject }}
+        run: python3 scripts/analysis/reject_by_pid.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -916,13 +916,61 @@ Pipeline data has strict PII boundaries:
 | Prolific demographics       | Yes (per-participant)      | No (in-memory join)  | Ephemeral         |
 | Step summaries              | No (aggregate counts)      | No (Actions UI)      | Workflow lifetime |
 | Workflow logs               | Yes (PIDs in debug output) | No (Actions UI)      | 90 days           |
+| GitHub issue bodies         | **No (redact to last 4)**  | Yes (issue history)  | Permanent         |
+| PR descriptions             | **No (redact to last 4)**  | Yes (PR history)     | Permanent         |
+| Issue / PR comments         | **No (redact to last 4)**  | Yes                  | Permanent         |
+| Commit messages             | **No**                     | Yes                  | Permanent         |
 
 **Rules**:
 
-- Never commit PROLIFIC_PID or participant-level data to the repository
-- Step summaries use aggregate counts only (no PID tables)
-- De-identified public dataset excludes all direct identifiers
-- Raw demographic CSVs exist only in `${{ runner.temp }}` (ephemeral workspace)
+- Never commit PROLIFIC_PID or participant-level data to the repository.
+- **"The repository" includes GitHub issue bodies, PR descriptions, issue/PR
+  comments, commit messages, and step summaries** - anything GitHub persists
+  alongside the repo. These surfaces are permanent, enumerable via the REST
+  API, and frequently indexed. Treat them the same as `git push`.
+- Step summaries and issue bodies use aggregate counts only (no PID tables).
+- If operators need a PID list for copy/paste, put the full list in a
+  retention-capped Actions artifact and link to it from the issue. Redact
+  any PID that still has to appear inline to its last 4 characters
+  (e.g. `****f305`).
+- De-identified public dataset excludes all direct identifiers.
+- Raw demographic CSVs exist only in `${{ runner.temp }}` (ephemeral workspace).
+
+### Post-mortem: stale-triage PID leak (2026-04-23)
+
+**What happened.** The first iteration of the stale-AWAITING-REVIEW section
+added to the daily disposition report (PR #1774) rendered full PROLIFIC_PIDs
+in the issue body, plus a collapsed `<details>` block with a comma-separated
+PID list for pasting into the reject workflow. Daily report issues are
+permanent GitHub content, so this put per-participant data into a surface
+the privacy table above marked as off-limits.
+
+**Why the rule didn't fire.** The Privacy & Data Flow table listed
+"Committed to Repo?" as the dimension, and issue bodies were not explicitly
+named. I was optimising for operator convenience (paste-friendly PID list)
+and treated the issue body as an ephemeral notification rather than
+persistent repo content. The older pattern ("Step summaries use aggregate
+counts only") was the right instinct and should have transferred — issues
+are strictly more public and longer-lived than step summaries — but I did
+not make that inference.
+
+**Fix applied.** Redact inline PIDs to `****<last-4>` and keep the full
+list only in the 1-day `stale-triage` Actions artifact. A link in the
+section points operators at the artifact.
+
+**How to prevent a recurrence.**
+
+1. Before any workflow step emits to a GitHub-managed surface (issue body,
+   PR description, issue/PR comment, commit message, step summary),
+   explicitly ask: "is any per-participant datum in this output?" If yes,
+   redact or move the raw data to a retention-capped Actions artifact and
+   link to it.
+2. The rule is now in the privacy table under **"'The repository' includes
+   ..."** — future contributions that touch these surfaces must compare
+   against that line, not just the committed-file boundary.
+3. When adding a new report section, run the output shape past the privacy
+   table as a review checklist item, the same way new routes run through
+   the sitemap + canonical check.
 
 ## Workflow Dispatch Quick Reference
 

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -28,9 +28,10 @@ submissions after its reserve timeout:
 Engaged participants (any reply after our most recent action) are excluded
 from all four buckets — they belong on the approve path.
 
-Submissions where the message-history API call fails are placed in a
-FETCH_ERROR category and excluded from all recommendations — they should
-not be assumed to have no reply.
+Submissions where the message-history API call fails are excluded from all
+four recommendation buckets and reported separately via the
+`fetch_errors`/`fetch_error_details` output fields — they should not be
+assumed to have no reply.
 
 Environment variables:
   PROLIFIC_API_TOKEN  - Prolific API token (required)

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -2,7 +2,7 @@
 """
 Find stale AWAITING REVIEW submissions that need operator attention.
 
-Emits three buckets that the daily report and ad-hoc operator checks both
+Emits four buckets that the daily report and ad-hoc operator checks both
 consume, based on the TABS policy that Prolific auto-APPROVES stale
 submissions after its reserve timeout:
 
@@ -17,12 +17,20 @@ submissions after its reserve timeout:
      reply after that message. These are the candidates for an API-level
      request-return (the formal next step before rejection).
 
-  3. IN_WINDOW
-     Anything above that is still within the STALE_HOURS window, so leave
-     alone until the window closes.
+  3. IN_WINDOW_RR
+     `return_requested` is set but still within the STALE_HOURS window, so
+     leave alone until the window closes.
+
+  4. IN_WINDOW_MSG
+     TABS has sent a message but no return request yet, still within the
+     STALE_HOURS window, so leave alone until the window closes.
 
 Engaged participants (any reply after our most recent action) are excluded
-from all three buckets — they belong on the approve path.
+from all four buckets — they belong on the approve path.
+
+Submissions where the message-history API call fails are placed in a
+FETCH_ERROR category and excluded from all recommendations — they should
+not be assumed to have no reply.
 
 Environment variables:
   PROLIFIC_API_TOKEN  - Prolific API token (required)
@@ -36,6 +44,7 @@ Environment variables:
 import json
 import os
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -47,6 +56,9 @@ from tabs_api import (
 )
 
 DEFAULT_RESEARCHER_ID = "68264cbfdeb62546fe6060fe"
+
+# Delay between per-PID message API calls to avoid Prolific rate limiting.
+_API_CALL_DELAY = 0.2
 
 
 def _require_env(name: str) -> str:
@@ -118,6 +130,30 @@ def classify_submission(sub, msgs, researcher_id, now, cutoff):
     return "in_window_msg", record
 
 
+def _fetch_messages_with_backoff(pid, api_token, max_retries=3):
+    """Fetch messages for a PID with exponential backoff on transient errors.
+
+    Returns ``(msgs, None)`` on success or ``(None, error_str)`` when all
+    retries are exhausted.  Callers **must** treat a ``None`` return as a
+    fetch error and skip classification rather than assuming no reply.
+    """
+    last_err = ""
+    for attempt in range(max_retries):
+        try:
+            if attempt > 0:
+                wait = 2 ** attempt
+                print(
+                    f"  Retry {attempt}/{max_retries - 1} for {pid} in {wait}s",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+            msgs = prolific_user_messages(pid, api_token)
+            return msgs, None
+        except Exception as e:
+            last_err = str(e)
+    return None, last_err
+
+
 def _print_bucket(title, items):
     print(f"=== {title} ({len(items)}) ===")
     for r in sorted(items, key=lambda x: -x["age_hours"]):
@@ -158,15 +194,30 @@ def main():
         "in_window_msg": [],
     }
 
+    fetch_errors = []
+    requests_made = 0
+    requests_skipped = 0  # PIDs with no participant_id
+
     for sub in awaiting:
         pid = sub.get("participant_id", "")
         if not pid:
+            requests_skipped += 1
             continue
-        try:
-            msgs = prolific_user_messages(pid, api_token)
-        except Exception as e:
-            print(f"  Warning: failed to fetch messages for {pid}: {e}", file=sys.stderr)
-            msgs = []
+        # Small inter-call delay to avoid Prolific rate limiting.
+        if requests_made > 0:
+            time.sleep(_API_CALL_DELAY)
+        msgs, err = _fetch_messages_with_backoff(pid, api_token)
+        requests_made += 1
+        if msgs is None:
+            # Fetch failed — do not classify this PID.  Assuming "no reply"
+            # here would risk a wrongful rejection if the participant had in
+            # fact replied and the API call merely failed transiently.
+            print(
+                f"  Error: failed to fetch messages for {pid}: {err}",
+                file=sys.stderr,
+            )
+            fetch_errors.append({"pid": pid, "error": err})
+            continue
         bucket, record = classify_submission(sub, msgs, researcher_id, now, cutoff)
         if bucket:
             buckets[bucket].append(record)
@@ -190,6 +241,21 @@ def main():
 
     rr_pids = ",".join(r["pid"] for r in buckets["stale_no_reply_to_rr"])
     msg_pids = ",".join(r["pid"] for r in buckets["stale_no_reply_to_message"])
+
+    if fetch_errors:
+        print(
+            f"=== FETCH ERRORS ({len(fetch_errors)}) "
+            f"— excluded from all recommendations ==="
+        )
+        for fe in fetch_errors:
+            print(f"  {fe['pid']}: {fe['error']}")
+        print()
+
+    print(
+        f"Message API requests: {requests_made} made, "
+        f"{requests_skipped} skipped (no PID), "
+        f"{len(fetch_errors)} errors"
+    )
     print(f"STALE_NO_REPLY_TO_RR_PID_LIST={rr_pids}")
     print(f"STALE_NO_REPLY_TO_MESSAGE_PID_LIST={msg_pids}")
 
@@ -199,6 +265,7 @@ def main():
             "computed_at": now.isoformat(),
             "stale_hours": stale_hours,
             "counts": {k: len(v) for k, v in buckets.items()},
+            "fetch_errors": len(fetch_errors),
             "buckets": buckets,
         }
         Path(output_json).write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -57,7 +57,9 @@ from tabs_api import (
 
 DEFAULT_RESEARCHER_ID = "68264cbfdeb62546fe6060fe"
 
-# Delay between per-PID message API calls to avoid Prolific rate limiting.
+# Delay between per-PID message API calls to stay well within Prolific's
+# undocumented rate limits (observed ~5 req/s on shared plans; 0.2s gives ~3/s
+# with some headroom and avoids bursting).
 _API_CALL_DELAY = 0.2
 
 
@@ -141,7 +143,7 @@ def _fetch_messages_with_backoff(pid, api_token, max_retries=3):
     for attempt in range(max_retries):
         try:
             if attempt > 0:
-                wait = 2 ** attempt
+                wait = min(2 ** attempt, 30)  # cap at 30s to avoid runaway delays
                 print(
                     f"  Retry {attempt}/{max_retries - 1} for {pid} in {wait}s",
                     file=sys.stderr,

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Find stale AWAITING REVIEW submissions that need operator attention.
+
+Emits three buckets that the daily report and ad-hoc operator checks both
+consume, based on the TABS policy that Prolific auto-APPROVES stale
+submissions after its reserve timeout:
+
+  1. STALE_NO_REPLY_TO_RR
+     AWAITING REVIEW, `return_requested` set, > STALE_HOURS old, and no
+     participant reply since `return_requested`. These are the reject
+     candidates.
+
+  2. STALE_NO_REPLY_TO_MESSAGE
+     AWAITING REVIEW, `return_requested` NOT set, TABS has sent at least one
+     message, last TABS message is > STALE_HOURS old, and no participant
+     reply after that message. These are the candidates for an API-level
+     request-return (the formal next step before rejection).
+
+  3. IN_WINDOW
+     Anything above that is still within the STALE_HOURS window, so leave
+     alone until the window closes.
+
+Engaged participants (any reply after our most recent action) are excluded
+from all three buckets — they belong on the approve path.
+
+Environment variables:
+  PROLIFIC_API_TOKEN  - Prolific API token (required)
+  STUDY_ID            - Prolific study ID (required)
+  STALE_HOURS         - Age threshold in hours (default: 48)
+  RESEARCHER_ID       - Prolific researcher user id (optional, has default)
+  OUTPUT_JSON_PATH    - Optional path to write a machine-readable summary
+                        that downstream workflow steps can consume.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from tabs_api import (
+    prolific_submissions,
+    prolific_user_messages,
+)
+
+DEFAULT_RESEARCHER_ID = "68264cbfdeb62546fe6060fe"
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        print(f"Error: {name} is required", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def _parse_iso(ts):
+    if not ts:
+        return None
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def _msg_time(m):
+    t = _parse_iso(m.get("sent_at")) or _parse_iso(m.get("created_at"))
+    return t or datetime.min.replace(tzinfo=timezone.utc)
+
+
+def classify_submission(sub, msgs, researcher_id, now, cutoff):
+    """Return (bucket_name, record_dict) or (None, None) if submission
+    doesn't qualify for any bucket."""
+    pid = sub.get("participant_id", "")
+    if not pid or sub.get("status") != "AWAITING REVIEW":
+        return None, None
+
+    researcher_msgs = [m for m in msgs if m.get("sender_id") == researcher_id]
+    participant_msgs = [m for m in msgs if m.get("sender_id") and m.get("sender_id") != researcher_id]
+    rr = _parse_iso(sub.get("return_requested"))
+
+    if rr is not None:
+        replies_after_rr = [m for m in participant_msgs if _msg_time(m) > rr]
+        if replies_after_rr:
+            return None, None
+        age_h = (now - rr).total_seconds() / 3600.0
+        record = {
+            "pid": pid,
+            "age_hours": round(age_h, 1),
+            "anchor": rr.isoformat(),
+            "anchor_kind": "return_requested",
+            "total_messages": len(msgs),
+            "researcher_messages": len(researcher_msgs),
+            "reasons": sub.get("return_requested_reasons") or [],
+        }
+        if rr < cutoff:
+            return "stale_no_reply_to_rr", record
+        return "in_window_rr", record
+
+    # No return_requested — consider the latest researcher message
+    if not researcher_msgs:
+        return None, None
+    last_msg_time = max(_msg_time(m) for m in researcher_msgs)
+    replies_after_msg = [m for m in participant_msgs if _msg_time(m) > last_msg_time]
+    if replies_after_msg:
+        return None, None
+    age_h = (now - last_msg_time).total_seconds() / 3600.0
+    record = {
+        "pid": pid,
+        "age_hours": round(age_h, 1),
+        "anchor": last_msg_time.isoformat(),
+        "anchor_kind": "last_researcher_message",
+        "total_messages": len(msgs),
+        "researcher_messages": len(researcher_msgs),
+    }
+    if last_msg_time < cutoff:
+        return "stale_no_reply_to_message", record
+    return "in_window_msg", record
+
+
+def _print_bucket(title, items):
+    print(f"=== {title} ({len(items)}) ===")
+    for r in sorted(items, key=lambda x: -x["age_hours"]):
+        reasons = "; ".join(r.get("reasons", []))[:60]
+        print(
+            f"  {r['pid']}  age={r['age_hours']:6.1f}h  "
+            f"msgs={r['total_messages']:>2} (rx={r['researcher_messages']})  "
+            f"anchor={r['anchor_kind']}"
+            + (f"  [{reasons}]" if reasons else "")
+        )
+    print()
+
+
+def main():
+    api_token = _require_env("PROLIFIC_API_TOKEN")
+    study_id = _require_env("STUDY_ID")
+    stale_hours = int(os.environ.get("STALE_HOURS", "48"))
+    researcher_id = os.environ.get("RESEARCHER_ID", DEFAULT_RESEARCHER_ID)
+    output_json = os.environ.get("OUTPUT_JSON_PATH")
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=stale_hours)
+
+    print(f"Study: {study_id}")
+    print(f"Stale threshold: {stale_hours}h (cutoff: {cutoff.isoformat()})")
+    print()
+
+    subs = prolific_submissions(study_id, api_token)
+    print(f"Total submissions fetched: {len(subs)}")
+    awaiting = [s for s in subs if s.get("status") == "AWAITING REVIEW"]
+    print(f"AWAITING REVIEW: {len(awaiting)}")
+    print()
+
+    buckets = {
+        "stale_no_reply_to_rr": [],
+        "stale_no_reply_to_message": [],
+        "in_window_rr": [],
+        "in_window_msg": [],
+    }
+
+    for sub in awaiting:
+        pid = sub.get("participant_id", "")
+        if not pid:
+            continue
+        try:
+            msgs = prolific_user_messages(pid, api_token)
+        except Exception as e:
+            print(f"  Warning: failed to fetch messages for {pid}: {e}", file=sys.stderr)
+            msgs = []
+        bucket, record = classify_submission(sub, msgs, researcher_id, now, cutoff)
+        if bucket:
+            buckets[bucket].append(record)
+
+    _print_bucket(
+        f"STALE_NO_REPLY_TO_RR (>{stale_hours}h since return_requested, no reply → reject)",
+        buckets["stale_no_reply_to_rr"],
+    )
+    _print_bucket(
+        f"STALE_NO_REPLY_TO_MESSAGE (>{stale_hours}h since last msg, no RR yet → request-return)",
+        buckets["stale_no_reply_to_message"],
+    )
+    _print_bucket(
+        f"IN_WINDOW / RR (≤{stale_hours}h since return_requested, no reply yet)",
+        buckets["in_window_rr"],
+    )
+    _print_bucket(
+        f"IN_WINDOW / MSG (≤{stale_hours}h since last msg, no RR yet)",
+        buckets["in_window_msg"],
+    )
+
+    rr_pids = ",".join(r["pid"] for r in buckets["stale_no_reply_to_rr"])
+    msg_pids = ",".join(r["pid"] for r in buckets["stale_no_reply_to_message"])
+    print(f"STALE_NO_REPLY_TO_RR_PID_LIST={rr_pids}")
+    print(f"STALE_NO_REPLY_TO_MESSAGE_PID_LIST={msg_pids}")
+
+    if output_json:
+        payload = {
+            "study_id": study_id,
+            "computed_at": now.isoformat(),
+            "stale_hours": stale_hours,
+            "counts": {k: len(v) for k, v in buckets.items()},
+            "buckets": buckets,
+        }
+        Path(output_json).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nWrote summary to {output_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -52,7 +52,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from tabs_api import (
-    prolific_recent_messages,
     prolific_submissions,
     prolific_user_messages,
 )
@@ -224,51 +223,17 @@ def main():
     fetch_errors = []
     requests_made = 0
     skipped_no_pid = 0
-    skipped_recent_reply = 0
-
-    # Pre-fetch all recent messages since the cutoff in one batch call.
-    # Participants who sent a message after the cutoff are safe to skip for
-    # *stale* detection: they replied within the review window and therefore
-    # cannot be stale.  This optimisation may conservatively undercount
-    # in_window_* entries in the edge case where the researcher sent a
-    # follow-up after the participant's reply (the batch data lacks
-    # per-participant conversation context to detect that pattern reliably).
-    # Per-PID calls are still issued for all other participants because a
-    # reply before the cutoff (e.g., just after the return request was set)
-    # also represents engagement but would not appear in this batch window.
-    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
-    recently_replied_pids: set = set()
-    try:
-        recent_msgs = prolific_recent_messages(cutoff_iso, api_token, study_id=study_id)
-        recently_replied_pids = {
-            m.get("sender_id", "")
-            for m in recent_msgs
-            if m.get("sender_id") and m.get("sender_id") != researcher_id
-        }
-        print(
-            f"Batch pre-fetch: {len(recent_msgs)} messages since {cutoff_iso}; "
-            f"{len(recently_replied_pids)} participants replied recently."
-        )
-    except Exception as exc:  # noqa: BLE001
-        print(
-            f"Warning: bulk message pre-fetch failed ({exc}), "
-            "falling back to per-PID calls for all submissions.",
-            file=sys.stderr,
-        )
 
     for sub in awaiting:
         pid = sub.get("participant_id", "")
         if not pid:
             skipped_no_pid += 1
             continue
-        # Skip per-PID call for recently-replied participants: they replied
-        # within the stale window so cannot be stale.  In the edge case where
-        # the researcher sent a follow-up after their reply, this PID may be
-        # absent from an in_window_* bucket — that conservative miss is
-        # accepted as a cost of the batch-optimisation.
-        if pid in recently_replied_pids:
-            skipped_recent_reply += 1
-            continue
+        # Do not skip per-PID history fetches based solely on a recent reply.
+        # A participant may have replied after the cutoff and still be stale
+        # if TABS sent a later follow-up (message or return request) that the
+        # participant never answered.  Full per-PID history is required to
+        # determine whether they replied after our most recent action.
         # Small inter-call delay to avoid Prolific rate limiting.
         if requests_made > 0:
             time.sleep(_API_CALL_DELAY)
@@ -328,7 +293,6 @@ def main():
     print(
         f"Message API requests: {requests_made} made, "
         f"{skipped_no_pid} skipped (no PID), "
-        f"{skipped_recent_reply} skipped (recent reply), "
         f"{len(fetch_errors)} errors"
     )
     print(f"STALE_NO_REPLY_TO_RR_PID_LIST={rr_pids}")

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -72,6 +72,22 @@ def _require_env(name: str) -> str:
     return value
 
 
+def _parse_stale_hours() -> int:
+    """Return the configured stale-hours threshold, or exit with a clear error."""
+    raw = os.environ.get("STALE_HOURS")
+    if raw is None:
+        return 48
+    try:
+        return int(raw.strip())
+    except (TypeError, ValueError):
+        print(
+            f"Invalid STALE_HOURS value: {raw!r}. "
+            "Expected an integer number of hours, e.g. 48.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
 def _parse_iso(ts):
     if not ts:
         return None
@@ -173,7 +189,7 @@ def _print_bucket(title, items):
 def main():
     api_token = _require_env("PROLIFIC_API_TOKEN")
     study_id = _require_env("STUDY_ID")
-    stale_hours = int(os.environ.get("STALE_HOURS", "48"))
+    stale_hours = _parse_stale_hours()
     researcher_id = os.environ.get("RESEARCHER_ID", DEFAULT_RESEARCHER_ID)
     output_json = os.environ.get("OUTPUT_JSON_PATH")
 
@@ -199,7 +215,8 @@ def main():
 
     fetch_errors = []
     requests_made = 0
-    requests_skipped = 0  # PIDs with no participant_id
+    skipped_no_pid = 0
+    skipped_recent_reply = 0
 
     # Pre-fetch all recent messages since the cutoff in one batch call.
     # Participants who sent a message after the cutoff are definitionally engaged
@@ -230,12 +247,12 @@ def main():
     for sub in awaiting:
         pid = sub.get("participant_id", "")
         if not pid:
-            requests_skipped += 1
+            skipped_no_pid += 1
             continue
         # Skip per-PID call for recently-replied participants: they are engaged
         # by definition (replied within the stale window), so they are not stale.
         if pid in recently_replied_pids:
-            requests_skipped += 1
+            skipped_recent_reply += 1
             continue
         # Small inter-call delay to avoid Prolific rate limiting.
         if requests_made > 0:
@@ -287,7 +304,8 @@ def main():
 
     print(
         f"Message API requests: {requests_made} made, "
-        f"{requests_skipped} skipped (no PID), "
+        f"{skipped_no_pid} skipped (no PID), "
+        f"{skipped_recent_reply} skipped (recent reply), "
         f"{len(fetch_errors)} errors"
     )
     print(f"STALE_NO_REPLY_TO_RR_PID_LIST={rr_pids}")

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -227,11 +227,15 @@ def main():
     skipped_recent_reply = 0
 
     # Pre-fetch all recent messages since the cutoff in one batch call.
-    # Participants who sent a message after the cutoff are definitionally engaged
-    # (they replied within the stale window), so we can exclude them without
-    # making a per-PID call.  Per-PID calls are still needed for all other PIDs
-    # because a reply before the cutoff (e.g., just after the return request was
-    # set) would also be engagement but would not appear in the batch.
+    # Participants who sent a message after the cutoff are safe to skip for
+    # *stale* detection: they replied within the review window and therefore
+    # cannot be stale.  This optimisation may conservatively undercount
+    # in_window_* entries in the edge case where the researcher sent a
+    # follow-up after the participant's reply (the batch data lacks
+    # per-participant conversation context to detect that pattern reliably).
+    # Per-PID calls are still issued for all other participants because a
+    # reply before the cutoff (e.g., just after the return request was set)
+    # also represents engagement but would not appear in this batch window.
     cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
     recently_replied_pids: set = set()
     try:
@@ -257,8 +261,11 @@ def main():
         if not pid:
             skipped_no_pid += 1
             continue
-        # Skip per-PID call for recently-replied participants: they are engaged
-        # by definition (replied within the stale window), so they are not stale.
+        # Skip per-PID call for recently-replied participants: they replied
+        # within the stale window so cannot be stale.  In the edge case where
+        # the researcher sent a follow-up after their reply, this PID may be
+        # absent from an in_window_* bucket — that conservative miss is
+        # accepted as a cost of the batch-optimisation.
         if pid in recently_replied_pids:
             skipped_recent_reply += 1
             continue

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -100,7 +100,11 @@ def _parse_iso(ts):
 
 def _msg_time(m):
     t = _parse_iso(m.get("sent_at")) or _parse_iso(m.get("created_at"))
-    return t or datetime.min.replace(tzinfo=timezone.utc)
+    if t is None:
+        raise ValueError(
+            "Message is missing a valid timestamp in both 'sent_at' and 'created_at'"
+        )
+    return t
 
 
 def classify_submission(sub, msgs, researcher_id, now, cutoff):
@@ -273,7 +277,15 @@ def main():
             )
             fetch_errors.append({"pid": pid, "error": err})
             continue
-        bucket, record = classify_submission(sub, msgs, researcher_id, now, cutoff)
+        try:
+            bucket, record = classify_submission(sub, msgs, researcher_id, now, cutoff)
+        except ValueError as exc:
+            print(
+                f"  Error: classification failed for {pid}: {exc}",
+                file=sys.stderr,
+            )
+            fetch_errors.append({"pid": pid, "error": str(exc)})
+            continue
         if bucket:
             buckets[bucket].append(record)
 

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -6,22 +6,22 @@ Emits four buckets that the daily report and ad-hoc operator checks both
 consume, based on the TABS policy that Prolific auto-APPROVES stale
 submissions after its reserve timeout:
 
-  1. STALE_NO_REPLY_TO_RR
+  1. `stale_no_reply_to_rr`
      AWAITING REVIEW, `return_requested` set, > STALE_HOURS old, and no
      participant reply since `return_requested`. These are the reject
      candidates.
 
-  2. STALE_NO_REPLY_TO_MESSAGE
+  2. `stale_no_reply_to_message`
      AWAITING REVIEW, `return_requested` NOT set, TABS has sent at least one
      message, last TABS message is > STALE_HOURS old, and no participant
      reply after that message. These are the candidates for an API-level
      request-return (the formal next step before rejection).
 
-  3. IN_WINDOW_RR
+  3. `in_window_rr`
      `return_requested` is set but still within the STALE_HOURS window, so
      leave alone until the window closes.
 
-  4. IN_WINDOW_MSG
+  4. `in_window_msg`
      TABS has sent a message but no return request yet, still within the
      STALE_HOURS window, so leave alone until the window closes.
 

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -92,7 +92,10 @@ def _parse_stale_hours() -> int:
 def _parse_iso(ts):
     if not ts:
         return None
-    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _msg_time(m):

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -51,6 +51,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from tabs_api import (
+    prolific_recent_messages,
     prolific_submissions,
     prolific_user_messages,
 )
@@ -200,9 +201,40 @@ def main():
     requests_made = 0
     requests_skipped = 0  # PIDs with no participant_id
 
+    # Pre-fetch all recent messages since the cutoff in one batch call.
+    # Participants who sent a message after the cutoff are definitionally engaged
+    # (they replied within the stale window), so we can exclude them without
+    # making a per-PID call.  Per-PID calls are still needed for all other PIDs
+    # because a reply before the cutoff (e.g., just after the return request was
+    # set) would also be engagement but would not appear in the batch.
+    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+    recently_replied_pids: set = set()
+    try:
+        recent_msgs = prolific_recent_messages(cutoff_iso, api_token, study_id=study_id)
+        recently_replied_pids = {
+            m.get("sender_id", "")
+            for m in recent_msgs
+            if m.get("sender_id") and m.get("sender_id") != researcher_id
+        }
+        print(
+            f"Batch pre-fetch: {len(recent_msgs)} messages since {cutoff_iso}; "
+            f"{len(recently_replied_pids)} participants replied recently."
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"Warning: bulk message pre-fetch failed ({exc}), "
+            "falling back to per-PID calls for all submissions.",
+            file=sys.stderr,
+        )
+
     for sub in awaiting:
         pid = sub.get("participant_id", "")
         if not pid:
+            requests_skipped += 1
+            continue
+        # Skip per-PID call for recently-replied participants: they are engaged
+        # by definition (replied within the stale window), so they are not stale.
+        if pid in recently_replied_pids:
             requests_skipped += 1
             continue
         # Small inter-call delay to avoid Prolific rate limiting.
@@ -268,6 +300,7 @@ def main():
             "stale_hours": stale_hours,
             "counts": {k: len(v) for k, v in buckets.items()},
             "fetch_errors": len(fetch_errors),
+            "fetch_error_details": fetch_errors,
             "buckets": buckets,
         }
         Path(output_json).write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -31,6 +31,10 @@ Exits non-zero if:
     unknown PID, since we would not know how to build a fair message)
   - A disposition is not one of the explicitly-handled types (refuse to
     invent a rejection reason for disposition types we have not modelled)
+  - Any PID is not in AWAITING REVIEW status on Prolific at the time of
+    the live run (prevents mid-run errors from stale-status PIDs)
+  - Any target PID could not be resolved to a submission ID after the live
+    rejection loop (indicates a PID was silently skipped)
 """
 
 import csv
@@ -47,6 +51,7 @@ from tabs_api import (
     prolific_get_submission_ids_map,
     prolific_reject_submission,
     prolific_study_info,
+    prolific_submission_statuses,
 )
 
 # Load the Smeal speed threshold from the shared constants file so this script
@@ -210,7 +215,17 @@ def main() -> None:
         print("================================================================", file=sys.stderr)
         sys.exit(1)
 
-    target_pids = [p.strip() for p in pid_list_raw.split(",") if p.strip()]
+    target_pids: List[str] = []
+    seen_pids: set = set()
+    for raw_pid in pid_list_raw.split(","):
+        pid = raw_pid.strip()
+        if not pid:
+            continue
+        if pid in seen_pids:
+            print(f"WARNING: duplicate PID in PID_LIST (ignored): {pid}", file=sys.stderr)
+            continue
+        seen_pids.add(pid)
+        target_pids.append(pid)
     if not target_pids:
         print("Error: PID_LIST must contain at least one PID", file=sys.stderr)
         sys.exit(1)
@@ -301,6 +316,27 @@ def main() -> None:
     print(f"  Resolved {len([p for p in pid_to_sub_id if pid_to_sub_id[p]])} / {len(records)}")
     print()
 
+    # Pre-validate that every target PID is currently AWAITING REVIEW.
+    # Any other status (APPROVED, RETURNED, REJECTED, …) would cause the
+    # Prolific API to error mid-run and leave a partial/unclear outcome.
+    print("Pre-validating submission statuses...")
+    status_map = prolific_submission_statuses(study_id, api_token)
+    not_rejectable: List[str] = []
+    for r in records:
+        status = status_map.get(r["pid"], "NOT FOUND")
+        if status != "AWAITING REVIEW":
+            print(f"  WARNING: PID {r['pid']} has status {status!r} — expected AWAITING REVIEW", file=sys.stderr)
+            not_rejectable.append(r["pid"])
+    if not_rejectable:
+        print(
+            f"\nAborting: {len(not_rejectable)} PID(s) are not in AWAITING REVIEW status.",
+            file=sys.stderr,
+        )
+        print("Re-run the triage to confirm current statuses before rejecting.", file=sys.stderr)
+        sys.exit(1)
+    print(f"  All {len(records)} PIDs confirmed AWAITING REVIEW.")
+    print()
+
     not_found: List[str] = []
     rejected = 0
 
@@ -323,7 +359,12 @@ def main() -> None:
     print()
     print(f"REJECTED: {rejected} | NOT FOUND: {len(not_found)}")
     if not_found:
-        print(f"PIDs not found: {', '.join(not_found)}")
+        print(
+            f"Error: {len(not_found)} PID(s) could not be resolved to a submission ID and were NOT rejected: "
+            f"{', '.join(not_found)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -38,7 +38,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Callable, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent))
 

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -48,10 +48,9 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from tabs_api import (
     REJECTION_CATEGORIES,
-    prolific_get_submission_ids_map,
     prolific_reject_submission,
     prolific_study_info,
-    prolific_submission_statuses,
+    prolific_submissions,
 )
 
 # Load the Smeal speed threshold from the shared constants file so this script
@@ -310,18 +309,26 @@ def main() -> None:
     print(f"  Study: {study.get('name', 'UNKNOWN')} (status: {study.get('status', 'UNKNOWN')})")
     print()
 
-    # Look up submission IDs for all PIDs up front
-    print("Looking up submission IDs...")
-    pid_to_sub_id = prolific_get_submission_ids_map(study_id, [r["pid"] for r in records], api_token)
-    print(f"  Resolved {len([p for p in pid_to_sub_id if pid_to_sub_id[p]])} / {len(records)}")
+    # Fetch all submissions once; derive both the PID→submission_id map and
+    # the PID→status map from the same API response to avoid double fetching.
+    print("Looking up submission IDs and statuses...")
+    target_pid_set = {r["pid"] for r in records}
+    all_subs = prolific_submissions(study_id, api_token)
+    pid_to_sub_id: Dict[str, str] = {}
+    status_map: Dict[str, str] = {}
+    for s in all_subs:
+        p = s.get("participant_id", "")
+        if not p:
+            continue
+        status_map[p] = s.get("status", "UNKNOWN")
+        if p in target_pid_set:
+            pid_to_sub_id[p] = s["id"]
+    print(f"  Resolved {len(pid_to_sub_id)} / {len(records)} submission IDs")
     print()
 
     # Pre-validate that every target PID is currently AWAITING REVIEW.
     # Any other status (APPROVED, RETURNED, REJECTED, …) would cause the
     # Prolific API to error mid-run and leave a partial/unclear outcome.
-    # prolific_submission_statuses returns a Dict[participant_id, status_string].
-    print("Pre-validating submission statuses...")
-    status_map = prolific_submission_statuses(study_id, api_token)
     non_awaiting_pids: List[str] = []
     for r in records:
         status = status_map.get(r["pid"], "NOT FOUND")

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -2,15 +2,20 @@
 """
 DESTRUCTIVE: Reject AWAITING REVIEW submissions by PID, disposition-aware.
 
-Generalises `reject_auto_exclude.py` to cover any disposition. Intended for
-stale PIDs that received a formal API request-return and did not respond
-within the 48h window — see `find_stale_return_requested.py` for the
-upstream triage.
+Generalises `reject_auto_exclude.py` to support the explicitly handled
+disposition types in `_classify_and_build()` (currently AUTO-EXCLUDE and the
+modelled FLAG-* variants). Intended for stale PIDs that received a formal API
+request-return and did not respond within the 48h window — see
+`find_stale_return_requested.py` for the upstream triage.
+
+A disposition not in the handled set will abort the run rather than inventing
+an unmodelled rejection reason.
 
 The rejection message and Prolific rejection categories are chosen per-PID
-from the disposition CSV, so a FLAG-SMEAL stale PID gets a speed-framed
-message and TOO_QUICKLY category while an AUTO-EXCLUDE:IRI3 stale PID gets
-an attention-check message and FAILED_ATTENTION_CHECK category.
+from the disposition CSV for supported dispositions, so a FLAG-SMEAL stale PID
+gets a speed-framed message and TOO_QUICKLY category while an
+AUTO-EXCLUDE:IRI3 stale PID gets an attention-check message and
+FAILED_ATTENTION_CHECK category.
 
 Environment variables:
   PROLIFIC_API_TOKEN  - Prolific API token (required)
@@ -44,7 +49,7 @@ from tabs_api import (
 )
 
 
-SMEAL_BENCHMARK_MIN = 5.0  # display-only; kept in sync with disposition_triage
+SMEAL_BENCHMARK_MIN = 5.0  # minutes; kept in sync with disposition_triage
 
 
 def _require_env(name: str) -> str:
@@ -57,6 +62,12 @@ def _require_env(name: str) -> str:
 
 def _fmt_minutes(duration_seconds: int) -> str:
     return f"{duration_seconds / 60:.1f}"
+
+
+def _safe_int(row: Dict[str, str], key: str) -> int:
+    """Parse an integer field from a CSV row, returning 0 for missing/non-integer values."""
+    raw = (row.get(key) or "").strip()
+    return int(raw) if raw.isdigit() else 0
 
 
 # ── Per-disposition message + category builders ──────────────────────────
@@ -112,7 +123,7 @@ def _build_flag_speed(duration: int) -> Tuple[str, List[str]]:
     msg = (
         "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
         f"Unfortunately, your submission has been rejected because it was completed in "
-        f"{_fmt_minutes(duration)} minutes, below our 5-minute minimum. We offered you the "
+        f"{_fmt_minutes(duration)} minutes, below our {SMEAL_BENCHMARK_MIN:.0f}-minute minimum. We offered you the "
         "option to return the submission voluntarily; we did not receive a reply within the "
         "review window. If you believe this is an error, please reply to this message with "
         "any questions."
@@ -148,13 +159,9 @@ def _classify_and_build(row: Dict[str, str]) -> Tuple[str, List[str]]:
 
     Raises ValueError if the disposition is not one of the handled types.
     """
-    def _int(key: str) -> int:
-        raw = (row.get(key) or "").strip()
-        return int(raw) if raw.isdigit() else 0
-
-    duration = _int("Duration_Seconds")
-    iri_fail = _int("IRI_Fail_Count")
-    speed_flag = _int("Speed_Flag")
+    duration = _safe_int(row, "Duration_Seconds")
+    iri_fail = _safe_int(row, "IRI_Fail_Count")
+    speed_flag = _safe_int(row, "Speed_Flag")
     disposition = (row.get("Disposition") or "").strip()
 
     if disposition == "AUTO-EXCLUDE":
@@ -243,9 +250,9 @@ def main() -> None:
         records.append({
             "pid": pid,
             "disposition": (row.get("Disposition") or "").strip(),
-            "duration": int((row.get("Duration_Seconds") or "0").strip() or 0),
-            "iri_fail": int((row.get("IRI_Fail_Count") or "0").strip() or 0),
-            "speed_flag": int((row.get("Speed_Flag") or "0").strip() or 0),
+            "duration": _safe_int(row, "Duration_Seconds"),
+            "iri_fail": _safe_int(row, "IRI_Fail_Count"),
+            "speed_flag": _safe_int(row, "Speed_Flag"),
             "message": msg,
             "categories": cats,
         })

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -42,7 +42,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -216,7 +216,7 @@ def main() -> None:
         sys.exit(1)
 
     target_pids: List[str] = []
-    seen_pids: set = set()
+    seen_pids: Set[str] = set()
     for raw_pid in pid_list_raw.split(","):
         pid = raw_pid.strip()
         if not pid:
@@ -319,17 +319,18 @@ def main() -> None:
     # Pre-validate that every target PID is currently AWAITING REVIEW.
     # Any other status (APPROVED, RETURNED, REJECTED, …) would cause the
     # Prolific API to error mid-run and leave a partial/unclear outcome.
+    # prolific_submission_statuses returns a Dict[participant_id, status_string].
     print("Pre-validating submission statuses...")
     status_map = prolific_submission_statuses(study_id, api_token)
-    not_rejectable: List[str] = []
+    non_awaiting_pids: List[str] = []
     for r in records:
         status = status_map.get(r["pid"], "NOT FOUND")
         if status != "AWAITING REVIEW":
             print(f"  WARNING: PID {r['pid']} has status {status!r} — expected AWAITING REVIEW", file=sys.stderr)
-            not_rejectable.append(r["pid"])
-    if not_rejectable:
+            non_awaiting_pids.append(r["pid"])
+    if non_awaiting_pids:
         print(
-            f"\nAborting: {len(not_rejectable)} PID(s) are not in AWAITING REVIEW status.",
+            f"\nAborting: {len(non_awaiting_pids)} PID(s) are not in AWAITING REVIEW status.",
             file=sys.stderr,
         )
         print("Re-run the triage to confirm current statuses before rejecting.", file=sys.stderr)

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -321,7 +321,7 @@ def main() -> None:
         if not p:
             continue
         status_map[p] = s.get("status", "UNKNOWN")
-        if p in target_pid_set:
+        if p in target_pid_set and s.get("id"):
             pid_to_sub_id[p] = s["id"]
     print(f"  Resolved {len(pid_to_sub_id)} / {len(records)} submission IDs")
     print()

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -34,6 +34,7 @@ Exits non-zero if:
 """
 
 import csv
+import json
 import os
 import sys
 from pathlib import Path
@@ -48,8 +49,12 @@ from tabs_api import (
     prolific_study_info,
 )
 
-
-SMEAL_BENCHMARK_MIN = 5.0  # minutes; kept in sync with disposition_triage
+# Load the Smeal speed threshold from the shared constants file so this script
+# stays in sync with the disposition logic in tabs_v2_data_audit.py.
+_CONSTANTS_PATH = Path(__file__).parent / "tabs_v2_constants.json"
+_CONSTANTS = json.loads(_CONSTANTS_PATH.read_text(encoding="utf-8")) if _CONSTANTS_PATH.exists() else {}
+_SMEAL_SECONDS = _CONSTANTS.get("DURATION_THRESHOLDS", {}).get("smealBenchmarkMin", 300)
+SMEAL_BENCHMARK_MIN: float = _SMEAL_SECONDS / 60  # convert to minutes for message text
 
 
 def _require_env(name: str) -> str:

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -78,7 +78,7 @@ def _safe_int(row: Dict[str, str], key: str) -> int:
 def _build_auto_exclude(duration: int, iri_fail: int, speed_flag: int) -> Tuple[str, List[str]]:
     reasons = []
     if speed_flag == 1:
-        reasons.append(f"it was completed in {_fmt_minutes(duration)} minutes (below our 5-minute minimum)")
+        reasons.append(f"it was completed in {_fmt_minutes(duration)} minutes (below our {SMEAL_BENCHMARK_MIN:.0f}-minute minimum)")
     reasons.append(f"{iri_fail} of 3 embedded attention checks were answered incorrectly")
     reason_text = " and ".join(reasons)
     msg = (
@@ -95,7 +95,7 @@ def _build_auto_exclude(duration: int, iri_fail: int, speed_flag: int) -> Tuple[
     return msg, cats
 
 
-def _build_flag_single_iri(duration: int, iri_fail: int) -> Tuple[str, List[str]]:
+def _build_flag_single_iri(_duration: int, iri_fail: int) -> Tuple[str, List[str]]:
     msg = (
         "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
         f"Unfortunately, your submission has been rejected because {iri_fail} of 3 "

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -104,7 +104,7 @@ def _build_flag_single_iri(_duration: int, iri_fail: int) -> Tuple[str, List[str
     msg = (
         "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
         "Unfortunately, your submission has been rejected because one of the 3 embedded "
-        "attention check questions was answered differently than the instructions specified. "
+        "attention-check questions was answered differently than the instructions specified. "
         "We asked you to review this via a return-offer message; we did not receive a reply "
         "within the review window, so we are unable to verify the answer. If you believe "
         "this is an error, please reply to this message with any questions."

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -103,11 +103,11 @@ def _build_auto_exclude(duration: int, iri_fail: int, speed_flag: int) -> Tuple[
 def _build_flag_single_iri(_duration: int, iri_fail: int) -> Tuple[str, List[str]]:
     msg = (
         "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
-        f"Unfortunately, your submission has been rejected because {iri_fail} of 3 "
-        "embedded attention check questions was answered differently than the instructions "
-        "specified. We asked you to review this via a return-offer message; we did not "
-        "receive a reply within the review window, so we are unable to verify the answer. "
-        "If you believe this is an error, please reply to this message with any questions."
+        "Unfortunately, your submission has been rejected because one of the 3 embedded "
+        "attention check questions was answered differently than the instructions specified. "
+        "We asked you to review this via a return-offer message; we did not receive a reply "
+        "within the review window, so we are unable to verify the answer. If you believe "
+        "this is an error, please reply to this message with any questions."
     )
     return msg, [REJECTION_CATEGORIES["FAILED_ATTENTION_CHECK"], REJECTION_CATEGORIES["OTHER"]]
 

--- a/scripts/analysis/reject_by_pid.py
+++ b/scripts/analysis/reject_by_pid.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+DESTRUCTIVE: Reject AWAITING REVIEW submissions by PID, disposition-aware.
+
+Generalises `reject_auto_exclude.py` to cover any disposition. Intended for
+stale PIDs that received a formal API request-return and did not respond
+within the 48h window — see `find_stale_return_requested.py` for the
+upstream triage.
+
+The rejection message and Prolific rejection categories are chosen per-PID
+from the disposition CSV, so a FLAG-SMEAL stale PID gets a speed-framed
+message and TOO_QUICKLY category while an AUTO-EXCLUDE:IRI3 stale PID gets
+an attention-check message and FAILED_ATTENTION_CHECK category.
+
+Environment variables:
+  PROLIFIC_API_TOKEN  - Prolific API token (required)
+  STUDY_ID            - Prolific study ID (required)
+  CSV_FILE_PATH       - Path to disposition CSV (required)
+  PID_LIST            - Comma-separated PIDs to reject (required)
+  CONFIRM_REJECT      - Must be exactly "REJECT" for live
+  DRY_RUN             - When "false" AND CONFIRM_REJECT=="REJECT", reject live
+
+Exits non-zero if:
+  - Required env vars are missing
+  - A PID in PID_LIST is not found in the CSV (safety: refuse to reject an
+    unknown PID, since we would not know how to build a fair message)
+  - A disposition is not one of the explicitly-handled types (refuse to
+    invent a rejection reason for disposition types we have not modelled)
+"""
+
+import csv
+import os
+import sys
+from pathlib import Path
+from typing import Callable, Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from tabs_api import (
+    REJECTION_CATEGORIES,
+    prolific_get_submission_ids_map,
+    prolific_reject_submission,
+    prolific_study_info,
+)
+
+
+SMEAL_BENCHMARK_MIN = 5.0  # display-only; kept in sync with disposition_triage
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        print(f"Error: {name} is required", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def _fmt_minutes(duration_seconds: int) -> str:
+    return f"{duration_seconds / 60:.1f}"
+
+
+# ── Per-disposition message + category builders ──────────────────────────
+# Each builder takes the raw CSV row fields it needs and returns
+# (message, categories). Common prefix/suffix are handled at the call site.
+
+
+def _build_auto_exclude(duration: int, iri_fail: int, speed_flag: int) -> Tuple[str, List[str]]:
+    reasons = []
+    if speed_flag == 1:
+        reasons.append(f"it was completed in {_fmt_minutes(duration)} minutes (below our 5-minute minimum)")
+    reasons.append(f"{iri_fail} of 3 embedded attention checks were answered incorrectly")
+    reason_text = " and ".join(reasons)
+    msg = (
+        "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
+        f"Unfortunately, your submission has been rejected because {reason_text}. "
+        "These checks are designed to confirm that respondents are reading each question "
+        "carefully. If you believe this is an error, please reply to this message with any "
+        "questions."
+    )
+    cats = [REJECTION_CATEGORIES["FAILED_ATTENTION_CHECK"]]
+    if speed_flag == 1:
+        cats.append(REJECTION_CATEGORIES["TOO_QUICKLY"])
+    cats.append(REJECTION_CATEGORIES["OTHER"])
+    return msg, cats
+
+
+def _build_flag_single_iri(duration: int, iri_fail: int) -> Tuple[str, List[str]]:
+    msg = (
+        "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
+        f"Unfortunately, your submission has been rejected because {iri_fail} of 3 "
+        "embedded attention check questions was answered differently than the instructions "
+        "specified. We asked you to review this via a return-offer message; we did not "
+        "receive a reply within the review window, so we are unable to verify the answer. "
+        "If you believe this is an error, please reply to this message with any questions."
+    )
+    return msg, [REJECTION_CATEGORIES["FAILED_ATTENTION_CHECK"], REJECTION_CATEGORIES["OTHER"]]
+
+
+def _build_flag_smeal(duration: int) -> Tuple[str, List[str]]:
+    msg = (
+        "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
+        f"Unfortunately, your submission has been rejected because the completion time of "
+        f"{_fmt_minutes(duration)} minutes was well below the typical time needed to read "
+        "and answer the survey carefully. We offered you the option to return the submission "
+        "voluntarily; we did not receive a reply within the review window. If you believe "
+        "this is an error, please reply to this message with any questions."
+    )
+    return msg, [REJECTION_CATEGORIES["TOO_QUICKLY"], REJECTION_CATEGORIES["OTHER"]]
+
+
+def _build_flag_speed(duration: int) -> Tuple[str, List[str]]:
+    msg = (
+        "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
+        f"Unfortunately, your submission has been rejected because it was completed in "
+        f"{_fmt_minutes(duration)} minutes, below our 5-minute minimum. We offered you the "
+        "option to return the submission voluntarily; we did not receive a reply within the "
+        "review window. If you believe this is an error, please reply to this message with "
+        "any questions."
+    )
+    return msg, [REJECTION_CATEGORIES["TOO_QUICKLY"], REJECTION_CATEGORIES["OTHER"]]
+
+
+def _build_flag_partial_straightlining(duration: int) -> Tuple[str, List[str]]:
+    msg = (
+        "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
+        "Unfortunately, your submission has been rejected because several blocks of answers "
+        "showed an identical-response pattern that suggests the questions were not read "
+        "carefully. We offered you the option to return the submission voluntarily; we did "
+        "not receive a reply within the review window. If you believe this is an error, "
+        "please reply to this message with any questions."
+    )
+    return msg, [REJECTION_CATEGORIES["LOW_EFFORT"], REJECTION_CATEGORIES["OTHER"]]
+
+
+def _build_flag_recaptcha(duration: int) -> Tuple[str, List[str]]:
+    msg = (
+        "Hi, thank you for participating in our Technology Adoption Barriers Survey. "
+        "Unfortunately, your submission has been rejected because the reCAPTCHA authenticity "
+        "score was below our threshold. We offered you the option to return the submission "
+        "voluntarily; we did not receive a reply within the review window. If you believe "
+        "this is an error, please reply to this message with any questions."
+    )
+    return msg, [REJECTION_CATEGORIES["FAILED_AUTHENTICITY_CHECK"], REJECTION_CATEGORIES["OTHER"]]
+
+
+def _classify_and_build(row: Dict[str, str]) -> Tuple[str, List[str]]:
+    """Return (message, categories) for the row's disposition.
+
+    Raises ValueError if the disposition is not one of the handled types.
+    """
+    def _int(key: str) -> int:
+        raw = (row.get(key) or "").strip()
+        return int(raw) if raw.isdigit() else 0
+
+    duration = _int("Duration_Seconds")
+    iri_fail = _int("IRI_Fail_Count")
+    speed_flag = _int("Speed_Flag")
+    disposition = (row.get("Disposition") or "").strip()
+
+    if disposition == "AUTO-EXCLUDE":
+        return _build_auto_exclude(duration, iri_fail, speed_flag)
+    if disposition == "FLAG-SINGLE-IRI":
+        return _build_flag_single_iri(duration, iri_fail)
+    if disposition == "FLAG-SMEAL":
+        return _build_flag_smeal(duration)
+    if disposition == "FLAG-SPEED":
+        return _build_flag_speed(duration)
+    if disposition == "FLAG-PARTIAL-STRAIGHTLINING":
+        return _build_flag_partial_straightlining(duration)
+    if disposition == "FLAG-RECAPTCHA":
+        return _build_flag_recaptcha(duration)
+
+    raise ValueError(
+        f"Unhandled disposition {disposition!r} for PID {row.get('PROLIFIC_PID')}"
+    )
+
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    print("================================================================")
+    print("  DESTRUCTIVE OPERATION: Reject stale PIDs by disposition")
+    print("================================================================")
+    print()
+
+    api_token = _require_env("PROLIFIC_API_TOKEN")
+    study_id = _require_env("STUDY_ID")
+    csv_path = _require_env("CSV_FILE_PATH")
+    pid_list_raw = _require_env("PID_LIST")
+    dry_run = os.environ.get("DRY_RUN", "true").strip().lower() != "false"
+    confirm = os.environ.get("CONFIRM_REJECT", "").strip()
+
+    if not dry_run and confirm != "REJECT":
+        print("================================================================", file=sys.stderr)
+        print('  SAFETY STOP: CONFIRM_REJECT must be exactly "REJECT"', file=sys.stderr)
+        print(f'  Received: "{confirm}"', file=sys.stderr)
+        print("================================================================", file=sys.stderr)
+        sys.exit(1)
+
+    target_pids = [p.strip() for p in pid_list_raw.split(",") if p.strip()]
+    if not target_pids:
+        print("Error: PID_LIST must contain at least one PID", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Target PIDs: {len(target_pids)}")
+    print(f"Mode: {'DRY RUN' if dry_run else 'LIVE REJECTION'}")
+    print()
+
+    # Load CSV and index by PID
+    print(f"Reading disposition CSV from {csv_path}")
+    with open(csv_path, encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows_by_pid: Dict[str, Dict[str, str]] = {}
+        for row in reader:
+            pid = (row.get("PROLIFIC_PID") or "").strip()
+            if pid:
+                rows_by_pid[pid] = row
+
+    print(f"  Loaded {len(rows_by_pid)} rows.")
+    print()
+
+    missing = [p for p in target_pids if p not in rows_by_pid]
+    if missing:
+        print("Error: the following PIDs are not in the disposition CSV:", file=sys.stderr)
+        for p in missing:
+            print(f"  {p}", file=sys.stderr)
+        print(
+            "Refusing to reject unknown PIDs - re-run the triage pipeline or correct the CSV.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Build rejection plan
+    records: List[Dict] = []
+    for pid in target_pids:
+        row = rows_by_pid[pid]
+        try:
+            msg, cats = _classify_and_build(row)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+        records.append({
+            "pid": pid,
+            "disposition": (row.get("Disposition") or "").strip(),
+            "duration": int((row.get("Duration_Seconds") or "0").strip() or 0),
+            "iri_fail": int((row.get("IRI_Fail_Count") or "0").strip() or 0),
+            "speed_flag": int((row.get("Speed_Flag") or "0").strip() or 0),
+            "message": msg,
+            "categories": cats,
+        })
+
+    # Log everything before doing anything destructive
+    by_disp: Dict[str, List[str]] = {}
+    print("Rejection plan:")
+    for r in records:
+        by_disp.setdefault(r["disposition"], []).append(r["pid"])
+        print(f"  PID: {r['pid']}")
+        print(
+            f"    Disposition: {r['disposition']} | Duration: {_fmt_minutes(r['duration'])} min "
+            f"| IRI Failed: {r['iri_fail']}/3 | Speed: {'TOO FAST' if r['speed_flag'] == 1 else 'OK'}"
+        )
+        print(f"    Categories: {', '.join(r['categories'])}")
+        print(f"    Message: {r['message']}")
+        print()
+
+    print("By disposition:")
+    for disp, pids in sorted(by_disp.items()):
+        print(f"  {disp}: {len(pids)}")
+    print()
+
+    if dry_run:
+        print("================================================================")
+        print("  DRY RUN - no submissions will be rejected")
+        print(f"  Would reject: {len(records)} participants")
+        print("  Set DRY_RUN=false and CONFIRM_REJECT=REJECT to execute")
+        print("================================================================")
+        return
+
+    # Verify Prolific access before touching anything
+    print("Verifying Prolific API connection...")
+    study = prolific_study_info(study_id, api_token)
+    print(f"  Study: {study.get('name', 'UNKNOWN')} (status: {study.get('status', 'UNKNOWN')})")
+    print()
+
+    # Look up submission IDs for all PIDs up front
+    print("Looking up submission IDs...")
+    pid_to_sub_id = prolific_get_submission_ids_map(study_id, [r["pid"] for r in records], api_token)
+    print(f"  Resolved {len([p for p in pid_to_sub_id if pid_to_sub_id[p]])} / {len(records)}")
+    print()
+
+    not_found: List[str] = []
+    rejected = 0
+
+    print("================================================================")
+    print(f"  LIVE REJECTION: {len(records)} submissions")
+    print("================================================================")
+    print()
+
+    for r in records:
+        sub_id = pid_to_sub_id.get(r["pid"])
+        if not sub_id:
+            print(f"  WARNING: No submission found for PID {r['pid']} - skipping")
+            not_found.append(r["pid"])
+            continue
+
+        print(f"  Rejecting {r['pid']} ({r['disposition']}, submission {sub_id})...")
+        prolific_reject_submission(sub_id, r["categories"], r["message"], api_token)
+        rejected += 1
+
+    print()
+    print(f"REJECTED: {rejected} | NOT FOUND: {len(not_found)}")
+    if not_found:
+        print(f"PIDs not found: {', '.join(not_found)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/tests/test_find_stale_return_requested.py
+++ b/scripts/analysis/tests/test_find_stale_return_requested.py
@@ -10,13 +10,9 @@ Covers:
   - custom STALE_HOURS threshold is respected
 """
 
-import sys
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from find_stale_return_requested import classify_submission
 

--- a/scripts/analysis/tests/test_find_stale_return_requested.py
+++ b/scripts/analysis/tests/test_find_stale_return_requested.py
@@ -1,0 +1,212 @@
+"""Unit tests for find_stale_return_requested.classify_submission.
+
+Covers:
+  - return-requested path (stale and in-window)
+  - message-only path (stale and in-window)
+  - engaged-participant exclusion (replied after RR, replied after last msg)
+  - non-AWAITING REVIEW submissions are excluded
+  - missing participant_id is excluded
+  - no researcher messages yields (None, None)
+  - custom STALE_HOURS threshold is respected
+"""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from find_stale_return_requested import classify_submission
+
+RESEARCHER_ID = "researcher_001"
+NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
+THRESHOLD_HOURS = 48
+CUTOFF = NOW - timedelta(hours=THRESHOLD_HOURS)
+
+
+def _ts(dt: datetime) -> str:
+    """Return an ISO-8601 string (UTC, Z-suffix) for a datetime."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _msg(sender_id: str, sent_at: datetime) -> dict:
+    return {"sender_id": sender_id, "sent_at": _ts(sent_at)}
+
+
+def _sub(pid: str, status: str = "AWAITING REVIEW", rr: datetime | None = None, reasons=None) -> dict:
+    s: dict = {"participant_id": pid, "status": status}
+    if rr is not None:
+        s["return_requested"] = _ts(rr)
+        s["return_requested_reasons"] = reasons or []
+    return s
+
+
+# ── Return-requested path ────────────────────────────────────────────────────
+
+class TestReturnRequestedPath:
+    def test_stale_rr_no_reply_is_reject_candidate(self):
+        """RR set >48h ago with no participant reply → stale_no_reply_to_rr."""
+        rr_time = NOW - timedelta(hours=60)
+        sub = _sub("PID_A", rr=rr_time, reasons=["failed attention check"])
+        msgs = [_msg(RESEARCHER_ID, rr_time - timedelta(hours=1))]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket == "stale_no_reply_to_rr"
+        assert record["pid"] == "PID_A"
+        assert record["age_hours"] == pytest.approx(60.0, abs=0.1)
+        assert record["anchor_kind"] == "return_requested"
+        assert record["reasons"] == ["failed attention check"]
+
+    def test_in_window_rr_not_stale(self):
+        """RR set <48h ago with no reply → in_window_rr (don't touch yet)."""
+        rr_time = NOW - timedelta(hours=24)
+        sub = _sub("PID_B", rr=rr_time)
+        msgs = []
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket == "in_window_rr"
+        assert record["pid"] == "PID_B"
+        assert record["age_hours"] == pytest.approx(24.0, abs=0.1)
+
+    def test_engaged_participant_after_rr_is_excluded(self):
+        """Participant replied after RR → excluded (engaged; approve path)."""
+        rr_time = NOW - timedelta(hours=60)
+        reply_time = rr_time + timedelta(hours=1)
+        sub = _sub("PID_C", rr=rr_time)
+        msgs = [
+            _msg(RESEARCHER_ID, rr_time - timedelta(hours=2)),
+            _msg("PID_C", reply_time),
+        ]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket is None
+        assert record is None
+
+    def test_rr_at_exact_cutoff_boundary(self):
+        """RR set exactly at cutoff (not strictly before) → in_window_rr."""
+        sub = _sub("PID_D", rr=CUTOFF)
+        msgs = []
+        bucket, _ = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket == "in_window_rr"
+
+    def test_stale_rr_record_contains_researcher_message_count(self):
+        """Record includes correct researcher_messages count."""
+        rr_time = NOW - timedelta(hours=72)
+        sub = _sub("PID_E", rr=rr_time)
+        msgs = [
+            _msg(RESEARCHER_ID, rr_time - timedelta(hours=10)),
+            _msg(RESEARCHER_ID, rr_time - timedelta(hours=5)),
+        ]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket == "stale_no_reply_to_rr"
+        assert record["researcher_messages"] == 2
+        assert record["total_messages"] == 2
+
+
+# ── Message-only path (no return_requested) ──────────────────────────────────
+
+class TestMessageOnlyPath:
+    def test_stale_msg_no_reply_is_request_return_candidate(self):
+        """Researcher messaged >48h ago, no RR, no participant reply → stale_no_reply_to_message."""
+        msg_time = NOW - timedelta(hours=72)
+        sub = _sub("PID_F")
+        msgs = [_msg(RESEARCHER_ID, msg_time)]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket == "stale_no_reply_to_message"
+        assert record["pid"] == "PID_F"
+        assert record["anchor_kind"] == "last_researcher_message"
+        assert record["age_hours"] == pytest.approx(72.0, abs=0.1)
+
+    def test_in_window_msg_not_stale(self):
+        """Researcher messaged <48h ago, no reply → in_window_msg."""
+        msg_time = NOW - timedelta(hours=10)
+        sub = _sub("PID_G")
+        msgs = [_msg(RESEARCHER_ID, msg_time)]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket == "in_window_msg"
+        assert record["pid"] == "PID_G"
+
+    def test_engaged_participant_after_msg_is_excluded(self):
+        """Participant replied after last researcher message → excluded."""
+        msg_time = NOW - timedelta(hours=72)
+        reply_time = msg_time + timedelta(hours=1)
+        sub = _sub("PID_H")
+        msgs = [
+            _msg(RESEARCHER_ID, msg_time),
+            _msg("PID_H", reply_time),
+        ]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket is None
+        assert record is None
+
+    def test_latest_researcher_msg_is_used_as_anchor(self):
+        """When there are multiple researcher messages, the latest determines staleness."""
+        old_msg = NOW - timedelta(hours=100)
+        recent_msg = NOW - timedelta(hours=10)  # within window
+        sub = _sub("PID_I")
+        msgs = [
+            _msg(RESEARCHER_ID, old_msg),
+            _msg(RESEARCHER_ID, recent_msg),
+        ]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        # Latest msg is only 10h old → in_window_msg
+        assert bucket == "in_window_msg"
+        assert record["age_hours"] == pytest.approx(10.0, abs=0.1)
+
+    def test_no_researcher_messages_yields_none(self):
+        """No researcher messages and no RR → submission is not in any bucket."""
+        sub = _sub("PID_J")
+        msgs = [_msg("PID_J", NOW - timedelta(hours=5))]  # only participant msg
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket is None
+        assert record is None
+
+    def test_no_messages_at_all_yields_none(self):
+        """No messages and no RR → not in any bucket."""
+        sub = _sub("PID_K")
+        bucket, record = classify_submission(sub, [], RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket is None
+        assert record is None
+
+
+# ── General exclusions ────────────────────────────────────────────────────────
+
+class TestGeneralExclusions:
+    def test_non_awaiting_review_is_excluded(self):
+        """Submissions with status other than AWAITING REVIEW are ignored."""
+        for status in ("APPROVED", "RETURNED", "REJECTED", "TIMED-OUT"):
+            sub = _sub("PID_L", status=status, rr=NOW - timedelta(hours=100))
+            bucket, record = classify_submission(sub, [], RESEARCHER_ID, NOW, CUTOFF)
+            assert bucket is None, f"Expected None for status={status}"
+            assert record is None
+
+    def test_missing_participant_id_is_excluded(self):
+        """Submissions with no participant_id are skipped."""
+        sub = {"status": "AWAITING REVIEW"}
+        bucket, record = classify_submission(sub, [], RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket is None
+        assert record is None
+
+    def test_empty_participant_id_is_excluded(self):
+        """Submissions with empty-string participant_id are skipped."""
+        sub = {"participant_id": "", "status": "AWAITING REVIEW"}
+        bucket, record = classify_submission(sub, [], RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket is None
+        assert record is None
+
+
+# ── Custom threshold ──────────────────────────────────────────────────────────
+
+class TestCustomThreshold:
+    def test_24h_threshold_reclassifies_borderline_submission(self):
+        """A submission 30h old is stale at 24h threshold but in-window at 48h."""
+        rr_time = NOW - timedelta(hours=30)
+        sub = _sub("PID_M", rr=rr_time)
+        msgs = []
+
+        cutoff_24h = NOW - timedelta(hours=24)
+        bucket_24, _ = classify_submission(sub, msgs, RESEARCHER_ID, NOW, cutoff_24h)
+        assert bucket_24 == "stale_no_reply_to_rr"
+
+        cutoff_48h = NOW - timedelta(hours=48)
+        bucket_48, _ = classify_submission(sub, msgs, RESEARCHER_ID, NOW, cutoff_48h)
+        assert bucket_48 == "in_window_rr"

--- a/scripts/analysis/tests/test_find_stale_return_requested.py
+++ b/scripts/analysis/tests/test_find_stale_return_requested.py
@@ -8,13 +8,14 @@ Covers:
   - missing participant_id is excluded
   - no researcher messages yields (None, None)
   - custom STALE_HOURS threshold is respected
+  - _msg_time raises ValueError for messages with no valid timestamp
 """
 
 from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from find_stale_return_requested import classify_submission
+from find_stale_return_requested import classify_submission, _msg_time
 
 RESEARCHER_ID = "researcher_001"
 NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
@@ -206,3 +207,37 @@ class TestCustomThreshold:
         cutoff_48h = NOW - timedelta(hours=48)
         bucket_48, _ = classify_submission(sub, msgs, RESEARCHER_ID, NOW, cutoff_48h)
         assert bucket_48 == "in_window_rr"
+
+
+# ── _msg_time sentinel behaviour ─────────────────────────────────────────────
+
+class TestMsgTime:
+    def test_valid_sent_at_is_returned(self):
+        """_msg_time returns the parsed sent_at timestamp."""
+        dt = NOW - timedelta(hours=5)
+        m = {"sender_id": "x", "sent_at": dt.strftime("%Y-%m-%dT%H:%M:%SZ")}
+        assert _msg_time(m) == dt
+
+    def test_falls_back_to_created_at(self):
+        """_msg_time uses created_at when sent_at is absent."""
+        dt = NOW - timedelta(hours=3)
+        m = {"sender_id": "x", "created_at": dt.strftime("%Y-%m-%dT%H:%M:%SZ")}
+        assert _msg_time(m) == dt
+
+    def test_missing_timestamps_raises_value_error(self):
+        """_msg_time raises ValueError when neither timestamp field is present."""
+        with pytest.raises(ValueError, match="missing a valid timestamp"):
+            _msg_time({"sender_id": "x"})
+
+    def test_unparseable_timestamps_raises_value_error(self):
+        """_msg_time raises ValueError when both timestamp fields are unparseable."""
+        with pytest.raises(ValueError, match="missing a valid timestamp"):
+            _msg_time({"sender_id": "x", "sent_at": "not-a-date", "created_at": None})
+
+    def test_classify_submission_raises_for_bad_msg_timestamp(self):
+        """classify_submission propagates ValueError when a message has no valid timestamp."""
+        rr_time = NOW - timedelta(hours=60)
+        sub = _sub("PID_N", rr=rr_time)
+        bad_msgs = [{"sender_id": "PID_N", "sent_at": "bad-timestamp"}]
+        with pytest.raises(ValueError, match="missing a valid timestamp"):
+            classify_submission(sub, bad_msgs, RESEARCHER_ID, NOW, CUTOFF)

--- a/scripts/analysis/tests/test_phase4_scripts.py
+++ b/scripts/analysis/tests/test_phase4_scripts.py
@@ -489,3 +489,125 @@ class TestRejectByPid:
             row = self._row(disp, **kwargs)
             msg, _ = _classify_and_build(row)
             assert "Technology Adoption Barriers Survey" in msg, f"Missing survey name for {disp}"
+
+
+# ── reject_by_pid.py (CLI / subprocess) ────────────────────────────────────
+
+class TestRejectByPidCli:
+    """CLI/subprocess integration tests for reject_by_pid.py safety guards."""
+
+    SCRIPT = str(SCRIPTS_DIR / "reject_by_pid.py")
+
+    _BASE_HEADERS = [
+        "PROLIFIC_PID", "Disposition", "Duration_Seconds",
+        "IRI_Fail_Count", "Speed_Flag",
+    ]
+
+    def _csv(self, tmp_path, rows):
+        return _write_csv(tmp_path, self._BASE_HEADERS, rows)
+
+    def test_safety_stop_wrong_confirm(self, tmp_path):
+        """Live mode with wrong CONFIRM_REJECT must abort with SAFETY STOP."""
+        csv_path = self._csv(
+            tmp_path,
+            [["PID_A", "AUTO-EXCLUDE", "600", "2", "0"]],
+        )
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT],
+            env={
+                "PROLIFIC_API_TOKEN": "test",
+                "STUDY_ID": "STUDY_1",
+                "CSV_FILE_PATH": csv_path,
+                "PID_LIST": "PID_A",
+                "DRY_RUN": "false",
+                "CONFIRM_REJECT": "wrong",
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "SAFETY STOP" in result.stderr
+
+    def test_safety_stop_missing_confirm(self, tmp_path):
+        """Live mode with empty CONFIRM_REJECT must abort with SAFETY STOP."""
+        csv_path = self._csv(
+            tmp_path,
+            [["PID_A", "AUTO-EXCLUDE", "600", "2", "0"]],
+        )
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT],
+            env={
+                "PROLIFIC_API_TOKEN": "test",
+                "STUDY_ID": "STUDY_1",
+                "CSV_FILE_PATH": csv_path,
+                "PID_LIST": "PID_A",
+                "DRY_RUN": "false",
+                # CONFIRM_REJECT deliberately absent
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "SAFETY STOP" in result.stderr
+
+    def test_abort_unknown_pid(self, tmp_path):
+        """PID in PID_LIST that is absent from the CSV must abort."""
+        csv_path = self._csv(
+            tmp_path,
+            [["PID_A", "AUTO-EXCLUDE", "600", "2", "0"]],
+        )
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT],
+            env={
+                "PROLIFIC_API_TOKEN": "test",
+                "STUDY_ID": "STUDY_1",
+                "CSV_FILE_PATH": csv_path,
+                "PID_LIST": "PID_UNKNOWN",
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "not in the disposition CSV" in result.stderr
+
+    def test_abort_unhandled_disposition(self, tmp_path):
+        """A PID whose disposition is not in the handled set must abort."""
+        csv_path = self._csv(
+            tmp_path,
+            [["PID_A", "CLEAN", "900", "0", "0"]],
+        )
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT],
+            env={
+                "PROLIFIC_API_TOKEN": "test",
+                "STUDY_ID": "STUDY_1",
+                "CSV_FILE_PATH": csv_path,
+                "PID_LIST": "PID_A",
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Unhandled disposition" in result.stderr
+
+    def test_dry_run_success(self, tmp_path):
+        """Dry run with a valid CSV and known PID must exit 0 and print summary."""
+        csv_path = self._csv(
+            tmp_path,
+            [["PID_A", "AUTO-EXCLUDE", "600", "2", "0"]],
+        )
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT],
+            env={
+                "PROLIFIC_API_TOKEN": "test",
+                "STUDY_ID": "STUDY_1",
+                "CSV_FILE_PATH": csv_path,
+                "PID_LIST": "PID_A",
+                # DRY_RUN defaults to true
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "DRY RUN" in result.stdout
+        assert "Would reject: 1" in result.stdout

--- a/scripts/analysis/tests/test_phase4_scripts.py
+++ b/scripts/analysis/tests/test_phase4_scripts.py
@@ -429,7 +429,7 @@ class TestRejectByPid:
     def test_flag_single_iri_message_and_categories(self):
         from reject_by_pid import _classify_and_build
         msg, cats = _classify_and_build(self._row("FLAG-SINGLE-IRI", duration=600, iri_fail=1))
-        assert "one of the 3 embedded attention check" in msg
+        assert "one of the 3 embedded attention-check" in msg
         assert "return-offer message" in msg
         assert "FAILED_ATTENTION_CHECK" in cats
         assert "OTHER" in cats

--- a/scripts/analysis/tests/test_phase4_scripts.py
+++ b/scripts/analysis/tests/test_phase4_scripts.py
@@ -611,3 +611,27 @@ class TestRejectByPidCli:
         assert result.returncode == 0
         assert "DRY RUN" in result.stdout
         assert "Would reject: 1" in result.stdout
+
+    def test_duplicate_pids_deduplicates_in_dry_run(self, tmp_path):
+        """Duplicate PIDs in PID_LIST are de-duplicated; dry run exits 0 with count=1."""
+        csv_path = self._csv(
+            tmp_path,
+            [["PID_A", "AUTO-EXCLUDE", "600", "2", "0"]],
+        )
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT],
+            env={
+                "PROLIFIC_API_TOKEN": "test",
+                "STUDY_ID": "STUDY_1",
+                "CSV_FILE_PATH": csv_path,
+                "PID_LIST": "PID_A,PID_A,PID_A",
+                # DRY_RUN defaults to true
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        # After de-duplication only 1 unique PID, so plan shows "Would reject: 1"
+        assert "Would reject: 1" in result.stdout
+        # A warning about duplicates must be emitted to stderr
+        assert "duplicate" in result.stderr.lower()

--- a/scripts/analysis/tests/test_phase4_scripts.py
+++ b/scripts/analysis/tests/test_phase4_scripts.py
@@ -392,3 +392,100 @@ class TestRejectFailedIRI:
             text=True,
         )
         assert "IRI_Fail_Count == 3: 2" in result.stdout
+
+
+# ── reject_by_pid.py ────────────────────────────────────────────
+
+class TestRejectByPid:
+    """Tests for disposition-aware rejection helpers in reject_by_pid.py."""
+
+    def _row(self, disposition, duration=600, iri_fail=2, speed_flag=0):
+        return {
+            "PROLIFIC_PID": "PID_TEST",
+            "Disposition": disposition,
+            "Duration_Seconds": str(duration),
+            "IRI_Fail_Count": str(iri_fail),
+            "Speed_Flag": str(speed_flag),
+        }
+
+    def test_auto_exclude_message_and_categories(self):
+        from reject_by_pid import _classify_and_build, SMEAL_BENCHMARK_MIN
+        msg, cats = _classify_and_build(self._row("AUTO-EXCLUDE", duration=600, iri_fail=2, speed_flag=0))
+        assert "2 of 3 embedded attention checks" in msg
+        assert f"{SMEAL_BENCHMARK_MIN:.0f}-minute minimum" not in msg  # no speed flag
+        assert "FAILED_ATTENTION_CHECK" in cats
+        assert "TOO_QUICKLY" not in cats
+        assert "OTHER" in cats
+
+    def test_auto_exclude_with_speed_uses_smeal_constant(self):
+        from reject_by_pid import _classify_and_build, SMEAL_BENCHMARK_MIN
+        msg, cats = _classify_and_build(self._row("AUTO-EXCLUDE", duration=180, iri_fail=3, speed_flag=1))
+        assert f"{SMEAL_BENCHMARK_MIN:.0f}-minute minimum" in msg
+        assert "3.0 minutes" in msg
+        assert "3 of 3 embedded attention checks" in msg
+        assert "FAILED_ATTENTION_CHECK" in cats
+        assert "TOO_QUICKLY" in cats
+
+    def test_flag_single_iri_message_and_categories(self):
+        from reject_by_pid import _classify_and_build
+        msg, cats = _classify_and_build(self._row("FLAG-SINGLE-IRI", duration=600, iri_fail=1))
+        assert "1 of 3 embedded attention check" in msg
+        assert "return-offer message" in msg
+        assert "FAILED_ATTENTION_CHECK" in cats
+        assert "OTHER" in cats
+
+    def test_flag_smeal_message_and_categories(self):
+        from reject_by_pid import _classify_and_build
+        msg, cats = _classify_and_build(self._row("FLAG-SMEAL", duration=240))
+        assert "4.0 minutes" in msg
+        assert "voluntarily" in msg
+        assert "TOO_QUICKLY" in cats
+        assert "OTHER" in cats
+
+    def test_flag_speed_uses_smeal_constant(self):
+        from reject_by_pid import _classify_and_build, SMEAL_BENCHMARK_MIN
+        msg, cats = _classify_and_build(self._row("FLAG-SPEED", duration=180))
+        assert f"{SMEAL_BENCHMARK_MIN:.0f}-minute minimum" in msg
+        assert "TOO_QUICKLY" in cats
+
+    def test_flag_partial_straightlining_message_and_categories(self):
+        from reject_by_pid import _classify_and_build
+        msg, cats = _classify_and_build(self._row("FLAG-PARTIAL-STRAIGHTLINING", duration=600))
+        assert "identical-response pattern" in msg
+        assert "LOW_EFFORT" in cats
+        assert "OTHER" in cats
+
+    def test_flag_recaptcha_message_and_categories(self):
+        from reject_by_pid import _classify_and_build
+        msg, cats = _classify_and_build(self._row("FLAG-RECAPTCHA", duration=600))
+        assert "reCAPTCHA" in msg
+        assert "FAILED_AUTHENTICITY_CHECK" in cats
+        assert "OTHER" in cats
+
+    def test_unhandled_disposition_raises(self):
+        from reject_by_pid import _classify_and_build
+        import pytest
+        with pytest.raises(ValueError, match="Unhandled disposition"):
+            _classify_and_build(self._row("CLEAN"))
+
+    def test_safe_int_empty_field(self):
+        from reject_by_pid import _safe_int
+        row = {"Duration_Seconds": "", "IRI_Fail_Count": "NaN", "Speed_Flag": "1"}
+        assert _safe_int(row, "Duration_Seconds") == 0
+        assert _safe_int(row, "IRI_Fail_Count") == 0
+        assert _safe_int(row, "Speed_Flag") == 1
+
+    def test_all_messages_include_survey_name(self):
+        from reject_by_pid import _classify_and_build
+        dispositions = [
+            ("AUTO-EXCLUDE", {"iri_fail": 2, "speed_flag": 0}),
+            ("FLAG-SINGLE-IRI", {"iri_fail": 1, "speed_flag": 0}),
+            ("FLAG-SMEAL", {}),
+            ("FLAG-SPEED", {}),
+            ("FLAG-PARTIAL-STRAIGHTLINING", {}),
+            ("FLAG-RECAPTCHA", {}),
+        ]
+        for disp, kwargs in dispositions:
+            row = self._row(disp, **kwargs)
+            msg, _ = _classify_and_build(row)
+            assert "Technology Adoption Barriers Survey" in msg, f"Missing survey name for {disp}"

--- a/scripts/analysis/tests/test_phase4_scripts.py
+++ b/scripts/analysis/tests/test_phase4_scripts.py
@@ -429,7 +429,7 @@ class TestRejectByPid:
     def test_flag_single_iri_message_and_categories(self):
         from reject_by_pid import _classify_and_build
         msg, cats = _classify_and_build(self._row("FLAG-SINGLE-IRI", duration=600, iri_fail=1))
-        assert "1 of 3 embedded attention check" in msg
+        assert "one of the 3 embedded attention check" in msg
         assert "return-offer message" in msg
         assert "FAILED_ATTENTION_CHECK" in cats
         assert "OTHER" in cats

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -288,6 +288,12 @@ STALEEOF
 > Check the \`stale-triage\` workflow artifact and runner logs for details.
 "
   fi
+else
+  STALE_TRIAGE_SECTION="## Stale AWAITING REVIEW
+
+> ⚠️ Stale triage data is unavailable — the \`stale-triage\` artifact was not found at \`$STALE_TRIAGE_FILE\`.
+> This usually means the artifact download failed or the stale-triage step did not run. Review the workflow run before acting on stale queue status.
+"
 fi
 
 STALE_TRIAGE_SECTION_FORMATTED=""

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -226,7 +226,8 @@ STALE_TRIAGE_SECTION=""
 if [ -f "$STALE_TRIAGE_FILE" ]; then
   if STALE_TRIAGE_SECTION=$(STALE_TRIAGE_FILE="$STALE_TRIAGE_FILE" python3 << 'STALEEOF'
 import json, os
-d = json.load(open(os.environ['STALE_TRIAGE_FILE']))
+with open(os.environ['STALE_TRIAGE_FILE'], encoding='utf-8') as f:
+    d = json.load(f)
 hours = d.get('stale_hours', 48)
 rr = d.get('buckets', {}).get('stale_no_reply_to_rr', [])
 mm = d.get('buckets', {}).get('stale_no_reply_to_message', [])

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -249,7 +249,7 @@ def fmt_bucket(title, action, items, empty_msg):
         if len(reasons) > 60:
             reasons = reasons[:57] + '...'
         pid = r.get('pid', '')
-        pid_redacted = f'****{pid[-4:]}' if len(pid) >= 4 else pid
+        pid_redacted = ('****' + pid[-4:]) if pid else '(no PID)'
         print(f"| `{pid_redacted}` | {r['age_hours']} | {r.get('researcher_messages', 0)} | {reasons} |")
     print('')
     print(f'*Full PID list is in the `stale-triage` workflow artifact (operators only).*')

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -248,15 +248,11 @@ def fmt_bucket(title, action, items, empty_msg):
         reasons = '; '.join(r.get('reasons') or [])
         if len(reasons) > 60:
             reasons = reasons[:57] + '...'
-        print(f"| `{r['pid']}` | {r['age_hours']} | {r.get('researcher_messages', 0)} | {reasons} |")
+        pid = r.get('pid', '')
+        pid_redacted = f'****{pid[-4:]}' if len(pid) >= 4 else pid
+        print(f"| `{pid_redacted}` | {r['age_hours']} | {r.get('researcher_messages', 0)} | {reasons} |")
     print('')
-    pids = ','.join(r['pid'] for r in items)
-    print('<details><summary>PID list for workflow dispatch</summary>')
-    print('')
-    print('```')
-    print(pids)
-    print('```')
-    print('</details>')
+    print(f'*Full PID list is in the `stale-triage` workflow artifact (operators only).*')
     print('')
 
 
@@ -264,17 +260,20 @@ print(f'## Stale AWAITING REVIEW ({hours}h threshold)')
 print('')
 print(f'Live Prolific data, computed at `{d.get("computed_at", "unknown")}`.')
 print('')
+if d.get('fetch_errors', 0) > 0:
+    print(f'> ⚠️ {d["fetch_errors"]} submission(s) could not be classified (message API error) — check the `stale-triage` artifact for details.')
+    print('')
 print(f'**Stale no response to return request:** {len(rr)} | **Stale no response (message only):** {len(mm)} | In window: {len(in_rr) + len(in_mm)}')
 print('')
 fmt_bucket(
     f'Stale no response to return request ({len(rr)})',
     'Prolific auto-APPROVES after the reserve timeout. Reject these.',
     rr,
-    'All return-requested submissions are still within the 48h window or have participant replies. No rejections needed right now.',
+    f'All return-requested submissions are still within the {hours}h window or have participant replies. No rejections needed right now.',
 )
 fmt_bucket(
     f'Stale no response to TABS message ({len(mm)})',
-    'Messaged > 48h ago with no API-level return request yet. Dispatch request-return for these.',
+    f'Messaged > {hours}h ago with no API-level return request yet. Dispatch request-return for these.',
     mm,
     'No untreated stale messages. Messaging pipeline is caught up.',
 )

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -246,6 +246,7 @@ def fmt_bucket(title, action, items, empty_msg):
     print('|---|---:|---:|---|')
     for r in sorted(items, key=lambda x: -x.get('age_hours', 0)):
         reasons = '; '.join(r.get('reasons') or [])
+        reasons = reasons.replace('|', r'\|').replace('\r', '').replace('\n', ' ')
         if len(reasons) > 60:
             reasons = reasons[:57] + '...'
         pid = r.get('pid', '')

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -250,7 +250,7 @@ def fmt_bucket(title, action, items, empty_msg):
             reasons = reasons[:57] + '...'
         pid = r.get('pid', '')
         pid_redacted = ('****' + pid[-4:]) if pid else '(no PID)'
-        print(f"| `{pid_redacted}` | {r['age_hours']} | {r.get('researcher_messages', 0)} | {reasons} |")
+        print(f"| `{pid_redacted}` | {r.get('age_hours', 'unknown')} | {r.get('researcher_messages', 0)} | {reasons} |")
     print('')
     print(f'*Full PID list is in the `stale-triage` workflow artifact (operators only).*')
     print('')

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -224,7 +224,7 @@ fi
 STALE_TRIAGE_FILE="$ARTIFACTS_DIR/stale-triage/stale-triage.json"
 STALE_TRIAGE_SECTION=""
 if [ -f "$STALE_TRIAGE_FILE" ]; then
-  STALE_TRIAGE_SECTION=$(STALE_TRIAGE_FILE="$STALE_TRIAGE_FILE" python3 << 'STALEEOF'
+  if STALE_TRIAGE_SECTION=$(STALE_TRIAGE_FILE="$STALE_TRIAGE_FILE" python3 << 'STALEEOF'
 import json, os
 d = json.load(open(os.environ['STALE_TRIAGE_FILE']))
 hours = d.get('stale_hours', 48)
@@ -278,7 +278,15 @@ fmt_bucket(
     'No untreated stale messages. Messaging pipeline is caught up.',
 )
 STALEEOF
-  ) || STALE_TRIAGE_SECTION=""
+  ); then
+    :
+  else
+    STALE_TRIAGE_SECTION="## Stale AWAITING REVIEW
+
+> ⚠️ Could not render stale triage section (artifact may be corrupted or schema changed).
+> Check the \`stale-triage\` workflow artifact and runner logs for details.
+"
+  fi
 fi
 
 STALE_TRIAGE_SECTION_FORMATTED=""

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -220,6 +220,74 @@ $RECOMMENDATIONS
 "
 fi
 
+# --- Stale AWAITING REVIEW triage (reject vs request-return candidates) ---
+STALE_TRIAGE_FILE="$ARTIFACTS_DIR/stale-triage/stale-triage.json"
+STALE_TRIAGE_SECTION=""
+if [ -f "$STALE_TRIAGE_FILE" ]; then
+  STALE_TRIAGE_SECTION=$(STALE_TRIAGE_FILE="$STALE_TRIAGE_FILE" python3 << 'STALEEOF'
+import json, os
+d = json.load(open(os.environ['STALE_TRIAGE_FILE']))
+hours = d.get('stale_hours', 48)
+rr = d.get('buckets', {}).get('stale_no_reply_to_rr', [])
+mm = d.get('buckets', {}).get('stale_no_reply_to_message', [])
+in_rr = d.get('buckets', {}).get('in_window_rr', [])
+in_mm = d.get('buckets', {}).get('in_window_msg', [])
+
+
+def fmt_bucket(title, action, items, empty_msg):
+    print(f'### {title}')
+    print(f'*{action}*')
+    print('')
+    if not items:
+        print(empty_msg)
+        print('')
+        return
+    print('| PID | Age (h) | Researcher msgs | Reasons |')
+    print('|---|---:|---:|---|')
+    for r in sorted(items, key=lambda x: -x.get('age_hours', 0)):
+        reasons = '; '.join(r.get('reasons') or [])
+        if len(reasons) > 60:
+            reasons = reasons[:57] + '...'
+        print(f"| `{r['pid']}` | {r['age_hours']} | {r.get('researcher_messages', 0)} | {reasons} |")
+    print('')
+    pids = ','.join(r['pid'] for r in items)
+    print('<details><summary>PID list for workflow dispatch</summary>')
+    print('')
+    print('```')
+    print(pids)
+    print('```')
+    print('</details>')
+    print('')
+
+
+print(f'## Stale AWAITING REVIEW ({hours}h threshold)')
+print('')
+print(f'Live Prolific data, computed at `{d.get("computed_at", "unknown")}`.')
+print('')
+print(f'**Stale no response to return request:** {len(rr)} | **Stale no response (message only):** {len(mm)} | In window: {len(in_rr) + len(in_mm)}')
+print('')
+fmt_bucket(
+    f'Stale no response to return request ({len(rr)})',
+    'Prolific auto-APPROVES after the reserve timeout. Reject these.',
+    rr,
+    'All return-requested submissions are still within the 48h window or have participant replies. No rejections needed right now.',
+)
+fmt_bucket(
+    f'Stale no response to TABS message ({len(mm)})',
+    'Messaged > 48h ago with no API-level return request yet. Dispatch request-return for these.',
+    mm,
+    'No untreated stale messages. Messaging pipeline is caught up.',
+)
+STALEEOF
+  ) || STALE_TRIAGE_SECTION=""
+fi
+
+STALE_TRIAGE_SECTION_FORMATTED=""
+if [ -n "$STALE_TRIAGE_SECTION" ]; then
+  STALE_TRIAGE_SECTION_FORMATTED="$STALE_TRIAGE_SECTION
+"
+fi
+
 # Build full reconciliation section (empty string if no data)
 RECONCILIATION_SECTION=""
 if [ -n "$RECONCILIATION_TABLE" ]; then
@@ -279,6 +347,7 @@ $TRIAGE_BREAKDOWN
 
 $RECONCILIATION_SECTION
 $RECOMMENDATIONS_SECTION
+$STALE_TRIAGE_SECTION_FORMATTED
 ## Auto-Approve CLEAN
 
 - **CLEAN dispositions:** $APPROVE_CLEAN_COUNT


### PR DESCRIPTION
## Summary

Prolific auto-**APPROVES** stale AWAITING REVIEW submissions after its reserve timeout, so anyone we messaged or formally requested-return from who never replied will silently get paid unless a human intervenes. This PR surfaces that queue in the daily report and adds a script that operators can run ad hoc.

## What's new

**`scripts/analysis/find_stale_return_requested.py`** — pulls live Prolific data and emits four buckets vs a 48h threshold (configurable via `STALE_HOURS`):

| Bucket | Meaning | Next action |
|---|---|---|
| `stale_no_reply_to_rr` | `return_requested` set >48h ago, no participant reply since | **Reject** |
| `stale_no_reply_to_message` | TABS messaged >48h ago, no API-level return request yet, no reply | **Request-return via API** |
| `in_window_rr` / `in_window_msg` | Still within the 48h window | Leave alone |

Submissions where the message-history API call fails are excluded from all four buckets and reported separately via `fetch_errors`/`fetch_error_details` fields.

Writes a structured summary to `$OUTPUT_JSON_PATH` when set.

**`scripts/analysis/reject_by_pid.py`** *(new)* — backs the new `prolific-reject-by-pid.yml` destructive workflow. Accepts a comma-separated `PID_LIST`, loads each PID's disposition from the triage CSV, and calls the Prolific API to reject it with a per-disposition message and rejection category. Only explicitly handled dispositions are supported (AUTO-EXCLUDE and the modelled FLAG-* variants); unsupported dispositions abort the run.

**`.github/workflows/prolific-reject-by-pid.yml`** *(new, **DESTRUCTIVE**)* — manual-trigger-only workflow for rejecting the stale PIDs surfaced by `find_stale_return_requested.py`. Safety guards:
1. `workflow_dispatch` only (no scheduled/automatic trigger)
2. Defaults to `dry_run: true` (safe preview — no API calls to Prolific)
3. Live rejection requires typing `REJECT` in the confirmation field
4. `PID_LIST` is required — no "reject all" shortcut
5. Unknown PIDs abort the run (no guessing reasons)
6. Full audit trail in workflow logs

**Daily pipeline** — `generate-dashboard` now runs the script with `OUTPUT_JSON_PATH` and uploads `stale-triage` as a 1-day artifact.

**Daily report** — `build-daily-report.sh` renders a new "Stale AWAITING REVIEW (48h threshold)" section with both buckets (PIDs redacted to last-4 in the issue body, age, reasons) and a note pointing operators to the artifact for the full PID list.

**Ad hoc** — `check-participant.yml` gains a `stale-return-requested` mode that runs the same script on demand without the artifact step.

## Why

Found today while triaging: we had 17 AUTO-EXCLUDE / FLAG-\* PIDs messaged and not-replied-to that were not yet in Return Requested state, plus 8 older ones that had been in Return Requested for >48h without reply. Without this visibility, Prolific would auto-approve the stale ones.

## Test plan

- [x] `bash -n scripts/build-daily-report.sh` — syntax OK
- [x] Embedded Python blocks parse cleanly (ast.parse) — OK
- [x] `python3 -c "ast.parse(find_stale_return_requested.py)"` — OK
- [x] Python unit tests — 52 tests pass (15 for `classify_submission`, 10 for `reject_by_pid`)
- [ ] CI green
- [ ] Dispatch `check-participant.yml mode=stale-return-requested` against the live study and confirm both buckets render as expected
- [ ] Verify next daily report issue includes the new section
- [ ] Dry-run `prolific-reject-by-pid.yml` against a known stale PID to confirm per-PID message and category selection

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>