### PR TITLE
ci(smoke): add Prolific/GA/GSC API smokes + post-deploy fan-out

### DIFF
--- a/.github/workflows/ga-api-smoke.yml
+++ b/.github/workflows/ga-api-smoke.yml
@@ -1,0 +1,70 @@
+name: Google Analytics API Smoke Test
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  ga-smoke:
+    name: GA Data API smoke
+    runs-on: ubuntu-latest
+    environment: google-prod
+    env:
+      GA_PROPERTY_ID: ${{ secrets.GA_PROPERTY_ID }}
+      GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+      GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Validate configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "${GA_PROPERTY_ID:-}" ]] && missing+=(GA_PROPERTY_ID)
+          [[ -z "${GOOGLE_SERVICE_ACCOUNT_EMAIL:-}" ]] && missing+=(GOOGLE_SERVICE_ACCOUNT_EMAIL)
+          [[ -z "${GOOGLE_PRIVATE_KEY:-}" ]] && missing+=(GOOGLE_PRIVATE_KEY)
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Missing secrets in environment google-prod: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Run a 1-day metadata report (connectivity check)
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module -e "
+            import { BetaAnalyticsDataClient } from '@google-analytics/data';
+            const client = new BetaAnalyticsDataClient({
+              credentials: {
+                client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
+                private_key: process.env.GOOGLE_PRIVATE_KEY.replace(/\\\\n/g, '\n'),
+              },
+            });
+            const property = process.env.GA_PROPERTY_ID.startsWith('properties/')
+              ? process.env.GA_PROPERTY_ID
+              : 'properties/' + process.env.GA_PROPERTY_ID;
+            const [response] = await client.runReport({
+              property,
+              dateRanges: [{ startDate: '1daysAgo', endDate: 'today' }],
+              metrics: [{ name: 'activeUsers' }],
+            });
+            const total = response.rows?.[0]?.metricValues?.[0]?.value ?? '0';
+            console.log('GA OK property=' + property + ' activeUsers(last1d)=' + total);
+          "

--- a/.github/workflows/ga-api-smoke.yml
+++ b/.github/workflows/ga-api-smoke.yml
@@ -3,6 +3,11 @@ name: Google Analytics API Smoke Test
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout (default: default branch HEAD)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -22,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -30,7 +37,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --omit=dev --ignore-scripts
 
       - name: Validate configuration
         shell: bash
@@ -62,7 +69,7 @@ jobs:
               : 'properties/' + process.env.GA_PROPERTY_ID;
             const [response] = await client.runReport({
               property,
-              dateRanges: [{ startDate: '1daysAgo', endDate: 'today' }],
+              dateRanges: [{ startDate: '1daysAgo', endDate: '1daysAgo' }],
               metrics: [{ name: 'activeUsers' }],
             });
             const total = response.rows?.[0]?.metricValues?.[0]?.value ?? '0';

--- a/.github/workflows/gsc-api-smoke.yml
+++ b/.github/workflows/gsc-api-smoke.yml
@@ -3,6 +3,11 @@ name: Google Search Console API Smoke Test
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout (default: default branch HEAD)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -22,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -30,7 +37,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --omit=dev --ignore-scripts
 
       - name: Validate configuration
         shell: bash
@@ -60,7 +67,7 @@ jobs:
             const sc = google.searchconsole({ version: 'v1', auth });
             const today = new Date();
             const end = today.toISOString().slice(0, 10);
-            const startDate = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+            const startDate = new Date(today.getTime() - 6 * 24 * 60 * 60 * 1000)
               .toISOString().slice(0, 10);
             const res = await sc.searchanalytics.query({
               siteUrl: process.env.GSC_SITE_URL,

--- a/.github/workflows/gsc-api-smoke.yml
+++ b/.github/workflows/gsc-api-smoke.yml
@@ -1,0 +1,76 @@
+name: Google Search Console API Smoke Test
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  gsc-smoke:
+    name: GSC API smoke
+    runs-on: ubuntu-latest
+    environment: google-prod
+    env:
+      GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+      GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+      GSC_SITE_URL: 'sc-domain:technologyadoptionbarriers.org'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Validate configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -z "${GOOGLE_SERVICE_ACCOUNT_EMAIL:-}" ]] && missing+=(GOOGLE_SERVICE_ACCOUNT_EMAIL)
+          [[ -z "${GOOGLE_PRIVATE_KEY:-}" ]] && missing+=(GOOGLE_PRIVATE_KEY)
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Missing secrets in environment google-prod: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Query searchanalytics for last 7 days (connectivity check)
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module -e "
+            import { google } from 'googleapis';
+            const auth = new google.auth.GoogleAuth({
+              credentials: {
+                client_email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
+                private_key: process.env.GOOGLE_PRIVATE_KEY.replace(/\\\\n/g, '\n'),
+              },
+              scopes: ['https://www.googleapis.com/auth/webmasters.readonly'],
+            });
+            const sc = google.searchconsole({ version: 'v1', auth });
+            const today = new Date();
+            const end = today.toISOString().slice(0, 10);
+            const startDate = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+              .toISOString().slice(0, 10);
+            const res = await sc.searchanalytics.query({
+              siteUrl: process.env.GSC_SITE_URL,
+              requestBody: {
+                startDate,
+                endDate: end,
+                dimensions: ['query'],
+                rowLimit: 1,
+              },
+            });
+            const rows = res.data.rows ?? [];
+            console.log('GSC OK site=' + process.env.GSC_SITE_URL + ' rowsReturned=' + rows.length);
+          "

--- a/.github/workflows/post-deploy-api-smoke.yml
+++ b/.github/workflows/post-deploy-api-smoke.yml
@@ -1,0 +1,94 @@
+name: Post-Deploy API Smoke
+
+on:
+  workflow_run:
+    workflows: ['Deploy to GitHub Pages']
+    types:
+      - completed
+    branches: ['main']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  qualtrics:
+    name: Qualtrics smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/qualtrics-api-smoke.yml
+    secrets: inherit
+
+  prolific:
+    name: Prolific smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/prolific-api-smoke.yml
+    secrets: inherit
+
+  ga:
+    name: Google Analytics smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/ga-api-smoke.yml
+    secrets: inherit
+
+  gsc:
+    name: Google Search Console smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/gsc-api-smoke.yml
+    secrets: inherit
+
+  zotero:
+    name: Zotero smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/zotero-api-smoke.yml
+    secrets: inherit
+
+  aggregate:
+    name: Aggregate result
+    needs: [qualtrics, prolific, ga, gsc, zotero]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize per-API results
+        shell: bash
+        run: |
+          set -euo pipefail
+          declare -A r=(
+            [qualtrics]='${{ needs.qualtrics.result }}'
+            [prolific]='${{ needs.prolific.result }}'
+            [ga]='${{ needs.ga.result }}'
+            [gsc]='${{ needs.gsc.result }}'
+            [zotero]='${{ needs.zotero.result }}'
+          )
+          {
+            echo "## Post-Deploy API Smoke results"
+            echo ""
+            echo "| API | Result |"
+            echo "| --- | --- |"
+            for k in qualtrics prolific ga gsc zotero; do
+              v="${r[$k]}"
+              icon=":x:"; [[ "$v" == "success" ]] && icon=":white_check_mark:"
+              [[ "$v" == "skipped" ]] && icon=":fast_forward:"
+              echo "| $k | $icon $v |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          fail=0
+          for k in qualtrics prolific ga gsc zotero; do
+            v="${r[$k]}"
+            [[ "$v" != "success" && "$v" != "skipped" ]] && fail=$((fail + 1))
+          done
+          if [[ $fail -gt 0 ]]; then
+            echo "::error::$fail API smoke job(s) did not succeed"
+            exit 1
+          fi
+          echo "All API smoke checks passed."

--- a/.github/workflows/post-deploy-api-smoke.yml
+++ b/.github/workflows/post-deploy-api-smoke.yml
@@ -55,7 +55,11 @@ jobs:
   aggregate:
     name: Aggregate result
     needs: [qualtrics, prolific, ga, gsc, zotero]
-    if: always()
+    if: >-
+      always() && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'success'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Summarize per-API results

--- a/.github/workflows/post-deploy-api-smoke.yml
+++ b/.github/workflows/post-deploy-api-smoke.yml
@@ -18,7 +18,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/qualtrics-api-smoke.yml
-    secrets: inherit
 
   prolific:
     name: Prolific smoke
@@ -26,7 +25,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/prolific-api-smoke.yml
-    secrets: inherit
 
   ga:
     name: Google Analytics smoke
@@ -34,7 +32,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/ga-api-smoke.yml
-    secrets: inherit
+    with:
+      ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
   gsc:
     name: Google Search Console smoke
@@ -42,7 +41,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/gsc-api-smoke.yml
-    secrets: inherit
+    with:
+      ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
   zotero:
     name: Zotero smoke
@@ -50,7 +50,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/zotero-api-smoke.yml
-    secrets: inherit
 
   aggregate:
     name: Aggregate result

--- a/.github/workflows/post-deploy-api-smoke.yml
+++ b/.github/workflows/post-deploy-api-smoke.yml
@@ -18,6 +18,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/qualtrics-api-smoke.yml
+    secrets: inherit
 
   prolific:
     name: Prolific smoke
@@ -25,6 +26,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/prolific-api-smoke.yml
+    secrets: inherit
 
   ga:
     name: Google Analytics smoke
@@ -33,7 +35,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/ga-api-smoke.yml
     with:
-      ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+    secrets: inherit
 
   gsc:
     name: Google Search Console smoke
@@ -42,7 +45,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/gsc-api-smoke.yml
     with:
-      ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+    secrets: inherit
 
   zotero:
     name: Zotero smoke
@@ -50,6 +54,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/zotero-api-smoke.yml
+    secrets: inherit
 
   aggregate:
     name: Aggregate result

--- a/.github/workflows/prolific-api-smoke.yml
+++ b/.github/workflows/prolific-api-smoke.yml
@@ -45,6 +45,4 @@ jobs:
             exit 1
           fi
 
-          echo "::group::Authenticated user"
-          jq '{id}' me.json
-          echo "::endgroup::"
+          echo "Prolific API connectivity check succeeded."

--- a/.github/workflows/prolific-api-smoke.yml
+++ b/.github/workflows/prolific-api-smoke.yml
@@ -41,10 +41,10 @@ jobs:
 
           if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
             echo "::error::Prolific API returned HTTP $http_code"
-            head -c 4000 me.json || true
+            echo "Request failed; response body suppressed to avoid exposing sensitive data in workflow logs."
             exit 1
           fi
 
           echo "::group::Authenticated user"
-          jq '{id, email, name, currency_code, datetime_created}' me.json
+          jq '{id}' me.json
           echo "::endgroup::"

--- a/.github/workflows/prolific-api-smoke.yml
+++ b/.github/workflows/prolific-api-smoke.yml
@@ -35,6 +35,11 @@ jobs:
           url="${PROLIFIC_BASE_URL%/}/users/me/"
 
           http_code=$(curl -sS -o me.json -w "%{http_code}" \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 2 \
+            --retry-delay 2 \
+            --retry-connrefused \
             -H "Authorization: Token ${PROLIFIC_API_TOKEN}" \
             -H "Accept: application/json" \
             "$url")

--- a/.github/workflows/prolific-api-smoke.yml
+++ b/.github/workflows/prolific-api-smoke.yml
@@ -1,0 +1,50 @@
+name: Prolific API Smoke Test
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  prolific-smoke:
+    name: Prolific API smoke
+    runs-on: ubuntu-latest
+    environment: prolific-prod
+    env:
+      PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+      PROLIFIC_BASE_URL: 'https://api.prolific.com/api/v1'
+    steps:
+      - name: Validate configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${PROLIFIC_API_TOKEN:-}" ]]; then
+            echo "::error::Missing secret TABS_PROLIFIC_TOKEN in environment prolific-prod"
+            exit 1
+          fi
+
+      - name: GET /users/me/ (connectivity check)
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="${PROLIFIC_BASE_URL%/}/users/me/"
+
+          http_code=$(curl -sS -o me.json -w "%{http_code}" \
+            -H "Authorization: Token ${PROLIFIC_API_TOKEN}" \
+            -H "Accept: application/json" \
+            "$url")
+
+          if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+            echo "::error::Prolific API returned HTTP $http_code"
+            head -c 4000 me.json || true
+            exit 1
+          fi
+
+          echo "::group::Authenticated user"
+          jq '{id, email, name, currency_code, datetime_created}' me.json
+          echo "::endgroup::"

--- a/.github/workflows/qualtrics-api-smoke.yml
+++ b/.github/workflows/qualtrics-api-smoke.yml
@@ -12,6 +12,15 @@ on:
         required: false
         type: string
   workflow_call:
+    inputs:
+      base_url:
+        description: 'Qualtrics base URL, e.g. https://yourdatacenter.qualtrics.com (overrides environment var QUALTRICS_BASE_URL)'
+        required: false
+        type: string
+      survey_id:
+        description: 'Optional Survey ID to fetch (overrides environment var QUALTRICS_SURVEY_ID). If omitted, the workflow uses the first survey from /surveys.'
+        required: false
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/qualtrics-api-smoke.yml
+++ b/.github/workflows/qualtrics-api-smoke.yml
@@ -11,6 +11,7 @@ on:
         description: 'Optional Survey ID to fetch (overrides environment var QUALTRICS_SURVEY_ID). If omitted, the workflow uses the first survey from /surveys.'
         required: false
         type: string
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/zotero-api-smoke.yml
+++ b/.github/workflows/zotero-api-smoke.yml
@@ -1,6 +1,7 @@
 name: Zotero API Smoke Test
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   smoke:


### PR DESCRIPTION
## Summary

Closes the post-deploy validation gap for automation/data APIs. Today `post-deploy-smoke.yml` only validates static-site routes; this adds equivalent post-deploy coverage for the API/data-pipeline surface.

**4 new workflows:**
- `prolific-api-smoke.yml` — `GET /users/me/` (`prolific-prod` env)
- `ga-api-smoke.yml` — `runReport` for `activeUsers` last-1-day via `@google-analytics/data` (`google-prod` env)
- `gsc-api-smoke.yml` — `searchanalytics.query` last-7-days via `googleapis` (`google-prod` env)
- `post-deploy-api-smoke.yml` — `workflow_run` after `Deploy to GitHub Pages` succeeds; fans out to all 5 smokes in parallel via `uses:` with `secrets: inherit`; aggregator job posts a markdown table to `$GITHUB_STEP_SUMMARY` and fails the run if any smoke fails

**2 modifications:**
- `qualtrics-api-smoke.yml` — added `workflow_call:` trigger (no behavior change to existing manual dispatch)
- `zotero-api-smoke.yml` — added `workflow_call:` trigger (no behavior change)

## How it fires

```
push → CI - Build and Test → Deploy to GitHub Pages → ┬→ post-deploy-smoke.yml      (existing: HTTP routes/assets)
                                                       └→ post-deploy-api-smoke.yml  (new: 5 APIs in parallel)
```

Each smoke is also dispatchable standalone via `gh workflow run <name>` for ad-hoc connectivity checks.

## Test plan

- [ ] CI passes (format/lint/test/build/E2E) — purely additive workflow files
- [ ] After merge, watch first deploy on main: `Deploy to GitHub Pages` → `Post-Deploy API Smoke` should fire and post a results table to the workflow summary
- [ ] Manual dispatch each new smoke once to verify env-scoped secrets are wired correctly

https://claude.ai/code/session_01UJYzTxy5BTyWypJKoCam38

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJYzTxy5BTyWypJKoCam38)_