### PR TITLE
fix(nav): add Featured Visualizations group to Home sidebar

### DIFF
--- a/src/data/sidebar-navigation.ts
+++ b/src/data/sidebar-navigation.ts
@@ -321,7 +321,15 @@ export const sidebarSections: SidebarSection[] = [
     label: 'Home',
     icon: '🏠',
     href: '/',
-    groups: [],
+    groups: [
+      {
+        title: 'Featured Visualizations',
+        links: [
+          { title: 'Mind Maps Gallery', href: '/making-of-tabs/mind-maps' },
+          { title: 'Full Mind Map', href: '/making-of-tabs/mind-maps/full-mind-map' },
+        ],
+      },
+    ],
   },
   {
     id: 'survey',


### PR DESCRIPTION
## Summary

Fixes the last remaining piece of #1788: the Mind Maps gallery isn't reachable from the Home sidebar in one click.

Closes #1788.

## Context

PR #1773 already added a dynamic **Mind Maps** group to the Making-of-TABS sidebar section (via `makingOfTabsSeries` + a case in `makingOfTabsToGroups`). Combined with the existing auto-expand effect in `Sidebar` (`src/components/sidebar/index.tsx:155-168`), that satisfies two of the three #1788 requirements:

- ✅ Mind Maps accordion auto-opens on any `/making-of-tabs/mind-maps/*` route.
- ✅ Users browsing the Making-of-TABS section see Mind Maps in the sidebar.

What was still missing: **from Home** (where `activeSection = 'home'` and `groups = []`), the sidebar showed nothing at all, so users had to switch sections before they could reach Mind Maps.

## Fix

Add a small **Featured Visualizations** group to the Home section with direct links to:

- Mind Maps Gallery (`/making-of-tabs/mind-maps`)
- Full Mind Map (`/making-of-tabs/mind-maps/full-mind-map`)

One-line data change in `src/data/sidebar-navigation.ts`. No sidebar-component change needed.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 564 tests pass (55 suites)
- [x] `npm run build` — static export succeeds, 268 pages generated
- [ ] Manual QA: from `/`, confirm "Featured Visualizations" group is visible with both links working
- [ ] Manual QA: confirm no regression on other sections (Survey, Results, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)