### PR TITLE
Update daily pipeline data

### DIFF
--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -2394,6 +2394,6 @@
       }
     ]
   },
-  "last_updated": "2026-04-23T13:52:47.997239Z",
-  "extended_last_updated": "2026-04-23T13:52:47.997239Z"
+  "last_updated": "2026-04-24T11:00:22.279333Z",
+  "extended_last_updated": "2026-04-24T11:00:22.279333Z"
 }

--- a/src/data/crp-validation.json
+++ b/src/data/crp-validation.json
@@ -85,7 +85,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9266,
           "bartlett_chi2": 1278.99,
-          "bartlett_p": 5.598940441600992e-185
+          "bartlett_p": 5.5989404416016324e-185
         },
         "parallel_analysis": {
           "n_factors": 1,

--- a/src/data/data-audit.json
+++ b/src/data/data-audit.json
@@ -1,102 +1,102 @@
 {
   "disposition_counts": {
-    "INCOMPLETE": 81,
-    "CLEAN": 103,
-    "FLAG-SMEAL": 61,
+    "INCOMPLETE": 84,
+    "CLEAN": 105,
+    "FLAG-SMEAL": 63,
     "FLAG-SPEED": 10,
     "FLAG-PARTIAL-STRAIGHTLINING": 40,
-    "FLAG-SINGLE-IRI": 93,
-    "AUTO-EXCLUDE": 142,
+    "FLAG-SINGLE-IRI": 98,
+    "AUTO-EXCLUDE": 146,
     "FLAG-RECAPTCHA": 4
   },
   "iri_pass_rates": {
-    "barrier": 0.49812734082397003,
-    "readiness": 0.5898876404494382,
-    "maturity": 0.702247191011236
+    "barrier": 0.49636363636363634,
+    "readiness": 0.5890909090909091,
+    "maturity": 0.7036363636363636
   },
   "duration_stats": {
-    "mean": 637.2453183520599,
-    "median": 532,
+    "mean": 635.7345454545455,
+    "median": 531,
     "q25": 318,
-    "q75": 781,
+    "q75": 783,
     "min": 2,
     "max": 5935
   },
   "straightlining_stats": {
-    "full_block_flagged": 15,
-    "partial_flagged": 159
+    "full_block_flagged": 16,
+    "partial_flagged": 164
   },
   "sample_sizes": {
-    "total": 534,
-    "complete": 453,
-    "clean": 103
+    "total": 550,
+    "complete": 466,
+    "clean": 105
   },
   "waterfall_steps": [
     {
       "step": 0,
       "name": "INCOMPLETE",
-      "count": 81,
-      "cumulative_excluded": 81
+      "count": 84,
+      "cumulative_excluded": 84
     },
     {
       "step": 1,
       "name": "FLAG-AUTH-FAIL",
       "count": 0,
-      "cumulative_excluded": 81
+      "cumulative_excluded": 84
     },
     {
       "step": 2,
       "name": "FLAG-AUTH-MIXED",
       "count": 0,
-      "cumulative_excluded": 81
+      "cumulative_excluded": 84
     },
     {
       "step": 3,
       "name": "AUTO-EXCLUDE",
-      "count": 142,
-      "cumulative_excluded": 223
+      "count": 146,
+      "cumulative_excluded": 230
     },
     {
       "step": 4,
       "name": "FLAG-SPEED",
       "count": 10,
-      "cumulative_excluded": 233
+      "cumulative_excluded": 240
     },
     {
       "step": 5,
       "name": "FLAG-SINGLE-IRI",
-      "count": 93,
-      "cumulative_excluded": 326
+      "count": 98,
+      "cumulative_excluded": 338
     },
     {
       "step": 6,
       "name": "FLAG-SMEAL",
-      "count": 61,
-      "cumulative_excluded": 387
+      "count": 63,
+      "cumulative_excluded": 401
     },
     {
       "step": 7,
       "name": "FLAG-RECAPTCHA",
       "count": 4,
-      "cumulative_excluded": 391
+      "cumulative_excluded": 405
     },
     {
       "step": 8,
       "name": "FLAG-STRAIGHTLINING",
       "count": 0,
-      "cumulative_excluded": 391
+      "cumulative_excluded": 405
     },
     {
       "step": 9,
       "name": "FLAG-PARTIAL-STRAIGHTLINING",
       "count": 40,
-      "cumulative_excluded": 431
+      "cumulative_excluded": 445
     },
     {
       "step": 10,
       "name": "CLEAN",
-      "count": 103,
-      "cumulative_excluded": 103
+      "count": 105,
+      "cumulative_excluded": 105
     }
   ]
 }

--- a/src/data/disposition-summary.json
+++ b/src/data/disposition-summary.json
@@ -1,55 +1,56 @@
 {
-  "updatedAt": "2026-04-23T13:57:06.339612+00:00",
-  "last_updated": "2026-04-23T13:57:06.339631+00:00",
+  "updatedAt": "2026-04-24T11:03:12.170831+00:00",
+  "last_updated": "2026-04-24T11:03:12.170846+00:00",
   "study": {
     "id": "69c17630acada6abeead2da5",
     "name": "Technology Adoption Barriers Survey (2026)",
     "status": "ACTIVE",
     "totalAvailablePlaces": 500,
-    "placesTaken": 323,
-    "averageRewardPerHour": 3994.65,
+    "placesTaken": 330,
+    "averageRewardPerHour": 3974.4,
     "averageTimeTaken": 10,
     "reward": 700,
     "publishedAt": "2026-03-23T18:00:28.650000Z"
   },
   "completionProgress": {
     "target": 500,
-    "completed": 323,
-    "approved": 298,
-    "awaitingReview": 25,
-    "percentComplete": 64.6
+    "completed": 330,
+    "approved": 300,
+    "awaitingReview": 30,
+    "percentComplete": 66.0
   },
-  "totalResponses": 548,
-  "uniqueParticipants": 534,
+  "totalResponses": 562,
+  "uniqueParticipants": 550,
   "duplicatesRemoved": 0,
   "dispositions": {
-    "INCOMPLETE": 81,
-    "CLEAN": 103,
-    "FLAG-SMEAL": 61,
+    "INCOMPLETE": 84,
+    "CLEAN": 105,
+    "FLAG-SMEAL": 63,
     "FLAG-SPEED": 10,
     "FLAG-PARTIAL-STRAIGHTLINING": 40,
-    "FLAG-SINGLE-IRI": 93,
-    "AUTO-EXCLUDE": 142,
+    "FLAG-SINGLE-IRI": 98,
+    "AUTO-EXCLUDE": 146,
     "FLAG-RECAPTCHA": 4
   },
   "dispositionByStatus": {
     "INCOMPLETE": {
-      "RETURNED": 75,
-      "TIMED-OUT": 6
+      "RETURNED": 77,
+      "TIMED-OUT": 6,
+      "AWAITING REVIEW": 1
     },
     "CLEAN": {
-      "APPROVED": 102,
+      "APPROVED": 104,
       "RETURNED": 1
     },
     "FLAG-SMEAL": {
       "APPROVED": 52,
-      "AWAITING REVIEW": 6,
-      "RETURNED": 3
+      "RETURNED": 7,
+      "AWAITING REVIEW": 4
     },
     "FLAG-SPEED": {
-      "RETURNED": 1,
+      "RETURNED": 2,
       "APPROVED": 7,
-      "AWAITING REVIEW": 2
+      "AWAITING REVIEW": 1
     },
     "FLAG-PARTIAL-STRAIGHTLINING": {
       "APPROVED": 39,
@@ -58,39 +59,39 @@
     "FLAG-SINGLE-IRI": {
       "RETURNED": 7,
       "APPROVED": 80,
-      "AWAITING REVIEW": 6
+      "AWAITING REVIEW": 11
     },
     "AUTO-EXCLUDE": {
-      "REJECTED": 42,
+      "REJECTED": 35,
       "APPROVED": 14,
-      "AWAITING REVIEW": 9,
-      "RETURNED": 77
+      "AWAITING REVIEW": 12,
+      "RETURNED": 85
     },
     "FLAG-RECAPTCHA": {
       "APPROVED": 4
     }
   },
   "autoExcludeBreakdown": {
-    "IRI3_SPEED": 13,
-    "IRI3": 33,
+    "IRI3_SPEED": 14,
+    "IRI3": 34,
     "IRI2_SPEED": 12,
-    "IRI2": 66,
-    "SPEED_IRI": 18
+    "IRI2": 67,
+    "SPEED_IRI": 19
   },
   "actions": {
-    "approved": 298,
-    "rejected": 42,
-    "returned": 177,
+    "approved": 300,
+    "rejected": 35,
+    "returned": 191,
     "timedOut": 6,
-    "awaitingReview": 25,
+    "awaitingReview": 30,
     "active": 0,
     "messaged": 0
   },
   "iriPassRates": {
-    "barrier": 58.5,
-    "readiness": 69.3,
+    "barrier": 58.2,
+    "readiness": 69.1,
     "maturity": 82.8,
-    "denominator": 453
+    "denominator": 466
   },
   "studyId": "69c17630acada6abeead2da5",
   "studyName": "Technology Adoption Barriers Survey (2026)"

--- a/src/data/live-validation.json
+++ b/src/data/live-validation.json
@@ -19,7 +19,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.7697,
           "bartlett_chi2": 475.36,
-          "bartlett_p": 9.872572339583875e-35
+          "bartlett_p": 9.872572339584435e-35
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -82,7 +82,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.8041,
           "bartlett_chi2": 483.27,
-          "bartlett_p": 2.0353603587604754e-40
+          "bartlett_p": 2.0353603587605912e-40
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -144,7 +144,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.8193,
           "bartlett_chi2": 240.4,
-          "bartlett_p": 1.2363475940982344e-35
+          "bartlett_p": 1.2363475940982518e-35
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -485,7 +485,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.8694,
           "bartlett_chi2": 836.66,
-          "bartlett_p": 9.948248328567006e-95
+          "bartlett_p": 9.94824832856757e-95
         },
         "parallel_analysis": {
           "n_factors": 2,
@@ -551,7 +551,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9057,
           "bartlett_chi2": 1028.58,
-          "bartlett_p": 6.242106740748429e-137
+          "bartlett_p": 6.24210674074772e-137
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -976,7 +976,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.8845,
           "bartlett_chi2": 1533.2,
-          "bartlett_p": 3.683864700366698e-226
+          "bartlett_p": 3.683864700367955e-226
         },
         "parallel_analysis": {
           "n_factors": 2,
@@ -1042,7 +1042,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9339,
           "bartlett_chi2": 1875.43,
-          "bartlett_p": 2.2601309138933976e-303
+          "bartlett_p": 2.2601309138936537e-303
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -1104,7 +1104,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9173,
           "bartlett_chi2": 961.91,
-          "bartlett_p": 1.6138339029205054e-184
+          "bartlett_p": 1.6138339029212406e-184
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -1452,187 +1452,187 @@
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 453,
-      "n_to_param_ratio": 9.8,
-      "adequacy": "adequate",
-      "adequacy_note": "N:parameter ratio 9.8:1 meets the 5:1 minimum but is below the recommended 10:1 threshold. Results are interpretable but may show instability in fit indices.",
+      "n": 466,
+      "n_to_param_ratio": 10.1,
+      "adequacy": "good",
+      "adequacy_note": "N:parameter ratio 10.1:1 meets the recommended 10:1 threshold for stable CFA estimation.",
       "Barriers": {
-        "cronbach_alpha": 0.8973,
-        "cronbach_alpha_ci": [0.8826, 0.9109],
-        "n_listwise": 428,
-        "mcdonalds_omega": 0.8976,
-        "composite_reliability": 0.8976,
-        "ave": 0.3331,
-        "split_half": 0.9194,
+        "cronbach_alpha": 0.8989,
+        "cronbach_alpha_ci": [0.8846, 0.9122],
+        "n_listwise": 439,
+        "mcdonalds_omega": 0.8993,
+        "composite_reliability": 0.8993,
+        "ave": 0.3371,
+        "split_half": 0.9206,
         "kmo_bartlett": {
-          "kmo_overall": 0.9216,
-          "bartlett_chi2": 2713.75,
+          "kmo_overall": 0.9243,
+          "bartlett_chi2": 2811.12,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 2,
-          "eigenvalues_real": [6.6495, 1.6432, 0.9946, 0.9465]
+          "eigenvalues_real": [6.7159, 1.6344, 0.9788, 0.934]
         },
         "efa": {
           "construct": "Barriers",
           "n_factors": 2,
-          "variance_explained": [0.3115, 0.1067],
-          "total_variance": 0.4182,
+          "variance_explained": [0.3145, 0.1054],
+          "total_variance": 0.4198,
           "factor_correlations": [
-            [1.0, 0.5677],
-            [0.5677, 1.0]
+            [1.0, 0.5645],
+            [0.5645, 1.0]
           ],
           "loadings": {
-            "B1": [0.7688, -0.1966],
-            "B2": [0.7921, -0.1537],
-            "B3": [0.6793, -0.0927],
-            "B4": [0.7115, -0.0635],
-            "B5": [0.6663, -0.046],
-            "B6": [0.4827, 0.045],
-            "B7": [0.5329, 0.0751],
-            "B8": [0.5442, 0.0835],
-            "B9": [0.5987, -0.0031],
-            "B10": [0.7662, -0.0694],
-            "B11": [0.5184, 0.1027],
-            "B12": [0.5432, 0.0725],
-            "B13": [-0.1867, 0.8997],
-            "B14": [-0.1342, 0.8616],
-            "B15": [0.4476, 0.1964],
-            "B16": [0.2142, 0.404],
-            "B17": [0.4748, 0.1121],
-            "B18": [0.3615, 0.2046]
+            "B1": [0.7539, -0.1837],
+            "B2": [0.7763, -0.1358],
+            "B3": [0.6863, -0.0943],
+            "B4": [0.7262, -0.0771],
+            "B5": [0.6756, -0.0506],
+            "B6": [0.4972, 0.0365],
+            "B7": [0.5444, 0.0634],
+            "B8": [0.562, 0.0788],
+            "B9": [0.5875, -0.0022],
+            "B10": [0.7596, -0.0588],
+            "B11": [0.5253, 0.1084],
+            "B12": [0.5578, 0.0657],
+            "B13": [-0.1723, 0.8821],
+            "B14": [-0.1371, 0.8712],
+            "B15": [0.4458, 0.2017],
+            "B16": [0.2206, 0.4128],
+            "B17": [0.4792, 0.107],
+            "B18": [0.3744, 0.1907]
           }
         },
         "cfa": {
           "construct": "Barriers",
-          "chi2": 568.901,
+          "chi2": 570.183,
           "df": 135,
           "chi2_p": 0.0,
-          "cfi": 0.8338,
-          "tli": 0.8117,
-          "rmsea": 0.0868,
+          "cfi": 0.8394,
+          "tli": 0.818,
+          "rmsea": 0.0858,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.3275,
-          "min_r": 0.1035,
-          "max_r": 0.6558,
-          "sd_r": 0.0923
+          "mean_r": 0.3313,
+          "min_r": 0.1116,
+          "max_r": 0.6536,
+          "sd_r": 0.0921
         },
         "itc_min": 0.39,
         "itc_all_above_030": true
       },
       "Readiness": {
-        "cronbach_alpha": 0.9293,
-        "cronbach_alpha_ci": [0.919, 0.9389],
-        "n_listwise": 409,
-        "mcdonalds_omega": 0.9301,
-        "composite_reliability": 0.9301,
-        "ave": 0.4405,
-        "split_half": 0.9349,
+        "cronbach_alpha": 0.9303,
+        "cronbach_alpha_ci": [0.9202, 0.9397],
+        "n_listwise": 420,
+        "mcdonalds_omega": 0.9311,
+        "composite_reliability": 0.9311,
+        "ave": 0.4441,
+        "split_half": 0.9356,
         "kmo_bartlett": {
-          "kmo_overall": 0.9589,
-          "bartlett_chi2": 3183.97,
+          "kmo_overall": 0.9605,
+          "bartlett_chi2": 3302.47,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [8.0399, 0.9454, 0.7977, 0.766]
+          "eigenvalues_real": [8.0987, 0.9476, 0.7806, 0.7586]
         },
         "efa": {
           "construct": "Readiness",
           "n_factors": 1,
-          "variance_explained": [0.4405],
-          "total_variance": 0.4405,
+          "variance_explained": [0.4441],
+          "total_variance": 0.4441,
           "factor_correlations": null,
           "loadings": {
-            "R1": [0.7291],
-            "R2": [0.6774],
-            "R3": [0.7105],
+            "R1": [0.7253],
+            "R2": [0.6788],
+            "R3": [0.7129],
             "R4": [0.5839],
-            "R5": [0.6062],
-            "R6": [0.6958],
-            "R7": [0.7053],
-            "R8": [0.6777],
-            "R9": [0.6572],
-            "R10": [0.6496],
-            "R11": [0.6687],
-            "R12": [0.6418],
-            "R13": [0.6845],
-            "R14": [0.6194],
-            "R15": [0.6754],
-            "R16": [0.7297],
-            "R17": [0.5386]
+            "R5": [0.603],
+            "R6": [0.6973],
+            "R7": [0.7081],
+            "R8": [0.6821],
+            "R9": [0.6604],
+            "R10": [0.6572],
+            "R11": [0.6735],
+            "R12": [0.6434],
+            "R13": [0.6856],
+            "R14": [0.6244],
+            "R15": [0.6776],
+            "R16": [0.7348],
+            "R17": [0.5508]
           }
         },
         "cfa": {
           "construct": "Readiness",
-          "chi2": 262.702,
+          "chi2": 261.213,
           "df": 119,
           "chi2_p": 0.0,
-          "cfi": 0.9538,
-          "tli": 0.9471,
-          "rmsea": 0.0544,
+          "cfi": 0.9559,
+          "tli": 0.9496,
+          "rmsea": 0.0534,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.438,
-          "min_r": 0.2792,
-          "max_r": 0.5921,
-          "sd_r": 0.0593
+          "mean_r": 0.4417,
+          "min_r": 0.286,
+          "max_r": 0.5891,
+          "sd_r": 0.0582
         },
-        "itc_min": 0.52,
+        "itc_min": 0.53,
         "itc_all_above_030": true
       },
       "Maturity": {
-        "cronbach_alpha": 0.8884,
-        "cronbach_alpha_ci": [0.8716, 0.9038],
-        "n_listwise": 423,
-        "mcdonalds_omega": 0.8889,
-        "composite_reliability": 0.8889,
-        "ave": 0.5016,
-        "split_half": 0.9124,
+        "cronbach_alpha": 0.8881,
+        "cronbach_alpha_ci": [0.8715, 0.9033],
+        "n_listwise": 436,
+        "mcdonalds_omega": 0.8886,
+        "composite_reliability": 0.8886,
+        "ave": 0.5006,
+        "split_half": 0.9114,
         "kmo_bartlett": {
-          "kmo_overall": 0.923,
-          "bartlett_chi2": 1474.17,
-          "bartlett_p": 2.3907785013745436e-293
+          "kmo_overall": 0.9242,
+          "bartlett_chi2": 1511.34,
+          "bartlett_p": 2.8093843511297256e-301
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [4.5027, 0.6406, 0.5909, 0.5532]
+          "eigenvalues_real": [4.4964, 0.6449, 0.5907, 0.5519]
         },
         "efa": {
           "construct": "Maturity",
           "n_factors": 1,
-          "variance_explained": [0.5016],
-          "total_variance": 0.5016,
+          "variance_explained": [0.5006],
+          "total_variance": 0.5006,
           "factor_correlations": null,
           "loadings": {
-            "M1": [0.762],
-            "M2": [0.7772],
-            "M3": [0.6488],
-            "M4": [0.6654],
-            "M5": [0.6505],
-            "M6": [0.7743],
-            "M7": [0.7168],
-            "M8": [0.654]
+            "M1": [0.7597],
+            "M2": [0.7761],
+            "M3": [0.6485],
+            "M4": [0.6694],
+            "M5": [0.6512],
+            "M6": [0.7735],
+            "M7": [0.7157],
+            "M8": [0.65]
           }
         },
         "cfa": {
           "construct": "Maturity",
-          "chi2": 41.969,
+          "chi2": 40.193,
           "df": 20,
-          "chi2_p": 0.0028,
-          "cfi": 0.985,
-          "tli": 0.979,
-          "rmsea": 0.051,
+          "chi2_p": 0.0047,
+          "cfi": 0.9865,
+          "tli": 0.9811,
+          "rmsea": 0.0482,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.4987,
-          "min_r": 0.406,
-          "max_r": 0.65,
-          "sd_r": 0.0552
+          "mean_r": 0.4978,
+          "min_r": 0.3999,
+          "max_r": 0.6436,
+          "sd_r": 0.0544
         },
         "itc_min": 0.61,
         "itc_all_above_030": true
@@ -1640,25 +1640,25 @@
       "htmt": [
         {
           "pair": "Barriers vs Readiness",
-          "htmt": 0.3518,
-          "ci_lower": 0.2706,
-          "ci_upper": 0.4604,
+          "htmt": 0.3526,
+          "ci_lower": 0.2749,
+          "ci_upper": 0.4635,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "htmt": 0.3742,
-          "ci_lower": 0.294,
-          "ci_upper": 0.4739,
+          "htmt": 0.3731,
+          "ci_lower": 0.3004,
+          "ci_upper": 0.4664,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "htmt": 0.8167,
-          "ci_lower": 0.7442,
-          "ci_upper": 0.8747,
+          "htmt": 0.8143,
+          "ci_lower": 0.7419,
+          "ci_upper": 0.8729,
           "below_085": true,
           "below_090": true
         }
@@ -1666,66 +1666,66 @@
       "fornell_larcker": [
         {
           "pair": "Barriers vs Readiness",
-          "sqrt_ave1": 0.5771,
-          "sqrt_ave2": 0.6637,
-          "abs_r": 0.2854,
+          "sqrt_ave1": 0.5806,
+          "sqrt_ave2": 0.6664,
+          "abs_r": 0.2869,
           "pass": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "sqrt_ave1": 0.5771,
-          "sqrt_ave2": 0.7082,
-          "abs_r": 0.3069,
+          "sqrt_ave1": 0.5806,
+          "sqrt_ave2": 0.7075,
+          "abs_r": 0.3048,
           "pass": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "sqrt_ave1": 0.6637,
-          "sqrt_ave2": 0.7082,
-          "abs_r": 0.7253,
+          "sqrt_ave1": 0.6664,
+          "sqrt_ave2": 0.7075,
+          "abs_r": 0.724,
           "pass": false
         }
       ],
       "construct_correlations": {
         "Barriers": {
           "Barriers": 1.0,
-          "Readiness": -0.2854,
-          "Maturity": -0.3069
+          "Readiness": -0.2869,
+          "Maturity": -0.3048
         },
         "Readiness": {
-          "Barriers": -0.2854,
+          "Barriers": -0.2869,
           "Readiness": 1.0,
-          "Maturity": 0.7253
+          "Maturity": 0.724
         },
         "Maturity": {
-          "Barriers": -0.3069,
-          "Readiness": 0.7253,
+          "Barriers": -0.3048,
+          "Readiness": 0.724,
           "Maturity": 1.0
         }
       },
       "barriers_4f_cfa": {
-        "chi2": 449.667,
+        "chi2": 447.161,
         "df": 129,
         "chi2_p": 0.0,
-        "cfi": 0.8772,
-        "tli": 0.8544,
-        "rmsea": 0.0763,
-        "aic": 81.9,
-        "bic": 252.38
+        "cfi": 0.8826,
+        "tli": 0.8607,
+        "rmsea": 0.075,
+        "aic": 81.96,
+        "bic": 253.51
       },
       "factor_analysis": {
         "efa_factors": [
           {
             "name": "F1",
             "items": 15,
-            "eigenvalue": 6.6495,
-            "variance_pct": 31.1
+            "eigenvalue": 6.7159,
+            "variance_pct": 31.4
           },
           {
             "name": "F2",
             "items": 3,
-            "eigenvalue": 1.6432,
-            "variance_pct": 10.7
+            "eigenvalue": 1.6344,
+            "variance_pct": 10.5
           }
         ],
         "three_groups": [
@@ -1733,28 +1733,28 @@
             "name": "F1a \u2014 Strategy & Culture",
             "item_ids": ["B1", "B2", "B3", "B5", "B9", "B10", "B11", "B15", "B17"],
             "items": 9,
-            "alpha": 0.8576,
-            "cr": 0.8617,
-            "ave": 0.4182
+            "alpha": 0.856,
+            "cr": 0.8599,
+            "ave": 0.4139
           },
           {
             "name": "F1b \u2014 Resources & Operations",
             "item_ids": ["B4", "B6", "B7", "B8", "B12"],
             "items": 5,
-            "alpha": 0.6972,
-            "cr": 0.7006,
-            "ave": 0.3229
+            "alpha": 0.7131,
+            "cr": 0.7163,
+            "ave": 0.3396
           },
           {
             "name": "F2 \u2014 External & Compliance",
             "item_ids": ["B13", "B14", "B16", "B18"],
             "items": 4,
-            "alpha": 0.6548,
-            "cr": 0.7146,
-            "ave": 0.4392
+            "alpha": 0.6505,
+            "cr": 0.7111,
+            "ave": 0.436
           }
         ],
-        "factor_correlation": 0.5677,
+        "factor_correlation": 0.5645,
         "barrier_names": [
           "Resistance to Change",
           "Lack of Leadership Support",
@@ -1778,110 +1778,110 @@
         "loadings_matrix": [
           {
             "id": "B1",
-            "f1": 0.7688,
-            "f2": -0.1966,
+            "f1": 0.7539,
+            "f2": -0.1837,
             "assigned": "F1"
           },
           {
             "id": "B2",
-            "f1": 0.7921,
-            "f2": -0.1537,
+            "f1": 0.7763,
+            "f2": -0.1358,
             "assigned": "F1"
           },
           {
             "id": "B3",
-            "f1": 0.6793,
-            "f2": -0.0927,
+            "f1": 0.6863,
+            "f2": -0.0943,
             "assigned": "F1"
           },
           {
             "id": "B4",
-            "f1": 0.7115,
-            "f2": -0.0635,
+            "f1": 0.7262,
+            "f2": -0.0771,
             "assigned": "F1"
           },
           {
             "id": "B5",
-            "f1": 0.6663,
-            "f2": -0.046,
+            "f1": 0.6756,
+            "f2": -0.0506,
             "assigned": "F1"
           },
           {
             "id": "B6",
-            "f1": 0.4827,
-            "f2": 0.045,
+            "f1": 0.4972,
+            "f2": 0.0365,
             "assigned": "F1"
           },
           {
             "id": "B7",
-            "f1": 0.5329,
-            "f2": 0.0751,
+            "f1": 0.5444,
+            "f2": 0.0634,
             "assigned": "F1"
           },
           {
             "id": "B8",
-            "f1": 0.5442,
-            "f2": 0.0835,
+            "f1": 0.562,
+            "f2": 0.0788,
             "assigned": "F1"
           },
           {
             "id": "B9",
-            "f1": 0.5987,
-            "f2": -0.0031,
+            "f1": 0.5875,
+            "f2": -0.0022,
             "assigned": "F1"
           },
           {
             "id": "B10",
-            "f1": 0.7662,
-            "f2": -0.0694,
+            "f1": 0.7596,
+            "f2": -0.0588,
             "assigned": "F1"
           },
           {
             "id": "B11",
-            "f1": 0.5184,
-            "f2": 0.1027,
+            "f1": 0.5253,
+            "f2": 0.1084,
             "assigned": "F1"
           },
           {
             "id": "B12",
-            "f1": 0.5432,
-            "f2": 0.0725,
+            "f1": 0.5578,
+            "f2": 0.0657,
             "assigned": "F1"
           },
           {
             "id": "B13",
-            "f1": -0.1867,
-            "f2": 0.8997,
+            "f1": -0.1723,
+            "f2": 0.8821,
             "assigned": "F2"
           },
           {
             "id": "B14",
-            "f1": -0.1342,
-            "f2": 0.8616,
+            "f1": -0.1371,
+            "f2": 0.8712,
             "assigned": "F2"
           },
           {
             "id": "B15",
-            "f1": 0.4476,
-            "f2": 0.1964,
+            "f1": 0.4458,
+            "f2": 0.2017,
             "assigned": "F1"
           },
           {
             "id": "B16",
-            "f1": 0.2142,
-            "f2": 0.404,
+            "f1": 0.2206,
+            "f2": 0.4128,
             "assigned": "F2"
           },
           {
             "id": "B17",
-            "f1": 0.4748,
-            "f2": 0.1121,
+            "f1": 0.4792,
+            "f2": 0.107,
             "assigned": "F1"
           },
           {
             "id": "B18",
-            "f1": 0.3615,
-            "f2": 0.2046,
+            "f1": 0.3744,
+            "f2": 0.1907,
             "assigned": "F1"
           }
         ]
@@ -1931,7 +1931,7 @@
         }
       },
       "metadata": {
-        "n_total": 453,
+        "n_total": 466,
         "crp200_mode": false,
         "constructs": ["Barriers", "Readiness", "Maturity"],
         "n_barriers": 18,
@@ -1943,187 +1943,187 @@
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 534,
-      "n_to_param_ratio": 11.6,
+      "n": 550,
+      "n_to_param_ratio": 12.0,
       "adequacy": "good",
-      "adequacy_note": "N:parameter ratio 11.6:1 meets the recommended 10:1 threshold for stable CFA estimation.",
+      "adequacy_note": "N:parameter ratio 12.0:1 meets the recommended 10:1 threshold for stable CFA estimation.",
       "Barriers": {
-        "cronbach_alpha": 0.8984,
-        "cronbach_alpha_ci": [0.884, 0.9119],
-        "n_listwise": 432,
-        "mcdonalds_omega": 0.8988,
-        "composite_reliability": 0.8988,
-        "ave": 0.3359,
-        "split_half": 0.9202,
+        "cronbach_alpha": 0.8998,
+        "cronbach_alpha_ci": [0.8857, 0.9128],
+        "n_listwise": 444,
+        "mcdonalds_omega": 0.9001,
+        "composite_reliability": 0.9001,
+        "ave": 0.3391,
+        "split_half": 0.9214,
         "kmo_bartlett": {
-          "kmo_overall": 0.9229,
-          "bartlett_chi2": 2760.15,
+          "kmo_overall": 0.9252,
+          "bartlett_chi2": 2862.3,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 2,
-          "eigenvalues_real": [6.6958, 1.6342, 0.9872, 0.9377]
+          "eigenvalues_real": [6.7497, 1.6363, 0.9694, 0.9306]
         },
         "efa": {
           "construct": "Barriers",
           "n_factors": 2,
-          "variance_explained": [0.3137, 0.1062],
-          "total_variance": 0.42,
+          "variance_explained": [0.3147, 0.1067],
+          "total_variance": 0.4214,
           "factor_correlations": [
-            [1.0, 0.5701],
-            [0.5701, 1.0]
+            [1.0, 0.5707],
+            [0.5707, 1.0]
           ],
           "loadings": {
-            "B1": [0.7681, -0.1999],
-            "B2": [0.7902, -0.1516],
-            "B3": [0.6826, -0.0901],
-            "B4": [0.7172, -0.0636],
-            "B5": [0.6715, -0.0508],
-            "B6": [0.4874, 0.045],
-            "B7": [0.5343, 0.0781],
-            "B8": [0.5493, 0.0845],
-            "B9": [0.5986, -0.0014],
-            "B10": [0.7696, -0.074],
-            "B11": [0.5195, 0.1076],
-            "B12": [0.5384, 0.0785],
-            "B13": [-0.1897, 0.8999],
-            "B14": [-0.1276, 0.8567],
-            "B15": [0.457, 0.1907],
-            "B16": [0.2143, 0.4014],
-            "B17": [0.478, 0.1147],
-            "B18": [0.3622, 0.2046]
+            "B1": [0.7547, -0.1949],
+            "B2": [0.7767, -0.1404],
+            "B3": [0.6863, -0.0858],
+            "B4": [0.7319, -0.0774],
+            "B5": [0.6789, -0.0512],
+            "B6": [0.5025, 0.0336],
+            "B7": [0.5384, 0.0769],
+            "B8": [0.5617, 0.0876],
+            "B9": [0.5893, -0.0075],
+            "B10": [0.7641, -0.0652],
+            "B11": [0.5214, 0.1206],
+            "B12": [0.5465, 0.0812],
+            "B13": [-0.1799, 0.8824],
+            "B14": [-0.1386, 0.8722],
+            "B15": [0.4492, 0.2038],
+            "B16": [0.214, 0.4179],
+            "B17": [0.4765, 0.1185],
+            "B18": [0.3723, 0.1938]
           }
         },
         "cfa": {
           "construct": "Barriers",
-          "chi2": 567.56,
+          "chi2": 576.278,
           "df": 135,
           "chi2_p": 0.0,
-          "cfi": 0.8373,
-          "tli": 0.8156,
-          "rmsea": 0.0862,
+          "cfi": 0.8402,
+          "tli": 0.8188,
+          "rmsea": 0.0859,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.3302,
-          "min_r": 0.1016,
-          "max_r": 0.6526,
-          "sd_r": 0.0921
+          "mean_r": 0.3334,
+          "min_r": 0.1057,
+          "max_r": 0.6514,
+          "sd_r": 0.0918
         },
         "itc_min": 0.39,
         "itc_all_above_030": true
       },
       "Readiness": {
-        "cronbach_alpha": 0.9293,
-        "cronbach_alpha_ci": [0.919, 0.9389],
-        "n_listwise": 409,
-        "mcdonalds_omega": 0.9301,
-        "composite_reliability": 0.9301,
-        "ave": 0.4405,
-        "split_half": 0.9349,
+        "cronbach_alpha": 0.9303,
+        "cronbach_alpha_ci": [0.9202, 0.9397],
+        "n_listwise": 420,
+        "mcdonalds_omega": 0.9311,
+        "composite_reliability": 0.9311,
+        "ave": 0.4441,
+        "split_half": 0.9356,
         "kmo_bartlett": {
-          "kmo_overall": 0.9589,
-          "bartlett_chi2": 3183.97,
+          "kmo_overall": 0.9605,
+          "bartlett_chi2": 3302.47,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [8.0399, 0.9454, 0.7977, 0.766]
+          "eigenvalues_real": [8.0987, 0.9476, 0.7806, 0.7586]
         },
         "efa": {
           "construct": "Readiness",
           "n_factors": 1,
-          "variance_explained": [0.4405],
-          "total_variance": 0.4405,
+          "variance_explained": [0.4441],
+          "total_variance": 0.4441,
           "factor_correlations": null,
           "loadings": {
-            "R1": [0.7291],
-            "R2": [0.6774],
-            "R3": [0.7105],
+            "R1": [0.7253],
+            "R2": [0.6788],
+            "R3": [0.7129],
             "R4": [0.5839],
-            "R5": [0.6062],
-            "R6": [0.6958],
-            "R7": [0.7053],
-            "R8": [0.6777],
-            "R9": [0.6572],
-            "R10": [0.6496],
-            "R11": [0.6687],
-            "R12": [0.6418],
-            "R13": [0.6845],
-            "R14": [0.6194],
-            "R15": [0.6754],
-            "R16": [0.7297],
-            "R17": [0.5386]
+            "R5": [0.603],
+            "R6": [0.6973],
+            "R7": [0.7081],
+            "R8": [0.6821],
+            "R9": [0.6604],
+            "R10": [0.6572],
+            "R11": [0.6735],
+            "R12": [0.6434],
+            "R13": [0.6856],
+            "R14": [0.6244],
+            "R15": [0.6776],
+            "R16": [0.7348],
+            "R17": [0.5508]
           }
         },
         "cfa": {
           "construct": "Readiness",
-          "chi2": 262.702,
+          "chi2": 261.213,
           "df": 119,
           "chi2_p": 0.0,
-          "cfi": 0.9538,
-          "tli": 0.9471,
-          "rmsea": 0.0544,
+          "cfi": 0.9559,
+          "tli": 0.9496,
+          "rmsea": 0.0534,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.438,
-          "min_r": 0.2792,
-          "max_r": 0.5921,
-          "sd_r": 0.0593
+          "mean_r": 0.4417,
+          "min_r": 0.286,
+          "max_r": 0.5891,
+          "sd_r": 0.0582
         },
-        "itc_min": 0.52,
+        "itc_min": 0.53,
         "itc_all_above_030": true
       },
       "Maturity": {
-        "cronbach_alpha": 0.8884,
-        "cronbach_alpha_ci": [0.8716, 0.9038],
-        "n_listwise": 423,
-        "mcdonalds_omega": 0.8889,
-        "composite_reliability": 0.8889,
-        "ave": 0.5016,
-        "split_half": 0.9124,
+        "cronbach_alpha": 0.8881,
+        "cronbach_alpha_ci": [0.8715, 0.9033],
+        "n_listwise": 436,
+        "mcdonalds_omega": 0.8886,
+        "composite_reliability": 0.8886,
+        "ave": 0.5006,
+        "split_half": 0.9114,
         "kmo_bartlett": {
-          "kmo_overall": 0.923,
-          "bartlett_chi2": 1474.17,
-          "bartlett_p": 2.3907785013745436e-293
+          "kmo_overall": 0.9242,
+          "bartlett_chi2": 1511.34,
+          "bartlett_p": 2.8093843511297256e-301
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [4.5027, 0.6406, 0.5909, 0.5532]
+          "eigenvalues_real": [4.4964, 0.6449, 0.5907, 0.5519]
         },
         "efa": {
           "construct": "Maturity",
           "n_factors": 1,
-          "variance_explained": [0.5016],
-          "total_variance": 0.5016,
+          "variance_explained": [0.5006],
+          "total_variance": 0.5006,
           "factor_correlations": null,
           "loadings": {
-            "M1": [0.762],
-            "M2": [0.7772],
-            "M3": [0.6488],
-            "M4": [0.6654],
-            "M5": [0.6505],
-            "M6": [0.7743],
-            "M7": [0.7168],
-            "M8": [0.654]
+            "M1": [0.7597],
+            "M2": [0.7761],
+            "M3": [0.6485],
+            "M4": [0.6694],
+            "M5": [0.6512],
+            "M6": [0.7735],
+            "M7": [0.7157],
+            "M8": [0.65]
           }
         },
         "cfa": {
           "construct": "Maturity",
-          "chi2": 41.969,
+          "chi2": 40.193,
           "df": 20,
-          "chi2_p": 0.0028,
-          "cfi": 0.985,
-          "tli": 0.979,
-          "rmsea": 0.051,
+          "chi2_p": 0.0047,
+          "cfi": 0.9865,
+          "tli": 0.9811,
+          "rmsea": 0.0482,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.4987,
-          "min_r": 0.406,
-          "max_r": 0.65,
-          "sd_r": 0.0552
+          "mean_r": 0.4978,
+          "min_r": 0.3999,
+          "max_r": 0.6436,
+          "sd_r": 0.0544
         },
         "itc_min": 0.61,
         "itc_all_above_030": true
@@ -2131,25 +2131,25 @@
       "htmt": [
         {
           "pair": "Barriers vs Readiness",
-          "htmt": 0.3518,
-          "ci_lower": 0.2706,
-          "ci_upper": 0.4604,
+          "htmt": 0.3526,
+          "ci_lower": 0.2749,
+          "ci_upper": 0.4635,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "htmt": 0.3742,
-          "ci_lower": 0.294,
-          "ci_upper": 0.4739,
+          "htmt": 0.3731,
+          "ci_lower": 0.3004,
+          "ci_upper": 0.4664,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "htmt": 0.8167,
-          "ci_lower": 0.7442,
-          "ci_upper": 0.8747,
+          "htmt": 0.8143,
+          "ci_lower": 0.7419,
+          "ci_upper": 0.8729,
           "below_085": true,
           "below_090": true
         }
@@ -2157,66 +2157,66 @@
       "fornell_larcker": [
         {
           "pair": "Barriers vs Readiness",
-          "sqrt_ave1": 0.5796,
-          "sqrt_ave2": 0.6637,
-          "abs_r": 0.2852,
+          "sqrt_ave1": 0.5823,
+          "sqrt_ave2": 0.6664,
+          "abs_r": 0.2865,
           "pass": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "sqrt_ave1": 0.5796,
-          "sqrt_ave2": 0.7082,
-          "abs_r": 0.3069,
+          "sqrt_ave1": 0.5823,
+          "sqrt_ave2": 0.7075,
+          "abs_r": 0.3048,
           "pass": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "sqrt_ave1": 0.6637,
-          "sqrt_ave2": 0.7082,
-          "abs_r": 0.7253,
+          "sqrt_ave1": 0.6664,
+          "sqrt_ave2": 0.7075,
+          "abs_r": 0.724,
           "pass": false
         }
       ],
       "construct_correlations": {
         "Barriers": {
           "Barriers": 1.0,
-          "Readiness": -0.2852,
-          "Maturity": -0.3069
+          "Readiness": -0.2865,
+          "Maturity": -0.3048
         },
         "Readiness": {
-          "Barriers": -0.2852,
+          "Barriers": -0.2865,
           "Readiness": 1.0,
-          "Maturity": 0.7253
+          "Maturity": 0.724
         },
         "Maturity": {
-          "Barriers": -0.3069,
-          "Readiness": 0.7253,
+          "Barriers": -0.3048,
+          "Readiness": 0.724,
           "Maturity": 1.0
         }
       },
       "barriers_4f_cfa": {
-        "chi2": 452.063,
+        "chi2": 454.972,
         "df": 129,
         "chi2_p": 0.0,
-        "cfi": 0.8785,
-        "tli": 0.8559,
-        "rmsea": 0.0762,
-        "aic": 81.91,
-        "bic": 252.78
+        "cfi": 0.8819,
+        "tli": 0.86,
+        "rmsea": 0.0755,
+        "aic": 81.95,
+        "bic": 253.98
       },
       "factor_analysis": {
         "efa_factors": [
           {
             "name": "F1",
             "items": 15,
-            "eigenvalue": 6.6958,
-            "variance_pct": 31.4
+            "eigenvalue": 6.7497,
+            "variance_pct": 31.5
           },
           {
             "name": "F2",
             "items": 3,
-            "eigenvalue": 1.6342,
-            "variance_pct": 10.6
+            "eigenvalue": 1.6363,
+            "variance_pct": 10.7
           }
         ],
         "three_groups": [
@@ -2224,28 +2224,28 @@
             "name": "F1a \u2014 Strategy & Culture",
             "item_ids": ["B1", "B2", "B3", "B5", "B9", "B10", "B11", "B15", "B17"],
             "items": 9,
-            "alpha": 0.8593,
-            "cr": 0.8632,
-            "ave": 0.421
+            "alpha": 0.8566,
+            "cr": 0.8605,
+            "ave": 0.4152
           },
           {
             "name": "F1b \u2014 Resources & Operations",
             "item_ids": ["B4", "B6", "B7", "B8", "B12"],
             "items": 5,
-            "alpha": 0.6999,
-            "cr": 0.7033,
-            "ave": 0.3258
+            "alpha": 0.7116,
+            "cr": 0.715,
+            "ave": 0.3384
           },
           {
             "name": "F2 \u2014 External & Compliance",
             "item_ids": ["B13", "B14", "B16", "B18"],
             "items": 4,
-            "alpha": 0.6526,
-            "cr": 0.7124,
-            "ave": 0.4367
+            "alpha": 0.6537,
+            "cr": 0.7135,
+            "ave": 0.4379
           }
         ],
-        "factor_correlation": 0.5701,
+        "factor_correlation": 0.5707,
         "barrier_names": [
           "Resistance to Change",
           "Lack of Leadership Support",
@@ -2269,110 +2269,110 @@
         "loadings_matrix": [
           {
             "id": "B1",
-            "f1": 0.7681,
-            "f2": -0.1999,
+            "f1": 0.7547,
+            "f2": -0.1949,
             "assigned": "F1"
           },
           {
             "id": "B2",
-            "f1": 0.7902,
-            "f2": -0.1516,
+            "f1": 0.7767,
+            "f2": -0.1404,
             "assigned": "F1"
           },
           {
             "id": "B3",
-            "f1": 0.6826,
-            "f2": -0.0901,
+            "f1": 0.6863,
+            "f2": -0.0858,
             "assigned": "F1"
           },
           {
             "id": "B4",
-            "f1": 0.7172,
-            "f2": -0.0636,
+            "f1": 0.7319,
+            "f2": -0.0774,
             "assigned": "F1"
           },
           {
             "id": "B5",
-            "f1": 0.6715,
-            "f2": -0.0508,
+            "f1": 0.6789,
+            "f2": -0.0512,
             "assigned": "F1"
           },
           {
             "id": "B6",
-            "f1": 0.4874,
-            "f2": 0.045,
+            "f1": 0.5025,
+            "f2": 0.0336,
             "assigned": "F1"
           },
           {
             "id": "B7",
-            "f1": 0.5343,
-            "f2": 0.0781,
+            "f1": 0.5384,
+            "f2": 0.0769,
             "assigned": "F1"
           },
           {
             "id": "B8",
-            "f1": 0.5493,
-            "f2": 0.0845,
+            "f1": 0.5617,
+            "f2": 0.0876,
             "assigned": "F1"
           },
           {
             "id": "B9",
-            "f1": 0.5986,
-            "f2": -0.0014,
+            "f1": 0.5893,
+            "f2": -0.0075,
             "assigned": "F1"
           },
           {
             "id": "B10",
-            "f1": 0.7696,
-            "f2": -0.074,
+            "f1": 0.7641,
+            "f2": -0.0652,
             "assigned": "F1"
           },
           {
             "id": "B11",
-            "f1": 0.5195,
-            "f2": 0.1076,
+            "f1": 0.5214,
+            "f2": 0.1206,
             "assigned": "F1"
           },
           {
             "id": "B12",
-            "f1": 0.5384,
-            "f2": 0.0785,
+            "f1": 0.5465,
+            "f2": 0.0812,
             "assigned": "F1"
           },
           {
             "id": "B13",
-            "f1": -0.1897,
-            "f2": 0.8999,
+            "f1": -0.1799,
+            "f2": 0.8824,
             "assigned": "F2"
           },
           {
             "id": "B14",
-            "f1": -0.1276,
-            "f2": 0.8567,
+            "f1": -0.1386,
+            "f2": 0.8722,
             "assigned": "F2"
           },
           {
             "id": "B15",
-            "f1": 0.457,
-            "f2": 0.1907,
+            "f1": 0.4492,
+            "f2": 0.2038,
             "assigned": "F1"
           },
           {
             "id": "B16",
-            "f1": 0.2143,
-            "f2": 0.4014,
+            "f1": 0.214,
+            "f2": 0.4179,
             "assigned": "F2"
           },
           {
             "id": "B17",
-            "f1": 0.478,
-            "f2": 0.1147,
+            "f1": 0.4765,
+            "f2": 0.1185,
             "assigned": "F1"
           },
           {
             "id": "B18",
-            "f1": 0.3622,
-            "f2": 0.2046,
+            "f1": 0.3723,
+            "f2": 0.1938,
             "assigned": "F1"
           }
         ]
@@ -2422,7 +2422,7 @@
         }
       },
       "metadata": {
-        "n_total": 534,
+        "n_total": 550,
         "crp200_mode": false,
         "constructs": ["Barriers", "Readiness", "Maturity"],
         "n_barriers": 18,

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -22,13 +22,13 @@
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 453
+      "n": 466
     },
     {
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 534
+      "n": 550
     }
   ],
   "metrics": [
@@ -39,8 +39,8 @@
         "conservative_clean": 2.8483,
         "flexible_clean": 2.8376,
         "prolific_accepted": 2.8297,
-        "v2_finished": 2.7868,
-        "v2_all": 2.791
+        "v2_finished": 2.7946,
+        "v2_all": 2.7972
       }
     },
     {
@@ -50,8 +50,8 @@
         "conservative_clean": 0.607,
         "flexible_clean": 0.6884,
         "prolific_accepted": 0.6952,
-        "v2_finished": 0.7594,
-        "v2_all": 0.7624
+        "v2_finished": 0.7635,
+        "v2_all": 0.7661
       }
     },
     {
@@ -61,8 +61,8 @@
         "conservative_clean": 3.0423,
         "flexible_clean": 3.0909,
         "prolific_accepted": 3.1186,
-        "v2_finished": 3.2187,
-        "v2_all": 3.2188
+        "v2_finished": 3.2203,
+        "v2_all": 3.2205
       }
     },
     {
@@ -72,8 +72,8 @@
         "conservative_clean": 0.5608,
         "flexible_clean": 0.6469,
         "prolific_accepted": 0.6688,
-        "v2_finished": 0.7146,
-        "v2_all": 0.7138
+        "v2_finished": 0.7155,
+        "v2_all": 0.7139
       }
     },
     {
@@ -83,8 +83,8 @@
         "conservative_clean": 3.0408,
         "flexible_clean": 3.0639,
         "prolific_accepted": 3.145,
-        "v2_finished": 3.2484,
-        "v2_all": 3.2484
+        "v2_finished": 3.2439,
+        "v2_all": 3.2441
       }
     },
     {
@@ -94,8 +94,8 @@
         "conservative_clean": 0.7035,
         "flexible_clean": 0.7926,
         "prolific_accepted": 0.7984,
-        "v2_finished": 0.8001,
-        "v2_all": 0.8001
+        "v2_finished": 0.7962,
+        "v2_all": 0.7954
       }
     },
     {
@@ -105,8 +105,8 @@
         "conservative_clean": -0.4145,
         "flexible_clean": -0.4197,
         "prolific_accepted": -0.3259,
-        "v2_finished": -0.2854,
-        "v2_all": -0.2852
+        "v2_finished": -0.2869,
+        "v2_all": -0.2865
       }
     },
     {
@@ -116,8 +116,8 @@
         "conservative_clean": -0.1742,
         "flexible_clean": -0.2956,
         "prolific_accepted": -0.2631,
-        "v2_finished": -0.3069,
-        "v2_all": -0.3069
+        "v2_finished": -0.3048,
+        "v2_all": -0.3048
       }
     },
     {
@@ -127,8 +127,8 @@
         "conservative_clean": 0.5944,
         "flexible_clean": 0.712,
         "prolific_accepted": 0.731,
-        "v2_finished": 0.7253,
-        "v2_all": 0.7253
+        "v2_finished": 0.724,
+        "v2_all": 0.724
       }
     },
     {
@@ -138,8 +138,8 @@
         "conservative_clean": 0.8446,
         "flexible_clean": 0.869,
         "prolific_accepted": 0.872,
-        "v2_finished": 0.8973,
-        "v2_all": 0.8984
+        "v2_finished": 0.8989,
+        "v2_all": 0.8998
       }
     },
     {
@@ -149,8 +149,8 @@
         "conservative_clean": 0.8588,
         "flexible_clean": 0.9112,
         "prolific_accepted": 0.9159,
-        "v2_finished": 0.9293,
-        "v2_all": 0.9293
+        "v2_finished": 0.9303,
+        "v2_all": 0.9303
       }
     },
     {
@@ -160,8 +160,8 @@
         "conservative_clean": 0.8299,
         "flexible_clean": 0.8833,
         "prolific_accepted": 0.8859,
-        "v2_finished": 0.8884,
-        "v2_all": 0.8884
+        "v2_finished": 0.8881,
+        "v2_all": 0.8881
       }
     }
   ],
@@ -1099,372 +1099,106 @@
     "v2_finished": {
       "demographics": {
         "roles": {
-          "Other": 86,
+          "Other": 93,
           "CIO": 67,
+          "CEO": 51,
           "COO": 49,
-          "CEO": 49,
-          "CSO": 39,
-          "CTO": 39,
-          "CFO": 36,
+          "CSO": 40,
+          "CTO": 40,
+          "CFO": 37,
           "CMO": 30,
-          "CRO": 27,
+          "CRO": 28,
           "CHRO": 25,
           "CISO": 6
         },
         "org_sizes": {
-          "<100": 67,
-          "100-499": 133,
-          "500-999": 66,
-          "1000-4999": 84,
-          "5000-9999": 38,
+          "<100": 69,
+          "100-499": 136,
+          "500-999": 68,
+          "1000-4999": 87,
+          "5000-9999": 41,
           "10000+": 65
         },
         "profit_models": {
-          "For-Profit": 334,
-          "Non-Profit": 78,
-          "Government/Public Sector": 41
-        },
-        "tech_vs_nontech": {
-          "technical": 117,
-          "non_technical": 336,
-          "other": 0
-        },
-        "other_roles": {
-          "total": 86,
-          "categories": {}
-        }
-      },
-      "effect_sizes": {
-        "tech_vs_nontech": {
-          "tech_n": 117,
-          "nontech_n": 336,
-          "constructs": {
-            "barriers": {
-              "tech_mean": 2.6956,
-              "tech_mean_ci_lower": 2.5532,
-              "tech_mean_ci_upper": 2.8381,
-              "nontech_mean": 2.8185,
-              "nontech_mean_ci_lower": 2.7379,
-              "nontech_mean_ci_upper": 2.8992,
-              "d": -0.1621,
-              "d_ci_lower": -0.3832,
-              "d_ci_upper": 0.056
-            },
-            "readiness": {
-              "tech_mean": 3.4822,
-              "tech_mean_ci_lower": 3.3575,
-              "tech_mean_ci_upper": 3.6069,
-              "nontech_mean": 3.1267,
-              "nontech_mean_ci_lower": 3.0511,
-              "nontech_mean_ci_upper": 3.2024,
-              "d": 0.5092,
-              "d_ci_lower": 0.3019,
-              "d_ci_upper": 0.7158
-            },
-            "maturity": {
-              "tech_mean": 3.4509,
-              "tech_mean_ci_lower": 3.3123,
-              "tech_mean_ci_upper": 3.5895,
-              "nontech_mean": 3.1775,
-              "nontech_mean_ci_lower": 3.091,
-              "nontech_mean_ci_upper": 3.264,
-              "d": 0.3452,
-              "d_ci_lower": 0.1335,
-              "d_ci_upper": 0.5526
-            }
-          }
-        },
-        "large_vs_small": {
-          "large_n": 103,
-          "small_medium_n": 350,
-          "constructs": {
-            "barriers": {
-              "large_mean": 2.8817,
-              "large_mean_ci_lower": 2.7331,
-              "large_mean_ci_upper": 3.0302,
-              "small_medium_mean": 2.7589,
-              "small_medium_mean_ci_lower": 2.6792,
-              "small_medium_mean_ci_upper": 2.8386,
-              "d": 0.1619,
-              "d_ci_lower": -0.0614,
-              "d_ci_upper": 0.3974
-            },
-            "readiness": {
-              "large_mean": 3.2297,
-              "large_mean_ci_lower": 3.0922,
-              "large_mean_ci_upper": 3.3673,
-              "small_medium_mean": 3.2155,
-              "small_medium_mean_ci_lower": 3.1398,
-              "small_medium_mean_ci_upper": 3.2912,
-              "d": 0.0199,
-              "d_ci_lower": -0.2074,
-              "d_ci_upper": 0.2287
-            }
-          }
-        }
-      },
-      "cross_tabs": {
-        "by_role": [
-          {
-            "group": "Technical",
-            "n": 117,
-            "barrier_mean": 2.6956,
-            "readiness_mean": 3.4822,
-            "maturity_mean": 3.4509
-          },
-          {
-            "group": "Non-Technical",
-            "n": 336,
-            "barrier_mean": 2.8185,
-            "readiness_mean": 3.1267,
-            "maturity_mean": 3.1775
-          }
-        ],
-        "by_org_size": [
-          {
-            "group": "Small (<500)",
-            "n": 200,
-            "barrier_mean": 2.7406,
-            "readiness_mean": 3.1271,
-            "maturity_mean": 3.1355
-          },
-          {
-            "group": "Medium (500-4999)",
-            "n": 150,
-            "barrier_mean": 2.7832,
-            "readiness_mean": 3.3341,
-            "maturity_mean": 3.3557
-          },
-          {
-            "group": "Large (5000+)",
-            "n": 103,
-            "barrier_mean": 2.8817,
-            "readiness_mean": 3.2297,
-            "maturity_mean": 3.3113
-          }
-        ]
-      },
-      "inferential": {
-        "t_tests_tech_vs_nontech": {
-          "tech_n": 117,
-          "nontech_n": 336,
-          "constructs": {
-            "barriers": {
-              "t": -1.4848,
-              "p": 0.1392,
-              "df": 196.45,
-              "mean_diff_ci_lower": -0.2862,
-              "mean_diff_ci_upper": 0.0403,
-              "sig": false
-            },
-            "readiness": {
-              "t": 4.8178,
-              "p": 0.0,
-              "df": 208.61,
-              "mean_diff_ci_lower": 0.21,
-              "mean_diff_ci_upper": 0.5009,
-              "sig": true
-            },
-            "maturity": {
-              "t": 3.3073,
-              "p": 0.0011,
-              "df": 214.11,
-              "mean_diff_ci_lower": 0.1105,
-              "mean_diff_ci_upper": 0.4363,
-              "sig": true
-            }
-          }
-        },
-        "t_tests_large_vs_small": {
-          "large_n": 103,
-          "small_medium_n": 350,
-          "constructs": {
-            "barriers": {
-              "t": 1.4416,
-              "p": 0.1513,
-              "df": 166.24,
-              "mean_diff_ci_lower": -0.0454,
-              "mean_diff_ci_upper": 0.2909,
-              "sig": false
-            },
-            "readiness": {
-              "t": 0.1795,
-              "p": 0.8578,
-              "df": 169.72,
-              "mean_diff_ci_lower": -0.1423,
-              "mean_diff_ci_upper": 0.1708,
-              "sig": false
-            },
-            "maturity": {
-              "t": 0.8889,
-              "p": 0.3754,
-              "df": 161.86,
-              "mean_diff_ci_lower": -0.0996,
-              "mean_diff_ci_upper": 0.2627,
-              "sig": false
-            }
-          }
-        },
-        "anova_by_role": {
-          "groups": ["Technical", "Non-Technical"],
-          "group_ns": [117, 336],
-          "constructs": {
-            "barriers": {
-              "f": 2.2798,
-              "p": 0.1318,
-              "df_between": 1,
-              "df_within": 451,
-              "sig": false
-            },
-            "readiness": {
-              "f": 22.483,
-              "p": 0.0,
-              "df_between": 1,
-              "df_within": 450,
-              "sig": true
-            },
-            "maturity": {
-              "f": 10.3234,
-              "p": 0.0014,
-              "df_between": 1,
-              "df_within": 449,
-              "sig": true
-            }
-          }
-        },
-        "anova_by_org_size": {
-          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [200, 150, 103],
-          "constructs": {
-            "barriers": {
-              "f": 1.1761,
-              "p": 0.3094,
-              "df_between": 2,
-              "df_within": 450,
-              "sig": false
-            },
-            "readiness": {
-              "f": 3.6401,
-              "p": 0.027,
-              "df_between": 2,
-              "df_within": 449,
-              "sig": true
-            },
-            "maturity": {
-              "f": 3.6825,
-              "p": 0.0259,
-              "df_between": 2,
-              "df_within": 448,
-              "sig": true
-            }
-          }
-        }
-      }
-    },
-    "v2_all": {
-      "demographics": {
-        "roles": {
-          "Other": 90,
-          "Unknown": 69,
-          "CIO": 68,
-          "COO": 50,
-          "CEO": 49,
-          "CSO": 41,
-          "CTO": 39,
-          "CFO": 37,
-          "CMO": 30,
-          "CRO": 28,
-          "CHRO": 27,
-          "CISO": 6
-        },
-        "org_sizes": {
-          "<100": 69,
-          "100-499": 138,
-          "500-999": 68,
-          "1000-4999": 85,
-          "5000-9999": 39,
-          "10000+": 66
-        },
-        "profit_models": {
-          "For-Profit": 344,
-          "Non-Profit": 80,
-          "Government/Public Sector": 41
+          "For-Profit": 342,
+          "Non-Profit": 79,
+          "Government/Public Sector": 45
         },
         "tech_vs_nontech": {
           "technical": 118,
-          "non_technical": 347,
-          "other": 69
+          "non_technical": 348,
+          "other": 0
         },
         "other_roles": {
-          "total": 90,
+          "total": 93,
           "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 118,
-          "nontech_n": 347,
+          "nontech_n": 348,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.6956,
-              "tech_mean_ci_lower": 2.5532,
-              "tech_mean_ci_upper": 2.8381,
-              "nontech_mean": 2.8238,
-              "nontech_mean_ci_lower": 2.7432,
-              "nontech_mean_ci_upper": 2.9044,
-              "d": -0.1684,
-              "d_ci_lower": -0.3858,
-              "d_ci_upper": 0.0453
+              "tech_mean": 2.7034,
+              "tech_mean_ci_lower": 2.5613,
+              "tech_mean_ci_upper": 2.8454,
+              "nontech_mean": 2.8256,
+              "nontech_mean_ci_lower": 2.7458,
+              "nontech_mean_ci_upper": 2.9054,
+              "d": -0.1603,
+              "d_ci_lower": -0.3623,
+              "d_ci_upper": 0.0537
             },
             "readiness": {
-              "tech_mean": 3.4822,
-              "tech_mean_ci_lower": 3.3575,
-              "tech_mean_ci_upper": 3.6069,
-              "nontech_mean": 3.1271,
-              "nontech_mean_ci_lower": 3.0517,
-              "nontech_mean_ci_upper": 3.2026,
-              "d": 0.5091,
-              "d_ci_lower": 0.311,
-              "d_ci_upper": 0.7178
+              "tech_mean": 3.4866,
+              "tech_mean_ci_lower": 3.3627,
+              "tech_mean_ci_upper": 3.6105,
+              "nontech_mean": 3.1298,
+              "nontech_mean_ci_lower": 3.0553,
+              "nontech_mean_ci_upper": 3.2042,
+              "d": 0.5104,
+              "d_ci_lower": 0.3129,
+              "d_ci_upper": 0.7156
             },
             "maturity": {
-              "tech_mean": 3.4509,
-              "tech_mean_ci_lower": 3.3123,
-              "tech_mean_ci_upper": 3.5895,
-              "nontech_mean": 3.1775,
-              "nontech_mean_ci_lower": 3.091,
-              "nontech_mean_ci_upper": 3.264,
-              "d": 0.3452,
-              "d_ci_lower": 0.1335,
-              "d_ci_upper": 0.5526
+              "tech_mean": 3.447,
+              "tech_mean_ci_lower": 3.3094,
+              "tech_mean_ci_upper": 3.5847,
+              "nontech_mean": 3.1746,
+              "nontech_mean_ci_lower": 3.0901,
+              "nontech_mean_ci_upper": 3.2591,
+              "d": 0.3457,
+              "d_ci_lower": 0.1379,
+              "d_ci_upper": 0.5521
             }
           }
         },
         "large_vs_small": {
-          "large_n": 105,
-          "small_medium_n": 429,
+          "large_n": 106,
+          "small_medium_n": 360,
           "constructs": {
             "barriers": {
-              "large_mean": 2.8897,
-              "large_mean_ci_lower": 2.7417,
-              "large_mean_ci_upper": 3.0377,
-              "small_medium_mean": 2.7619,
-              "small_medium_mean_ci_lower": 2.6822,
-              "small_medium_mean_ci_upper": 2.8416,
-              "d": 0.168,
-              "d_ci_lower": -0.0466,
-              "d_ci_upper": 0.3922
+              "large_mean": 2.893,
+              "large_mean_ci_lower": 2.7466,
+              "large_mean_ci_upper": 3.0394,
+              "small_medium_mean": 2.7657,
+              "small_medium_mean_ci_lower": 2.6866,
+              "small_medium_mean_ci_upper": 2.8448,
+              "d": 0.167,
+              "d_ci_lower": -0.0469,
+              "d_ci_upper": 0.3875
             },
             "readiness": {
-              "large_mean": 3.2297,
-              "large_mean_ci_lower": 3.0922,
-              "large_mean_ci_upper": 3.3673,
-              "small_medium_mean": 3.2156,
-              "small_medium_mean_ci_lower": 3.1402,
-              "small_medium_mean_ci_upper": 3.2911,
-              "d": 0.0197,
-              "d_ci_lower": -0.1917,
-              "d_ci_upper": 0.232
+              "large_mean": 3.2451,
+              "large_mean_ci_lower": 3.1073,
+              "large_mean_ci_upper": 3.3828,
+              "small_medium_mean": 3.213,
+              "small_medium_mean_ci_lower": 3.1386,
+              "small_medium_mean_ci_upper": 3.2874,
+              "d": 0.0448,
+              "d_ci_lower": -0.1846,
+              "d_ci_upper": 0.2729
             }
           }
         }
@@ -1474,20 +1208,286 @@
           {
             "group": "Technical",
             "n": 118,
-            "barrier_mean": 2.6956,
-            "readiness_mean": 3.4822,
-            "maturity_mean": 3.4509
+            "barrier_mean": 2.7034,
+            "readiness_mean": 3.4866,
+            "maturity_mean": 3.447
           },
           {
             "group": "Non-Technical",
-            "n": 347,
-            "barrier_mean": 2.8238,
-            "readiness_mean": 3.1271,
-            "maturity_mean": 3.1775
+            "n": 348,
+            "barrier_mean": 2.8256,
+            "readiness_mean": 3.1298,
+            "maturity_mean": 3.1746
+          }
+        ],
+        "by_org_size": [
+          {
+            "group": "Small (<500)",
+            "n": 205,
+            "barrier_mean": 2.742,
+            "readiness_mean": 3.1252,
+            "maturity_mean": 3.1328
+          },
+          {
+            "group": "Medium (500-4999)",
+            "n": 155,
+            "barrier_mean": 2.7969,
+            "readiness_mean": 3.3299,
+            "maturity_mean": 3.3401
+          },
+          {
+            "group": "Large (5000+)",
+            "n": 106,
+            "barrier_mean": 2.893,
+            "readiness_mean": 3.2451,
+            "maturity_mean": 3.3178
+          }
+        ]
+      },
+      "inferential": {
+        "t_tests_tech_vs_nontech": {
+          "tech_n": 118,
+          "nontech_n": 348,
+          "constructs": {
+            "barriers": {
+              "t": -1.4829,
+              "p": 0.1397,
+              "df": 197.02,
+              "mean_diff_ci_lower": -0.2847,
+              "mean_diff_ci_upper": 0.0403,
+              "sig": false
+            },
+            "readiness": {
+              "t": 4.8779,
+              "p": 0.0,
+              "df": 208.91,
+              "mean_diff_ci_lower": 0.2126,
+              "mean_diff_ci_upper": 0.5011,
+              "sig": true
+            },
+            "maturity": {
+              "t": 3.3348,
+              "p": 0.001,
+              "df": 212.99,
+              "mean_diff_ci_lower": 0.1114,
+              "mean_diff_ci_upper": 0.4335,
+              "sig": true
+            }
+          }
+        },
+        "t_tests_large_vs_small": {
+          "large_n": 106,
+          "small_medium_n": 360,
+          "constructs": {
+            "barriers": {
+              "t": 1.5146,
+              "p": 0.1317,
+              "df": 172.16,
+              "mean_diff_ci_lower": -0.0386,
+              "mean_diff_ci_upper": 0.2933,
+              "sig": false
+            },
+            "readiness": {
+              "t": 0.4052,
+              "p": 0.6858,
+              "df": 172.02,
+              "mean_diff_ci_lower": -0.1241,
+              "mean_diff_ci_upper": 0.1881,
+              "sig": false
+            },
+            "maturity": {
+              "t": 1.0635,
+              "p": 0.2891,
+              "df": 166.12,
+              "mean_diff_ci_lower": -0.0821,
+              "mean_diff_ci_upper": 0.2738,
+              "sig": false
+            }
+          }
+        },
+        "anova_by_role": {
+          "groups": ["Technical", "Non-Technical"],
+          "group_ns": [118, 348],
+          "constructs": {
+            "barriers": {
+              "f": 2.2633,
+              "p": 0.1332,
+              "df_between": 1,
+              "df_within": 464,
+              "sig": false
+            },
+            "readiness": {
+              "f": 22.9401,
+              "p": 0.0,
+              "df_between": 1,
+              "df_within": 463,
+              "sig": true
+            },
+            "maturity": {
+              "f": 10.5139,
+              "p": 0.0013,
+              "df_between": 1,
+              "df_within": 462,
+              "sig": true
+            }
+          }
+        },
+        "anova_by_org_size": {
+          "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
+          "group_ns": [205, 155, 106],
+          "constructs": {
+            "barriers": {
+              "f": 1.3687,
+              "p": 0.2555,
+              "df_between": 2,
+              "df_within": 463,
+              "sig": false
+            },
+            "readiness": {
+              "f": 3.7258,
+              "p": 0.0248,
+              "df_between": 2,
+              "df_within": 462,
+              "sig": true
+            },
+            "maturity": {
+              "f": 3.607,
+              "p": 0.0279,
+              "df_between": 2,
+              "df_within": 461,
+              "sig": true
+            }
+          }
+        }
+      }
+    },
+    "v2_all": {
+      "demographics": {
+        "roles": {
+          "Other": 97,
+          "Unknown": 71,
+          "CIO": 68,
+          "COO": 51,
+          "CEO": 51,
+          "CSO": 42,
+          "CTO": 40,
+          "CFO": 38,
+          "CMO": 30,
+          "CRO": 29,
+          "CHRO": 27,
+          "CISO": 6
+        },
+        "org_sizes": {
+          "<100": 71,
+          "100-499": 141,
+          "500-999": 71,
+          "1000-4999": 88,
+          "5000-9999": 42,
+          "10000+": 66
+        },
+        "profit_models": {
+          "For-Profit": 352,
+          "Non-Profit": 82,
+          "Government/Public Sector": 45
+        },
+        "tech_vs_nontech": {
+          "technical": 119,
+          "non_technical": 360,
+          "other": 71
+        },
+        "other_roles": {
+          "total": 97,
+          "categories": {}
+        }
+      },
+      "effect_sizes": {
+        "tech_vs_nontech": {
+          "tech_n": 119,
+          "nontech_n": 360,
+          "constructs": {
+            "barriers": {
+              "tech_mean": 2.7034,
+              "tech_mean_ci_lower": 2.5613,
+              "tech_mean_ci_upper": 2.8454,
+              "nontech_mean": 2.8285,
+              "nontech_mean_ci_lower": 2.7489,
+              "nontech_mean_ci_upper": 2.9081,
+              "d": -0.1636,
+              "d_ci_lower": -0.3717,
+              "d_ci_upper": 0.0557
+            },
+            "readiness": {
+              "tech_mean": 3.4866,
+              "tech_mean_ci_lower": 3.3627,
+              "tech_mean_ci_upper": 3.6105,
+              "nontech_mean": 3.1305,
+              "nontech_mean_ci_lower": 3.0565,
+              "nontech_mean_ci_upper": 3.2046,
+              "d": 0.5103,
+              "d_ci_lower": 0.3041,
+              "d_ci_upper": 0.7246
+            },
+            "maturity": {
+              "tech_mean": 3.447,
+              "tech_mean_ci_lower": 3.3094,
+              "tech_mean_ci_upper": 3.5847,
+              "nontech_mean": 3.175,
+              "nontech_mean_ci_lower": 3.0908,
+              "nontech_mean_ci_upper": 3.2593,
+              "d": 0.3454,
+              "d_ci_lower": 0.131,
+              "d_ci_upper": 0.554
+            }
+          }
+        },
+        "large_vs_small": {
+          "large_n": 108,
+          "small_medium_n": 442,
+          "constructs": {
+            "barriers": {
+              "large_mean": 2.9007,
+              "large_mean_ci_lower": 2.755,
+              "large_mean_ci_upper": 3.0465,
+              "small_medium_mean": 2.7667,
+              "small_medium_mean_ci_lower": 2.6878,
+              "small_medium_mean_ci_upper": 2.8457,
+              "d": 0.1752,
+              "d_ci_lower": -0.0483,
+              "d_ci_upper": 0.3923
+            },
+            "readiness": {
+              "large_mean": 3.2451,
+              "large_mean_ci_lower": 3.1073,
+              "large_mean_ci_upper": 3.3828,
+              "small_medium_mean": 3.2133,
+              "small_medium_mean_ci_lower": 3.1394,
+              "small_medium_mean_ci_upper": 3.2872,
+              "d": 0.0444,
+              "d_ci_lower": -0.168,
+              "d_ci_upper": 0.2811
+            }
+          }
+        }
+      },
+      "cross_tabs": {
+        "by_role": [
+          {
+            "group": "Technical",
+            "n": 119,
+            "barrier_mean": 2.7034,
+            "readiness_mean": 3.4866,
+            "maturity_mean": 3.447
+          },
+          {
+            "group": "Non-Technical",
+            "n": 360,
+            "barrier_mean": 2.8285,
+            "readiness_mean": 3.1305,
+            "maturity_mean": 3.175
           },
           {
             "group": "Unclassified",
-            "n": 69,
+            "n": 71,
             "barrier_mean": null,
             "readiness_mean": null,
             "maturity_mean": null
@@ -1496,138 +1496,138 @@
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 207,
-            "barrier_mean": 2.7509,
-            "readiness_mean": 3.1278,
-            "maturity_mean": 3.1355
+            "n": 212,
+            "barrier_mean": 2.7521,
+            "readiness_mean": 3.1259,
+            "maturity_mean": 3.1328
           },
           {
             "group": "Medium (500-4999)",
-            "n": 153,
-            "barrier_mean": 2.7766,
-            "readiness_mean": 3.3341,
-            "maturity_mean": 3.3557
+            "n": 159,
+            "barrier_mean": 2.786,
+            "readiness_mean": 3.3295,
+            "maturity_mean": 3.3401
           },
           {
             "group": "Large (5000+)",
-            "n": 105,
-            "barrier_mean": 2.8897,
-            "readiness_mean": 3.2297,
-            "maturity_mean": 3.3113
+            "n": 108,
+            "barrier_mean": 2.9007,
+            "readiness_mean": 3.2451,
+            "maturity_mean": 3.3178
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 118,
-          "nontech_n": 347,
+          "tech_n": 119,
+          "nontech_n": 360,
           "constructs": {
             "barriers": {
-              "t": -1.5484,
-              "p": 0.1231,
-              "df": 196.4,
-              "mean_diff_ci_lower": -0.2914,
-              "mean_diff_ci_upper": 0.0351,
+              "t": -1.5195,
+              "p": 0.1302,
+              "df": 196.69,
+              "mean_diff_ci_lower": -0.2875,
+              "mean_diff_ci_upper": 0.0373,
               "sig": false
             },
             "readiness": {
-              "t": 4.816,
+              "t": 4.8745,
               "p": 0.0,
-              "df": 208.09,
-              "mean_diff_ci_lower": 0.2097,
-              "mean_diff_ci_upper": 0.5004,
+              "df": 207.91,
+              "mean_diff_ci_lower": 0.2121,
+              "mean_diff_ci_upper": 0.5001,
               "sig": true
             },
             "maturity": {
-              "t": 3.3073,
-              "p": 0.0011,
-              "df": 214.11,
-              "mean_diff_ci_lower": 0.1105,
-              "mean_diff_ci_upper": 0.4363,
+              "t": 3.3318,
+              "p": 0.001,
+              "df": 212.47,
+              "mean_diff_ci_lower": 0.1111,
+              "mean_diff_ci_upper": 0.4329,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 105,
-          "small_medium_n": 429,
+          "large_n": 108,
+          "small_medium_n": 442,
           "constructs": {
             "barriers": {
-              "t": 1.5057,
-              "p": 0.134,
-              "df": 168.41,
-              "mean_diff_ci_lower": -0.0398,
-              "mean_diff_ci_upper": 0.2955,
+              "t": 1.5997,
+              "p": 0.1115,
+              "df": 174.11,
+              "mean_diff_ci_lower": -0.0313,
+              "mean_diff_ci_upper": 0.2994,
               "sig": false
             },
             "readiness": {
-              "t": 0.1778,
-              "p": 0.8591,
-              "df": 169.33,
-              "mean_diff_ci_lower": -0.1424,
-              "mean_diff_ci_upper": 0.1705,
+              "t": 0.402,
+              "p": 0.6882,
+              "df": 171.27,
+              "mean_diff_ci_lower": -0.1242,
+              "mean_diff_ci_upper": 0.1877,
               "sig": false
             },
             "maturity": {
-              "t": 0.8889,
-              "p": 0.3754,
-              "df": 161.86,
-              "mean_diff_ci_lower": -0.0996,
-              "mean_diff_ci_upper": 0.2627,
+              "t": 1.0607,
+              "p": 0.2904,
+              "df": 165.77,
+              "mean_diff_ci_lower": -0.0823,
+              "mean_diff_ci_upper": 0.2734,
               "sig": false
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Unclassified"],
-          "group_ns": [118, 347, 69],
+          "group_ns": [119, 360, 71],
           "constructs": {
             "barriers": {
-              "f": 2.4677,
-              "p": 0.1169,
+              "f": 2.3664,
+              "p": 0.1246,
               "df_between": 1,
-              "df_within": 455,
+              "df_within": 469,
               "sig": false
             },
             "readiness": {
-              "f": 22.4956,
+              "f": 22.9676,
               "p": 0.0,
               "df_between": 1,
-              "df_within": 451,
+              "df_within": 465,
               "sig": true
             },
             "maturity": {
-              "f": 10.3234,
-              "p": 0.0014,
+              "f": 10.5081,
+              "p": 0.0013,
               "df_between": 1,
-              "df_within": 449,
+              "df_within": 463,
               "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [207, 153, 105],
+          "group_ns": [212, 159, 108],
           "constructs": {
             "barriers": {
-              "f": 1.18,
-              "p": 0.3082,
+              "f": 1.3554,
+              "p": 0.2589,
               "df_between": 2,
-              "df_within": 454,
+              "df_within": 468,
               "sig": false
             },
             "readiness": {
-              "f": 3.631,
-              "p": 0.0273,
+              "f": 3.7221,
+              "p": 0.0249,
               "df_between": 2,
-              "df_within": 450,
+              "df_within": 464,
               "sig": true
             },
             "maturity": {
-              "f": 3.6825,
-              "p": 0.0259,
+              "f": 3.6212,
+              "p": 0.0275,
               "df_between": 2,
-              "df_within": 448,
+              "df_within": 462,
               "sig": true
             }
           }
@@ -1638,22 +1638,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 1.24,
-      "p_value": 0.7424,
+      "chi2": 0.91,
+      "p_value": 0.8242,
       "df": 3,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 7.04,
-      "p_value": 0.9566,
+      "chi2": 7.48,
+      "p_value": 0.9429,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 3.16,
-      "p_value": 0.7889,
+      "chi2": 2.58,
+      "p_value": 0.8593,
       "df": 6,
       "error": null
     },
@@ -1676,9 +1676,9 @@
           "Government/Public Sector": 30
         },
         "All V2 Finished": {
-          "For-Profit": 334,
-          "Non-Profit": 78,
-          "Government/Public Sector": 41
+          "For-Profit": 342,
+          "Non-Profit": 79,
+          "Government/Public Sector": 45
         }
       }
     }
@@ -2404,6 +2404,6 @@
       }
     ]
   },
-  "last_updated": "2026-04-23T13:41:07.569142Z",
-  "extended_last_updated": "2026-04-23T13:41:07.569142Z"
+  "last_updated": "2026-04-24T10:54:13.404386Z",
+  "extended_last_updated": "2026-04-24T10:54:13.404386Z"
 }


### PR DESCRIPTION
Automated update from the unified daily pipeline.

**Data flow**: Qualtrics export → Prolific enrichment →
disposition waterfall → analysis suite → CRP dataset (N=200) →
approve CLEAN → dashboard summary.

All statistics computed across 5 sample definitions.
CRP dataset: N=200 tiered selection + NIST de-identification.