### PR TITLE
feat(glossary): inline <Term> tooltip component for psychometric terms

### DIFF
--- a/__tests__/components/glossary-term/index.test.tsx
+++ b/__tests__/components/glossary-term/index.test.tsx
@@ -78,6 +78,23 @@ describe('Term', () => {
     expect(screen.getByText('nonexistent-term-xyz')).toBeInTheDocument()
   })
 
+  it('closes when a pointerdown event fires outside the component', () => {
+    render(
+      <div>
+        <Term termId="kmo">KMO</Term>
+        <button type="button" data-testid="outside">
+          Outside
+        </button>
+      </div>
+    )
+    // Open the tooltip
+    fireEvent.click(screen.getAllByRole('button')[0])
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    // Pointer down outside the component closes it
+    fireEvent.pointerDown(screen.getByTestId('outside'))
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
   it('has no accessibility violations in the closed state', async () => {
     const { container } = render(<Term termId="kmo">KMO</Term>)
     const results = await axe(container)

--- a/__tests__/components/glossary-term/index.test.tsx
+++ b/__tests__/components/glossary-term/index.test.tsx
@@ -55,6 +55,32 @@ describe('Term', () => {
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 
+  it('toggles closed on a second click (keyboard/touch — no mouse hover active)', () => {
+    render(<Term termId="rmsea">RMSEA</Term>)
+    const btn = screen.getByRole('button')
+
+    // First click opens (no mouseenter, so mouseInsideRef is false → toggle)
+    fireEvent.click(btn)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // Second click closes (mouseInsideRef still false → toggle again)
+    fireEvent.click(btn)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('does not toggle closed on click when mouse is inside (hover-open scenario)', () => {
+    render(<Term termId="rmsea">RMSEA</Term>)
+    const btn = screen.getByRole('button')
+
+    // Simulate hover opening the popover
+    fireEvent.mouseEnter(btn)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // Click while mouse is still inside should NOT close the popover
+    fireEvent.click(btn)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
   it('sets aria-expanded in sync with open state and opens a dialog', () => {
     render(<Term termId="htmt">HTMT</Term>)
     const btn = screen.getByRole('button')

--- a/__tests__/components/glossary-term/index.test.tsx
+++ b/__tests__/components/glossary-term/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import Term from '@/components/glossary-term'
 
@@ -16,14 +16,14 @@ describe('Term', () => {
     expect(screen.getByRole('button')).toHaveTextContent('KMO')
   })
 
-  it('opens the tooltip on click and renders the short definition', () => {
+  it('opens the dialog on click and renders the short definition', () => {
     render(<Term termId="kmo">KMO</Term>)
     const btn = screen.getByRole('button')
-    expect(screen.queryByRole('tooltip')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
     fireEvent.click(btn)
-    const tip = screen.getByRole('tooltip')
-    expect(tip).toBeInTheDocument()
-    expect(tip).toHaveTextContent(/sampling adequacy for factor analysis/i)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveTextContent(/sampling adequacy for factor analysis/i)
   })
 
   it('includes a link to the full glossary entry when open', () => {
@@ -42,29 +42,50 @@ describe('Term', () => {
     )
     const termBtn = screen.getAllByRole('button')[0]
     fireEvent.focus(termBtn)
-    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
     fireEvent.blur(termBtn)
-    expect(screen.queryByRole('tooltip')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('closes on Escape key', () => {
     render(<Term termId="rmsea">RMSEA</Term>)
     fireEvent.click(screen.getByRole('button'))
-    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
     fireEvent.keyDown(document, { key: 'Escape' })
-    expect(screen.queryByRole('tooltip')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
-  it('sets aria-expanded and aria-describedby in sync with open state', () => {
+  it('sets aria-expanded in sync with open state and opens a dialog', () => {
     render(<Term termId="htmt">HTMT</Term>)
     const btn = screen.getByRole('button')
     expect(btn).toHaveAttribute('aria-expanded', 'false')
-    expect(btn).not.toHaveAttribute('aria-describedby')
+    expect(screen.queryByRole('dialog')).toBeNull()
 
     fireEvent.click(btn)
     expect(btn).toHaveAttribute('aria-expanded', 'true')
-    const tip = screen.getByRole('tooltip')
-    expect(btn).toHaveAttribute('aria-describedby', tip.getAttribute('id')!)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('restores focus to the trigger when Escape is pressed from within the dialog', async () => {
+    render(<Term termId="kmo">KMO</Term>)
+    const btn = screen.getByRole('button')
+
+    // Open the dialog
+    fireEvent.click(btn)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // Move focus to the "See full entry" link inside the dialog
+    const link = screen.getByRole('link', { name: /see full entry/i })
+    act(() => link.focus())
+    expect(link).toHaveFocus()
+
+    // Press Escape — dialog should close and focus should return to trigger
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    await waitFor(() => {
+      expect(btn).toHaveFocus()
+    })
   })
 
   it('falls back to plain text when the termId is not in the glossary', () => {
@@ -87,12 +108,12 @@ describe('Term', () => {
         </button>
       </div>
     )
-    // Open the tooltip
+    // Open the dialog
     fireEvent.click(screen.getAllByRole('button')[0])
-    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
     // Pointer down outside the component closes it
     fireEvent.pointerDown(screen.getByTestId('outside'))
-    expect(screen.queryByRole('tooltip')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('has no accessibility violations in the closed state', async () => {

--- a/__tests__/components/glossary-term/index.test.tsx
+++ b/__tests__/components/glossary-term/index.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import Term from '@/components/glossary-term'
+
+expect.extend(toHaveNoViolations)
+
+describe('Term', () => {
+  it('renders the entry term by default', () => {
+    render(<Term termId="cronbach-alpha" />)
+    expect(screen.getByRole('button')).toHaveTextContent(/Cronbach/i)
+  })
+
+  it('accepts override children as the visible text', () => {
+    render(<Term termId="kmo">KMO</Term>)
+    expect(screen.getByRole('button')).toHaveTextContent('KMO')
+  })
+
+  it('opens the tooltip on click and renders the short definition', () => {
+    render(<Term termId="kmo">KMO</Term>)
+    const btn = screen.getByRole('button')
+    expect(screen.queryByRole('tooltip')).toBeNull()
+    fireEvent.click(btn)
+    const tip = screen.getByRole('tooltip')
+    expect(tip).toBeInTheDocument()
+    expect(tip).toHaveTextContent(/sampling adequacy for factor analysis/i)
+  })
+
+  it('includes a link to the full glossary entry when open', () => {
+    render(<Term termId="kmo">KMO</Term>)
+    fireEvent.click(screen.getByRole('button'))
+    const link = screen.getByRole('link', { name: /see full entry/i })
+    expect(link).toHaveAttribute('href', '/results/glossary#kmo')
+  })
+
+  it('opens on focus and closes on blur when focus leaves entirely', () => {
+    render(
+      <div>
+        <Term termId="htmt">HTMT</Term>
+        <button type="button">After</button>
+      </div>
+    )
+    const termBtn = screen.getAllByRole('button')[0]
+    fireEvent.focus(termBtn)
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    fireEvent.blur(termBtn)
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('closes on Escape key', () => {
+    render(<Term termId="rmsea">RMSEA</Term>)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('sets aria-expanded and aria-describedby in sync with open state', () => {
+    render(<Term termId="htmt">HTMT</Term>)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveAttribute('aria-expanded', 'false')
+    expect(btn).not.toHaveAttribute('aria-describedby')
+
+    fireEvent.click(btn)
+    expect(btn).toHaveAttribute('aria-expanded', 'true')
+    const tip = screen.getByRole('tooltip')
+    expect(btn).toHaveAttribute('aria-describedby', tip.getAttribute('id')!)
+  })
+
+  it('falls back to plain text when the termId is not in the glossary', () => {
+    render(<Term termId="nonexistent-term-xyz">fallback text</Term>)
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.getByText('fallback text')).toBeInTheDocument()
+  })
+
+  it('renders the termId when a missing term has no children', () => {
+    render(<Term termId="nonexistent-term-xyz" />)
+    expect(screen.getByText('nonexistent-term-xyz')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations in the closed state', async () => {
+    const { container } = render(<Term termId="kmo">KMO</Term>)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no accessibility violations in the open state', async () => {
+    const { container } = render(<Term termId="kmo">KMO</Term>)
+    fireEvent.click(screen.getByRole('button'))
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/__tests__/components/glossary-term/index.test.tsx
+++ b/__tests__/components/glossary-term/index.test.tsx
@@ -88,6 +88,29 @@ describe('Term', () => {
     })
   })
 
+  it('closes when focus leaves the component entirely (Tab past the link)', () => {
+    render(
+      <div>
+        <Term termId="kmo">KMO</Term>
+        <button type="button">after</button>
+      </div>
+    )
+    const trigger = screen.getAllByRole('button')[0]
+    // Open via focus on trigger
+    fireEvent.focus(trigger)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // Simulate Tab into the link (focus stays inside container → dialog stays open)
+    const link = screen.getByRole('link', { name: /see full entry/i })
+    fireEvent.blur(trigger, { relatedTarget: link })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // Simulate Tab past the link → relatedTarget is the outside "after" button
+    const after = screen.getAllByRole('button')[1]
+    fireEvent.blur(link, { relatedTarget: after })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
   it('falls back to plain text when the termId is not in the glossary', () => {
     render(<Term termId="nonexistent-term-xyz">fallback text</Term>)
     expect(screen.queryByRole('button')).toBeNull()

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,7 +3492,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -4418,7 +4418,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6640,7 +6640,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -13811,7 +13811,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -13830,7 +13830,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14192,7 +14192,6 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,7 +3492,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -4418,7 +4418,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6640,7 +6640,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -13811,7 +13811,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -13830,7 +13830,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14192,6 +14192,7 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13843,6 +13843,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/results/crp-2026/reliability/page.tsx
+++ b/src/app/results/crp-2026/reliability/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/lib/articleStyles'
 import Link from 'next/link'
 import sensitivityData from '@/data/crp-sensitivity-analysis.json'
+import Term from '@/components/glossary-term'
 export const metadata: Metadata = {
   title: 'CRP 2026 Scale Reliability - TABS',
   description:
@@ -54,7 +55,8 @@ const CrpReliabilityPage = () => {
 
         <section className={SECTION_CLASSES}>
           <p className={PARAGRAPH_CLASSES}>
-            Scale reliability is assessed using Cronbach&rsquo;s alpha (&alpha;), the most widely
+            Scale reliability is assessed using{' '}
+            <Term termId="cronbach-alpha">Cronbach&rsquo;s alpha</Term> (&alpha;), the most widely
             used measure of internal consistency. A coefficient of &alpha; &ge; 0.70 is generally
             considered acceptable for research purposes (Nunnally &amp; Bernstein, 1994), while
             values above 0.80 indicate good to excellent reliability.

--- a/src/app/results/glossary/page.tsx
+++ b/src/app/results/glossary/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/lib/articleStyles'
 import Link from 'next/link'
 import validationData from '@/data/crp-validation.json'
+import { glossaryTerms } from '@/data/glossary-terms'
 export const metadata: Metadata = {
   title: 'Statistics Glossary - TABS Results',
   description:
@@ -52,14 +53,19 @@ type GlossaryEntry = {
   tabsContext?: string
 }
 
-const ENTRIES: GlossaryEntry[] = [
+/**
+ * Page-specific fields: howCalculated, thresholds, and optional tabsContext.
+ * id, term, category, and whatItMeasures are derived from glossary-terms.ts
+ * (the single source of truth for inline-tooltip copy) so they never drift.
+ */
+type GlossaryPageExtra = Omit<GlossaryEntry, 'term' | 'category' | 'whatItMeasures'>
+
+const _termBase = new Map(glossaryTerms.map((g) => [g.id, g]))
+
+const PAGE_EXTRAS: GlossaryPageExtra[] = [
   /* ── Reliability ── */
   {
     id: 'cronbach-alpha',
-    term: "Cronbach's Alpha (α)",
-    category: 'Reliability',
-    whatItMeasures:
-      'Internal consistency reliability - the degree to which all items in a scale measure the same underlying construct. Higher alpha means items are more closely related.',
     howCalculated:
       'α = (k / (k − 1)) × (1 − Σs²ᵢ / s²ₜ), where k = number of items, s²ᵢ = variance of each item, s²ₜ = variance of the total score. TABS also reports the Feldt (1965) 95% confidence interval.',
     thresholds:
@@ -68,10 +74,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'mcdonalds-omega',
-    term: "McDonald's Omega (ω)",
-    category: 'Reliability',
-    whatItMeasures:
-      'Model-based reliability that accounts for varying item-factor loadings. Unlike alpha, which assumes all items contribute equally (tau-equivalent model), omega uses the actual factor loading weights from a single-factor model.',
     howCalculated:
       'ω = (Σλᵢ)² / ((Σλᵢ)² + Σ(1 − λ²ᵢ)), where λᵢ are the standardized factor loadings from a single-factor model. This is equivalent to total reliability omega.',
     thresholds:
@@ -80,10 +82,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'composite-reliability',
-    term: 'Composite Reliability (CR)',
-    category: 'Reliability',
-    whatItMeasures:
-      'The proportion of variance in the composite score that is attributable to the true score. CR is computed from factor loadings and is a key component of construct validity assessment alongside AVE.',
     howCalculated:
       'CR = (Σλᵢ)² / ((Σλᵢ)² + Σε²ᵢ), where λᵢ are standardized factor loadings and ε²ᵢ = 1 − λ²ᵢ are the error variances. Numerically equivalent to omega when computed from the same loadings.',
     thresholds:
@@ -92,10 +90,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'split-half',
-    term: 'Split-Half Reliability',
-    category: 'Reliability',
-    whatItMeasures:
-      'An alternative reliability estimate that splits the scale into two halves (odd-numbered vs even-numbered items), computes the correlation between halves, and adjusts for test length.',
     howCalculated:
       'rₛₕ = 2r / (1 + r), where r is the Pearson correlation between the two half-scores. This is the Spearman-Brown prophecy formula, which estimates what the reliability would be if both halves were combined.',
     thresholds:
@@ -104,10 +98,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'alpha-if-deleted',
-    term: 'Alpha-if-Deleted',
-    category: 'Reliability',
-    whatItMeasures:
-      "What Cronbach's alpha would be if a specific item were removed from the scale. Items whose deletion would increase alpha may be weakening internal consistency.",
     howCalculated:
       "Recompute Cronbach's alpha on the remaining k−1 items for each item in turn. Report the change (Δα) and flag items where deletion would increase alpha.",
     thresholds:
@@ -118,10 +108,6 @@ const ENTRIES: GlossaryEntry[] = [
   /* ── Item Analysis ── */
   {
     id: 'corrected-itc',
-    term: 'Corrected Item-Total Correlation (CITC)',
-    category: 'Item Analysis',
-    whatItMeasures:
-      "The Pearson correlation between each item and the sum of all other items in the scale (excluding that item). This avoids the part-whole correlation inflation that occurs if the item is included in its own total. It measures how well each item 'tracks' with the rest of the scale.",
     howCalculated:
       'For item i, CITCᵢ = r(xᵢ, T₋ᵢ), where T₋ᵢ is the sum of all items except item i.',
     thresholds:
@@ -132,10 +118,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'inter-item-correlation',
-    term: 'Inter-Item Correlation Matrix',
-    category: 'Item Analysis',
-    whatItMeasures:
-      'The full matrix of pairwise Pearson correlations between all items in a scale. Summary statistics (mean, min, max, SD) describe how tightly items cluster together.',
     howCalculated:
       'Standard Pearson r between each pair of items. Summary: mean of all unique pairwise correlations, plus minimum, maximum, and standard deviation.',
     thresholds:
@@ -146,10 +128,6 @@ const ENTRIES: GlossaryEntry[] = [
   /* ── Factor Analysis ── */
   {
     id: 'kmo',
-    term: 'Kaiser-Meyer-Olkin (KMO) Measure',
-    category: 'Factor Analysis',
-    whatItMeasures:
-      'Sampling adequacy for factor analysis. It compares the magnitudes of observed correlations to partial correlations. High KMO means the correlations between variables are largely explained by other variables, making factor analysis appropriate.',
     howCalculated:
       'KMO = ΣΣr²ᵢⱼ / (ΣΣr²ᵢⱼ + ΣΣp²ᵢⱼ), where rᵢⱼ are correlations and pᵢⱼ are partial correlations. Values closer to 1.0 mean factor analysis is more appropriate.',
     thresholds:
@@ -158,10 +136,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'bartlett',
-    term: "Bartlett's Test of Sphericity",
-    category: 'Factor Analysis',
-    whatItMeasures:
-      'Whether the correlation matrix is significantly different from an identity matrix (where all correlations are zero). A significant result means the items share enough variance to support factor analysis.',
     howCalculated:
       'χ² = −(N − 1 − (2k+5)/6) × ln|R|, where N = sample size, k = number of variables, |R| = determinant of the correlation matrix. Tested against a chi-squared distribution with k(k−1)/2 degrees of freedom.',
     thresholds:
@@ -171,10 +145,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'efa',
-    term: 'Exploratory Factor Analysis (EFA)',
-    category: 'Factor Analysis',
-    whatItMeasures:
-      'The underlying latent factor structure of a set of items without imposing a pre-specified model. EFA identifies how many factors the data supports and which items load on each factor.',
     howCalculated:
       'TABS uses Maximum Likelihood (ML) estimation with Promax oblique rotation. ML is preferred for normally-distributed data; Promax allows factors to correlate (appropriate for related constructs). The number of factors is determined by Parallel Analysis, not the Kaiser criterion.',
     thresholds:
@@ -184,10 +154,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'parallel-analysis',
-    term: "Horn's Parallel Analysis",
-    category: 'Factor Analysis',
-    whatItMeasures:
-      'The number of factors to retain in EFA. It compares actual eigenvalues from the data against eigenvalues generated from random data of the same dimensionality. Factors are retained only when actual eigenvalues exceed the random expectation.',
     howCalculated:
       'Generate many (typically 100-1,000) random datasets with the same N and k. Compute eigenvalues for each. Retain factors whose actual eigenvalues exceed the 95th percentile of the random eigenvalues.',
     thresholds:
@@ -196,10 +162,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'cfa',
-    term: 'Confirmatory Factor Analysis (CFA)',
-    category: 'Factor Analysis',
-    whatItMeasures:
-      'Tests whether a pre-specified factor structure fits the observed data. Unlike EFA (which discovers structure), CFA confirms whether a hypothesized model adequately reproduces the observed covariance matrix.',
     howCalculated:
       'Fit a structural equation model where latent factors predict observed items. Estimate factor loadings, error variances, and factor correlations using ML estimation. Evaluate fit using multiple indices (CFI, TLI, RMSEA, SRMR).',
     thresholds:
@@ -210,10 +172,6 @@ const ENTRIES: GlossaryEntry[] = [
   /* ── Validity ── */
   {
     id: 'ave',
-    term: 'Average Variance Extracted (AVE)',
-    category: 'Validity',
-    whatItMeasures:
-      'The proportion of variance in the items that is captured by the latent construct (as opposed to measurement error). AVE is the core measure of convergent validity - whether items converge on their intended construct.',
     howCalculated:
       'AVE = Σλ²ᵢ / k, where λᵢ are the standardized factor loadings and k is the number of items. This is the mean of the squared loadings - the average communality.',
     thresholds:
@@ -222,10 +180,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'htmt',
-    term: 'Heterotrait-Monotrait Ratio (HTMT)',
-    category: 'Validity',
-    whatItMeasures:
-      'Discriminant validity - whether two constructs are empirically distinct. HTMT estimates the correlation between constructs as if they were measured perfectly (correcting for measurement error). Lower values indicate better discrimination.',
     howCalculated:
       'HTMT = mean(heterotrait-heteromethod correlations) / geometric mean of (mean(monotrait-heteromethod correlations) for each construct). Bootstrap confidence intervals (2,000 iterations) are reported for inferential testing.',
     thresholds:
@@ -234,10 +188,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'fornell-larcker',
-    term: 'Fornell-Larcker Criterion',
-    category: 'Validity',
-    whatItMeasures:
-      "Discriminant validity by comparing the square root of each construct's AVE against its correlations with other constructs. If a construct shares more variance with its own items than with another construct, they are discriminant.",
     howCalculated:
       'For each construct pair (A, B): check whether √AVE(A) > |r(A,B)| and √AVE(B) > |r(A,B)|. Both conditions must hold for discriminant validity.',
     thresholds:
@@ -248,10 +198,6 @@ const ENTRIES: GlossaryEntry[] = [
   /* ── Normality ── */
   {
     id: 'shapiro-wilk',
-    term: 'Shapiro-Wilk Test',
-    category: 'Normality',
-    whatItMeasures:
-      'Whether a variable follows a normal distribution. A significant result (p < .05) means the distribution departs significantly from normality.',
     howCalculated:
       'W = (Σaᵢx₍ᵢ₎)² / Σ(xᵢ − x̄)², where x₍ᵢ₎ are the ordered values and aᵢ are tabulated coefficients. W ranges from 0 to 1, with 1 indicating perfect normality.',
     thresholds:
@@ -261,10 +207,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'skewness-kurtosis',
-    term: 'Skewness and Kurtosis',
-    category: 'Normality',
-    whatItMeasures:
-      'Skewness measures distributional asymmetry (0 = symmetric). Kurtosis measures tail heaviness relative to a normal distribution (0 = normal, positive = heavy tails, negative = light tails).',
     howCalculated:
       'Skewness = E[(X−μ)³] / σ³. Kurtosis (excess) = E[(X−μ)⁴] / σ⁴ − 3. Both are standardized moments of the distribution.',
     thresholds:
@@ -276,10 +218,6 @@ const ENTRIES: GlossaryEntry[] = [
   /* ── Additional ── */
   {
     id: 'eigenvalue',
-    term: 'Eigenvalue',
-    category: 'Factor Analysis',
-    whatItMeasures:
-      "The amount of total variance in the items that a single factor accounts for. Each factor's eigenvalue represents its explanatory power. Eigenvalues sum to the number of variables.",
     howCalculated:
       'Computed from the eigendecomposition of the correlation matrix R. The eigenvalue λⱼ for factor j is the sum of squared factor loadings for that factor across all items.',
     thresholds:
@@ -288,10 +226,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'communality',
-    term: 'Communality',
-    category: 'Factor Analysis',
-    whatItMeasures:
-      'The proportion of an item\'s variance that is explained by the extracted factors. It is the item-level analogue of R² - "how much of this item is captured by the factors?"',
     howCalculated:
       'h²ᵢ = Σλ²ᵢⱼ across all retained factors, where λᵢⱼ is the loading of item i on factor j. Equivalently, 1 minus the uniqueness.',
     thresholds:
@@ -301,10 +235,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'variance-explained',
-    term: 'Cumulative Variance Explained',
-    category: 'Factor Analysis',
-    whatItMeasures:
-      'The total percentage of item variance accounted for by all retained factors combined. Higher values mean the factor solution captures more of the systematic variation in the data.',
     howCalculated:
       'Sum of (eigenvalue / k) × 100 for each retained factor, where k is the number of items.',
     thresholds:
@@ -313,10 +243,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'promax',
-    term: 'Promax Rotation',
-    category: 'Factor Analysis',
-    whatItMeasures:
-      'An oblique rotation method for factor analysis that allows extracted factors to be correlated. This is appropriate when the underlying constructs are theoretically related (as opposed to Varimax, which forces orthogonal/uncorrelated factors).',
     howCalculated:
       'Start with a Varimax (orthogonal) rotation, then raise the loadings to a power (kappa, typically 4) and use the resulting matrix as a target for oblique Procrustes rotation. This simplifies the loading pattern while allowing inter-factor correlations.',
     thresholds:
@@ -325,10 +251,6 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'cfi',
-    term: 'Comparative Fit Index (CFI)',
-    category: 'CFA Fit Indices',
-    whatItMeasures:
-      'How much better the hypothesized model fits compared to a null (independence) model where all items are uncorrelated. Ranges from 0 to 1.',
     howCalculated:
       'CFI = 1 − max((χ²ₘ − dfₘ), 0) / max((χ²₀ − df₀), (χ²ₘ − dfₘ), 0), where m = proposed model, 0 = null model.',
     thresholds: '≥ .95 good fit, ≥ .90 acceptable fit (Hu & Bentler, 1999).',
@@ -336,30 +258,18 @@ const ENTRIES: GlossaryEntry[] = [
   },
   {
     id: 'tli',
-    term: 'Tucker-Lewis Index (TLI)',
-    category: 'CFA Fit Indices',
-    whatItMeasures:
-      'Similar to CFI but penalizes model complexity. Values can exceed 1.0 or fall below 0. More conservative than CFI for models with many parameters.',
     howCalculated: 'TLI = ((χ²₀/df₀) − (χ²ₘ/dfₘ)) / ((χ²₀/df₀) − 1).',
     thresholds: '≥ .95 good fit, ≥ .90 acceptable (same as CFI).',
     tabsContext: `Maturity TLI = ${f3(m.cfa.tli)} (excellent). Readiness TLI = ${f3(r.cfa.tli)} (acceptable). Barriers TLI = ${f3(b.cfa.tli)} (poor).`,
   },
   {
     id: 'rmsea',
-    term: 'Root Mean Square Error of Approximation (RMSEA)',
-    category: 'CFA Fit Indices',
-    whatItMeasures:
-      'The average amount of misfit per degree of freedom. It estimates how well the model fits the population covariance matrix (not just the sample). Lower is better.',
     howCalculated: 'RMSEA = √(max((χ²ₘ − dfₘ) / (dfₘ × (N−1)), 0)).',
     thresholds: '≤ .06 good, ≤ .08 acceptable, > .10 poor (Browne & Cudeck, 1993).',
     tabsContext: `Maturity RMSEA = ${f3(m.cfa.rmsea)} (good). Readiness RMSEA = ${f3(r.cfa.rmsea)} (acceptable). Barriers RMSEA = ${f3(b.cfa.rmsea)} (borderline poor).`,
   },
   {
     id: 'srmr',
-    term: 'Standardized Root Mean Square Residual (SRMR)',
-    category: 'CFA Fit Indices',
-    whatItMeasures:
-      'The average discrepancy between the observed and model-implied correlation matrices, standardized to a 0-1 scale. Lower values indicate the model reproduces the correlations more faithfully.',
     howCalculated:
       'SRMR = √(ΣΣ(sᵢⱼ − σ̂ᵢⱼ)² / (k(k+1)/2)), where s and σ̂ are observed and predicted correlations.',
     thresholds:
@@ -368,6 +278,18 @@ const ENTRIES: GlossaryEntry[] = [
       'SRMR is not always available from all estimation methods. When computed, all TABS constructs fall within acceptable ranges.',
   },
 ]
+
+/* ── Derive full ENTRIES from the shared glossary-terms data + page-specific extras ── */
+const ENTRIES: GlossaryEntry[] = PAGE_EXTRAS.map((extra) => {
+  const base = _termBase.get(extra.id)!
+  return {
+    id: base.id,
+    term: base.term,
+    category: base.category,
+    whatItMeasures: base.shortDefinition,
+    ...extra,
+  }
+})
 
 /* ── Group entries by category ── */
 const categories = [...new Set(ENTRIES.map((e) => e.category))]

--- a/src/app/results/glossary/page.tsx
+++ b/src/app/results/glossary/page.tsx
@@ -281,13 +281,17 @@ const PAGE_EXTRAS: GlossaryPageExtra[] = [
 
 /* ── Derive full ENTRIES from the shared glossary-terms data + page-specific extras ── */
 const ENTRIES: GlossaryEntry[] = PAGE_EXTRAS.map((extra) => {
-  const base = _termBase.get(extra.id)!
+  const base = _termBase.get(extra.id)
+  if (!base) {
+    throw new Error(
+      `Glossary configuration error: PAGE_EXTRAS entry "${extra.id}" does not exist in glossaryTerms.`
+    )
+  }
   return {
-    id: base.id,
+    ...extra,
     term: base.term,
     category: base.category,
     whatItMeasures: base.shortDefinition,
-    ...extra,
   }
 })
 

--- a/src/app/results/glossary/page.tsx
+++ b/src/app/results/glossary/page.tsx
@@ -282,12 +282,13 @@ const PAGE_EXTRAS: GlossaryPageExtra[] = [
 /* ── Derive full ENTRIES from the shared glossary-terms data + page-specific extras ── */
 const ENTRIES: GlossaryEntry[] = PAGE_EXTRAS.map((extra) => {
   const base = _termBase.get(extra.id)!
+  // Spread `extra` first so `id` comes through once; static fields from the
+  // shared glossary-terms data then override anything on `extra` if needed.
   return {
-    id: base.id,
+    ...extra,
     term: base.term,
     category: base.category,
     whatItMeasures: base.shortDefinition,
-    ...extra,
   }
 })
 

--- a/src/app/results/reliability/page.tsx
+++ b/src/app/results/reliability/page.tsx
@@ -9,6 +9,7 @@ import {
 import Link from 'next/link'
 import sensitivityData from '@/data/sensitivity-analysis.json'
 import LastUpdated from '@/components/last-updated'
+import Term from '@/components/glossary-term'
 
 export const metadata: Metadata = {
   title: 'Scale Reliability - TABS Results',
@@ -48,7 +49,8 @@ const ReliabilityPage = () => {
 
         <section className={SECTION_CLASSES}>
           <p className={PARAGRAPH_CLASSES}>
-            Scale reliability is assessed using Cronbach&rsquo;s alpha (&alpha;), the most widely
+            Scale reliability is assessed using{' '}
+            <Term termId="cronbach-alpha">Cronbach&rsquo;s alpha</Term> (&alpha;), the most widely
             used measure of internal consistency. A coefficient of &alpha; &ge; 0.70 is generally
             considered acceptable for research purposes (Nunnally &amp; Bernstein, 1994), while
             values above 0.80 indicate good to excellent reliability.

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
 import Link from 'next/link'
 import { glossaryTerms, type GlossaryTermEntry } from '@/data/glossary-terms'
 
@@ -16,7 +17,7 @@ type TermProps = {
    * Useful for rendering short forms (e.g. "KMO") when the entry's `term`
    * is "Kaiser-Meyer-Olkin (KMO) Measure".
    */
-  children?: React.ReactNode
+  children?: ReactNode
   /** Where the "See full entry" link points. Defaults to the canonical glossary. */
   glossaryHref?: string
 }
@@ -37,7 +38,6 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
 
   const [open, setOpen] = useState(false)
   const tooltipId = useId()
-  const buttonRef = useRef<HTMLButtonElement>(null)
   const containerRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
@@ -49,16 +49,16 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
         setOpen(false)
       }
     }
-    const onClickOutside = (e: MouseEvent) => {
+    const onClickOutside = (e: PointerEvent) => {
       if (!containerRef.current?.contains(e.target as Node)) {
         setOpen(false)
       }
     }
     document.addEventListener('keydown', onKey)
-    document.addEventListener('mousedown', onClickOutside)
+    document.addEventListener('pointerdown', onClickOutside)
     return () => {
       document.removeEventListener('keydown', onKey)
-      document.removeEventListener('mousedown', onClickOutside)
+      document.removeEventListener('pointerdown', onClickOutside)
     }
   }, [open])
 
@@ -71,7 +71,6 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
   return (
     <span ref={containerRef} className="relative inline-block">
       <button
-        ref={buttonRef}
         type="button"
         aria-describedby={open ? tooltipId : undefined}
         aria-expanded={open ? 'true' : 'false'}

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -51,6 +51,11 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
   const definitionId = useId()
   const containerRef = useRef<HTMLSpanElement>(null)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // True while the pointer is inside the trigger button or the popover.
+  // Used to suppress click-toggling when hover already controls open state:
+  // mouseenter (hover) fires before click on desktop, so without this guard
+  // a hover+click sequence would open then immediately close the popover.
+  const mouseInsideRef = useRef(false)
 
   const cancelClose = useCallback(() => {
     if (closeTimerRef.current !== null) {
@@ -155,16 +160,27 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
       <button
         type="button"
         aria-haspopup="dialog"
-        aria-expanded={open ? 'true' : 'false'}
+        aria-expanded={open}
         aria-controls={open ? popoverId : undefined}
         aria-describedby={open ? definitionId : undefined}
         className="decoration-dotted decoration-blue-500 underline underline-offset-2 text-current bg-transparent border-0 p-0 cursor-help focus-visible:outline-2 focus-visible:outline-blue-600"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          // When the mouse is inside the component, hover already controls the
+          // open state — suppress toggling so hover+click doesn't close the
+          // popover immediately after hover opened it. For keyboard and touch
+          // (where mouseInsideRef stays false), allow normal toggle behavior.
+          if (mouseInsideRef.current) return
+          setOpen((v) => !v)
+        }}
         onMouseEnter={() => {
+          mouseInsideRef.current = true
           cancelClose()
           setOpen(true)
         }}
-        onMouseLeave={scheduleClose}
+        onMouseLeave={() => {
+          mouseInsideRef.current = false
+          scheduleClose()
+        }}
         onFocus={() => {
           cancelClose()
           setOpen(true)
@@ -180,10 +196,14 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
           aria-labelledby={titleId}
           className="absolute bottom-full left-0 mb-2 w-72 rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-800 shadow-lg z-50"
           onMouseEnter={() => {
+            mouseInsideRef.current = true
             cancelClose()
             setOpen(true)
           }}
-          onMouseLeave={scheduleClose}
+          onMouseLeave={() => {
+            mouseInsideRef.current = false
+            scheduleClose()
+          }}
         >
           <span id={titleId} className="block font-semibold text-blue-900 mb-1">
             {entry.term}

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -138,12 +138,24 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
 
   const display = children ?? entry.term
 
+  // Close when focus exits the entire component. React synthetic onBlur
+  // bubbles, so a blur on either the trigger button or the "See full
+  // entry" link hits this handler; relatedTarget is the element receiving
+  // focus next. If the next focus is outside the container (e.g. the user
+  // Tabs past the link), close the popover. If it's still inside (e.g.
+  // Tab from button into link), leave it open.
+  const handleContainerBlur = (e: React.FocusEvent<HTMLSpanElement>) => {
+    if (!containerRef.current?.contains(e.relatedTarget as Node | null)) {
+      setOpen(false)
+    }
+  }
+
   return (
-    <span ref={containerRef} className="relative inline-block">
+    <span ref={containerRef} className="relative inline-block" onBlur={handleContainerBlur}>
       <button
         type="button"
         aria-haspopup="dialog"
-        aria-expanded={open}
+        aria-expanded={open ? 'true' : 'false'}
         aria-controls={open ? popoverId : undefined}
         aria-describedby={open ? definitionId : undefined}
         className="decoration-dotted decoration-blue-500 underline underline-offset-2 text-current bg-transparent border-0 p-0 cursor-help focus-visible:outline-2 focus-visible:outline-blue-600"
@@ -156,12 +168,6 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
         onFocus={() => {
           cancelClose()
           setOpen(true)
-        }}
-        onBlur={(e) => {
-          // Keep open if focus moved into the popover (e.g. onto the "See full entry" link).
-          if (!containerRef.current?.contains(e.relatedTarget as Node | null)) {
-            setOpen(false)
-          }
         }}
       >
         {display}

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -49,34 +49,66 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
   const popoverId = useId()
   const titleId = useId()
   const containerRef = useRef<HTMLSpanElement>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const closeTooltip = useCallback(({ restoreFocus = false }: { restoreFocus?: boolean } = {}) => {
-    const container = containerRef.current
-    const trigger = container?.querySelector<HTMLButtonElement>('button')
-    const activeElement = document.activeElement
-    const shouldRestoreFocus =
-      restoreFocus &&
-      trigger instanceof HTMLButtonElement &&
-      !!activeElement &&
-      container?.contains(activeElement) &&
-      activeElement !== trigger
-
-    setOpen(false)
-
-    if (!shouldRestoreFocus || !(trigger instanceof HTMLButtonElement)) {
-      return
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
     }
+  }, [])
 
-    // Intercept the programmatic focusin in capture phase so React's
-    // onFocus handler (which would re-open the popover) never fires.
-    const swallowProgrammaticFocus = (event: FocusEvent) => {
-      event.stopPropagation()
-      trigger.removeEventListener('focusin', swallowProgrammaticFocus, true)
+  // Delays closing by 150 ms so the pointer can traverse the mb-2 gap between
+  // the trigger and the popover without unmounting the popover prematurely.
+  // Also skips closing when keyboard focus is still inside the component.
+  const scheduleClose = useCallback(() => {
+    cancelClose()
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null
+      if (!containerRef.current?.contains(document.activeElement)) {
+        setOpen(false)
+      }
+    }, 150)
+  }, [cancelClose])
+
+  const closeTooltip = useCallback(
+    ({ restoreFocus = false }: { restoreFocus?: boolean } = {}) => {
+      cancelClose()
+      const container = containerRef.current
+      const trigger = container?.querySelector<HTMLButtonElement>('button')
+      const activeElement = document.activeElement
+      const shouldRestoreFocus =
+        restoreFocus &&
+        trigger instanceof HTMLButtonElement &&
+        !!activeElement &&
+        container?.contains(activeElement) &&
+        activeElement !== trigger
+
+      setOpen(false)
+
+      if (!shouldRestoreFocus || !(trigger instanceof HTMLButtonElement)) {
+        return
+      }
+
+      // Intercept the programmatic focusin in capture phase so React's
+      // onFocus handler (which would re-open the popover) never fires.
+      const swallowProgrammaticFocus = (event: FocusEvent) => {
+        event.stopPropagation()
+        trigger.removeEventListener('focusin', swallowProgrammaticFocus, true)
+      }
+      trigger.addEventListener('focusin', swallowProgrammaticFocus, true)
+      requestAnimationFrame(() => {
+        trigger.focus()
+      })
+    },
+    [cancelClose]
+  )
+
+  // Cleanup pending timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current)
     }
-    trigger.addEventListener('focusin', swallowProgrammaticFocus, true)
-    requestAnimationFrame(() => {
-      trigger.focus()
-    })
   }, [])
 
   useEffect(() => {
@@ -111,11 +143,18 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
         type="button"
         aria-haspopup="dialog"
         aria-expanded={open ? 'true' : 'false'}
+        aria-controls={open ? popoverId : undefined}
         className="decoration-dotted decoration-blue-500 underline underline-offset-2 text-current bg-transparent border-0 p-0 cursor-help focus-visible:outline-2 focus-visible:outline-blue-600"
         onClick={() => setOpen((v) => !v)}
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        onFocus={() => setOpen(true)}
+        onMouseEnter={() => {
+          cancelClose()
+          setOpen(true)
+        }}
+        onMouseLeave={scheduleClose}
+        onFocus={() => {
+          cancelClose()
+          setOpen(true)
+        }}
         onBlur={(e) => {
           // Keep open if focus moved into the popover (e.g. onto the "See full entry" link).
           if (!containerRef.current?.contains(e.relatedTarget as Node | null)) {
@@ -132,9 +171,11 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
           aria-modal="false"
           aria-labelledby={titleId}
           className="absolute bottom-full left-0 mb-2 w-72 rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-800 shadow-lg z-50"
-          // Keep the popover open while the pointer is over it.
-          onMouseEnter={() => setOpen(true)}
-          onMouseLeave={() => setOpen(false)}
+          onMouseEnter={() => {
+            cancelClose()
+            setOpen(true)
+          }}
+          onMouseLeave={scheduleClose}
         >
           <span id={titleId} className="block font-semibold text-blue-900 mb-1">
             {entry.term}

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -48,6 +48,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
   const [open, setOpen] = useState(false)
   const popoverId = useId()
   const titleId = useId()
+  const definitionId = useId()
   const containerRef = useRef<HTMLSpanElement>(null)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -144,6 +145,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={open ? popoverId : undefined}
+        aria-describedby={open ? definitionId : undefined}
         className="decoration-dotted decoration-blue-500 underline underline-offset-2 text-current bg-transparent border-0 p-0 cursor-help focus-visible:outline-2 focus-visible:outline-blue-600"
         onClick={() => setOpen(true)}
         onMouseEnter={() => {
@@ -180,7 +182,9 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
           <span id={titleId} className="block font-semibold text-blue-900 mb-1">
             {entry.term}
           </span>
-          <span className="block leading-relaxed">{entry.shortDefinition}</span>
+          <span id={definitionId} className="block leading-relaxed">
+            {entry.shortDefinition}
+          </span>
           <Link
             href={`${glossaryHref}#${entry.id}`}
             className="mt-2 inline-block text-xs text-blue-700 hover:underline focus-visible:underline"

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -1,9 +1,17 @@
 'use client'
 
-import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 import { glossaryTerms, type GlossaryTermEntry } from '@/data/glossary-terms'
+
+/**
+ * Note: intentionally separate from src/components/ui/tooltip.tsx.
+ * That component uses role="tooltip" (non-interactive) for icon labels.
+ * This component uses role="dialog" because its popover contains a
+ * focusable "See full entry" link, which ARIA 1.2 prohibits inside
+ * role="tooltip".
+ */
 
 const termLookup: Map<string, GlossaryTermEntry> = new Map(
   glossaryTerms.map((entry) => [entry.id, entry])
@@ -23,35 +31,64 @@ type TermProps = {
 }
 
 /**
- * Inline glossary term with an accessible hover/focus/tap tooltip.
+ * Inline glossary term with an accessible hover/focus/tap popover.
  *
- * Renders as a `<button>` so the tooltip can be triggered by keyboard
- * (focus), mouse (hover), or touch (tap). Escape dismisses. A click
- * outside the button closes it.
+ * Renders as a `<button>` so the popover can be triggered by keyboard
+ * (focus), mouse (hover), or touch (tap). Escape dismisses and restores
+ * focus to the trigger when called from within the popover. A pointerdown
+ * outside the component closes it.
  *
  * If `termId` is not in the glossary data, the component renders its
- * children (or the id) as plain text without a tooltip - no crash and no
+ * children (or the id) as plain text without a popover - no crash and no
  * silent "popover on an unknown term" trap.
  */
 export default function Term({ termId, children, glossaryHref = '/results/glossary' }: TermProps) {
   const entry = useMemo(() => termLookup.get(termId), [termId])
 
   const [open, setOpen] = useState(false)
-  const tooltipId = useId()
+  const popoverId = useId()
+  const titleId = useId()
   const containerRef = useRef<HTMLSpanElement>(null)
+
+  const closeTooltip = useCallback(({ restoreFocus = false }: { restoreFocus?: boolean } = {}) => {
+    const container = containerRef.current
+    const trigger = container?.querySelector<HTMLButtonElement>('button')
+    const activeElement = document.activeElement
+    const shouldRestoreFocus =
+      restoreFocus &&
+      trigger instanceof HTMLButtonElement &&
+      !!activeElement &&
+      container?.contains(activeElement) &&
+      activeElement !== trigger
+
+    setOpen(false)
+
+    if (!shouldRestoreFocus || !(trigger instanceof HTMLButtonElement)) {
+      return
+    }
+
+    // Intercept the programmatic focusin in capture phase so React's
+    // onFocus handler (which would re-open the popover) never fires.
+    const swallowProgrammaticFocus = (event: FocusEvent) => {
+      event.stopPropagation()
+      trigger.removeEventListener('focusin', swallowProgrammaticFocus, true)
+    }
+    trigger.addEventListener('focusin', swallowProgrammaticFocus, true)
+    requestAnimationFrame(() => {
+      trigger.focus()
+    })
+  }, [])
 
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        // Do not re-focus the trigger here - it fires onFocus, which re-opens
-        // the tooltip. The trigger already has focus when Escape is pressed.
-        setOpen(false)
+        closeTooltip({ restoreFocus: true })
       }
     }
     const onClickOutside = (e: PointerEvent) => {
       if (!containerRef.current?.contains(e.target as Node)) {
-        setOpen(false)
+        closeTooltip()
       }
     }
     document.addEventListener('keydown', onKey)
@@ -60,7 +97,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
       document.removeEventListener('keydown', onKey)
       document.removeEventListener('pointerdown', onClickOutside)
     }
-  }, [open])
+  }, [open, closeTooltip])
 
   if (!entry) {
     return <>{children ?? termId}</>
@@ -72,7 +109,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
     <span ref={containerRef} className="relative inline-block">
       <button
         type="button"
-        aria-describedby={open ? tooltipId : undefined}
+        aria-haspopup="dialog"
         aria-expanded={open ? 'true' : 'false'}
         className="decoration-dotted decoration-blue-500 underline underline-offset-2 text-current bg-transparent border-0 p-0 cursor-help focus-visible:outline-2 focus-visible:outline-blue-600"
         onClick={() => setOpen((v) => !v)}
@@ -80,7 +117,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
         onMouseLeave={() => setOpen(false)}
         onFocus={() => setOpen(true)}
         onBlur={(e) => {
-          // Keep open if focus moved into the tooltip (e.g. onto the "See full entry" link).
+          // Keep open if focus moved into the popover (e.g. onto the "See full entry" link).
           if (!containerRef.current?.contains(e.relatedTarget as Node | null)) {
             setOpen(false)
           }
@@ -90,14 +127,18 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
       </button>
       {open && (
         <span
-          id={tooltipId}
-          role="tooltip"
+          id={popoverId}
+          role="dialog"
+          aria-modal="false"
+          aria-labelledby={titleId}
           className="absolute bottom-full left-0 mb-2 w-72 rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-800 shadow-lg z-50"
-          // Keep the tooltip open while the pointer is over it.
+          // Keep the popover open while the pointer is over it.
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
         >
-          <span className="block font-semibold text-blue-900 mb-1">{entry.term}</span>
+          <span id={titleId} className="block font-semibold text-blue-900 mb-1">
+            {entry.term}
+          </span>
           <span className="block leading-relaxed">{entry.shortDefinition}</span>
           <Link
             href={`${glossaryHref}#${entry.id}`}

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -71,7 +71,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
     }, 150)
   }, [cancelClose])
 
-  const closeTooltip = useCallback(
+  const closePopover = useCallback(
     ({ restoreFocus = false }: { restoreFocus?: boolean } = {}) => {
       cancelClose()
       const container = containerRef.current
@@ -115,12 +115,12 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        closeTooltip({ restoreFocus: true })
+        closePopover({ restoreFocus: true })
       }
     }
     const onClickOutside = (e: PointerEvent) => {
       if (!containerRef.current?.contains(e.target as Node)) {
-        closeTooltip()
+        closePopover()
       }
     }
     document.addEventListener('keydown', onKey)
@@ -129,7 +129,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
       document.removeEventListener('keydown', onKey)
       document.removeEventListener('pointerdown', onClickOutside)
     }
-  }, [open, closeTooltip])
+  }, [open, closePopover])
 
   if (!entry) {
     return <>{children ?? termId}</>
@@ -142,7 +142,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
       <button
         type="button"
         aria-haspopup="dialog"
-        aria-expanded={open ? 'true' : 'false'}
+        aria-expanded={open}
         aria-controls={open ? popoverId : undefined}
         className="decoration-dotted decoration-blue-500 underline underline-offset-2 text-current bg-transparent border-0 p-0 cursor-help focus-visible:outline-2 focus-visible:outline-blue-600"
         onClick={() => setOpen(true)}

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import { glossaryTerms, type GlossaryTermEntry } from '@/data/glossary-terms'
+
+const termLookup: Map<string, GlossaryTermEntry> = new Map(
+  glossaryTerms.map((entry) => [entry.id, entry])
+)
+
+type TermProps = {
+  /** Id of the entry in src/data/glossary-terms.ts. */
+  termId: string
+  /**
+   * Optional override for the visible text. Defaults to the entry's `term`.
+   * Useful for rendering short forms (e.g. "KMO") when the entry's `term`
+   * is "Kaiser-Meyer-Olkin (KMO) Measure".
+   */
+  children?: React.ReactNode
+  /** Where the "See full entry" link points. Defaults to the canonical glossary. */
+  glossaryHref?: string
+}
+
+/**
+ * Inline glossary term with an accessible hover/focus/tap tooltip.
+ *
+ * Renders as a `<button>` so the tooltip can be triggered by keyboard
+ * (focus), mouse (hover), or touch (tap). Escape dismisses. A click
+ * outside the button closes it.
+ *
+ * If `termId` is not in the glossary data, the component renders its
+ * children (or the id) as plain text without a tooltip - no crash and no
+ * silent "popover on an unknown term" trap.
+ */
+export default function Term({ termId, children, glossaryHref = '/results/glossary' }: TermProps) {
+  const entry = useMemo(() => termLookup.get(termId), [termId])
+
+  const [open, setOpen] = useState(false)
+  const tooltipId = useId()
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const containerRef = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        // Do not re-focus the trigger here - it fires onFocus, which re-opens
+        // the tooltip. The trigger already has focus when Escape is pressed.
+        setOpen(false)
+      }
+    }
+    const onClickOutside = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onClickOutside)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onClickOutside)
+    }
+  }, [open])
+
+  if (!entry) {
+    return <>{children ?? termId}</>
+  }
+
+  const display = children ?? entry.term
+
+  return (
+    <span ref={containerRef} className="relative inline-block">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-describedby={open ? tooltipId : undefined}
+        aria-expanded={open ? 'true' : 'false'}
+        className="decoration-dotted decoration-blue-500 underline underline-offset-2 text-current bg-transparent border-0 p-0 cursor-help focus-visible:outline-2 focus-visible:outline-blue-600"
+        onClick={() => setOpen((v) => !v)}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={(e) => {
+          // Keep open if focus moved into the tooltip (e.g. onto the "See full entry" link).
+          if (!containerRef.current?.contains(e.relatedTarget as Node | null)) {
+            setOpen(false)
+          }
+        }}
+      >
+        {display}
+      </button>
+      {open && (
+        <span
+          id={tooltipId}
+          role="tooltip"
+          className="absolute bottom-full left-0 mb-2 w-72 rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-800 shadow-lg z-50"
+          // Keep the tooltip open while the pointer is over it.
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+        >
+          <span className="block font-semibold text-blue-900 mb-1">{entry.term}</span>
+          <span className="block leading-relaxed">{entry.shortDefinition}</span>
+          <Link
+            href={`${glossaryHref}#${entry.id}`}
+            className="mt-2 inline-block text-xs text-blue-700 hover:underline focus-visible:underline"
+          >
+            See full entry
+          </Link>
+        </span>
+      )}
+    </span>
+  )
+}

--- a/src/components/glossary-term/index.tsx
+++ b/src/components/glossary-term/index.tsx
@@ -145,7 +145,7 @@ export default function Term({ termId, children, glossaryHref = '/results/glossa
         aria-expanded={open ? 'true' : 'false'}
         aria-controls={open ? popoverId : undefined}
         className="decoration-dotted decoration-blue-500 underline underline-offset-2 text-current bg-transparent border-0 p-0 cursor-help focus-visible:outline-2 focus-visible:outline-blue-600"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen(true)}
         onMouseEnter={() => {
           cancelClose()
           setOpen(true)

--- a/src/data/glossary-terms.ts
+++ b/src/data/glossary-terms.ts
@@ -1,0 +1,185 @@
+export type GlossaryTermEntry = {
+  id: string
+  term: string
+  category: string
+  /** Short definition used in inline tooltips. */
+  shortDefinition: string
+}
+
+export const glossaryTerms: readonly GlossaryTermEntry[] = [
+  {
+    id: 'cronbach-alpha',
+    term: "Cronbach's Alpha (α)",
+    category: 'Reliability',
+    shortDefinition:
+      'Internal consistency reliability - the degree to which all items in a scale measure the same underlying construct. Higher alpha means items are more closely related.',
+  },
+  {
+    id: 'mcdonalds-omega',
+    term: "McDonald's Omega (ω)",
+    category: 'Reliability',
+    shortDefinition:
+      'Model-based reliability that accounts for varying item-factor loadings. Unlike alpha, which assumes all items contribute equally (tau-equivalent model), omega uses the actual factor loading weights from a single-factor model.',
+  },
+  {
+    id: 'composite-reliability',
+    term: 'Composite Reliability (CR)',
+    category: 'Reliability',
+    shortDefinition:
+      'The proportion of variance in the composite score that is attributable to the true score. CR is computed from factor loadings and is a key component of construct validity assessment alongside AVE.',
+  },
+  {
+    id: 'split-half',
+    term: 'Split-Half Reliability',
+    category: 'Reliability',
+    shortDefinition:
+      'An alternative reliability estimate that splits the scale into two halves (odd-numbered vs even-numbered items), computes the correlation between halves, and adjusts for test length.',
+  },
+  {
+    id: 'alpha-if-deleted',
+    term: 'Alpha-if-Deleted',
+    category: 'Reliability',
+    shortDefinition:
+      "What Cronbach's alpha would be if a specific item were removed from the scale. Items whose deletion would increase alpha may be weakening internal consistency.",
+  },
+  {
+    id: 'corrected-itc',
+    term: 'Corrected Item-Total Correlation (CITC)',
+    category: 'Item Analysis',
+    shortDefinition:
+      "The Pearson correlation between each item and the sum of all other items in the scale (excluding that item). This avoids the part-whole correlation inflation that occurs if the item is included in its own total. It measures how well each item 'tracks' with the rest of the scale.",
+  },
+  {
+    id: 'inter-item-correlation',
+    term: 'Inter-Item Correlation Matrix',
+    category: 'Item Analysis',
+    shortDefinition:
+      'The full matrix of pairwise Pearson correlations between all items in a scale. Summary statistics (mean, min, max, SD) describe how tightly items cluster together.',
+  },
+  {
+    id: 'kmo',
+    term: 'Kaiser-Meyer-Olkin (KMO) Measure',
+    category: 'Factor Analysis',
+    shortDefinition:
+      'Sampling adequacy for factor analysis. It compares the magnitudes of observed correlations to partial correlations. High KMO means the correlations between variables are largely explained by other variables, making factor analysis appropriate.',
+  },
+  {
+    id: 'bartlett',
+    term: "Bartlett's Test of Sphericity",
+    category: 'Factor Analysis',
+    shortDefinition:
+      'Whether the correlation matrix is significantly different from an identity matrix (where all correlations are zero). A significant result means the items share enough variance to support factor analysis.',
+  },
+  {
+    id: 'efa',
+    term: 'Exploratory Factor Analysis (EFA)',
+    category: 'Factor Analysis',
+    shortDefinition:
+      'The underlying latent factor structure of a set of items without imposing a pre-specified model. EFA identifies how many factors the data supports and which items load on each factor.',
+  },
+  {
+    id: 'parallel-analysis',
+    term: "Horn's Parallel Analysis",
+    category: 'Factor Analysis',
+    shortDefinition:
+      'The number of factors to retain in EFA. It compares actual eigenvalues from the data against eigenvalues generated from random data of the same dimensionality. Factors are retained only when actual eigenvalues exceed the random expectation.',
+  },
+  {
+    id: 'cfa',
+    term: 'Confirmatory Factor Analysis (CFA)',
+    category: 'Factor Analysis',
+    shortDefinition:
+      'Tests whether a pre-specified factor structure fits the observed data. Unlike EFA (which discovers structure), CFA confirms whether a hypothesized model adequately reproduces the observed covariance matrix.',
+  },
+  {
+    id: 'ave',
+    term: 'Average Variance Extracted (AVE)',
+    category: 'Validity',
+    shortDefinition:
+      'The proportion of variance in the items that is captured by the latent construct (as opposed to measurement error). AVE is the core measure of convergent validity - whether items converge on their intended construct.',
+  },
+  {
+    id: 'htmt',
+    term: 'Heterotrait-Monotrait Ratio (HTMT)',
+    category: 'Validity',
+    shortDefinition:
+      'Discriminant validity - whether two constructs are empirically distinct. HTMT estimates the correlation between constructs as if they were measured perfectly (correcting for measurement error). Lower values indicate better discrimination.',
+  },
+  {
+    id: 'fornell-larcker',
+    term: 'Fornell-Larcker Criterion',
+    category: 'Validity',
+    shortDefinition:
+      "Discriminant validity by comparing the square root of each construct's AVE against its correlations with other constructs. If a construct shares more variance with its own items than with another construct, they are discriminant.",
+  },
+  {
+    id: 'shapiro-wilk',
+    term: 'Shapiro-Wilk Test',
+    category: 'Normality',
+    shortDefinition:
+      'Whether a variable follows a normal distribution. A significant result (p < .05) means the distribution departs significantly from normality.',
+  },
+  {
+    id: 'skewness-kurtosis',
+    term: 'Skewness and Kurtosis',
+    category: 'Normality',
+    shortDefinition:
+      'Skewness measures distributional asymmetry (0 = symmetric). Kurtosis measures tail heaviness relative to a normal distribution (0 = normal, positive = heavy tails, negative = light tails).',
+  },
+  {
+    id: 'eigenvalue',
+    term: 'Eigenvalue',
+    category: 'Factor Analysis',
+    shortDefinition:
+      "The amount of total variance in the items that a single factor accounts for. Each factor's eigenvalue represents its explanatory power. Eigenvalues sum to the number of variables.",
+  },
+  {
+    id: 'communality',
+    term: 'Communality',
+    category: 'Factor Analysis',
+    shortDefinition:
+      "The proportion of an item's variance that is explained by the extracted factors. It is the item-level analogue of R² - how much of this item is captured by the factors.",
+  },
+  {
+    id: 'variance-explained',
+    term: 'Cumulative Variance Explained',
+    category: 'Factor Analysis',
+    shortDefinition:
+      'The total percentage of item variance accounted for by all retained factors combined. Higher values mean the factor solution captures more of the systematic variation in the data.',
+  },
+  {
+    id: 'promax',
+    term: 'Promax Rotation',
+    category: 'Factor Analysis',
+    shortDefinition:
+      'An oblique rotation method for factor analysis that allows extracted factors to be correlated. This is appropriate when the underlying constructs are theoretically related (as opposed to Varimax, which forces orthogonal/uncorrelated factors).',
+  },
+  {
+    id: 'cfi',
+    term: 'Comparative Fit Index (CFI)',
+    category: 'CFA Fit Indices',
+    shortDefinition:
+      'How much better the hypothesized model fits compared to a null (independence) model where all items are uncorrelated. Ranges from 0 to 1.',
+  },
+  {
+    id: 'tli',
+    term: 'Tucker-Lewis Index (TLI)',
+    category: 'CFA Fit Indices',
+    shortDefinition:
+      'Similar to CFI but penalizes model complexity. Values can exceed 1.0 or fall below 0. More conservative than CFI for models with many parameters.',
+  },
+  {
+    id: 'rmsea',
+    term: 'Root Mean Square Error of Approximation (RMSEA)',
+    category: 'CFA Fit Indices',
+    shortDefinition:
+      'The average amount of misfit per degree of freedom. It estimates how well the model fits the population covariance matrix (not just the sample). Lower is better.',
+  },
+  {
+    id: 'srmr',
+    term: 'Standardized Root Mean Square Residual (SRMR)',
+    category: 'CFA Fit Indices',
+    shortDefinition:
+      'The average discrepancy between the observed and model-implied correlation matrices, standardized to a 0-1 scale. Lower values indicate the model reproduces the correlations more faithfully.',
+  },
+] as const

--- a/src/data/glossary-terms.ts
+++ b/src/data/glossary-terms.ts
@@ -6,7 +6,7 @@ export type GlossaryTermEntry = {
   shortDefinition: string
 }
 
-export const glossaryTerms: readonly GlossaryTermEntry[] = [
+export const glossaryTerms = [
   {
     id: 'cronbach-alpha',
     term: "Cronbach's Alpha (α)",
@@ -182,4 +182,4 @@ export const glossaryTerms: readonly GlossaryTermEntry[] = [
     shortDefinition:
       'The average discrepancy between the observed and model-implied correlation matrices, standardized to a 0-1 scale. Lower values indicate the model reproduces the correlations more faithfully.',
   },
-] as const
+] satisfies readonly GlossaryTermEntry[]

--- a/tests/glossary-term.spec.ts
+++ b/tests/glossary-term.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Glossary Term inline-popover E2E tests.
+ *
+ * Covers the Cronbach's alpha Term component wired on /results/reliability
+ * (the first production page to use the <Term> component).
+ */
+
+test.describe('Glossary Term popover on /results/reliability', () => {
+  test('opens on hover and closes on Escape', async ({ page }) => {
+    await page.goto('/results/reliability')
+
+    // Find the Cronbach's alpha trigger button
+    const triggerButton = page.getByRole('button', { name: /cronbach/i }).first()
+    await expect(triggerButton).toBeVisible()
+
+    // Hover to open the popover
+    await triggerButton.hover()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // Dialog should contain the short definition
+    await expect(dialog).toContainText(/internal consistency/i)
+
+    // Press Escape to close
+    await page.keyboard.press('Escape')
+    await expect(dialog).not.toBeVisible()
+  })
+
+  test('opens on click and closes on click outside', async ({ page }) => {
+    await page.goto('/results/reliability')
+
+    const triggerButton = page.getByRole('button', { name: /cronbach/i }).first()
+    await triggerButton.click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // Click somewhere outside the component (the page heading)
+    await page.locator('h1').click()
+    await expect(dialog).not.toBeVisible()
+  })
+
+  test('includes a working link to the full glossary entry', async ({ page }) => {
+    await page.goto('/results/reliability')
+
+    const triggerButton = page.getByRole('button', { name: /cronbach/i }).first()
+    await triggerButton.hover()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const link = dialog.getByRole('link', { name: /see full entry/i })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute('href', /\/results\/glossary#cronbach-alpha/)
+  })
+})

--- a/tests/glossary-term.spec.ts
+++ b/tests/glossary-term.spec.ts
@@ -17,7 +17,7 @@ test.describe('Glossary Term popover on /results/reliability', () => {
 
     // Hover to open the popover
     await triggerButton.hover()
-    const dialog = page.getByRole('dialog')
+    const dialog = page.getByRole('dialog', { name: /cronbach/i })
     await expect(dialog).toBeVisible()
 
     // Dialog should contain the short definition
@@ -34,18 +34,27 @@ test.describe('Glossary Term popover on /results/reliability', () => {
     const triggerButton = page.getByRole('button', { name: /cronbach/i }).first()
     await triggerButton.click()
 
-    const dialog = page.getByRole('dialog')
+    const dialog = page.getByRole('dialog', { name: /cronbach/i })
     await expect(dialog).toBeVisible()
 
-    // Click somewhere outside the component. The popover opens ABOVE the
-    // trigger (`bottom-full left-0`), so the h1 directly above the
-    // Cronbach's alpha paragraph ends up covered by the dialog. Dispatch a
-    // raw pointerdown at a known-safe coordinate (far below the popover)
-    // which matches the outside-click contract the component actually
-    // listens for.
-    await page.mouse.move(5, 500)
-    await page.mouse.down()
-    await page.mouse.up()
+    // Click somewhere outside the component using a layout-aware position.
+    // The popover opens ABOVE the trigger (`bottom-full left-0`), so we
+    // derive a point below the trigger that is clear of both the trigger
+    // and the popover without relying on hard-coded viewport coordinates.
+    const triggerBox = await triggerButton.boundingBox()
+    const body = page.locator('body')
+    const bodyBox = await body.boundingBox()
+
+    expect(triggerBox).not.toBeNull()
+    expect(bodyBox).not.toBeNull()
+
+    const clickX = Math.max(1, Math.min(10, bodyBox!.width - 1))
+    const clickY = Math.min(
+      bodyBox!.height - 1,
+      Math.max(triggerBox!.y + triggerBox!.height + 24, 1)
+    )
+
+    await body.click({ position: { x: clickX, y: clickY } })
     await expect(dialog).not.toBeVisible()
   })
 
@@ -55,7 +64,7 @@ test.describe('Glossary Term popover on /results/reliability', () => {
     const triggerButton = page.getByRole('button', { name: /cronbach/i }).first()
     await triggerButton.hover()
 
-    const dialog = page.getByRole('dialog')
+    const dialog = page.getByRole('dialog', { name: /cronbach/i })
     await expect(dialog).toBeVisible()
 
     const link = dialog.getByRole('link', { name: /see full entry/i })

--- a/tests/glossary-term.spec.ts
+++ b/tests/glossary-term.spec.ts
@@ -53,6 +53,9 @@ test.describe('Glossary Term popover on /results/reliability', () => {
 
     const link = dialog.getByRole('link', { name: /see full entry/i })
     await expect(link).toBeVisible()
-    await expect(link).toHaveAttribute('href', /\/results\/glossary#cronbach-alpha/)
+    // Next.js static export adds a trailing slash before fragments, so
+    // /results/glossary#cronbach-alpha is rewritten to
+    // /results/glossary/#cronbach-alpha. Accept either form.
+    await expect(link).toHaveAttribute('href', /\/results\/glossary\/?#cronbach-alpha/)
   })
 })

--- a/tests/glossary-term.spec.ts
+++ b/tests/glossary-term.spec.ts
@@ -37,8 +37,15 @@ test.describe('Glossary Term popover on /results/reliability', () => {
     const dialog = page.getByRole('dialog')
     await expect(dialog).toBeVisible()
 
-    // Click somewhere outside the component (the page heading)
-    await page.locator('h1').click()
+    // Click somewhere outside the component. The popover opens ABOVE the
+    // trigger (`bottom-full left-0`), so the h1 directly above the
+    // Cronbach's alpha paragraph ends up covered by the dialog. Dispatch a
+    // raw pointerdown at a known-safe coordinate (far below the popover)
+    // which matches the outside-click contract the component actually
+    // listens for.
+    await page.mouse.move(5, 500)
+    await page.mouse.down()
+    await page.mouse.up()
     await expect(dialog).not.toBeVisible()
   })
 


### PR DESCRIPTION
Partially addresses #1780 — the `<Term>` component is fully implemented and wired on both reliability pages; remaining pages are tracked as follow-ups below.

## Summary

Adds an inline `<Term>` component that shows a glossary definition in a popover on hover / focus / tap for terms like Cronbach's α, KMO, HTMT, CFI, RMSEA, AVE. Keeps readers in the flow of the results pages instead of sending them to `/results/glossary` and back.

## What changed

- `src/data/glossary-terms.ts` (new) — single source of truth for inline popover copy. 25 entries extracted from the existing `/results/glossary` page.
- `src/components/glossary-term/` (new) — the `<Term termId="...">` component.
  - Renders as a `<button>` with a dotted underline
  - Opens on hover, focus, or tap; closes on blur / Esc / click-outside
  - **`role="dialog"`** (not `role="tooltip"`) — the popover contains a focusable "See full entry" link, which ARIA 1.2 forbids inside `role="tooltip"`. This is intentional.
  - `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`, and `aria-describedby` wired in
  - Click **toggles** open/closed when activated by keyboard or touch; click is a no-op when the mouse is hovering (hover already controls open state, preventing a hover+click race that would immediately close the popover)
  - Falls back to plain text when `termId` isn't in the glossary (typo-safe)
- `__tests__/components/glossary-term/` (new) — 16 tests including two jest-axe a11y checks (open and closed), toggle-on-click, and hover-suppresses-toggle. All pass.
- Wired Cronbach's alpha on `/results/reliability` and `/results/crp-2026/reliability` to demonstrate the pattern.

## Test plan

- [x] 16/16 unit tests pass (`jest __tests__/components/glossary-term`)
- [x] jest-axe passes in both closed and open states
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — both reliability pages prerender
- [ ] CI green
- [ ] Playwright: hover on Cronbach's alpha on `/results/reliability` reveals popover; Esc closes

## Follow-up scope (future PRs)

- Wrap additional terms on `/results/factor-analysis`, `/results/validation`, and `/results/crp-2026/*` counterparts (mechanical)
- Consider a `<TermList>` bibliography-style index for pages with many terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)