### PR TITLE
fix(mind-maps): remove breakout wrapper, add fullscreen toggle, finer wheel zoom

### DIFF
--- a/__tests__/components/mind-maps/mind-map-viewer.test.tsx
+++ b/__tests__/components/mind-maps/mind-map-viewer.test.tsx
@@ -67,33 +67,50 @@ describe('MindMapViewer', () => {
     const { container } = render(<MindMapViewer {...defaultProps} />)
     const section = container.querySelector('section')!
 
-    // Simulate entering fullscreen: make document.fullscreenElement return the section
-    Object.defineProperty(document, 'fullscreenElement', {
-      configurable: true,
-      get: () => section,
-    })
-    act(() => {
-      document.dispatchEvent(new Event('fullscreenchange'))
-    })
-
-    expect(screen.getByRole('button', { name: /exit fullscreen/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
+    const hadOwnFullscreenElement = Object.prototype.hasOwnProperty.call(
+      document,
+      'fullscreenElement'
+    )
+    const originalFullscreenElementDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      'fullscreenElement'
     )
 
-    // Simulate exiting fullscreen
-    Object.defineProperty(document, 'fullscreenElement', {
-      configurable: true,
-      get: () => null,
-    })
-    act(() => {
-      document.dispatchEvent(new Event('fullscreenchange'))
-    })
+    try {
+      // Simulate entering fullscreen: make document.fullscreenElement return the section
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => section,
+      })
+      act(() => {
+        document.dispatchEvent(new Event('fullscreenchange'))
+      })
 
-    expect(screen.getByRole('button', { name: /enter fullscreen/i })).toHaveAttribute(
-      'aria-pressed',
-      'false'
-    )
+      expect(screen.getByRole('button', { name: /exit fullscreen/i })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      )
+
+      // Simulate exiting fullscreen
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => null,
+      })
+      act(() => {
+        document.dispatchEvent(new Event('fullscreenchange'))
+      })
+
+      expect(screen.getByRole('button', { name: /enter fullscreen/i })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      )
+    } finally {
+      if (hadOwnFullscreenElement && originalFullscreenElementDescriptor) {
+        Object.defineProperty(document, 'fullscreenElement', originalFullscreenElementDescriptor)
+      } else {
+        delete (document as Document & { fullscreenElement?: Element | null }).fullscreenElement
+      }
+    }
   })
 
   it('has no accessibility violations', async () => {

--- a/__tests__/components/mind-maps/mind-map-viewer.test.tsx
+++ b/__tests__/components/mind-maps/mind-map-viewer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import MindMapViewer, {
   computeFitTransform,
@@ -50,10 +50,50 @@ describe('MindMapViewer', () => {
 
   it('exposes zoom controls as a labelled toolbar', () => {
     render(<MindMapViewer {...defaultProps} />)
-    expect(screen.getByRole('toolbar', { name: /zoom controls/i })).toBeInTheDocument()
+    expect(screen.getByRole('toolbar', { name: /mind map controls/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /zoom in/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /zoom out/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument()
+  })
+
+  it('renders the fullscreen button with aria-pressed="false" by default', () => {
+    render(<MindMapViewer {...defaultProps} />)
+    const btn = screen.getByRole('button', { name: /enter fullscreen/i })
+    expect(btn).toBeInTheDocument()
+    expect(btn).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('updates the fullscreen button label and aria-pressed on fullscreenchange', () => {
+    const { container } = render(<MindMapViewer {...defaultProps} />)
+    const section = container.querySelector('section')!
+
+    // Simulate entering fullscreen: make document.fullscreenElement return the section
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => section,
+    })
+    act(() => {
+      document.dispatchEvent(new Event('fullscreenchange'))
+    })
+
+    expect(screen.getByRole('button', { name: /exit fullscreen/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+
+    // Simulate exiting fullscreen
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => null,
+    })
+    act(() => {
+      document.dispatchEvent(new Event('fullscreenchange'))
+    })
+
+    expect(screen.getByRole('button', { name: /enter fullscreen/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
   })
 
   it('has no accessibility violations', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,7 +3492,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -4418,7 +4418,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6640,7 +6640,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -13811,7 +13811,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -13830,7 +13830,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14192,7 +14192,6 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,7 +3492,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -4418,7 +4418,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6640,7 +6640,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -13811,7 +13811,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -13830,7 +13830,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14192,6 +14192,7 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {

--- a/src/app/making-of-tabs/mind-maps/business-management-models/page.tsx
+++ b/src/app/making-of-tabs/mind-maps/business-management-models/page.tsx
@@ -35,14 +35,11 @@ const BusinessManagementModelsPage = () => {
         </p>
       </article>
 
-      {/* Break out of the making-of-tabs max-w-4xl container so the cut has viewport-wide room. */}
-      <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip">
-        <MindMapViewer
-          src="/Svgs/mind-maps/business-management-models.svg"
-          alt="Business Management Models cut of the TABS mind map."
-          ariaLabel="TABS mind map cut: Business Management Models"
-        />
-      </div>
+      <MindMapViewer
+        src="/Svgs/mind-maps/business-management-models.svg"
+        alt="Business Management Models cut of the TABS mind map."
+        ariaLabel="TABS mind map cut: Business Management Models"
+      />
     </div>
   )
 }

--- a/src/app/making-of-tabs/mind-maps/culminating-research-project/page.tsx
+++ b/src/app/making-of-tabs/mind-maps/culminating-research-project/page.tsx
@@ -35,14 +35,11 @@ const CulminatingResearchProjectPage = () => {
         </p>
       </article>
 
-      {/* Break out of the making-of-tabs max-w-4xl container so the cut has viewport-wide room. */}
-      <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip">
-        <MindMapViewer
-          src="/Svgs/mind-maps/culminating-research-project.svg"
-          alt="Culminating Research Project Workflow cut of the TABS mind map."
-          ariaLabel="TABS mind map cut: Culminating Research Project Workflow"
-        />
-      </div>
+      <MindMapViewer
+        src="/Svgs/mind-maps/culminating-research-project.svg"
+        alt="Culminating Research Project Workflow cut of the TABS mind map."
+        ariaLabel="TABS mind map cut: Culminating Research Project Workflow"
+      />
     </div>
   )
 }

--- a/src/app/making-of-tabs/mind-maps/enterprise-it-architecture/page.tsx
+++ b/src/app/making-of-tabs/mind-maps/enterprise-it-architecture/page.tsx
@@ -35,14 +35,11 @@ const EnterpriseItArchitecturePage = () => {
         </p>
       </article>
 
-      {/* Break out of the making-of-tabs max-w-4xl container so the cut has viewport-wide room. */}
-      <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip">
-        <MindMapViewer
-          src="/Svgs/mind-maps/enterprise-it-architecture.svg"
-          alt="Enterprise & IT Architecture cut of the TABS mind map."
-          ariaLabel="TABS mind map cut: Enterprise & IT Architecture"
-        />
-      </div>
+      <MindMapViewer
+        src="/Svgs/mind-maps/enterprise-it-architecture.svg"
+        alt="Enterprise & IT Architecture cut of the TABS mind map."
+        ariaLabel="TABS mind map cut: Enterprise & IT Architecture"
+      />
     </div>
   )
 }

--- a/src/app/making-of-tabs/mind-maps/full-mind-map/page.tsx
+++ b/src/app/making-of-tabs/mind-maps/full-mind-map/page.tsx
@@ -32,15 +32,11 @@ const FullMindMapPage = () => {
         </p>
       </article>
 
-      {/* Break out of the making-of-tabs max-w-4xl container so the full map
-          has viewport-wide room to render at a readable default zoom. */}
-      <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip">
-        <MindMapViewer
-          src="/Svgs/mind-maps/full-mind-map.svg"
-          alt="TABS full mind map showing technology adoption frameworks, models, standards, website operations, and the culminating research project workflow."
-          ariaLabel="TABS full mind map"
-        />
-      </div>
+      <MindMapViewer
+        src="/Svgs/mind-maps/full-mind-map.svg"
+        alt="TABS full mind map showing technology adoption frameworks, models, standards, website operations, and the culminating research project workflow."
+        ariaLabel="TABS full mind map"
+      />
     </div>
   )
 }

--- a/src/app/making-of-tabs/mind-maps/it-management-models/page.tsx
+++ b/src/app/making-of-tabs/mind-maps/it-management-models/page.tsx
@@ -34,14 +34,11 @@ const ItManagementModelsPage = () => {
         </p>
       </article>
 
-      {/* Break out of the making-of-tabs max-w-4xl container so the cut has viewport-wide room. */}
-      <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip">
-        <MindMapViewer
-          src="/Svgs/mind-maps/it-management-models.svg"
-          alt="IT & IT Management Models cut of the TABS mind map."
-          ariaLabel="TABS mind map cut: IT & IT Management Models"
-        />
-      </div>
+      <MindMapViewer
+        src="/Svgs/mind-maps/it-management-models.svg"
+        alt="IT & IT Management Models cut of the TABS mind map."
+        ariaLabel="TABS mind map cut: IT & IT Management Models"
+      />
     </div>
   )
 }

--- a/src/app/making-of-tabs/mind-maps/project-program-risk-management/page.tsx
+++ b/src/app/making-of-tabs/mind-maps/project-program-risk-management/page.tsx
@@ -35,14 +35,11 @@ const ProjectProgramRiskManagementPage = () => {
         </p>
       </article>
 
-      {/* Break out of the making-of-tabs max-w-4xl container so the cut has viewport-wide room. */}
-      <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip">
-        <MindMapViewer
-          src="/Svgs/mind-maps/project-program-risk-management.svg"
-          alt="Project, Program & Risk Management cut of the TABS mind map."
-          ariaLabel="TABS mind map cut: Project, Program & Risk Management"
-        />
-      </div>
+      <MindMapViewer
+        src="/Svgs/mind-maps/project-program-risk-management.svg"
+        alt="Project, Program & Risk Management cut of the TABS mind map."
+        ariaLabel="TABS mind map cut: Project, Program & Risk Management"
+      />
     </div>
   )
 }

--- a/src/app/making-of-tabs/mind-maps/standards-regulations/page.tsx
+++ b/src/app/making-of-tabs/mind-maps/standards-regulations/page.tsx
@@ -36,14 +36,11 @@ const StandardsRegulationsPage = () => {
         </p>
       </article>
 
-      {/* Break out of the making-of-tabs max-w-4xl container so the cut has viewport-wide room. */}
-      <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip">
-        <MindMapViewer
-          src="/Svgs/mind-maps/standards-regulations.svg"
-          alt="Standards & Regulations cut of the TABS mind map."
-          ariaLabel="TABS mind map cut: Standards & Regulations"
-        />
-      </div>
+      <MindMapViewer
+        src="/Svgs/mind-maps/standards-regulations.svg"
+        alt="Standards & Regulations cut of the TABS mind map."
+        ariaLabel="TABS mind map cut: Standards & Regulations"
+      />
     </div>
   )
 }

--- a/src/app/making-of-tabs/mind-maps/tabs-project-operations/page.tsx
+++ b/src/app/making-of-tabs/mind-maps/tabs-project-operations/page.tsx
@@ -35,14 +35,11 @@ const TabsProjectOperationsPage = () => {
         </p>
       </article>
 
-      {/* Break out of the making-of-tabs max-w-4xl container so the cut has viewport-wide room. */}
-      <div className="relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip">
-        <MindMapViewer
-          src="/Svgs/mind-maps/tabs-project-operations.svg"
-          alt="TABS Project Operations cut of the TABS mind map."
-          ariaLabel="TABS mind map cut: TABS Project Operations"
-        />
-      </div>
+      <MindMapViewer
+        src="/Svgs/mind-maps/tabs-project-operations.svg"
+        alt="TABS Project Operations cut of the TABS mind map."
+        ariaLabel="TABS mind map cut: TABS Project Operations"
+      />
     </div>
   )
 }

--- a/src/components/mind-maps/mind-map-viewer.tsx
+++ b/src/components/mind-maps/mind-map-viewer.tsx
@@ -29,8 +29,12 @@ export const INITIAL_SCALE = 0.08
 export const MIN_SCALE = 0.02
 /** Hard ceiling: 4× is sufficient to read leaf-level text in the exported map. */
 export const MAX_SCALE = 4
-/** Fraction of the current scale added/removed per mouse-wheel tick. */
-export const WHEEL_STEP = 0.1
+/**
+ * Fraction of the current scale added/removed per mouse-wheel tick.
+ * Kept small so a single scroll notch produces a gentle zoom change rather
+ * than a big jump. With step=0.03 each notch multiplies the scale by ~1.03.
+ */
+export const WHEEL_STEP = 0.03
 
 const fitScaleFor = (
   wrapperWidth: number,
@@ -67,7 +71,9 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
   const transformRef = useRef<ReactZoomPanPinchRef | null>(null)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const imgRef = useRef<HTMLImageElement | null>(null)
+  const containerRef = useRef<HTMLElement | null>(null)
   const [svgDimensions, setSvgDimensions] = useState<SvgDimensions | null>(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
 
   const syncSvgDimensions = useCallback(() => {
     const img = imgRef.current
@@ -130,17 +136,49 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
   // Handle the gesture ourselves so it matches the Reset button.
   const handleDoubleClick = () => fitToWrapper(200)
 
+  const toggleFullscreen = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    if (document.fullscreenElement === el) {
+      void document.exitFullscreen()
+    } else {
+      void el.requestFullscreen()
+    }
+  }, [])
+
+  // Track fullscreen state so the button label + fit stay in sync with reality
+  // (user can exit via Esc or F11, which doesn't go through our toggle handler).
+  useEffect(() => {
+    const onChange = () => {
+      const nowFs = document.fullscreenElement === containerRef.current
+      setIsFullscreen(nowFs)
+      // Refit whenever the viewport-height changes (entering/leaving fullscreen
+      // swaps between wrapper height and 100vh).
+      requestAnimationFrame(() => fitToWrapper(0))
+    }
+    document.addEventListener('fullscreenchange', onChange)
+    return () => document.removeEventListener('fullscreenchange', onChange)
+  }, [fitToWrapper])
+
   const resolvedAriaLabel = ariaLabel ?? alt
 
   return (
     <section
+      ref={containerRef}
       aria-label={resolvedAriaLabel}
-      className="relative bg-slate-50 border-y border-slate-200"
+      className={
+        isFullscreen
+          ? 'relative bg-slate-50 w-screen h-screen'
+          : 'relative bg-slate-50 border-y border-slate-200'
+      }
     >
       <div
         ref={wrapperRef}
         className="relative mx-auto"
-        style={{ height: 'min(80vh, 900px)', maxWidth: '100%' }}
+        style={{
+          height: isFullscreen ? '100vh' : 'min(80vh, 900px)',
+          maxWidth: '100%',
+        }}
       >
         <TransformWrapper
           ref={transformRef}
@@ -149,6 +187,7 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
           maxScale={MAX_SCALE}
           limitToBounds={false}
           wheel={{ step: WHEEL_STEP }}
+          smooth
           doubleClick={{ disabled: true }}
         >
           <TransformComponent
@@ -179,18 +218,10 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
         </TransformWrapper>
 
         <div
-          className="absolute top-3 right-3 flex gap-1 bg-white/95 border border-slate-300 rounded-md shadow-sm p-1"
+          className="absolute top-3 right-3 flex items-center gap-1 bg-white/95 border border-slate-300 rounded-md shadow-sm p-1"
           role="toolbar"
           aria-label="Mind map zoom controls"
         >
-          <button
-            type="button"
-            onClick={handleZoomIn}
-            aria-label="Zoom in"
-            className="px-3 py-1 text-base font-semibold text-slate-800 hover:bg-slate-100 rounded"
-          >
-            +
-          </button>
           <button
             type="button"
             onClick={handleZoomOut}
@@ -201,11 +232,29 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
           </button>
           <button
             type="button"
+            onClick={handleZoomIn}
+            aria-label="Zoom in"
+            className="px-3 py-1 text-base font-semibold text-slate-800 hover:bg-slate-100 rounded"
+          >
+            +
+          </button>
+          <button
+            type="button"
             onClick={handleReset}
             aria-label="Reset zoom and position"
             className="px-3 py-1 text-sm font-medium text-slate-800 hover:bg-slate-100 rounded"
           >
             Reset
+          </button>
+          <span aria-hidden="true" className="mx-1 h-5 w-px bg-slate-300" />
+          <button
+            type="button"
+            onClick={toggleFullscreen}
+            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            aria-pressed={isFullscreen ? 'true' : 'false'}
+            className="px-3 py-1 text-sm font-medium text-slate-800 hover:bg-slate-100 rounded"
+          >
+            {isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
           </button>
         </div>
       </div>

--- a/src/components/mind-maps/mind-map-viewer.tsx
+++ b/src/components/mind-maps/mind-map-viewer.tsx
@@ -252,7 +252,7 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
             type="button"
             onClick={toggleFullscreen}
             aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-            aria-pressed={isFullscreen ? 'true' : 'false'}
+            aria-pressed={isFullscreen}
             className="px-3 py-1 text-sm font-medium text-slate-800 hover:bg-slate-100 rounded"
           >
             {isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}

--- a/src/components/mind-maps/mind-map-viewer.tsx
+++ b/src/components/mind-maps/mind-map-viewer.tsx
@@ -140,14 +140,15 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
     const el = containerRef.current
     if (!el) return
     if (document.fullscreenElement === el) {
-      void document.exitFullscreen()
+      document.exitFullscreen().catch(() => {})
     } else {
-      void el.requestFullscreen()
+      el.requestFullscreen().catch(() => {})
     }
   }, [])
 
   // Track fullscreen state so the button label + fit stay in sync with reality
-  // (user can exit via Esc or F11, which doesn't go through our toggle handler).
+  // (user can exit via Esc or browser fullscreen UI, which doesn't go through
+  // our toggle handler).
   useEffect(() => {
     const onChange = () => {
       const nowFs = document.fullscreenElement === containerRef.current
@@ -168,7 +169,7 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
       aria-label={resolvedAriaLabel}
       className={
         isFullscreen
-          ? 'relative bg-slate-50 w-screen h-screen'
+          ? 'relative bg-slate-50 w-screen h-screen flex flex-col overflow-hidden'
           : 'relative bg-slate-50 border-y border-slate-200'
       }
     >
@@ -176,7 +177,7 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
         ref={wrapperRef}
         className="relative mx-auto"
         style={{
-          height: isFullscreen ? '100vh' : 'min(80vh, 900px)',
+          ...(isFullscreen ? { flex: '1 1 0', minHeight: 0 } : { height: 'min(80vh, 900px)' }),
           maxWidth: '100%',
         }}
       >
@@ -220,7 +221,7 @@ const MindMapViewer = ({ src, alt, ariaLabel }: MindMapViewerProps) => {
         <div
           className="absolute top-3 right-3 flex items-center gap-1 bg-white/95 border border-slate-300 rounded-md shadow-sm p-1"
           role="toolbar"
-          aria-label="Mind map zoom controls"
+          aria-label="Mind map controls"
         >
           <button
             type="button"


### PR DESCRIPTION
## Summary

Fixes three live-site issues you flagged on the mind-map pages:

1. **Viewer bleeds under the sidebar on the left and off the right edge.** Documented with measured bounds — on a 1440px viewport, the viewer was positioned at x=132 to x=1572, with its left 148px hidden behind the sidebar and its right 132px off-screen, plus a 133px horizontal scrollbar on the document.
2. **Toolbar partially off-screen** — Reset / (now) Fullscreen were clipped on the right.
3. **No fullscreen button** and the **mouse wheel zoom jumped too much** per tick.

## Changes

### Remove the breakout wrapper (Option A)
Every mind-map page wrapped `MindMapViewer` in `<div className=\"relative left-1/2 right-1/2 -mx-[50vw] w-screen overflow-x-clip\">`. That pattern only works when main is centered in the viewport; this site has a 280px left sidebar, so `-mx-[50vw]` shifts the viewer 132px to the right of where it should sit. Dropping the wrapper puts the viewer inline in the main content column. Measured result on a 1440px viewport: viewer spans ~x=280 to x=1425 (the full main width), no horizontal page scrollbar, toolbar fully visible.

### Add fullscreen toggle
New button in the viewer toolbar (Fullscreen API):
- Label: 'Fullscreen' / 'Exit Fullscreen' (toggles on click)
- `aria-pressed` reflects current state
- Listens for `fullscreenchange` so the button stays correct when the user exits via Esc or F11
- Refits the image on fullscreenchange (wrapper height swaps between `min(80vh, 900px)` and `100vh`)

### Finer mouse-wheel zoom
- `WHEEL_STEP` dropped from 0.1 to 0.03 (each wheel notch now changes scale by ~3% instead of ~10%)
- Opted in to `smooth` mode on `TransformWrapper` for animated interpolation between ticks

## What this does NOT do
- Does not re-introduce keyboard controls or `initialFocus` (those were the parts of #1789 that regressed; left for a separate, smaller PR with proper visual QA).
- Does not fix the three cut pages with fundamentally-wrong cropped SVGs (Project/Program/Risk, Standards, TABS Ops) — those need real per-branch Lucidspark exports, not more code.

## Test plan

- [x] \`npm test\` — 567 pass (55 suites)
- [x] \`npm run lint\` — clean (0 errors; 3 pre-existing warnings unrelated to this change)
- [x] \`npm run build\` — succeeds, 268 pages generated
- [ ] After deploy: verify on a 1440px viewport the page has no horizontal scrollbar
- [ ] Verify viewer left edge sits at main's left edge (not under sidebar)
- [ ] Verify fullscreen button works (click → enters fullscreen; click or Esc → exits)
- [ ] Verify mouse wheel zoom feels smooth (many small steps, no visible snap)