### PR TITLE
fix(mind-maps): drop wheel step so a mouse notch isn't a max-zoom jump

### DIFF
--- a/__tests__/components/mind-maps/mind-map-viewer.test.tsx
+++ b/__tests__/components/mind-maps/mind-map-viewer.test.tsx
@@ -5,6 +5,7 @@ import MindMapViewer, {
   computeFitTransform,
   MIN_SCALE,
   MAX_SCALE,
+  WHEEL_STEP,
 } from '@/components/mind-maps/mind-map-viewer'
 
 expect.extend(toHaveNoViolations)
@@ -117,6 +118,14 @@ describe('MindMapViewer', () => {
     const { container } = render(<MindMapViewer {...defaultProps} />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
+  })
+
+  it('WHEEL_STEP is small enough that a single mouse-wheel notch does not max out zoom', () => {
+    // react-zoom-pan-pinch v4 computes scale_delta = deltaY * WHEEL_STEP.
+    // A typical mouse-wheel notch produces |deltaY| ~100; the resulting scale
+    // delta must stay well below 1.0 to avoid leaping to MIN_SCALE/MAX_SCALE.
+    expect(WHEEL_STEP).toBe(0.0003)
+    expect(Math.abs(100 * WHEEL_STEP)).toBeLessThan(0.1)
   })
 
   describe('computeFitTransform – scale clamping', () => {

--- a/__tests__/components/mind-maps/mind-map-viewer.test.tsx
+++ b/__tests__/components/mind-maps/mind-map-viewer.test.tsx
@@ -120,12 +120,21 @@ describe('MindMapViewer', () => {
     expect(results).toHaveNoViolations()
   })
 
-  it('WHEEL_STEP is small enough that a single mouse-wheel notch does not max out zoom', () => {
+  it('keeps a single mouse-wheel notch within zoom bounds from a representative fit scale', () => {
     // react-zoom-pan-pinch v4 computes scale_delta = deltaY * WHEEL_STEP.
-    // A typical mouse-wheel notch produces |deltaY| ~100; the resulting scale
-    // delta must stay well below 1.0 to avoid leaping to MIN_SCALE/MAX_SCALE.
+    // Start from a representative fit scale that is comfortably within bounds,
+    // then verify a typical mouse-wheel notch (|deltaY| ~100) does not jump
+    // directly to either zoom extreme.
     expect(WHEEL_STEP).toBe(0.0003)
-    expect(Math.abs(100 * WHEEL_STEP)).toBeLessThan(0.1)
+
+    const { scale: fitScale } = computeFitTransform(800, 600, 800, 600)
+    const wheelNotchDelta = 100 * WHEEL_STEP
+
+    expect(fitScale).toBeGreaterThan(MIN_SCALE)
+    expect(fitScale).toBeLessThan(MAX_SCALE)
+
+    expect(fitScale + wheelNotchDelta).toBeLessThan(MAX_SCALE)
+    expect(fitScale - wheelNotchDelta).toBeGreaterThan(MIN_SCALE)
   })
 
   describe('computeFitTransform – scale clamping', () => {

--- a/src/components/mind-maps/mind-map-viewer.tsx
+++ b/src/components/mind-maps/mind-map-viewer.tsx
@@ -35,10 +35,13 @@ export const MAX_SCALE = 4
  * scale delta, not a per-notch fraction, so this needs to be small enough that
  * a single mouse-wheel notch (|deltaY| ~100) produces a gentle zoom change.
  *
- * Typical zoom-in wheel input uses a negative deltaY, though the sign can vary
- * with scroll direction or invert settings; the magnitude is what matters here.
- * At step=0.0003: deltaY=-100 -> -0.03 scale delta; trackpad deltaY=-10 ->
- * -0.003 scale delta (near-continuous fine zoom).
+ * The library applies the raw `deltaY` sign directly: negative `deltaY`
+ * decreases scale and positive `deltaY` increases scale. Devices and OS/browser
+ * settings can still produce different signs for the same physical gesture, so
+ * the examples below describe the arithmetic, not a universal "zoom in/out"
+ * direction across all hardware.
+ * At step=0.0003: deltaY=-100 -> -0.03 additive scale delta; trackpad
+ * deltaY=-10 -> -0.003 additive scale delta (near-continuous fine zoom).
  */
 export const WHEEL_STEP = 0.0003
 

--- a/src/components/mind-maps/mind-map-viewer.tsx
+++ b/src/components/mind-maps/mind-map-viewer.tsx
@@ -33,10 +33,12 @@ export const MAX_SCALE = 4
  * Multiplier applied to raw `deltaY` values when computing how much to zoom
  * per wheel event. react-zoom-pan-pinch v4 uses `deltaY * step` as an additive
  * scale delta, not a per-notch fraction, so this needs to be small enough that
- * a single mouse-wheel notch (deltaY ~100) produces a gentle zoom change.
+ * a single mouse-wheel notch (|deltaY| ~100) produces a gentle zoom change.
  *
- * At step=0.0003: deltaY=100 -> +0.03 scale (~10% relative at fit, ~1% near max);
- * trackpad deltaY=10 -> +0.003 scale (near-continuous fine zoom).
+ * Typical zoom-in wheel input uses a negative deltaY, though the sign can vary
+ * with scroll direction or invert settings; the magnitude is what matters here.
+ * At step=0.0003: deltaY=-100 -> -0.03 scale delta; trackpad deltaY=-10 ->
+ * -0.003 scale delta (near-continuous fine zoom).
  */
 export const WHEEL_STEP = 0.0003
 

--- a/src/components/mind-maps/mind-map-viewer.tsx
+++ b/src/components/mind-maps/mind-map-viewer.tsx
@@ -35,13 +35,11 @@ export const MAX_SCALE = 4
  * scale delta, not a per-notch fraction, so this needs to be small enough that
  * a single mouse-wheel notch (|deltaY| ~100) produces a gentle zoom change.
  *
- * The library applies the raw `deltaY` sign directly: negative `deltaY`
- * decreases scale and positive `deltaY` increases scale. Devices and OS/browser
- * settings can still produce different signs for the same physical gesture, so
- * the examples below describe the arithmetic, not a universal "zoom in/out"
- * direction across all hardware.
- * At step=0.0003: deltaY=-100 -> -0.03 additive scale delta; trackpad
- * deltaY=-10 -> -0.003 additive scale delta (near-continuous fine zoom).
+ * The key constraint is magnitude: `|deltaY| * step` must stay well below 1.0
+ * so a single notch never leaps to MIN_SCALE/MAX_SCALE. Sign behavior varies
+ * by OS/browser/invert settings and is handled internally by the library.
+ * At step=0.0003: |deltaY|=100 (mouse notch) -> 0.03 additive scale change;
+ * |deltaY|=10 (trackpad) -> 0.003 (near-continuous fine zoom).
  */
 export const WHEEL_STEP = 0.0003
 

--- a/src/components/mind-maps/mind-map-viewer.tsx
+++ b/src/components/mind-maps/mind-map-viewer.tsx
@@ -30,11 +30,15 @@ export const MIN_SCALE = 0.02
 /** Hard ceiling: 4× is sufficient to read leaf-level text in the exported map. */
 export const MAX_SCALE = 4
 /**
- * Fraction of the current scale added/removed per mouse-wheel tick.
- * Kept small so a single scroll notch produces a gentle zoom change rather
- * than a big jump. With step=0.03 each notch multiplies the scale by ~1.03.
+ * Multiplier applied to raw `deltaY` values when computing how much to zoom
+ * per wheel event. react-zoom-pan-pinch v4 uses `deltaY * step` as an additive
+ * scale delta, not a per-notch fraction, so this needs to be small enough that
+ * a single mouse-wheel notch (deltaY ~100) produces a gentle zoom change.
+ *
+ * At step=0.0003: deltaY=100 -> +0.03 scale (~10% relative at fit, ~1% near max);
+ * trackpad deltaY=10 -> +0.003 scale (near-continuous fine zoom).
  */
-export const WHEEL_STEP = 0.03
+export const WHEEL_STEP = 0.0003
 
 const fitScaleFor = (
   wrapperWidth: number,


### PR DESCRIPTION
## What

Follow-up to #1792. Live QA on the deployed mind-map viewer showed the wheel zoom was far too aggressive: a single mouse-wheel notch (deltaY=100) took scale from 0.37 to 3.37 (a +3.0 jump, ~9× relative zoom), effectively maxing out in one scroll.

## Why

react-zoom-pan-pinch v4 interprets the \`wheel.step\` prop as an additive multiplier on the raw \`deltaY\` magnitude, not as a per-notch fraction. So \`deltaY=100 * step=0.03\` was adding 3.0 to the scale. The previous value (0.1 before #1792) had the same bug, just harder - it immediately clamped to MAX_SCALE.

Measured on live prod after #1792 merged:

| deltaY | step=0.03 result |
|--------|------------------|
| -100 (mouse notch) | 0.37 -> 3.37 (+9.11×, maxes out) |
| -10 (trackpad) | 0.21 -> 0.51 (+140%) |
| -5 (trackpad) | 0.21 -> 0.36 (+70%) |
| -1 (fine trackpad) | 0.21 -> 0.24 (+14%) |

## Fix

Drop \`WHEEL_STEP\` from 0.03 to 0.0003, with an updated JSDoc explaining the math:

| deltaY | step=0.0003 result |
|--------|--------------------|
| -100 (mouse notch) | scale += 0.03 (~10% relative at fit) |
| -10 (trackpad) | scale += 0.003 |
| -1 | scale += 0.0003 (near-continuous) |

## Test plan

- [x] \`npm test\` — 569 pass
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run build\` — ok
- [ ] Live QA: scroll wheel on a mind-map page, verify zoom grows/shrinks in small steps rather than leaping to min/max
- [ ] Trackpad QA: two-finger scroll should feel smooth/continuous