### PR TITLE
fix(homepage): correct Surveys Completed (300) and Survey Questions (57)

### DIFF
--- a/src/components/tabs-page/statistics.tsx
+++ b/src/components/tabs-page/statistics.tsx
@@ -1,13 +1,14 @@
+import dispositionData from '@/data/disposition-summary.json'
 import impactData from '@/data/impact.json'
-import metricsData from '@/data/qualtrics-metrics.json'
-import { getSurveysCompletedCount } from '@/lib/qualtricsStats'
+import { TOTAL_ITEMS_PRESENTED } from '@/lib/tabs-survey-constants'
 
 /**
  * Statistics Section
  * Simple counters matching live site style
  */
 const Statistics = () => {
-  const surveysCompleted = getSurveysCompletedCount(metricsData.responseCounts)
+  // Prolific-approved submissions from the daily disposition pipeline.
+  const surveysCompleted = dispositionData.completionProgress.approved
   // Production hostname visitors (excludes localhost/CI/Playwright test traffic).
   const verifiedVisitors = parseInt(impactData.verifiedVisitors) || 0
 
@@ -32,7 +33,7 @@ const Statistics = () => {
               Survey Questions
             </h3>
             <div className="text-[60px] font-bold text-tabs-orange mb-[5px] leading-none">
-              {metricsData.questionCount > 0 ? metricsData.questionCount.toLocaleString() : '56'}
+              {TOTAL_ITEMS_PRESENTED.toLocaleString()}
             </div>
           </div>
 

--- a/src/components/tabs-page/statistics.tsx
+++ b/src/components/tabs-page/statistics.tsx
@@ -10,7 +10,7 @@ const Statistics = () => {
   // Prolific-approved submissions from the daily disposition pipeline.
   const surveysCompleted = dispositionData.completionProgress.approved
   // Production hostname visitors (excludes localhost/CI/Playwright test traffic).
-  const verifiedVisitors = parseInt(impactData.verifiedVisitors) || 0
+  const verifiedVisitors = parseInt(impactData.verifiedVisitors, 10) || 0
 
   return (
     <section id="statistics" className="w-full py-[80px] bg-white">

--- a/src/lib/tabs-survey-constants.ts
+++ b/src/lib/tabs-survey-constants.ts
@@ -98,8 +98,8 @@ export const DEMOGRAPHIC_COLUMNS = {
 /*  before the survey (tracked as FLAG-RECAPTCHA in disposition data). */
 /* ------------------------------------------------------------------ */
 
-const IRI_ITEMS_TOTAL = 3 // 1 attention-check item per Likert block (barriers + readiness + maturity)
-const DEMOGRAPHIC_ITEMS = 10 // Q1-Q9 plus Q74 open-ended feedback
+const IRI_ITEMS_TOTAL = Object.keys(IRI_COLUMNS).length // 1 per Likert block (barriers + readiness + maturity)
+const DEMOGRAPHIC_ITEMS = Object.keys(DEMOGRAPHIC_COLUMNS).length // Q1-Q9 plus Q74 open-ended feedback
 const RECAPTCHA_ITEMS = 1
 
 export const TOTAL_ITEMS_PRESENTED =

--- a/src/lib/tabs-survey-constants.ts
+++ b/src/lib/tabs-survey-constants.ts
@@ -98,7 +98,7 @@ export const DEMOGRAPHIC_COLUMNS = {
 /*  before the survey (tracked as FLAG-RECAPTCHA in disposition data). */
 /* ------------------------------------------------------------------ */
 
-const IRI_ITEMS_PER_LIKERT_BLOCK = 3 // barriers + readiness + maturity
+const IRI_ITEMS_TOTAL = 3 // 1 attention-check item per Likert block (barriers + readiness + maturity)
 const DEMOGRAPHIC_ITEMS = 10 // Q1-Q9 plus Q74 open-ended feedback
 const RECAPTCHA_ITEMS = 1
 
@@ -106,7 +106,7 @@ export const TOTAL_ITEMS_PRESENTED =
   ITEM_COUNTS.barriers +
   ITEM_COUNTS.readiness +
   ITEM_COUNTS.maturity +
-  IRI_ITEMS_PER_LIKERT_BLOCK +
+  IRI_ITEMS_TOTAL +
   DEMOGRAPHIC_ITEMS +
   RECAPTCHA_ITEMS
 

--- a/src/lib/tabs-survey-constants.ts
+++ b/src/lib/tabs-survey-constants.ts
@@ -88,6 +88,29 @@ export const DEMOGRAPHIC_COLUMNS = {
 } as const
 
 /* ------------------------------------------------------------------ */
+/*  Participant-facing item count                                      */
+/*                                                                     */
+/*  Total items a respondent actually sees in a complete submission.   */
+/*  Barriers/Readiness/Maturity blocks each include 1 IRI attention-   */
+/*  check item (presented inline in the matrix, excluded from scoring).*/
+/*  Demographics cover Q1-Q9 plus the open-ended Q74 feedback prompt.  */
+/*  The reCAPTCHA challenge is a gating item participants complete     */
+/*  before the survey (tracked as FLAG-RECAPTCHA in disposition data). */
+/* ------------------------------------------------------------------ */
+
+const IRI_ITEMS_PER_LIKERT_BLOCK = 3 // barriers + readiness + maturity
+const DEMOGRAPHIC_ITEMS = 10 // Q1-Q9 plus Q74 open-ended feedback
+const RECAPTCHA_ITEMS = 1
+
+export const TOTAL_ITEMS_PRESENTED =
+  ITEM_COUNTS.barriers +
+  ITEM_COUNTS.readiness +
+  ITEM_COUNTS.maturity +
+  IRI_ITEMS_PER_LIKERT_BLOCK +
+  DEMOGRAPHIC_ITEMS +
+  RECAPTCHA_ITEMS
+
+/* ------------------------------------------------------------------ */
 /*  Duration Thresholds                                                */
 /* ------------------------------------------------------------------ */
 

--- a/tests/homepage-statistics.spec.ts
+++ b/tests/homepage-statistics.spec.ts
@@ -19,7 +19,7 @@ test.describe('Homepage Statistics Section', () => {
 
     // Surveys Completed: Prolific-approved count from disposition-summary.json
     await expect(section).toContainText(
-      dispositionData.completionProgress.approved.toLocaleString(),
+      dispositionData.completionProgress.approved.toLocaleString()
     )
 
     // Survey Questions: participant-facing item total derived from constants
@@ -27,7 +27,7 @@ test.describe('Homepage Statistics Section', () => {
 
     // Verified Visitors: production hostname visitors from impact.json
     await expect(section).toContainText(
-      (parseInt(impactData.verifiedVisitors, 10) || 0).toLocaleString(),
+      (parseInt(impactData.verifiedVisitors, 10) || 0).toLocaleString()
     )
   })
 })

--- a/tests/homepage-statistics.spec.ts
+++ b/tests/homepage-statistics.spec.ts
@@ -17,17 +17,25 @@ test.describe('Homepage Statistics Section', () => {
     const section = page.locator('#statistics')
     await expect(section).toBeVisible()
 
+    // Locate each counter block by its heading, then assert the value within
+    // that same container so label↔value pairing is validated (not just
+    // presence of a number somewhere in the section).
+    const getCounterBlock = (label: string) =>
+      section.getByText(label, { exact: true }).locator('xpath=ancestor::div[1]')
+
     // Surveys Completed: Prolific-approved count from disposition-summary.json
-    await expect(section).toContainText(
-      dispositionData.completionProgress.approved.toLocaleString()
+    await expect(getCounterBlock('Surveys Completed')).toContainText(
+      dispositionData.completionProgress.approved.toLocaleString(),
     )
 
     // Survey Questions: participant-facing item total derived from constants
-    await expect(section).toContainText(TOTAL_ITEMS_PRESENTED.toLocaleString())
+    await expect(getCounterBlock('Survey Questions')).toContainText(
+      TOTAL_ITEMS_PRESENTED.toLocaleString(),
+    )
 
     // Verified Visitors: production hostname visitors from impact.json
-    await expect(section).toContainText(
-      (parseInt(impactData.verifiedVisitors, 10) || 0).toLocaleString()
+    await expect(getCounterBlock('Verified Visitors')).toContainText(
+      (parseInt(impactData.verifiedVisitors, 10) || 0).toLocaleString(),
     )
   })
 })

--- a/tests/homepage-statistics.spec.ts
+++ b/tests/homepage-statistics.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import dispositionData from '../src/data/disposition-summary.json'
+import impactData from '../src/data/impact.json'
+import { TOTAL_ITEMS_PRESENTED } from '../src/lib/tabs-survey-constants'
+
+/**
+ * Verifies the three homepage Statistics counters match their canonical data
+ * sources so regressions are caught before they reach production.
+ *
+ * Expected values are derived from the same imports/constants used by
+ * statistics.tsx, so the test stays in sync automatically when data updates.
+ */
+test.describe('Homepage Statistics Section', () => {
+  test('should display correct counter values from canonical data sources', async ({ page }) => {
+    await page.goto('/')
+
+    const section = page.locator('#statistics')
+    await expect(section).toBeVisible()
+
+    // Surveys Completed: Prolific-approved count from disposition-summary.json
+    await expect(section).toContainText(
+      dispositionData.completionProgress.approved.toLocaleString(),
+    )
+
+    // Survey Questions: participant-facing item total derived from constants
+    await expect(section).toContainText(TOTAL_ITEMS_PRESENTED.toLocaleString())
+
+    // Verified Visitors: production hostname visitors from impact.json
+    await expect(section).toContainText(
+      (parseInt(impactData.verifiedVisitors, 10) || 0).toLocaleString(),
+    )
+  })
+})

--- a/tests/homepage-statistics.spec.ts
+++ b/tests/homepage-statistics.spec.ts
@@ -25,17 +25,17 @@ test.describe('Homepage Statistics Section', () => {
 
     // Surveys Completed: Prolific-approved count from disposition-summary.json
     await expect(getCounterBlock('Surveys Completed')).toContainText(
-      dispositionData.completionProgress.approved.toLocaleString(),
+      dispositionData.completionProgress.approved.toLocaleString()
     )
 
     // Survey Questions: participant-facing item total derived from constants
     await expect(getCounterBlock('Survey Questions')).toContainText(
-      TOTAL_ITEMS_PRESENTED.toLocaleString(),
+      TOTAL_ITEMS_PRESENTED.toLocaleString()
     )
 
     // Verified Visitors: production hostname visitors from impact.json
     await expect(getCounterBlock('Verified Visitors')).toContainText(
-      (parseInt(impactData.verifiedVisitors, 10) || 0).toLocaleString(),
+      (parseInt(impactData.verifiedVisitors, 10) || 0).toLocaleString()
     )
   })
 })


### PR DESCRIPTION
Closes #1800

## Summary

Homepage Statistics counters were showing the wrong numbers. This PR points each counter at the correct source of truth.

| Counter | Before | After | Source |
|---|---|---|---|
| Surveys Completed | 364 | **300** | `disposition-summary.json` -> `completionProgress.approved` (Prolific-approved) |
| Survey Questions | 21 | **57** | `TOTAL_ITEMS_PRESENTED` derived in `tabs-survey-constants.ts` |
| Verified Visitors | 1,028 | (unchanged) | `impact.json` |

### Why 364 was wrong
`getSurveysCompletedCount()` resolved to Qualtrics `responseCounts.auditable` -- a raw response count, not the Prolific-approved completion total used everywhere else in the project (daily report, dashboard, ops pipeline).

### Why 21 was wrong
`questionCount` from `qualtrics-metrics.json` counts Qualtrics question IDs. Matrix/Likert batteries (TPB, IRI, etc.) each collapse to 1 ID even though they present many items.

### Canonical participant-facing item count

Derived from the existing `ITEM_COUNTS` constants:

| Block | Substantive | IRI | Presented |
|---|---|---|---|
| Barriers (Q10-Q28) | 18 | 1 | 19 |
| Readiness (Q47-Q64) | 17 | 1 | 18 |
| Maturity (Q65-Q73) | 8 | 1 | 9 |
| Demographics (Q1-Q9) | 9 | 0 | 9 |
| Open-ended feedback (Q74) | 1 | 0 | 1 |
| reCAPTCHA challenge | 1 | 0 | 1 |
| **Total** | **54** | **3** | **57** |

## Changes

- [src/lib/tabs-survey-constants.ts](../blob/fix/homepage-statistics-source/src/lib/tabs-survey-constants.ts): export `TOTAL_ITEMS_PRESENTED` derived from `ITEM_COUNTS` + IRI items + demographics + reCAPTCHA. Survives instrument changes automatically.
- [src/components/tabs-page/statistics.tsx](../blob/fix/homepage-statistics-source/src/components/tabs-page/statistics.tsx): swap data sources, drop unused `qualtrics-metrics.json` import and `getSurveysCompletedCount` call.

## Out of scope

- `/results/survey-stats` page still uses `qualtrics-metrics.json` and `getSurveysCompletedCount` -- those are correct in that context (raw Qualtrics breakdown).
- The upstream `questionCount` field in `qualtrics-metrics.json` still reports 21. Not touched here because nothing reads it after this PR; can be fixed separately if needed.

## Test plan

- [x] `npm run format` -- clean
- [x] `npm run lint` -- 0 errors (3 pre-existing warnings unrelated to this PR)
- [x] `npm test` -- 583/583 pass (56 suites)
- [x] `npm run build` -- static export succeeds
- [ ] After deploy: verify homepage shows Surveys Completed = 300, Survey Questions = 57
- [ ] After deploy: verify `/results/survey-stats` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)