### PR TITLE
fix(homepage): align Live Results prose N with Statistics callout

### DIFF
--- a/__tests__/components/tabs-page/LiveResults.test.tsx
+++ b/__tests__/components/tabs-page/LiveResults.test.tsx
@@ -69,10 +69,13 @@ describe('LiveResults component', () => {
   it('should display explanatory text about the results', () => {
     render(<LiveResults />)
 
-    expect(
-      screen.getByText(/most commonly identified technology adoption barriers/i)
-    ).toBeInTheDocument()
+    // "Surveys Completed" counter is a separate status line, not part of the top-3 intro
     expect(screen.getByText(/surveys completed/i)).toBeInTheDocument()
+    // Top-3 intro is a standalone sentence with no N reference (avoids implying the
+    // card percentages use the same denominator as the completion counter)
+    expect(
+      screen.getByText(/here are the most commonly identified technology adoption barriers/i)
+    ).toBeInTheDocument()
     expect(
       screen.getByText(/Explore detailed analysis, cross-tabulations, and statistical findings/i)
     ).toBeInTheDocument()

--- a/__tests__/components/tabs-page/LiveResults.test.tsx
+++ b/__tests__/components/tabs-page/LiveResults.test.tsx
@@ -19,10 +19,8 @@ describe('LiveResults component', () => {
     render(<LiveResults />)
     const totalN = dispositionData.completionProgress.approved
     const formattedTotalN = totalN.toLocaleString()
-    // Match the full status-line text so a barrier count equal to approved N cannot cause a false positive.
-    expect(
-      screen.getByText(new RegExp(`^${formattedTotalN} Surveys Completed$`))
-    ).toBeInTheDocument()
+    // Exact string match — avoids false positives from locale metacharacters (e.g. "." thousands separator).
+    expect(screen.getByText(`${formattedTotalN} Surveys Completed`)).toBeInTheDocument()
   })
 
   it('should display exactly 3 barriers', () => {

--- a/__tests__/components/tabs-page/LiveResults.test.tsx
+++ b/__tests__/components/tabs-page/LiveResults.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import LiveResults from '../../../src/components/tabs-page/live-results'
+import dispositionData from '../../../src/data/disposition-summary.json'
 import sensitivityData from '../../../src/data/sensitivity-analysis.json'
 
 // Extend Jest matchers
@@ -14,9 +15,9 @@ describe('LiveResults component', () => {
     expect(screen.getByText('Live Results: Top Barriers')).toBeInTheDocument()
   })
 
-  it('should display the participant count', () => {
+  it('should display the participant count from the same source as the homepage Statistics callout', () => {
     render(<LiveResults />)
-    const totalN = sensitivityData.top3_pick_counts.total_n
+    const totalN = dispositionData.completionProgress.approved
     const formattedTotalN = totalN.toLocaleString()
     expect(screen.getByText(new RegExp(formattedTotalN))).toBeInTheDocument()
   })

--- a/__tests__/components/tabs-page/LiveResults.test.tsx
+++ b/__tests__/components/tabs-page/LiveResults.test.tsx
@@ -15,7 +15,7 @@ describe('LiveResults component', () => {
     expect(screen.getByText('Live Results: Top Barriers')).toBeInTheDocument()
   })
 
-  it('should display the participant count from the same source as the homepage Statistics callout', () => {
+  it('should display the survey-completion count from the same source as the homepage Statistics callout', () => {
     render(<LiveResults />)
     const totalN = dispositionData.completionProgress.approved
     const formattedTotalN = totalN.toLocaleString()
@@ -72,6 +72,7 @@ describe('LiveResults component', () => {
     expect(
       screen.getByText(/most commonly identified technology adoption barriers/i)
     ).toBeInTheDocument()
+    expect(screen.getByText(/surveys completed/i)).toBeInTheDocument()
     expect(
       screen.getByText(/Explore detailed analysis, cross-tabulations, and statistical findings/i)
     ).toBeInTheDocument()

--- a/__tests__/components/tabs-page/LiveResults.test.tsx
+++ b/__tests__/components/tabs-page/LiveResults.test.tsx
@@ -19,7 +19,10 @@ describe('LiveResults component', () => {
     render(<LiveResults />)
     const totalN = dispositionData.completionProgress.approved
     const formattedTotalN = totalN.toLocaleString()
-    expect(screen.getByText(new RegExp(formattedTotalN))).toBeInTheDocument()
+    // Match the full status-line text so a barrier count equal to approved N cannot cause a false positive.
+    expect(
+      screen.getByText(new RegExp(`^${formattedTotalN} Surveys Completed$`))
+    ).toBeInTheDocument()
   })
 
   it('should display exactly 3 barriers', () => {

--- a/src/components/tabs-page/live-results.tsx
+++ b/src/components/tabs-page/live-results.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import dispositionData from '@/data/disposition-summary.json'
 import sensitivityData from '@/data/sensitivity-analysis.json'
 
 /**
@@ -9,7 +10,10 @@ const LiveResults = () => {
   // Get top 3 barriers by count without mutating imported JSON data
   const top3Barriers = sensitivityData.top3_pick_counts.items_sorted_desc.slice(0, 3)
 
-  const totalN = sensitivityData.top3_pick_counts.total_n
+  // Headline N reads from the same source as the homepage Statistics callout
+  // so the prose cannot drift from the counter when the two pipeline JSON
+  // files refresh on different schedules.
+  const totalN = dispositionData.completionProgress.approved
 
   return (
     <section id="live-results" className="w-full py-[80px] bg-gray-50">

--- a/src/components/tabs-page/live-results.tsx
+++ b/src/components/tabs-page/live-results.tsx
@@ -24,8 +24,8 @@ const LiveResults = () => {
             Live Results: Top Barriers
           </h2>
           <p className="text-[20px] text-gray-700 max-w-[800px] mx-auto">
-            Based on responses from {totalN.toLocaleString()} verified participants, here are the
-            most commonly identified technology adoption barriers.
+            {totalN.toLocaleString()} surveys completed. Here are the most commonly identified
+            technology adoption barriers.
           </p>
         </div>
 

--- a/src/components/tabs-page/live-results.tsx
+++ b/src/components/tabs-page/live-results.tsx
@@ -20,12 +20,17 @@ const LiveResults = () => {
       <div className="w-[90%] mx-auto max-w-[4096px]">
         {/* Section Header */}
         <div className="text-center mb-[60px]">
-          <h2 className="text-[48px] font-bold text-gray-900 mb-[20px] font-serif">
+          <h2 className="text-[48px] font-bold text-gray-900 mb-[16px] font-serif">
             Live Results: Top Barriers
           </h2>
+          {/* Surveys-completed counter — matches the Statistics callout value.
+              Kept visually separate so it is read as a status line, not as
+              the denominator for the top-3 card percentages below. */}
+          <p className="text-[14px] text-gray-500 uppercase tracking-widest mb-[16px]">
+            {totalN.toLocaleString()} Surveys Completed
+          </p>
           <p className="text-[20px] text-gray-700 max-w-[800px] mx-auto">
-            {totalN.toLocaleString()} surveys completed. Here are the most commonly identified
-            technology adoption barriers.
+            Here are the most commonly identified technology adoption barriers.
           </p>
         </div>
 

--- a/tests/homepage-live-results.spec.ts
+++ b/tests/homepage-live-results.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import sensitivityData from '../src/data/sensitivity-analysis.json'
+import dispositionData from '../src/data/disposition-summary.json'
 
 test.describe('Homepage Live Results Section', () => {
   test('should display live results section with top 3 barriers', async ({ page }) => {
@@ -8,8 +8,8 @@ test.describe('Homepage Live Results Section', () => {
     // Check section heading
     await expect(page.getByRole('heading', { name: 'Live Results: Top Barriers' })).toBeVisible()
 
-    // Check participant count is displayed (derive from data to avoid brittleness)
-    const totalN = sensitivityData.top3_pick_counts.total_n
+    // Headline N reads from the same source as the homepage Statistics callout.
+    const totalN = dispositionData.completionProgress.approved
     await expect(page.locator('#live-results')).toContainText(totalN.toLocaleString())
 
     // Check all 3 rank badges are visible

--- a/tests/homepage-live-results.spec.ts
+++ b/tests/homepage-live-results.spec.ts
@@ -9,8 +9,12 @@ test.describe('Homepage Live Results Section', () => {
     await expect(page.getByRole('heading', { name: 'Live Results: Top Barriers' })).toBeVisible()
 
     // Headline N reads from the same source as the homepage Statistics callout.
+    // Assert on the full "N Surveys Completed" string so the test cannot pass by
+    // coincidentally matching a barrier count that happens to equal the approved N.
     const totalN = dispositionData.completionProgress.approved
-    await expect(page.locator('#live-results')).toContainText(totalN.toLocaleString())
+    await expect(page.locator('#live-results')).toContainText(
+      `${totalN.toLocaleString()} Surveys Completed`
+    )
 
     // Check all 3 rank badges are visible
     const section = page.locator('#live-results')


### PR DESCRIPTION
Closes #1805

## Problem

After #1801, the homepage Statistics callout reads "Surveys Completed: 302" (from `disposition-summary.completionProgress.approved`), but the Live Results prose just below it reads "Based on responses from 300 verified participants" (from `sensitivity-analysis.top3_pick_counts.total_n`). The two values come from separate pipeline JSON files that refresh on different cadences, so they can drift.

## Fix

Point the prose at the same lookup as the callout. Now both read `disposition-summary.completionProgress.approved` -- they cannot disagree.

Per-barrier `count` and `pct` inside the Top 3 cards still come from `sensitivity-analysis.json`, since those are computed against that snapshot's analytical sample.

## Test plan

- [x] Updated `LiveResults.test.tsx` to assert the new data source
- [x] \`npm run format\` -- clean
- [x] \`npm run lint\` -- 0 errors
- [x] \`npm test\` -- 583/583 pass
- [x] \`npm run build\` -- static export succeeds
- [ ] After deploy: confirm homepage prose N matches Statistics "Surveys Completed" callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)