### PR TITLE
feat(survey-stats): redesign as canonical Response Funnel page

### DIFF
--- a/__tests__/components/survey-stats/response-funnel.test.tsx
+++ b/__tests__/components/survey-stats/response-funnel.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import QualtricsSurveyStats from '../../../src/components/survey-stats/qualtrics-survey-stats'
+import dispositionData from '../../../src/data/disposition-summary.json'
+import metricsData from '../../../src/data/qualtrics-metrics.json'
+import { TOTAL_ITEMS_PRESENTED } from '../../../src/lib/tabs-survey-constants'
+
+expect.extend(toHaveNoViolations)
+
+describe('Response Funnel page (QualtricsSurveyStats)', () => {
+  it('renders the new Response funnel page heading', () => {
+    render(<QualtricsSurveyStats />)
+    expect(screen.getByRole('heading', { name: /response funnel/i, level: 2 })).toBeInTheDocument()
+  })
+
+  it('renders all 7 numbered funnel sections', () => {
+    render(<QualtricsSurveyStats />)
+    const titles = [
+      /1\. Top of funnel/i,
+      /2\. Prolific study state/i,
+      /3\. Submission outcomes/i,
+      /4\. TABS disposition categories/i,
+      /5\. AUTO-EXCLUDE reasons/i,
+      /6\. IRI attention-check pass rates/i,
+      /7\. Items presented/i,
+    ]
+    for (const title of titles) {
+      expect(screen.getByRole('heading', { name: title, level: 3 })).toBeInTheDocument()
+    }
+  })
+
+  it('renders Prolific approved (Surveys Completed) value from disposition data', () => {
+    render(<QualtricsSurveyStats />)
+    const approved = dispositionData.actions.approved
+    // Approved appears at least once; also matches the homepage Statistics callout.
+    expect(screen.getAllByText(approved.toLocaleString()).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders Qualtrics question IDs and items presented as separate values', () => {
+    render(<QualtricsSurveyStats />)
+    expect(
+      screen.getByText(metricsData.questionCount.toLocaleString(), { exact: false })
+    ).toBeInTheDocument()
+    expect(screen.getByText(TOTAL_ITEMS_PRESENTED.toLocaleString())).toBeInTheDocument()
+  })
+
+  it('labels each metric card with its API source via badge text', () => {
+    render(<QualtricsSurveyStats />)
+    expect(screen.getAllByText(/Qualtrics API v3/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Prolific API v1/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/TABS analysis pipeline/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/TABS instrument constants/).length).toBeGreaterThan(0)
+  })
+
+  it('has no axe-core accessibility violations', async () => {
+    const { container } = render(<QualtricsSurveyStats />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/src/app/results/survey-stats/page.tsx
+++ b/src/app/results/survey-stats/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next'
 import QualtricsSurveyStats from '@/components/survey-stats/qualtrics-survey-stats'
 export const metadata: Metadata = {
-  title: 'Survey Statistics - TABS Results',
+  title: 'Response Funnel - TABS Results',
   description:
-    'Live survey metrics and response data from the Technology Adoption Barriers Survey (TABS), pulled from Qualtrics via GitHub Actions.',
+    'Every count the TABS daily pipeline tracks - Qualtrics raw responses, Prolific submissions, disposition triage, attention-check pass rates - with the API source and an explanation for each number.',
   alternates: {
     canonical: '/results/survey-stats',
   },
@@ -13,9 +13,9 @@ export default function SurveyStatsPage() {
   return (
     <div className="pt-20 sm:pt-[120px] bg-white">
       <div className="bg-blue-600 py-[60px] text-center text-white">
-        <h1 className="text-[48px] font-bold">Survey Statistics</h1>
+        <h1 className="text-[48px] font-bold">Response Funnel</h1>
         <p className="text-[20px] opacity-90">
-          Live metrics pulled from Qualtrics via GitHub Actions.
+          From raw Qualtrics submissions to the final analysis dataset — every step, every count.
         </p>
       </div>
       <QualtricsSurveyStats />

--- a/src/components/survey-stats/metric-explanations.ts
+++ b/src/components/survey-stats/metric-explanations.ts
@@ -1,0 +1,272 @@
+/**
+ * Metric explanations for the Response Funnel page.
+ *
+ * Every number on /results/survey-stats lives here with three things:
+ *   - label:       short human-readable name shown in the card heading
+ *   - source:      which API or system surfaces the number
+ *   - explanation: 1-2 sentences on what it means in the context of TABS
+ *
+ * Keeping these in one structured map makes the wording auditable and
+ * lets the component focus on layout rather than copy.
+ */
+
+export type MetricSource = 'qualtrics' | 'prolific' | 'pipeline' | 'instrument'
+
+export interface MetricMeta {
+  label: string
+  source: MetricSource
+  explanation: string
+}
+
+export const SOURCE_LABEL: Record<MetricSource, string> = {
+  qualtrics: 'Qualtrics API v3',
+  prolific: 'Prolific API v1',
+  pipeline: 'TABS analysis pipeline',
+  instrument: 'TABS instrument constants',
+}
+
+export const SOURCE_BADGE_CLASS: Record<MetricSource, string> = {
+  qualtrics: 'bg-blue-100 text-blue-800 border-blue-200',
+  prolific: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  pipeline: 'bg-purple-100 text-purple-800 border-purple-200',
+  instrument: 'bg-amber-100 text-amber-800 border-amber-200',
+}
+
+export const METRIC_META = {
+  // Section 1 — top-of-funnel raw response counts
+  qualtricsGenerated: {
+    label: 'Generated',
+    source: 'qualtrics',
+    explanation:
+      'Every response row Qualtrics has ever created for this survey, including previews, partial sessions, and rows later soft-deleted. This is the broadest count Qualtrics exposes and includes traffic that never became a real submission.',
+  },
+  qualtricsAuditable: {
+    label: 'Auditable',
+    source: 'qualtrics',
+    explanation:
+      'Responses Qualtrics considers eligible for export and audit. Excludes preview-mode and obviously-spammed rows but still includes incompletes and quality-flagged submissions before TABS triage.',
+  },
+  qualtricsDeleted: {
+    label: 'Deleted',
+    source: 'qualtrics',
+    explanation:
+      'Soft-deleted rows in Qualtrics. Includes test runs from the build phase, withdrawn duplicates, and any rows the survey administrator removed. Counted but not part of the analysis dataset.',
+  },
+  totalResponses: {
+    label: 'Total responses (reconciled)',
+    source: 'pipeline',
+    explanation:
+      'TABS-reconciled response total after joining the Qualtrics export with Prolific submission data. This is the canonical denominator the daily pipeline starts from.',
+  },
+  uniqueParticipants: {
+    label: 'Unique participants',
+    source: 'pipeline',
+    explanation:
+      'Distinct Prolific PIDs in the reconciled dataset. Differs from total responses when a participant submits more than once (we keep the first complete attempt).',
+  },
+  duplicatesRemoved: {
+    label: 'Duplicates removed',
+    source: 'pipeline',
+    explanation:
+      'Submissions dropped because the same Prolific PID had a more complete attempt elsewhere in the data. Currently zero — Prolific blocks reentry by default.',
+  },
+
+  // Section 2 — Prolific study state
+  totalAvailablePlaces: {
+    label: 'Total available places',
+    source: 'prolific',
+    explanation:
+      'The participant cap configured for this Prolific study. Once filled, the study automatically pauses recruitment.',
+  },
+  placesTaken: {
+    label: 'Places taken',
+    source: 'prolific',
+    explanation:
+      'Slots Prolific has handed out — every participant who at least clicked through to start the survey, regardless of whether they finished, returned, or timed out.',
+  },
+  reward: {
+    label: 'Reward per submission',
+    source: 'prolific',
+    explanation:
+      'Cash payment Prolific pays each approved participant. Stored in pence (UK) or cents (US) by Prolific; displayed here in major-unit currency.',
+  },
+  averageTimeTaken: {
+    label: 'Average time taken',
+    source: 'prolific',
+    explanation:
+      'Mean minutes a participant spent on the survey, computed by Prolific across all submitted attempts.',
+  },
+  averageRewardPerHour: {
+    label: 'Effective hourly rate',
+    source: 'prolific',
+    explanation:
+      'Implied hourly pay Prolific reports based on reward and average time. Prolific uses this to show participants whether a study meets fair-pay thresholds.',
+  },
+
+  // Section 3 — submission outcomes (Prolific-reported status)
+  actionApproved: {
+    label: 'Approved',
+    source: 'prolific',
+    explanation:
+      "Submissions the TABS team has accepted on Prolific. Approval pays the participant and locks the row into the analysis dataset. This is the headline 'Surveys Completed' number on the homepage.",
+  },
+  actionAwaitingReview: {
+    label: 'Awaiting review',
+    source: 'prolific',
+    explanation:
+      "Submitted attempts that haven't been approved or rejected yet. The daily pipeline messages quality flags and approves clean submissions automatically; this bucket should drain to zero between runs.",
+  },
+  actionRejected: {
+    label: 'Rejected',
+    source: 'prolific',
+    explanation:
+      'Submissions the team rejected on Prolific because they failed quality gates (multiple failed attention checks plus speed). Participants are not paid; the response is not part of the analysis dataset.',
+  },
+  actionReturned: {
+    label: 'Returned',
+    source: 'prolific',
+    explanation:
+      'Participants who claimed a slot and then returned the study without submitting. Returned slots are recycled back into the pool for new participants.',
+  },
+  actionTimedOut: {
+    label: 'Timed out',
+    source: 'prolific',
+    explanation:
+      'Slots Prolific reclaimed because the participant started but did not submit within the allowed window. The slot is recycled for a new participant.',
+  },
+  actionActive: {
+    label: 'Active',
+    source: 'prolific',
+    explanation:
+      'Participants currently in the survey at the moment the daily pipeline ran. Snapshot only — usually zero except mid-burst.',
+  },
+  actionMessaged: {
+    label: 'Messaged',
+    source: 'pipeline',
+    explanation:
+      'Participants the daily pipeline sent a Prolific message to (typically about a quality flag). Counted by the TABS messaging script, not Prolific itself.',
+  },
+
+  // Section 4 — TABS disposition categories
+  dispositionClean: {
+    label: 'CLEAN',
+    source: 'pipeline',
+    explanation:
+      'Passed every quality check: all 3 attention checks, no straightlining, duration above threshold, reCAPTCHA fine. Auto-approved on Prolific and included in the primary analysis sample.',
+  },
+  dispositionFlagSmeal: {
+    label: 'FLAG-SMEAL',
+    source: 'pipeline',
+    explanation:
+      'Completed within the 5-9 minute Smeal benchmark band. Borderline-fast but otherwise passes checks; almost always approved after manual review.',
+  },
+  dispositionFlagSpeed: {
+    label: 'FLAG-SPEED',
+    source: 'pipeline',
+    explanation:
+      'Finished in under 5 minutes. Flagged for review because that pace is hard to reconcile with thoughtful answers, but not auto-excluded.',
+  },
+  dispositionFlagPartialStraightlining: {
+    label: 'FLAG-PARTIAL-STRAIGHTLINING',
+    source: 'pipeline',
+    explanation:
+      'Showed low within-person variance on at least one Likert block (e.g., picked the same point on every readiness item). Not auto-excluded because some respondents legitimately answer that way.',
+  },
+  dispositionFlagSingleIri: {
+    label: 'FLAG-SINGLE-IRI',
+    source: 'pipeline',
+    explanation:
+      'Failed exactly 1 of the 3 instructed-response (attention check) items. One miss is usually inattention, not a bot — flagged for review and typically approved.',
+  },
+  dispositionFlagRecaptcha: {
+    label: 'FLAG-RECAPTCHA',
+    source: 'pipeline',
+    explanation:
+      'reCAPTCHA score sat in the borderline range. Flagged so the team can decide if the response should still count.',
+  },
+  dispositionAutoExclude: {
+    label: 'AUTO-EXCLUDE',
+    source: 'pipeline',
+    explanation:
+      'Failed multiple quality gates (typically 2 or 3 attention checks, often with speed). Removed from the analysis dataset and the participant is rejected on Prolific.',
+  },
+  dispositionIncomplete: {
+    label: 'INCOMPLETE',
+    source: 'pipeline',
+    explanation:
+      'Started the survey but did not reach the end. Includes both Prolific-returned and Prolific-timed-out attempts. Excluded from analysis but kept for funnel accounting.',
+  },
+
+  // Section 5 — AUTO-EXCLUDE reason breakdown
+  autoExcludeIri3: {
+    label: 'IRI3',
+    source: 'pipeline',
+    explanation:
+      'Failed all 3 instructed-response items. Strong signal of inattention or automation; auto-excluded.',
+  },
+  autoExcludeIri3Speed: {
+    label: 'IRI3 + SPEED',
+    source: 'pipeline',
+    explanation:
+      'Failed all 3 attention checks AND completed too fast. The combination is the highest-confidence auto-exclude.',
+  },
+  autoExcludeIri2: {
+    label: 'IRI2',
+    source: 'pipeline',
+    explanation:
+      "Failed 2 of 3 attention checks. Two misses crosses the threshold from 'inattention' to 'pattern,' so the response is auto-excluded.",
+  },
+  autoExcludeIri2Speed: {
+    label: 'IRI2 + SPEED',
+    source: 'pipeline',
+    explanation: 'Failed 2 attention checks AND completed too fast. Treated as auto-exclude.',
+  },
+  autoExcludeSpeedIri: {
+    label: 'SPEED + IRI',
+    source: 'pipeline',
+    explanation:
+      'Speed flag combined with at least one IRI failure that, together, crosses the auto-exclude threshold. Tracks responses where speed is the leading signal.',
+  },
+
+  // Section 6 — IRI attention-check pass rates
+  iriPassBarrier: {
+    label: 'Barriers IRI pass rate',
+    source: 'pipeline',
+    explanation:
+      "Share of evaluable submissions that selected the expected option ('Major Barrier') on the embedded barriers attention-check item.",
+  },
+  iriPassReadiness: {
+    label: 'Readiness IRI pass rate',
+    source: 'pipeline',
+    explanation:
+      "Share that selected the expected option ('Low Readiness/Capability') on the readiness attention-check item.",
+  },
+  iriPassMaturity: {
+    label: 'Maturity IRI pass rate',
+    source: 'pipeline',
+    explanation:
+      "Share that selected the expected option ('Level 2: Developing/Repeatable') on the maturity attention-check item.",
+  },
+  iriDenominator: {
+    label: 'IRI denominator',
+    source: 'pipeline',
+    explanation:
+      'Submissions evaluated for IRI pass rates (excludes incompletes and rows missing the IRI columns).',
+  },
+
+  // Section 7 — items presented to participants
+  qualtricsQuestionIds: {
+    label: 'Qualtrics question IDs',
+    source: 'qualtrics',
+    explanation:
+      'Distinct question IDs the Qualtrics survey definition reports. Matrix Likert blocks (Barriers / Readiness / Maturity) collapse to 1 ID even though they present many items.',
+  },
+  itemsPresented: {
+    label: 'Items presented',
+    source: 'instrument',
+    explanation:
+      'What a participant actually sees: 19 barriers + 18 readiness + 9 maturity + 9 demographics + 1 open-ended feedback + 1 reCAPTCHA = 57. Derived from the TABS instrument constants.',
+  },
+} as const satisfies Record<string, MetricMeta>
+
+export type MetricKey = keyof typeof METRIC_META

--- a/src/components/survey-stats/metric-explanations.ts
+++ b/src/components/survey-stats/metric-explanations.ts
@@ -152,7 +152,7 @@ export const METRIC_META = {
     label: 'CLEAN',
     source: 'pipeline',
     explanation:
-      'Passed every quality check: all 3 attention checks, no straightlining, duration above threshold, reCAPTCHA fine. Auto-approved on Prolific and included in the primary analysis sample.',
+      'Passed every quality check: all 3 attention checks, no straightlining, duration above threshold, reCAPTCHA fine. Indicates a response is eligible for the standard approval path when submitted and included in the primary analysis sample.',
   },
   dispositionFlagSmeal: {
     label: 'FLAG-SMEAL',
@@ -188,7 +188,7 @@ export const METRIC_META = {
     label: 'AUTO-EXCLUDE',
     source: 'pipeline',
     explanation:
-      'Failed multiple quality gates (typically 2 or 3 attention checks, often with speed). Removed from the analysis dataset and the participant is rejected on Prolific.',
+      'Failed multiple quality gates (typically 2 or 3 attention checks, often with speed). Removed from the analysis dataset; Prolific outcome may vary and is often reviewed separately.',
   },
   dispositionIncomplete: {
     label: 'INCOMPLETE',

--- a/src/components/survey-stats/qualtrics-survey-stats.tsx
+++ b/src/components/survey-stats/qualtrics-survey-stats.tsx
@@ -1,106 +1,311 @@
-import metricsData from '@/data/qualtrics-metrics.json'
 import dispositionData from '@/data/disposition-summary.json'
+import metricsData from '@/data/qualtrics-metrics.json'
+import { TOTAL_ITEMS_PRESENTED } from '@/lib/tabs-survey-constants'
 import { formatUtcTimestamp } from '@/lib/formatUtcTimestamp'
+import {
+  METRIC_META,
+  SOURCE_BADGE_CLASS,
+  SOURCE_LABEL,
+  type MetricKey,
+} from './metric-explanations'
 
-type QualtricsMetrics = typeof metricsData
+function formatNumber(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—'
+  return value.toLocaleString()
+}
 
-function formatMetricName(metric: string): string {
-  return metric.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+function formatPercent(value: number | null | undefined, fractionDigits = 1): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—'
+  return `${value.toFixed(fractionDigits)}%`
+}
+
+function formatMinutes(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—'
+  return `${value} min`
+}
+
+function formatCurrency(pence: number | null | undefined): string {
+  if (pence === null || pence === undefined || Number.isNaN(pence)) return '—'
+  // Prolific stores reward in minor units (pence/cents). Show as £ since the study is GBP-priced.
+  const major = pence / 100
+  return `£${major.toFixed(2)}`
+}
+
+function formatHourlyRate(centsPerHour: number | null | undefined): string {
+  if (centsPerHour === null || centsPerHour === undefined || Number.isNaN(centsPerHour)) return '—'
+  // Prolific reports averageRewardPerHour in minor units of the study currency.
+  const major = centsPerHour / 100
+  return `£${major.toFixed(2)}/hr`
+}
+
+interface MetricCardProps {
+  metricKey: MetricKey
+  value: string
+}
+
+function MetricCard({ metricKey, value }: MetricCardProps) {
+  const meta = METRIC_META[metricKey]
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-700">
+          {meta.label}
+        </h4>
+        <span
+          className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${SOURCE_BADGE_CLASS[meta.source]}`}
+          title={SOURCE_LABEL[meta.source]}
+        >
+          {SOURCE_LABEL[meta.source]}
+        </span>
+      </div>
+      <div className="mt-2 text-3xl font-bold text-slate-900">{value}</div>
+      <p className="mt-2 text-sm leading-relaxed text-slate-600">{meta.explanation}</p>
+    </div>
+  )
+}
+
+interface SectionProps {
+  id: string
+  title: string
+  intro: string
+  children: React.ReactNode
+}
+
+function FunnelSection({ id, title, intro, children }: SectionProps) {
+  return (
+    <section id={id} className="mt-12">
+      <header className="mb-4 max-w-3xl">
+        <h3 className="text-2xl font-bold text-slate-900">{title}</h3>
+        <p className="mt-2 text-sm text-slate-700">{intro}</p>
+      </header>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    </section>
+  )
 }
 
 export default function QualtricsSurveyStats() {
-  const metrics = metricsData.metrics
-  const maxValue = Math.max(1, ...metrics.map((m) => m.value))
-  const placesTaken: number | null = dispositionData.study?.placesTaken ?? null
-  const questionCount: number | null = metricsData.questionCount ?? null
-
   const dispositionUpdatedAt = formatUtcTimestamp(dispositionData.updatedAt)
   const qualtricsUpdatedAt = formatUtcTimestamp(metricsData.collectedAt)
 
+  // Look up Qualtrics raw counts by metric name (workflow writes them as an array of {metric, value}).
+  const findMetric = (name: string): number | null =>
+    metricsData.metrics.find((m) => m.metric === name)?.value ?? null
+
+  const generated = findMetric('generated')
+  const auditable = findMetric('auditable')
+  const deleted = findMetric('deleted')
+
   return (
-    <section className="mx-auto w-full max-w-5xl px-6 py-10">
-      <header className="mb-8">
-        <h2 className="text-3xl font-bold text-slate-900">Survey stats</h2>
-        <p className="mt-2 text-slate-700">
-          Source: Qualtrics API (cached via GitHub Actions). Last updated{' '}
-          <span className="font-medium">{qualtricsUpdatedAt ?? '—'}</span>.
+    <section className="mx-auto w-full max-w-6xl px-6 py-10">
+      <header className="mb-8 max-w-3xl">
+        <h2 className="text-3xl font-bold text-slate-900">Response funnel</h2>
+        <p className="mt-3 text-base text-slate-700">
+          Every count the daily pipeline tracks, with the API that surfaces it and what it means for
+          the analysis. The homepage shows the marketing-friendly Prolific-approved number; this
+          page shows the rest of the funnel — the participants who started, returned, timed out,
+          were flagged, and were excluded.
         </p>
-        <div className="mt-4 rounded-lg border border-slate-200 bg-white p-4">
-          <div className="text-sm text-slate-600">Survey</div>
-          <div className="mt-1 flex flex-col gap-1">
-            <div className="text-lg font-semibold text-slate-900">{metricsData.survey.name}</div>
-            <div className="text-sm text-slate-700">
-              <span className="font-medium">Survey ID:</span> {metricsData.survey.id}
-            </div>
-            <div className="text-sm text-slate-700">
-              <span className="font-medium">Org:</span> {metricsData.survey.organizationId}
-            </div>
+        <div className="mt-4 grid grid-cols-1 gap-3 text-sm text-slate-600 sm:grid-cols-2">
+          <div className="rounded-md bg-slate-100 px-3 py-2">
+            <span className="font-semibold text-slate-800">Qualtrics snapshot:</span>{' '}
+            {qualtricsUpdatedAt ?? '—'}
+          </div>
+          <div className="rounded-md bg-slate-100 px-3 py-2">
+            <span className="font-semibold text-slate-800">Prolific snapshot:</span>{' '}
+            {dispositionUpdatedAt ?? '—'}
           </div>
         </div>
-
-        {/* Cached counts from Prolific and Qualtrics */}
-        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
-            <div className="text-sm font-medium text-blue-900">Places Taken</div>
-            <div className="mt-1 text-3xl font-bold text-blue-700">
-              {placesTaken !== null ? placesTaken.toLocaleString() : '—'}
-            </div>
-            <div className="mt-1 text-xs text-blue-600">
-              Cached snapshot from Prolific. Last updated{' '}
-              <span className="font-medium">{dispositionUpdatedAt ?? '—'}</span>.
-            </div>
-          </div>
-          <div className="rounded-lg border border-orange-200 bg-orange-50 p-4">
-            <div className="text-sm font-medium text-orange-900">Question Count</div>
-            <div className="mt-1 text-3xl font-bold text-orange-700">
-              {questionCount !== null ? questionCount.toLocaleString() : '—'}
-            </div>
-            <div className="mt-1 text-xs text-orange-600">Total survey questions</div>
+        <div className="mt-4 rounded-lg border border-slate-200 bg-white p-4 text-sm">
+          <div className="text-slate-600">Survey</div>
+          <div className="mt-1 font-semibold text-slate-900">{metricsData.survey.name}</div>
+          <div className="mt-1 text-slate-600">
+            <span className="font-medium">Survey ID:</span> {metricsData.survey.id} ·{' '}
+            <span className="font-medium">Org:</span> {metricsData.survey.organizationId}
           </div>
         </div>
       </header>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-6">
-        <div className="mb-4 flex items-end justify-between gap-4">
-          <h3 className="text-xl font-semibold text-slate-900">Response counts</h3>
-          <div className="text-sm text-slate-600">Max: {maxValue.toLocaleString()}</div>
-        </div>
+      <FunnelSection
+        id="raw-response-counts"
+        title="1. Top of funnel — raw response counts"
+        intro="Where a row first shows up. Qualtrics tracks several count types in parallel; the TABS pipeline reconciles them with Prolific to produce the canonical totals used downstream."
+      >
+        <MetricCard metricKey="qualtricsGenerated" value={formatNumber(generated)} />
+        <MetricCard metricKey="qualtricsAuditable" value={formatNumber(auditable)} />
+        <MetricCard metricKey="qualtricsDeleted" value={formatNumber(deleted)} />
+        <MetricCard
+          metricKey="totalResponses"
+          value={formatNumber(dispositionData.totalResponses)}
+        />
+        <MetricCard
+          metricKey="uniqueParticipants"
+          value={formatNumber(dispositionData.uniqueParticipants)}
+        />
+        <MetricCard
+          metricKey="duplicatesRemoved"
+          value={formatNumber(dispositionData.duplicatesRemoved)}
+        />
+      </FunnelSection>
 
-        <div className="space-y-4">
-          {metrics.map((m) => {
-            return (
-              <div key={m.metric} className="grid grid-cols-12 gap-3">
-                <div className="col-span-12 sm:col-span-3">
-                  <div className="text-sm font-medium text-slate-900">
-                    {formatMetricName(m.metric)}
-                  </div>
-                  <div className="text-xs text-slate-600">{m.metric}</div>
-                </div>
+      <FunnelSection
+        id="prolific-study-state"
+        title="2. Prolific study state"
+        intro="The shape of the study itself, as Prolific reports it. These numbers describe capacity and pricing rather than outcomes."
+      >
+        <MetricCard
+          metricKey="totalAvailablePlaces"
+          value={formatNumber(dispositionData.study?.totalAvailablePlaces)}
+        />
+        <MetricCard
+          metricKey="placesTaken"
+          value={formatNumber(dispositionData.study?.placesTaken)}
+        />
+        <MetricCard metricKey="reward" value={formatCurrency(dispositionData.study?.reward)} />
+        <MetricCard
+          metricKey="averageTimeTaken"
+          value={formatMinutes(dispositionData.study?.averageTimeTaken)}
+        />
+        <MetricCard
+          metricKey="averageRewardPerHour"
+          value={formatHourlyRate(dispositionData.study?.averageRewardPerHour)}
+        />
+      </FunnelSection>
 
-                <div className="col-span-12 sm:col-span-7">
-                  <progress
-                    className="h-3 w-full overflow-hidden rounded-full"
-                    value={m.value}
-                    max={maxValue}
-                    aria-label={`${formatMetricName(m.metric)} count`}
-                  />
-                </div>
+      <FunnelSection
+        id="submission-outcomes"
+        title="3. Submission outcomes"
+        intro="What Prolific itself says about each submitted attempt. The 'Approved' number here is the same one shown on the homepage Statistics callout."
+      >
+        <MetricCard
+          metricKey="actionApproved"
+          value={formatNumber(dispositionData.actions?.approved)}
+        />
+        <MetricCard
+          metricKey="actionAwaitingReview"
+          value={formatNumber(dispositionData.actions?.awaitingReview)}
+        />
+        <MetricCard
+          metricKey="actionRejected"
+          value={formatNumber(dispositionData.actions?.rejected)}
+        />
+        <MetricCard
+          metricKey="actionReturned"
+          value={formatNumber(dispositionData.actions?.returned)}
+        />
+        <MetricCard
+          metricKey="actionTimedOut"
+          value={formatNumber(dispositionData.actions?.timedOut)}
+        />
+        <MetricCard
+          metricKey="actionActive"
+          value={formatNumber(dispositionData.actions?.active)}
+        />
+        <MetricCard
+          metricKey="actionMessaged"
+          value={formatNumber(dispositionData.actions?.messaged)}
+        />
+      </FunnelSection>
 
-                <div className="col-span-12 sm:col-span-2 text-right text-sm font-semibold text-slate-900">
-                  {m.value.toLocaleString()}
-                </div>
-              </div>
-            )
-          })}
-        </div>
+      <FunnelSection
+        id="disposition-categories"
+        title="4. TABS disposition categories"
+        intro="Quality-triage labels the daily pipeline assigns based on attention checks, straightlining, duration, and reCAPTCHA. CLEAN is the unambiguously usable bucket; FLAG-* responses are reviewed before approval; AUTO-EXCLUDE drops out of the analysis dataset."
+      >
+        <MetricCard
+          metricKey="dispositionClean"
+          value={formatNumber(dispositionData.dispositions?.CLEAN)}
+        />
+        <MetricCard
+          metricKey="dispositionFlagSmeal"
+          value={formatNumber(dispositionData.dispositions?.['FLAG-SMEAL'])}
+        />
+        <MetricCard
+          metricKey="dispositionFlagSpeed"
+          value={formatNumber(dispositionData.dispositions?.['FLAG-SPEED'])}
+        />
+        <MetricCard
+          metricKey="dispositionFlagPartialStraightlining"
+          value={formatNumber(dispositionData.dispositions?.['FLAG-PARTIAL-STRAIGHTLINING'])}
+        />
+        <MetricCard
+          metricKey="dispositionFlagSingleIri"
+          value={formatNumber(dispositionData.dispositions?.['FLAG-SINGLE-IRI'])}
+        />
+        <MetricCard
+          metricKey="dispositionFlagRecaptcha"
+          value={formatNumber(dispositionData.dispositions?.['FLAG-RECAPTCHA'])}
+        />
+        <MetricCard
+          metricKey="dispositionAutoExclude"
+          value={formatNumber(dispositionData.dispositions?.['AUTO-EXCLUDE'])}
+        />
+        <MetricCard
+          metricKey="dispositionIncomplete"
+          value={formatNumber(dispositionData.dispositions?.INCOMPLETE)}
+        />
+      </FunnelSection>
 
-        <p className="mt-6 text-sm text-slate-700">
-          Note: Qualtrics exposes multiple count types (for example,{' '}
-          <span className="font-medium">auditable</span>,{' '}
-          <span className="font-medium">generated</span>,{' '}
-          <span className="font-medium">deleted</span>). We chart each type as its own metric.
-        </p>
-      </div>
+      <FunnelSection
+        id="auto-exclude-reasons"
+        title="5. AUTO-EXCLUDE reasons"
+        intro="Why each AUTO-EXCLUDE was triggered. Categories overlap by design — the pipeline tags every relevant signal so post-hoc analysis can be re-cut later."
+      >
+        <MetricCard
+          metricKey="autoExcludeIri3"
+          value={formatNumber(dispositionData.autoExcludeBreakdown?.IRI3)}
+        />
+        <MetricCard
+          metricKey="autoExcludeIri3Speed"
+          value={formatNumber(dispositionData.autoExcludeBreakdown?.IRI3_SPEED)}
+        />
+        <MetricCard
+          metricKey="autoExcludeIri2"
+          value={formatNumber(dispositionData.autoExcludeBreakdown?.IRI2)}
+        />
+        <MetricCard
+          metricKey="autoExcludeIri2Speed"
+          value={formatNumber(dispositionData.autoExcludeBreakdown?.IRI2_SPEED)}
+        />
+        <MetricCard
+          metricKey="autoExcludeSpeedIri"
+          value={formatNumber(dispositionData.autoExcludeBreakdown?.SPEED_IRI)}
+        />
+      </FunnelSection>
+
+      <FunnelSection
+        id="iri-pass-rates"
+        title="6. IRI attention-check pass rates"
+        intro="Each Likert block embeds one instructed-response item with a pre-specified correct answer. Pass rates describe how often the embedded check was answered as instructed across the IRI denominator."
+      >
+        <MetricCard
+          metricKey="iriPassBarrier"
+          value={formatPercent(dispositionData.iriPassRates?.barrier)}
+        />
+        <MetricCard
+          metricKey="iriPassReadiness"
+          value={formatPercent(dispositionData.iriPassRates?.readiness)}
+        />
+        <MetricCard
+          metricKey="iriPassMaturity"
+          value={formatPercent(dispositionData.iriPassRates?.maturity)}
+        />
+        <MetricCard
+          metricKey="iriDenominator"
+          value={formatNumber(dispositionData.iriPassRates?.denominator)}
+        />
+      </FunnelSection>
+
+      <FunnelSection
+        id="items-presented"
+        title="7. Items presented to participants"
+        intro="What 'Question Count' means depends on who's counting. Qualtrics counts the question IDs in the survey definition; participants experience each Likert matrix as many separate items."
+      >
+        <MetricCard
+          metricKey="qualtricsQuestionIds"
+          value={formatNumber(metricsData.questionCount)}
+        />
+        <MetricCard metricKey="itemsPresented" value={formatNumber(TOTAL_ITEMS_PRESENTED)} />
+      </FunnelSection>
     </section>
   )
 }

--- a/src/components/survey-stats/qualtrics-survey-stats.tsx
+++ b/src/components/survey-stats/qualtrics-survey-stats.tsx
@@ -32,7 +32,11 @@ function formatCurrency(pence: number | null | undefined): string {
 }
 
 function formatHourlyRate(minorUnitsPerHour: number | null | undefined): string {
-  if (minorUnitsPerHour === null || minorUnitsPerHour === undefined || Number.isNaN(minorUnitsPerHour))
+  if (
+    minorUnitsPerHour === null ||
+    minorUnitsPerHour === undefined ||
+    Number.isNaN(minorUnitsPerHour)
+  )
     return '—'
   // Prolific reports averageRewardPerHour in minor units (for example pence/cents) of the study currency.
   const major = minorUnitsPerHour / 100

--- a/src/components/survey-stats/qualtrics-survey-stats.tsx
+++ b/src/components/survey-stats/qualtrics-survey-stats.tsx
@@ -31,10 +31,11 @@ function formatCurrency(pence: number | null | undefined): string {
   return `£${major.toFixed(2)}`
 }
 
-function formatHourlyRate(centsPerHour: number | null | undefined): string {
-  if (centsPerHour === null || centsPerHour === undefined || Number.isNaN(centsPerHour)) return '—'
-  // Prolific reports averageRewardPerHour in minor units of the study currency.
-  const major = centsPerHour / 100
+function formatHourlyRate(minorUnitsPerHour: number | null | undefined): string {
+  if (minorUnitsPerHour === null || minorUnitsPerHour === undefined || Number.isNaN(minorUnitsPerHour))
+    return '—'
+  // Prolific reports averageRewardPerHour in minor units (for example pence/cents) of the study currency.
+  const major = minorUnitsPerHour / 100
   return `£${major.toFixed(2)}/hr`
 }
 


### PR DESCRIPTION
Closes #1808

## What

Redesigns `/results/survey-stats` as the canonical Response Funnel page. Every count the daily pipeline tracks - Qualtrics raw responses, Prolific submissions, TABS disposition triage, attention-check pass rates - now has a place on this page with its API source and a 1-2 sentence explanation.

## Sections

| # | Section | Source | Sample metrics |
|---|---|---|---|
| 1 | Top of funnel - raw response counts | Qualtrics + pipeline | generated 562, auditable 364, deleted 612, totalResponses 562, uniqueParticipants 550, duplicatesRemoved 0 |
| 2 | Prolific study state | Prolific | placesTaken 330, totalAvailablePlaces 500, reward, averageTimeTaken 10 min |
| 3 | Submission outcomes | Prolific (+ pipeline for messaged) | approved 300, awaitingReview 30, rejected 35, returned 191, timedOut 6, active 0, messaged 0 |
| 4 | TABS disposition categories | Pipeline | CLEAN 105, FLAG-SMEAL 63, FLAG-SPEED 10, FLAG-PARTIAL-STRAIGHTLINING 40, FLAG-SINGLE-IRI 98, FLAG-RECAPTCHA 4, AUTO-EXCLUDE 146, INCOMPLETE 84 |
| 5 | AUTO-EXCLUDE reasons | Pipeline | IRI3 34, IRI3+SPEED 14, IRI2 67, IRI2+SPEED 12, SPEED+IRI 19 |
| 6 | IRI attention-check pass rates | Pipeline | barriers 58.2%, readiness 69.1%, maturity 82.8% (n=466) |
| 7 | Items presented | Qualtrics + instrument | Qualtrics question IDs 21 vs TABS items presented 57 |

## Files

- `src/components/survey-stats/metric-explanations.ts` - new structured map of every metric's label, source, and explanation. Lives separately so the wording is auditable and reusable.
- `src/components/survey-stats/qualtrics-survey-stats.tsx` - rewritten layout using a shared MetricCard + FunnelSection pattern.
- `src/app/results/survey-stats/page.tsx` - hero text reframed from \"Survey Statistics\" to \"Response Funnel\".
- `__tests__/components/survey-stats/response-funnel.test.tsx` - 6 new tests covering page heading, all 7 section headings, source-badge labels, key data values, and axe-core accessibility.

## Why

After #1801 (homepage Statistics) and #1806 (Live Results), the marketing-facing pages all show the Prolific-approved number (300). That's the right number for the front door, but it hid the rest of the funnel - the responses we returned, timed out, flagged, or excluded. This page captures all of it so the broader picture is documented and inspectable.

## Test plan

- [x] \`npm run format\` - clean
- [x] \`npm run lint\` - 0 errors (3 pre-existing warnings unrelated)
- [x] \`npm test\` - 589/589 pass (+6 new tests)
- [x] \`npm run build\` - static export succeeds
- [ ] After deploy: visit /results/survey-stats and verify all 7 sections render with current data values
- [ ] After deploy: confirm /barriers/survey-stats redirect still lands on the new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)