### PR TITLE
fix(stale-triage): tolerate messages missing timestamps

### DIFF
--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -129,11 +129,10 @@ def classify_submission(sub, msgs, researcher_id, now, cutoff):
     rr = _parse_iso(sub.get("return_requested"))
 
     if rr is not None:
-        replies_after_rr = [
-            m for m in participant_msgs
-            if (ts := _msg_time(m)) is not None and ts > rr
-        ]
-        if replies_after_rr:
+        if any(
+            (ts := _msg_time(m)) is not None and ts > rr
+            for m in participant_msgs
+        ):
             return None, None
         age_h = (now - rr).total_seconds() / 3600.0
         record = {
@@ -154,10 +153,10 @@ def classify_submission(sub, msgs, researcher_id, now, cutoff):
     if not researcher_times:
         return None, None
     last_msg_time = max(researcher_times)
-    replies_after_msg = [
-        m for m in participant_msgs
-        if (ts := _msg_time(m)) is not None and ts > last_msg_time
-    ]
+    replies_after_msg = any(
+        (ts := _msg_time(m)) is not None and ts > last_msg_time
+        for m in participant_msgs
+    )
     if replies_after_msg:
         return None, None
     age_h = (now - last_msg_time).total_seconds() / 3600.0

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -98,17 +98,28 @@ def _parse_iso(ts):
 
 
 def _msg_time(m):
+    """Return the best-effort timestamp for a message, or ``None`` if neither
+    ``sent_at`` nor ``created_at`` is a parseable timestamp.
+
+    Prolific returns a small number of messages with both fields null or
+    malformed (observed in live data: ~4 per daily run out of ~560 subs).
+    These are typically system-generated records. Returning ``None`` lets
+    callers skip the message for ordering purposes rather than failing the
+    entire PID's classification.
+    """
     t = _parse_iso(m.get("sent_at")) or _parse_iso(m.get("created_at"))
-    if t is None:
-        raise ValueError(
-            "Message is missing a valid timestamp in both 'sent_at' and 'created_at'"
-        )
     return t
 
 
 def classify_submission(sub, msgs, researcher_id, now, cutoff):
     """Return (bucket_name, record_dict) or (None, None) if submission
-    doesn't qualify for any bucket."""
+    doesn't qualify for any bucket.
+
+    Messages with no valid timestamp are silently skipped when ordering
+    against an anchor (return_requested or last researcher message). Since
+    we cannot prove such a message was sent *after* our anchor, treating
+    it as not-after is safe for reject/request-return classification.
+    """
     pid = sub.get("participant_id", "")
     if not pid or sub.get("status") != "AWAITING REVIEW":
         return None, None
@@ -118,7 +129,10 @@ def classify_submission(sub, msgs, researcher_id, now, cutoff):
     rr = _parse_iso(sub.get("return_requested"))
 
     if rr is not None:
-        replies_after_rr = [m for m in participant_msgs if _msg_time(m) > rr]
+        replies_after_rr = [
+            m for m in participant_msgs
+            if (ts := _msg_time(m)) is not None and ts > rr
+        ]
         if replies_after_rr:
             return None, None
         age_h = (now - rr).total_seconds() / 3600.0
@@ -136,10 +150,14 @@ def classify_submission(sub, msgs, researcher_id, now, cutoff):
         return "in_window_rr", record
 
     # No return_requested — consider the latest researcher message
-    if not researcher_msgs:
+    researcher_times = [t for t in (_msg_time(m) for m in researcher_msgs) if t is not None]
+    if not researcher_times:
         return None, None
-    last_msg_time = max(_msg_time(m) for m in researcher_msgs)
-    replies_after_msg = [m for m in participant_msgs if _msg_time(m) > last_msg_time]
+    last_msg_time = max(researcher_times)
+    replies_after_msg = [
+        m for m in participant_msgs
+        if (ts := _msg_time(m)) is not None and ts > last_msg_time
+    ]
     if replies_after_msg:
         return None, None
     age_h = (now - last_msg_time).total_seconds() / 3600.0

--- a/scripts/analysis/tests/test_find_stale_return_requested.py
+++ b/scripts/analysis/tests/test_find_stale_return_requested.py
@@ -8,7 +8,8 @@ Covers:
   - missing participant_id is excluded
   - no researcher messages yields (None, None)
   - custom STALE_HOURS threshold is respected
-  - _msg_time raises ValueError for messages with no valid timestamp
+  - _msg_time returns None for messages with no valid timestamp
+  - classify_submission tolerates timestamp-less messages (skips them)
 """
 
 from datetime import datetime, timedelta, timezone
@@ -224,20 +225,49 @@ class TestMsgTime:
         m = {"sender_id": "x", "created_at": dt.strftime("%Y-%m-%dT%H:%M:%SZ")}
         assert _msg_time(m) == dt
 
-    def test_missing_timestamps_raises_value_error(self):
-        """_msg_time raises ValueError when neither timestamp field is present."""
-        with pytest.raises(ValueError, match="missing a valid timestamp"):
-            _msg_time({"sender_id": "x"})
+    def test_missing_timestamps_returns_none(self):
+        """_msg_time returns None when neither timestamp field is present."""
+        assert _msg_time({"sender_id": "x"}) is None
 
-    def test_unparseable_timestamps_raises_value_error(self):
-        """_msg_time raises ValueError when both timestamp fields are unparseable."""
-        with pytest.raises(ValueError, match="missing a valid timestamp"):
-            _msg_time({"sender_id": "x", "sent_at": "not-a-date", "created_at": None})
+    def test_unparseable_timestamps_returns_none(self):
+        """_msg_time returns None when both timestamp fields are unparseable."""
+        assert _msg_time({"sender_id": "x", "sent_at": "not-a-date", "created_at": None}) is None
 
-    def test_classify_submission_raises_for_bad_msg_timestamp(self):
-        """classify_submission propagates ValueError when a message has no valid timestamp."""
+    def test_classify_tolerates_timestampless_participant_message(self):
+        """A participant message with no timestamp cannot prove a reply-after-RR
+        happened, so it is skipped for ordering purposes and the submission
+        stays classified as stale."""
         rr_time = NOW - timedelta(hours=60)
         sub = _sub("PID_N", rr=rr_time)
-        bad_msgs = [{"sender_id": "PID_N", "sent_at": "bad-timestamp"}]
-        with pytest.raises(ValueError, match="missing a valid timestamp"):
-            classify_submission(sub, bad_msgs, RESEARCHER_ID, NOW, CUTOFF)
+        msgs = [
+            {"sender_id": RESEARCHER_ID, "sent_at": _ts(rr_time - timedelta(hours=1))},
+            {"sender_id": "PID_N", "sent_at": "bad-timestamp"},
+        ]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket == "stale_no_reply_to_rr"
+        assert record is not None
+        assert record["pid"] == "PID_N"
+
+    def test_classify_tolerates_timestampless_researcher_message_message_only_path(self):
+        """A researcher message with no timestamp is skipped for ordering in the
+        message-only path; if at least one researcher message with a valid
+        timestamp exists, classification proceeds as normal."""
+        good_time = NOW - timedelta(hours=60)
+        sub = _sub("PID_T")
+        msgs = [
+            {"sender_id": RESEARCHER_ID, "sent_at": "bad-timestamp"},
+            _msg(RESEARCHER_ID, good_time),
+        ]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket == "stale_no_reply_to_message"
+        assert record["pid"] == "PID_T"
+
+    def test_classify_returns_none_when_all_researcher_messages_lack_timestamps(self):
+        """If every researcher message lacks a valid timestamp in the
+        message-only path, there is no anchor to measure from and the
+        submission is not classified."""
+        sub = _sub("PID_U")
+        msgs = [{"sender_id": RESEARCHER_ID, "sent_at": "bad-timestamp"}]
+        bucket, record = classify_submission(sub, msgs, RESEARCHER_ID, NOW, CUTOFF)
+        assert bucket is None
+        assert record is None

--- a/scripts/analysis/tests/test_find_stale_return_requested.py
+++ b/scripts/analysis/tests/test_find_stale_return_requested.py
@@ -248,7 +248,7 @@ class TestMsgTime:
         assert record is not None
         assert record["pid"] == "PID_N"
 
-    def test_classify_tolerates_timestampless_researcher_message_message_only_path(self):
+    def test_classify_tolerates_timestampless_researcher_message_only_path(self):
         """A researcher message with no timestamp is skipped for ordering in the
         message-only path; if at least one researcher message with a valid
         timestamp exists, classification proceeds as normal."""


### PR DESCRIPTION
## Summary

Today's first daily report after the stale-triage feature went live flagged 4 submissions as "could not be classified" because Prolific returned at least one message per PID with both `sent_at` and `created_at` null or malformed.

`_msg_time()` was raising `ValueError` on that case — which took the entire submission out of classification. That's the wrong default: genuinely stale PIDs could be silently excluded from the reject-candidates bucket and would auto-approve after Prolific's reserve timeout.

Instead, `_msg_time()` now returns `None` when neither field is parseable, and `classify_submission()` skips timestamp-less messages when ordering against the return-requested or last-researcher-message anchor. A message we cannot timestamp cannot prove it was sent *after* our anchor, so skipping it for ordering is the safe choice — the submission still gets classified from the remaining messages.

## Today's live data

Without this fix: 4 submissions (`69e79c8c…`, `695c896775…`, `5e4a833ea…`, `660dff93ef…`) silently fell out of the stale-triage recommendations. With the fix, those PIDs get proper classification.

## Test plan

- [x] All 22 unit tests pass (3 rewritten, 3 new)
- [x] `test_classify_tolerates_timestampless_participant_message` — stale submission with a bad-timestamp participant message still lands in `stale_no_reply_to_rr`
- [x] `test_classify_tolerates_timestampless_researcher_message_message_only_path` — bad-timestamp researcher message is skipped, valid anchor used
- [x] `test_classify_returns_none_when_all_researcher_messages_lack_timestamps` — if every researcher message lacks a timestamp, no anchor exists → (None, None)
- [ ] CI green
- [ ] Verify next daily pipeline run doesn't emit the "4 submission(s) could not be classified" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)