### PR TITLE
Update daily pipeline data

### DIFF
--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -2394,6 +2394,6 @@
       }
     ]
   },
-  "last_updated": "2026-04-28T11:19:45.428929Z",
-  "extended_last_updated": "2026-04-28T11:19:45.428929Z"
+  "last_updated": "2026-04-29T11:15:37.602645Z",
+  "extended_last_updated": "2026-04-29T11:15:37.602645Z"
 }

--- a/src/data/crp-validation.json
+++ b/src/data/crp-validation.json
@@ -85,7 +85,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9266,
           "bartlett_chi2": 1278.99,
-          "bartlett_p": 5.598940441600992e-185
+          "bartlett_p": 5.5989404416016324e-185
         },
         "parallel_analysis": {
           "n_factors": 1,

--- a/src/data/data-audit.json
+++ b/src/data/data-audit.json
@@ -1,35 +1,35 @@
 {
   "disposition_counts": {
     "INCOMPLETE": 86,
-    "CLEAN": 110,
+    "CLEAN": 112,
     "FLAG-SMEAL": 65,
     "FLAG-SPEED": 10,
     "FLAG-PARTIAL-STRAIGHTLINING": 42,
     "FLAG-SINGLE-IRI": 105,
-    "AUTO-EXCLUDE": 153,
+    "AUTO-EXCLUDE": 154,
     "FLAG-RECAPTCHA": 4
   },
   "iri_pass_rates": {
-    "barrier": 0.4956521739130435,
-    "readiness": 0.5895652173913043,
-    "maturity": 0.7043478260869566
+    "barrier": 0.4982698961937716,
+    "readiness": 0.5899653979238755,
+    "maturity": 0.7041522491349481
   },
   "duration_stats": {
-    "mean": 635.1495652173913,
-    "median": 536,
-    "q25": 320,
-    "q75": 783,
+    "mean": 634.9826989619377,
+    "median": 537,
+    "q25": 321,
+    "q75": 782,
     "min": 2,
     "max": 5935
   },
   "straightlining_stats": {
     "full_block_flagged": 16,
-    "partial_flagged": 173
+    "partial_flagged": 174
   },
   "sample_sizes": {
-    "total": 575,
-    "complete": 489,
-    "clean": 110
+    "total": 578,
+    "complete": 492,
+    "clean": 112
   },
   "waterfall_steps": [
     {
@@ -53,50 +53,50 @@
     {
       "step": 3,
       "name": "AUTO-EXCLUDE",
-      "count": 153,
-      "cumulative_excluded": 239
+      "count": 154,
+      "cumulative_excluded": 240
     },
     {
       "step": 4,
       "name": "FLAG-SPEED",
       "count": 10,
-      "cumulative_excluded": 249
+      "cumulative_excluded": 250
     },
     {
       "step": 5,
       "name": "FLAG-SINGLE-IRI",
       "count": 105,
-      "cumulative_excluded": 354
+      "cumulative_excluded": 355
     },
     {
       "step": 6,
       "name": "FLAG-SMEAL",
       "count": 65,
-      "cumulative_excluded": 419
+      "cumulative_excluded": 420
     },
     {
       "step": 7,
       "name": "FLAG-RECAPTCHA",
       "count": 4,
-      "cumulative_excluded": 423
+      "cumulative_excluded": 424
     },
     {
       "step": 8,
       "name": "FLAG-STRAIGHTLINING",
       "count": 0,
-      "cumulative_excluded": 423
+      "cumulative_excluded": 424
     },
     {
       "step": 9,
       "name": "FLAG-PARTIAL-STRAIGHTLINING",
       "count": 42,
-      "cumulative_excluded": 465
+      "cumulative_excluded": 466
     },
     {
       "step": 10,
       "name": "CLEAN",
-      "count": 110,
-      "cumulative_excluded": 110
+      "count": 112,
+      "cumulative_excluded": 112
     }
   ]
 }

--- a/src/data/disposition-summary.json
+++ b/src/data/disposition-summary.json
@@ -1,12 +1,12 @@
 {
-  "updatedAt": "2026-04-28T11:23:08.452082+00:00",
-  "last_updated": "2026-04-28T11:23:08.452097+00:00",
+  "updatedAt": "2026-04-29T11:19:26.363894+00:00",
+  "last_updated": "2026-04-29T11:19:26.363936+00:00",
   "study": {
     "id": "69c17630acada6abeead2da5",
     "name": "Technology Adoption Barriers Survey (2026)",
     "status": "ACTIVE",
     "totalAvailablePlaces": 500,
-    "placesTaken": 349,
+    "placesTaken": 350,
     "averageRewardPerHour": 3955.5,
     "averageTimeTaken": 10,
     "reward": 700,
@@ -14,22 +14,22 @@
   },
   "completionProgress": {
     "target": 500,
-    "completed": 349,
-    "approved": 305,
-    "awaitingReview": 44,
-    "percentComplete": 69.8
+    "completed": 350,
+    "approved": 307,
+    "awaitingReview": 43,
+    "percentComplete": 70.0
   },
-  "totalResponses": 587,
-  "uniqueParticipants": 575,
+  "totalResponses": 590,
+  "uniqueParticipants": 578,
   "duplicatesRemoved": 0,
   "dispositions": {
     "INCOMPLETE": 86,
-    "CLEAN": 110,
+    "CLEAN": 112,
     "FLAG-SMEAL": 65,
     "FLAG-SPEED": 10,
     "FLAG-PARTIAL-STRAIGHTLINING": 42,
     "FLAG-SINGLE-IRI": 105,
-    "AUTO-EXCLUDE": 153,
+    "AUTO-EXCLUDE": 154,
     "FLAG-RECAPTCHA": 4
   },
   "dispositionByStatus": {
@@ -39,7 +39,7 @@
       "AWAITING REVIEW": 1
     },
     "CLEAN": {
-      "APPROVED": 109,
+      "APPROVED": 111,
       "RETURNED": 1
     },
     "FLAG-SMEAL": {
@@ -64,8 +64,8 @@
     "AUTO-EXCLUDE": {
       "REJECTED": 35,
       "APPROVED": 14,
-      "AWAITING REVIEW": 15,
-      "RETURNED": 89
+      "AWAITING REVIEW": 14,
+      "RETURNED": 91
     },
     "FLAG-RECAPTCHA": {
       "APPROVED": 4
@@ -75,23 +75,23 @@
     "IRI3_SPEED": 16,
     "IRI3": 35,
     "IRI2_SPEED": 12,
-    "IRI2": 71,
+    "IRI2": 72,
     "SPEED_IRI": 19
   },
   "actions": {
-    "approved": 305,
+    "approved": 307,
     "rejected": 35,
-    "returned": 197,
+    "returned": 199,
     "timedOut": 6,
-    "awaitingReview": 44,
+    "awaitingReview": 43,
     "active": 0,
     "messaged": 0
   },
   "iriPassRates": {
-    "barrier": 57.9,
+    "barrier": 58.1,
     "readiness": 68.9,
-    "maturity": 82.6,
-    "denominator": 489
+    "maturity": 82.5,
+    "denominator": 492
   },
   "studyId": "69c17630acada6abeead2da5",
   "studyName": "Technology Adoption Barriers Survey (2026)"

--- a/src/data/live-validation.json
+++ b/src/data/live-validation.json
@@ -485,7 +485,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.8796,
           "bartlett_chi2": 876.63,
-          "bartlett_p": 6.993538268613718e-102
+          "bartlett_p": 6.993538268613319e-102
         },
         "parallel_analysis": {
           "n_factors": 2,
@@ -551,7 +551,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9044,
           "bartlett_chi2": 1036.8,
-          "bartlett_p": 1.744429172237105e-138
+          "bartlett_p": 1.7444291722369053e-138
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -976,7 +976,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.8902,
           "bartlett_chi2": 1573.21,
-          "bartlett_p": 5.259945906285966e-234
+          "bartlett_p": 5.259945906298544e-234
         },
         "parallel_analysis": {
           "n_factors": 2,
@@ -1042,7 +1042,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9328,
           "bartlett_chi2": 1885.02,
-          "bartlett_p": 2.6343831453243563e-305
+          "bartlett_p": 2.634383145318359e-305
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -1104,7 +1104,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.918,
           "bartlett_chi2": 959.71,
-          "bartlett_p": 4.718146868962546e-184
+          "bartlett_p": 4.718146868955558e-184
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -1452,187 +1452,187 @@
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 489,
-      "n_to_param_ratio": 10.6,
+      "n": 492,
+      "n_to_param_ratio": 10.7,
       "adequacy": "good",
-      "adequacy_note": "N:parameter ratio 10.6:1 meets the recommended 10:1 threshold for stable CFA estimation.",
+      "adequacy_note": "N:parameter ratio 10.7:1 meets the recommended 10:1 threshold for stable CFA estimation.",
       "Barriers": {
-        "cronbach_alpha": 0.9026,
-        "cronbach_alpha_ci": [0.8892, 0.9151],
-        "n_listwise": 460,
-        "mcdonalds_omega": 0.903,
-        "composite_reliability": 0.903,
-        "ave": 0.3461,
-        "split_half": 0.923,
+        "cronbach_alpha": 0.9033,
+        "cronbach_alpha_ci": [0.89, 0.9157],
+        "n_listwise": 462,
+        "mcdonalds_omega": 0.9036,
+        "composite_reliability": 0.9036,
+        "ave": 0.3477,
+        "split_half": 0.9214,
         "kmo_bartlett": {
-          "kmo_overall": 0.9283,
-          "bartlett_chi2": 3029.05,
+          "kmo_overall": 0.929,
+          "bartlett_chi2": 3056.89,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 2,
-          "eigenvalues_real": [6.8696, 1.5952, 0.9733, 0.9193]
+          "eigenvalues_real": [6.8963, 1.5903, 0.9708, 0.917]
         },
         "efa": {
           "construct": "Barriers",
           "n_factors": 2,
-          "variance_explained": [0.3207, 0.1039],
-          "total_variance": 0.4246,
+          "variance_explained": [0.3222, 0.1036],
+          "total_variance": 0.4258,
           "factor_correlations": [
-            [1.0, 0.5721],
-            [0.5721, 1.0]
+            [1.0, 0.5724],
+            [0.5724, 1.0]
           ],
           "loadings": {
-            "B1": [0.7516, -0.1752],
-            "B2": [0.7838, -0.1329],
-            "B3": [0.6903, -0.0926],
-            "B4": [0.7289, -0.0758],
-            "B5": [0.6714, -0.0462],
-            "B6": [0.4912, 0.0412],
-            "B7": [0.5581, 0.0557],
-            "B8": [0.5791, 0.0751],
-            "B9": [0.5842, -0.0004],
-            "B10": [0.7656, -0.056],
-            "B11": [0.546, 0.1066],
-            "B12": [0.5695, 0.0611],
-            "B13": [-0.1628, 0.8775],
-            "B14": [-0.1269, 0.8667],
-            "B15": [0.4572, 0.1982],
-            "B16": [0.2223, 0.4151],
-            "B17": [0.4839, 0.1088],
-            "B18": [0.4032, 0.1793]
+            "B1": [0.7521, -0.1732],
+            "B2": [0.7835, -0.1331],
+            "B3": [0.6935, -0.0925],
+            "B4": [0.7277, -0.076],
+            "B5": [0.6748, -0.0466],
+            "B6": [0.4906, 0.0412],
+            "B7": [0.5576, 0.0558],
+            "B8": [0.5822, 0.0739],
+            "B9": [0.5867, 0.0002],
+            "B10": [0.7682, -0.0564],
+            "B11": [0.5487, 0.1059],
+            "B12": [0.5669, 0.06],
+            "B13": [-0.1612, 0.8774],
+            "B14": [-0.1255, 0.8658],
+            "B15": [0.4588, 0.1971],
+            "B16": [0.2256, 0.4141],
+            "B17": [0.4862, 0.1085],
+            "B18": [0.409, 0.1772]
           }
         },
         "cfa": {
           "construct": "Barriers",
-          "chi2": 581.657,
+          "chi2": 581.333,
           "df": 135,
           "chi2_p": 0.0,
-          "cfi": 0.8475,
-          "tli": 0.8271,
-          "rmsea": 0.0849,
+          "cfi": 0.849,
+          "tli": 0.8289,
+          "rmsea": 0.0847,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.3405,
-          "min_r": 0.1268,
-          "max_r": 0.6511,
-          "sd_r": 0.0906
+          "mean_r": 0.3421,
+          "min_r": 0.1304,
+          "max_r": 0.651,
+          "sd_r": 0.0904
         },
         "itc_min": 0.4,
         "itc_all_above_030": true
       },
       "Readiness": {
-        "cronbach_alpha": 0.9298,
-        "cronbach_alpha_ci": [0.9198, 0.939],
-        "n_listwise": 440,
-        "mcdonalds_omega": 0.9305,
-        "composite_reliability": 0.9305,
-        "ave": 0.442,
-        "split_half": 0.9351,
+        "cronbach_alpha": 0.93,
+        "cronbach_alpha_ci": [0.9201, 0.9392],
+        "n_listwise": 442,
+        "mcdonalds_omega": 0.9308,
+        "composite_reliability": 0.9308,
+        "ave": 0.4429,
+        "split_half": 0.9355,
         "kmo_bartlett": {
-          "kmo_overall": 0.9607,
-          "bartlett_chi2": 3435.29,
+          "kmo_overall": 0.9612,
+          "bartlett_chi2": 3460.11,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [8.0646, 0.9695, 0.7768, 0.7597]
+          "eigenvalues_real": [8.0787, 0.9717, 0.7757, 0.7615]
         },
         "efa": {
           "construct": "Readiness",
           "n_factors": 1,
-          "variance_explained": [0.442],
-          "total_variance": 0.442,
+          "variance_explained": [0.4429],
+          "total_variance": 0.4429,
           "factor_correlations": null,
           "loadings": {
-            "R1": [0.7237],
-            "R2": [0.6802],
-            "R3": [0.713],
-            "R4": [0.5805],
-            "R5": [0.6013],
-            "R6": [0.6935],
+            "R1": [0.7224],
+            "R2": [0.6796],
+            "R3": [0.7147],
+            "R4": [0.5816],
+            "R5": [0.5993],
+            "R6": [0.6944],
             "R7": [0.7067],
-            "R8": [0.6818],
-            "R9": [0.6614],
-            "R10": [0.6621],
-            "R11": [0.6695],
-            "R12": [0.6479],
-            "R13": [0.6814],
-            "R14": [0.6224],
-            "R15": [0.6651],
-            "R16": [0.7346],
-            "R17": [0.5464]
+            "R8": [0.6821],
+            "R9": [0.6613],
+            "R10": [0.6636],
+            "R11": [0.6714],
+            "R12": [0.6492],
+            "R13": [0.6842],
+            "R14": [0.6225],
+            "R15": [0.6662],
+            "R16": [0.7353],
+            "R17": [0.548]
           }
         },
         "cfa": {
           "construct": "Readiness",
-          "chi2": 270.951,
+          "chi2": 270.77,
           "df": 119,
           "chi2_p": 0.0,
-          "cfi": 0.9548,
-          "tli": 0.9483,
-          "rmsea": 0.0539,
+          "cfi": 0.9551,
+          "tli": 0.9487,
+          "rmsea": 0.0538,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.4396,
-          "min_r": 0.2693,
-          "max_r": 0.5823,
+          "mean_r": 0.4405,
+          "min_r": 0.2665,
+          "max_r": 0.585,
           "sd_r": 0.0587
         },
         "itc_min": 0.53,
         "itc_all_above_030": true
       },
       "Maturity": {
-        "cronbach_alpha": 0.889,
-        "cronbach_alpha_ci": [0.8729, 0.9038],
-        "n_listwise": 456,
-        "mcdonalds_omega": 0.8895,
-        "composite_reliability": 0.8895,
-        "ave": 0.5031,
-        "split_half": 0.9121,
+        "cronbach_alpha": 0.8905,
+        "cronbach_alpha_ci": [0.8747, 0.905],
+        "n_listwise": 459,
+        "mcdonalds_omega": 0.891,
+        "composite_reliability": 0.891,
+        "ave": 0.5068,
+        "split_half": 0.9129,
         "kmo_bartlett": {
-          "kmo_overall": 0.9262,
-          "bartlett_chi2": 1590.94,
+          "kmo_overall": 0.9268,
+          "bartlett_chi2": 1623.77,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [4.5133, 0.6435, 0.5807, 0.5403]
+          "eigenvalues_real": [4.5396, 0.6434, 0.5743, 0.5356]
         },
         "efa": {
           "construct": "Maturity",
           "n_factors": 1,
-          "variance_explained": [0.5031],
-          "total_variance": 0.5031,
+          "variance_explained": [0.5068],
+          "total_variance": 0.5068,
           "factor_correlations": null,
           "loadings": {
-            "M1": [0.761],
-            "M2": [0.7765],
-            "M3": [0.6522],
-            "M4": [0.6778],
-            "M5": [0.6558],
-            "M6": [0.7777],
-            "M7": [0.7115],
-            "M8": [0.6454]
+            "M1": [0.7654],
+            "M2": [0.7797],
+            "M3": [0.6565],
+            "M4": [0.6798],
+            "M5": [0.6607],
+            "M6": [0.7771],
+            "M7": [0.7138],
+            "M8": [0.6463]
           }
         },
         "cfa": {
           "construct": "Maturity",
-          "chi2": 37.53,
+          "chi2": 38.375,
           "df": 20,
-          "chi2_p": 0.0101,
-          "cfi": 0.9889,
-          "tli": 0.9845,
-          "rmsea": 0.0439,
+          "chi2_p": 0.008,
+          "cfi": 0.9886,
+          "tli": 0.984,
+          "rmsea": 0.0448,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.5002,
-          "min_r": 0.4032,
-          "max_r": 0.6373,
-          "sd_r": 0.0539
+          "mean_r": 0.504,
+          "min_r": 0.4049,
+          "max_r": 0.6425,
+          "sd_r": 0.0538
         },
         "itc_min": 0.61,
         "itc_all_above_030": true
@@ -1640,24 +1640,24 @@
       "htmt": [
         {
           "pair": "Barriers vs Readiness",
-          "htmt": 0.3402,
-          "ci_lower": 0.267,
-          "ci_upper": 0.4507,
+          "htmt": 0.3308,
+          "ci_lower": 0.2556,
+          "ci_upper": 0.4415,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "htmt": 0.3562,
-          "ci_lower": 0.2794,
-          "ci_upper": 0.4534,
+          "htmt": 0.3447,
+          "ci_lower": 0.2706,
+          "ci_upper": 0.4412,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "htmt": 0.8161,
-          "ci_lower": 0.7481,
+          "htmt": 0.8173,
+          "ci_lower": 0.7511,
           "ci_upper": 0.8715,
           "below_085": true,
           "below_090": true
@@ -1666,65 +1666,65 @@
       "fornell_larcker": [
         {
           "pair": "Barriers vs Readiness",
-          "sqrt_ave1": 0.5883,
-          "sqrt_ave2": 0.6648,
-          "abs_r": 0.282,
+          "sqrt_ave1": 0.5897,
+          "sqrt_ave2": 0.6655,
+          "abs_r": 0.273,
           "pass": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "sqrt_ave1": 0.5883,
-          "sqrt_ave2": 0.7093,
-          "abs_r": 0.2891,
+          "sqrt_ave1": 0.5897,
+          "sqrt_ave2": 0.7119,
+          "abs_r": 0.272,
           "pass": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "sqrt_ave1": 0.6648,
-          "sqrt_ave2": 0.7093,
-          "abs_r": 0.726,
+          "sqrt_ave1": 0.6655,
+          "sqrt_ave2": 0.7119,
+          "abs_r": 0.7248,
           "pass": false
         }
       ],
       "construct_correlations": {
         "Barriers": {
           "Barriers": 1.0,
-          "Readiness": -0.282,
-          "Maturity": -0.2891
+          "Readiness": -0.273,
+          "Maturity": -0.272
         },
         "Readiness": {
-          "Barriers": -0.282,
+          "Barriers": -0.273,
           "Readiness": 1.0,
-          "Maturity": 0.726
+          "Maturity": 0.7248
         },
         "Maturity": {
-          "Barriers": -0.2891,
-          "Readiness": 0.726,
+          "Barriers": -0.272,
+          "Readiness": 0.7248,
           "Maturity": 1.0
         }
       },
       "barriers_4f_cfa": {
-        "chi2": 460.759,
+        "chi2": 460.833,
         "df": 129,
         "chi2_p": 0.0,
-        "cfi": 0.8867,
-        "tli": 0.8656,
-        "rmsea": 0.0749,
-        "aic": 82.0,
-        "bic": 255.51
+        "cfi": 0.8878,
+        "tli": 0.8669,
+        "rmsea": 0.0747,
+        "aic": 82.01,
+        "bic": 255.7
       },
       "factor_analysis": {
         "efa_factors": [
           {
             "name": "F1",
             "items": 15,
-            "eigenvalue": 6.8696,
-            "variance_pct": 32.1
+            "eigenvalue": 6.8963,
+            "variance_pct": 32.2
           },
           {
             "name": "F2",
             "items": 3,
-            "eigenvalue": 1.5952,
+            "eigenvalue": 1.5903,
             "variance_pct": 10.4
           }
         ],
@@ -1733,28 +1733,28 @@
             "name": "F1a \u2014 Strategy & Culture",
             "item_ids": ["B1", "B2", "B3", "B5", "B9", "B10", "B11", "B15", "B17"],
             "items": 9,
-            "alpha": 0.8593,
-            "cr": 0.8629,
-            "ave": 0.4195
+            "alpha": 0.8606,
+            "cr": 0.8642,
+            "ave": 0.422
           },
           {
             "name": "F1b \u2014 Resources & Operations",
             "item_ids": ["B4", "B6", "B7", "B8", "B12"],
             "items": 5,
-            "alpha": 0.7213,
-            "cr": 0.7246,
-            "ave": 0.3487
+            "alpha": 0.721,
+            "cr": 0.7242,
+            "ave": 0.3483
           },
           {
             "name": "F2 \u2014 External & Compliance",
             "item_ids": ["B13", "B14", "B16", "B18"],
             "items": 4,
-            "alpha": 0.6446,
-            "cr": 0.7063,
-            "ave": 0.4314
+            "alpha": 0.6432,
+            "cr": 0.7053,
+            "ave": 0.4306
           }
         ],
-        "factor_correlation": 0.5721,
+        "factor_correlation": 0.5724,
         "barrier_names": [
           "Resistance to Change",
           "Lack of Leadership Support",
@@ -1778,110 +1778,110 @@
         "loadings_matrix": [
           {
             "id": "B1",
-            "f1": 0.7516,
-            "f2": -0.1752,
+            "f1": 0.7521,
+            "f2": -0.1732,
             "assigned": "F1"
           },
           {
             "id": "B2",
-            "f1": 0.7838,
-            "f2": -0.1329,
+            "f1": 0.7835,
+            "f2": -0.1331,
             "assigned": "F1"
           },
           {
             "id": "B3",
-            "f1": 0.6903,
-            "f2": -0.0926,
+            "f1": 0.6935,
+            "f2": -0.0925,
             "assigned": "F1"
           },
           {
             "id": "B4",
-            "f1": 0.7289,
-            "f2": -0.0758,
+            "f1": 0.7277,
+            "f2": -0.076,
             "assigned": "F1"
           },
           {
             "id": "B5",
-            "f1": 0.6714,
-            "f2": -0.0462,
+            "f1": 0.6748,
+            "f2": -0.0466,
             "assigned": "F1"
           },
           {
             "id": "B6",
-            "f1": 0.4912,
+            "f1": 0.4906,
             "f2": 0.0412,
             "assigned": "F1"
           },
           {
             "id": "B7",
-            "f1": 0.5581,
-            "f2": 0.0557,
+            "f1": 0.5576,
+            "f2": 0.0558,
             "assigned": "F1"
           },
           {
             "id": "B8",
-            "f1": 0.5791,
-            "f2": 0.0751,
+            "f1": 0.5822,
+            "f2": 0.0739,
             "assigned": "F1"
           },
           {
             "id": "B9",
-            "f1": 0.5842,
-            "f2": -0.0004,
+            "f1": 0.5867,
+            "f2": 0.0002,
             "assigned": "F1"
           },
           {
             "id": "B10",
-            "f1": 0.7656,
-            "f2": -0.056,
+            "f1": 0.7682,
+            "f2": -0.0564,
             "assigned": "F1"
           },
           {
             "id": "B11",
-            "f1": 0.546,
-            "f2": 0.1066,
+            "f1": 0.5487,
+            "f2": 0.1059,
             "assigned": "F1"
           },
           {
             "id": "B12",
-            "f1": 0.5695,
-            "f2": 0.0611,
+            "f1": 0.5669,
+            "f2": 0.06,
             "assigned": "F1"
           },
           {
             "id": "B13",
-            "f1": -0.1628,
-            "f2": 0.8775,
+            "f1": -0.1612,
+            "f2": 0.8774,
             "assigned": "F2"
           },
           {
             "id": "B14",
-            "f1": -0.1269,
-            "f2": 0.8667,
+            "f1": -0.1255,
+            "f2": 0.8658,
             "assigned": "F2"
           },
           {
             "id": "B15",
-            "f1": 0.4572,
-            "f2": 0.1982,
+            "f1": 0.4588,
+            "f2": 0.1971,
             "assigned": "F1"
           },
           {
             "id": "B16",
-            "f1": 0.2223,
-            "f2": 0.4151,
+            "f1": 0.2256,
+            "f2": 0.4141,
             "assigned": "F2"
           },
           {
             "id": "B17",
-            "f1": 0.4839,
-            "f2": 0.1088,
+            "f1": 0.4862,
+            "f2": 0.1085,
             "assigned": "F1"
           },
           {
             "id": "B18",
-            "f1": 0.4032,
-            "f2": 0.1793,
+            "f1": 0.409,
+            "f2": 0.1772,
             "assigned": "F1"
           }
         ]
@@ -1931,7 +1931,7 @@
         }
       },
       "metadata": {
-        "n_total": 489,
+        "n_total": 492,
         "crp200_mode": false,
         "constructs": ["Barriers", "Readiness", "Maturity"],
         "n_barriers": 18,
@@ -1943,187 +1943,187 @@
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 575,
-      "n_to_param_ratio": 12.5,
+      "n": 578,
+      "n_to_param_ratio": 12.6,
       "adequacy": "good",
-      "adequacy_note": "N:parameter ratio 12.5:1 meets the recommended 10:1 threshold for stable CFA estimation.",
+      "adequacy_note": "N:parameter ratio 12.6:1 meets the recommended 10:1 threshold for stable CFA estimation.",
       "Barriers": {
-        "cronbach_alpha": 0.9031,
-        "cronbach_alpha_ci": [0.8899, 0.9155],
-        "n_listwise": 466,
-        "mcdonalds_omega": 0.9035,
-        "composite_reliability": 0.9035,
-        "ave": 0.3473,
-        "split_half": 0.9237,
+        "cronbach_alpha": 0.9038,
+        "cronbach_alpha_ci": [0.8906, 0.916],
+        "n_listwise": 468,
+        "mcdonalds_omega": 0.9041,
+        "composite_reliability": 0.9041,
+        "ave": 0.3488,
+        "split_half": 0.9221,
         "kmo_bartlett": {
-          "kmo_overall": 0.9286,
-          "bartlett_chi2": 3082.59,
+          "kmo_overall": 0.9293,
+          "bartlett_chi2": 3110.17,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 2,
-          "eigenvalues_real": [6.8906, 1.6002, 0.9641, 0.917]
+          "eigenvalues_real": [6.9166, 1.5952, 0.9616, 0.915]
         },
         "efa": {
           "construct": "Barriers",
           "n_factors": 2,
-          "variance_explained": [0.321, 0.1049],
-          "total_variance": 0.4259,
+          "variance_explained": [0.3224, 0.1046],
+          "total_variance": 0.427,
           "factor_correlations": [
-            [1.0, 0.5755],
-            [0.5755, 1.0]
+            [1.0, 0.5758],
+            [0.5758, 1.0]
           ],
           "loadings": {
-            "B1": [0.7451, -0.1795],
-            "B2": [0.7851, -0.139],
-            "B3": [0.6897, -0.0839],
-            "B4": [0.7357, -0.0784],
-            "B5": [0.6781, -0.053],
-            "B6": [0.4972, 0.0372],
-            "B7": [0.5542, 0.0667],
-            "B8": [0.5758, 0.0858],
-            "B9": [0.5812, -0.0012],
-            "B10": [0.7727, -0.0679],
-            "B11": [0.5401, 0.1198],
-            "B12": [0.5615, 0.0729],
-            "B13": [-0.1692, 0.8775],
-            "B14": [-0.1277, 0.8678],
-            "B15": [0.4616, 0.1989],
-            "B16": [0.2193, 0.4172],
-            "B17": [0.4852, 0.115],
-            "B18": [0.3997, 0.1837]
+            "B1": [0.7456, -0.1775],
+            "B2": [0.7849, -0.1392],
+            "B3": [0.6929, -0.0839],
+            "B4": [0.7346, -0.0787],
+            "B5": [0.6815, -0.0535],
+            "B6": [0.4965, 0.0372],
+            "B7": [0.5537, 0.0668],
+            "B8": [0.5789, 0.0845],
+            "B9": [0.5836, -0.0006],
+            "B10": [0.7752, -0.0683],
+            "B11": [0.5428, 0.119],
+            "B12": [0.5591, 0.0716],
+            "B13": [-0.1676, 0.8773],
+            "B14": [-0.1262, 0.8668],
+            "B15": [0.4631, 0.1978],
+            "B16": [0.2226, 0.4162],
+            "B17": [0.4874, 0.1147],
+            "B18": [0.4055, 0.1816]
           }
         },
         "cfa": {
           "construct": "Barriers",
-          "chi2": 590.105,
+          "chi2": 589.703,
           "df": 135,
           "chi2_p": 0.0,
-          "cfi": 0.8474,
-          "tli": 0.8271,
-          "rmsea": 0.0851,
+          "cfi": 0.8489,
+          "tli": 0.8288,
+          "rmsea": 0.0849,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.3418,
-          "min_r": 0.1223,
-          "max_r": 0.6497,
-          "sd_r": 0.0906
+          "mean_r": 0.3433,
+          "min_r": 0.1258,
+          "max_r": 0.6495,
+          "sd_r": 0.0904
         },
         "itc_min": 0.4,
         "itc_all_above_030": true
       },
       "Readiness": {
-        "cronbach_alpha": 0.9298,
-        "cronbach_alpha_ci": [0.9198, 0.939],
-        "n_listwise": 440,
-        "mcdonalds_omega": 0.9305,
-        "composite_reliability": 0.9305,
-        "ave": 0.442,
-        "split_half": 0.9351,
+        "cronbach_alpha": 0.93,
+        "cronbach_alpha_ci": [0.9201, 0.9392],
+        "n_listwise": 442,
+        "mcdonalds_omega": 0.9308,
+        "composite_reliability": 0.9308,
+        "ave": 0.4429,
+        "split_half": 0.9355,
         "kmo_bartlett": {
-          "kmo_overall": 0.9607,
-          "bartlett_chi2": 3435.29,
+          "kmo_overall": 0.9612,
+          "bartlett_chi2": 3460.11,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [8.0646, 0.9695, 0.7768, 0.7597]
+          "eigenvalues_real": [8.0787, 0.9717, 0.7757, 0.7615]
         },
         "efa": {
           "construct": "Readiness",
           "n_factors": 1,
-          "variance_explained": [0.442],
-          "total_variance": 0.442,
+          "variance_explained": [0.4429],
+          "total_variance": 0.4429,
           "factor_correlations": null,
           "loadings": {
-            "R1": [0.7237],
-            "R2": [0.6802],
-            "R3": [0.713],
-            "R4": [0.5805],
-            "R5": [0.6013],
-            "R6": [0.6935],
+            "R1": [0.7224],
+            "R2": [0.6796],
+            "R3": [0.7147],
+            "R4": [0.5816],
+            "R5": [0.5993],
+            "R6": [0.6944],
             "R7": [0.7067],
-            "R8": [0.6818],
-            "R9": [0.6614],
-            "R10": [0.6621],
-            "R11": [0.6695],
-            "R12": [0.6479],
-            "R13": [0.6814],
-            "R14": [0.6224],
-            "R15": [0.6651],
-            "R16": [0.7346],
-            "R17": [0.5464]
+            "R8": [0.6821],
+            "R9": [0.6613],
+            "R10": [0.6636],
+            "R11": [0.6714],
+            "R12": [0.6492],
+            "R13": [0.6842],
+            "R14": [0.6225],
+            "R15": [0.6662],
+            "R16": [0.7353],
+            "R17": [0.548]
           }
         },
         "cfa": {
           "construct": "Readiness",
-          "chi2": 270.951,
+          "chi2": 270.77,
           "df": 119,
           "chi2_p": 0.0,
-          "cfi": 0.9548,
-          "tli": 0.9483,
-          "rmsea": 0.0539,
+          "cfi": 0.9551,
+          "tli": 0.9487,
+          "rmsea": 0.0538,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.4396,
-          "min_r": 0.2693,
-          "max_r": 0.5823,
+          "mean_r": 0.4405,
+          "min_r": 0.2665,
+          "max_r": 0.585,
           "sd_r": 0.0587
         },
         "itc_min": 0.53,
         "itc_all_above_030": true
       },
       "Maturity": {
-        "cronbach_alpha": 0.889,
-        "cronbach_alpha_ci": [0.8729, 0.9038],
-        "n_listwise": 456,
-        "mcdonalds_omega": 0.8895,
-        "composite_reliability": 0.8895,
-        "ave": 0.5031,
-        "split_half": 0.9121,
+        "cronbach_alpha": 0.8905,
+        "cronbach_alpha_ci": [0.8747, 0.905],
+        "n_listwise": 459,
+        "mcdonalds_omega": 0.891,
+        "composite_reliability": 0.891,
+        "ave": 0.5068,
+        "split_half": 0.9129,
         "kmo_bartlett": {
-          "kmo_overall": 0.9262,
-          "bartlett_chi2": 1590.94,
+          "kmo_overall": 0.9268,
+          "bartlett_chi2": 1623.77,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [4.5133, 0.6435, 0.5807, 0.5403]
+          "eigenvalues_real": [4.5396, 0.6434, 0.5743, 0.5356]
         },
         "efa": {
           "construct": "Maturity",
           "n_factors": 1,
-          "variance_explained": [0.5031],
-          "total_variance": 0.5031,
+          "variance_explained": [0.5068],
+          "total_variance": 0.5068,
           "factor_correlations": null,
           "loadings": {
-            "M1": [0.761],
-            "M2": [0.7765],
-            "M3": [0.6522],
-            "M4": [0.6778],
-            "M5": [0.6558],
-            "M6": [0.7777],
-            "M7": [0.7115],
-            "M8": [0.6454]
+            "M1": [0.7654],
+            "M2": [0.7797],
+            "M3": [0.6565],
+            "M4": [0.6798],
+            "M5": [0.6607],
+            "M6": [0.7771],
+            "M7": [0.7138],
+            "M8": [0.6463]
           }
         },
         "cfa": {
           "construct": "Maturity",
-          "chi2": 37.53,
+          "chi2": 38.375,
           "df": 20,
-          "chi2_p": 0.0101,
-          "cfi": 0.9889,
-          "tli": 0.9845,
-          "rmsea": 0.0439,
+          "chi2_p": 0.008,
+          "cfi": 0.9886,
+          "tli": 0.984,
+          "rmsea": 0.0448,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.5002,
-          "min_r": 0.4032,
-          "max_r": 0.6373,
-          "sd_r": 0.0539
+          "mean_r": 0.504,
+          "min_r": 0.4049,
+          "max_r": 0.6425,
+          "sd_r": 0.0538
         },
         "itc_min": 0.61,
         "itc_all_above_030": true
@@ -2131,24 +2131,24 @@
       "htmt": [
         {
           "pair": "Barriers vs Readiness",
-          "htmt": 0.3402,
-          "ci_lower": 0.267,
-          "ci_upper": 0.4507,
+          "htmt": 0.3308,
+          "ci_lower": 0.2556,
+          "ci_upper": 0.4415,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "htmt": 0.3562,
-          "ci_lower": 0.2794,
-          "ci_upper": 0.4534,
+          "htmt": 0.3447,
+          "ci_lower": 0.2706,
+          "ci_upper": 0.4412,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "htmt": 0.8161,
-          "ci_lower": 0.7481,
+          "htmt": 0.8173,
+          "ci_lower": 0.7511,
           "ci_upper": 0.8715,
           "below_085": true,
           "below_090": true
@@ -2157,65 +2157,65 @@
       "fornell_larcker": [
         {
           "pair": "Barriers vs Readiness",
-          "sqrt_ave1": 0.5893,
-          "sqrt_ave2": 0.6648,
-          "abs_r": 0.2817,
+          "sqrt_ave1": 0.5906,
+          "sqrt_ave2": 0.6655,
+          "abs_r": 0.2727,
           "pass": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "sqrt_ave1": 0.5893,
-          "sqrt_ave2": 0.7093,
-          "abs_r": 0.289,
+          "sqrt_ave1": 0.5906,
+          "sqrt_ave2": 0.7119,
+          "abs_r": 0.2719,
           "pass": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "sqrt_ave1": 0.6648,
-          "sqrt_ave2": 0.7093,
-          "abs_r": 0.726,
+          "sqrt_ave1": 0.6655,
+          "sqrt_ave2": 0.7119,
+          "abs_r": 0.7248,
           "pass": false
         }
       ],
       "construct_correlations": {
         "Barriers": {
           "Barriers": 1.0,
-          "Readiness": -0.2817,
-          "Maturity": -0.289
+          "Readiness": -0.2727,
+          "Maturity": -0.2719
         },
         "Readiness": {
-          "Barriers": -0.2817,
+          "Barriers": -0.2727,
           "Readiness": 1.0,
-          "Maturity": 0.726
+          "Maturity": 0.7248
         },
         "Maturity": {
-          "Barriers": -0.289,
-          "Readiness": 0.726,
+          "Barriers": -0.2719,
+          "Readiness": 0.7248,
           "Maturity": 1.0
         }
       },
       "barriers_4f_cfa": {
-        "chi2": 471.844,
+        "chi2": 471.763,
         "df": 129,
         "chi2_p": 0.0,
-        "cfi": 0.885,
-        "tli": 0.8637,
-        "rmsea": 0.0756,
-        "aic": 81.97,
-        "bic": 256.03
+        "cfi": 0.8861,
+        "tli": 0.8649,
+        "rmsea": 0.0754,
+        "aic": 81.98,
+        "bic": 256.22
       },
       "factor_analysis": {
         "efa_factors": [
           {
             "name": "F1",
             "items": 15,
-            "eigenvalue": 6.8906,
-            "variance_pct": 32.1
+            "eigenvalue": 6.9166,
+            "variance_pct": 32.2
           },
           {
             "name": "F2",
             "items": 3,
-            "eigenvalue": 1.6002,
+            "eigenvalue": 1.5952,
             "variance_pct": 10.5
           }
         ],
@@ -2224,28 +2224,28 @@
             "name": "F1a \u2014 Strategy & Culture",
             "item_ids": ["B1", "B2", "B3", "B5", "B9", "B10", "B11", "B15", "B17"],
             "items": 9,
-            "alpha": 0.8596,
-            "cr": 0.8632,
-            "ave": 0.4202
+            "alpha": 0.8609,
+            "cr": 0.8645,
+            "ave": 0.4227
           },
           {
             "name": "F1b \u2014 Resources & Operations",
             "item_ids": ["B4", "B6", "B7", "B8", "B12"],
             "items": 5,
-            "alpha": 0.7208,
-            "cr": 0.7242,
-            "ave": 0.3485
+            "alpha": 0.7204,
+            "cr": 0.7238,
+            "ave": 0.3481
           },
           {
             "name": "F2 \u2014 External & Compliance",
             "item_ids": ["B13", "B14", "B16", "B18"],
             "items": 4,
-            "alpha": 0.6473,
-            "cr": 0.7081,
-            "ave": 0.4327
+            "alpha": 0.6458,
+            "cr": 0.707,
+            "ave": 0.4318
           }
         ],
-        "factor_correlation": 0.5755,
+        "factor_correlation": 0.5758,
         "barrier_names": [
           "Resistance to Change",
           "Lack of Leadership Support",
@@ -2269,110 +2269,110 @@
         "loadings_matrix": [
           {
             "id": "B1",
-            "f1": 0.7451,
-            "f2": -0.1795,
+            "f1": 0.7456,
+            "f2": -0.1775,
             "assigned": "F1"
           },
           {
             "id": "B2",
-            "f1": 0.7851,
-            "f2": -0.139,
+            "f1": 0.7849,
+            "f2": -0.1392,
             "assigned": "F1"
           },
           {
             "id": "B3",
-            "f1": 0.6897,
+            "f1": 0.6929,
             "f2": -0.0839,
             "assigned": "F1"
           },
           {
             "id": "B4",
-            "f1": 0.7357,
-            "f2": -0.0784,
+            "f1": 0.7346,
+            "f2": -0.0787,
             "assigned": "F1"
           },
           {
             "id": "B5",
-            "f1": 0.6781,
-            "f2": -0.053,
+            "f1": 0.6815,
+            "f2": -0.0535,
             "assigned": "F1"
           },
           {
             "id": "B6",
-            "f1": 0.4972,
+            "f1": 0.4965,
             "f2": 0.0372,
             "assigned": "F1"
           },
           {
             "id": "B7",
-            "f1": 0.5542,
-            "f2": 0.0667,
+            "f1": 0.5537,
+            "f2": 0.0668,
             "assigned": "F1"
           },
           {
             "id": "B8",
-            "f1": 0.5758,
-            "f2": 0.0858,
+            "f1": 0.5789,
+            "f2": 0.0845,
             "assigned": "F1"
           },
           {
             "id": "B9",
-            "f1": 0.5812,
-            "f2": -0.0012,
+            "f1": 0.5836,
+            "f2": -0.0006,
             "assigned": "F1"
           },
           {
             "id": "B10",
-            "f1": 0.7727,
-            "f2": -0.0679,
+            "f1": 0.7752,
+            "f2": -0.0683,
             "assigned": "F1"
           },
           {
             "id": "B11",
-            "f1": 0.5401,
-            "f2": 0.1198,
+            "f1": 0.5428,
+            "f2": 0.119,
             "assigned": "F1"
           },
           {
             "id": "B12",
-            "f1": 0.5615,
-            "f2": 0.0729,
+            "f1": 0.5591,
+            "f2": 0.0716,
             "assigned": "F1"
           },
           {
             "id": "B13",
-            "f1": -0.1692,
-            "f2": 0.8775,
+            "f1": -0.1676,
+            "f2": 0.8773,
             "assigned": "F2"
           },
           {
             "id": "B14",
-            "f1": -0.1277,
-            "f2": 0.8678,
+            "f1": -0.1262,
+            "f2": 0.8668,
             "assigned": "F2"
           },
           {
             "id": "B15",
-            "f1": 0.4616,
-            "f2": 0.1989,
+            "f1": 0.4631,
+            "f2": 0.1978,
             "assigned": "F1"
           },
           {
             "id": "B16",
-            "f1": 0.2193,
-            "f2": 0.4172,
+            "f1": 0.2226,
+            "f2": 0.4162,
             "assigned": "F2"
           },
           {
             "id": "B17",
-            "f1": 0.4852,
-            "f2": 0.115,
+            "f1": 0.4874,
+            "f2": 0.1147,
             "assigned": "F1"
           },
           {
             "id": "B18",
-            "f1": 0.3997,
-            "f2": 0.1837,
+            "f1": 0.4055,
+            "f2": 0.1816,
             "assigned": "F1"
           }
         ]
@@ -2422,7 +2422,7 @@
         }
       },
       "metadata": {
-        "n_total": 575,
+        "n_total": 578,
         "crp200_mode": false,
         "constructs": ["Barriers", "Readiness", "Maturity"],
         "n_barriers": 18,

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -22,13 +22,13 @@
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 489
+      "n": 492
     },
     {
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 575
+      "n": 578
     }
   ],
   "metrics": [
@@ -39,8 +39,8 @@
         "conservative_clean": 2.8605,
         "flexible_clean": 2.8459,
         "prolific_accepted": 2.8345,
-        "v2_finished": 2.8111,
-        "v2_all": 2.8141
+        "v2_finished": 2.813,
+        "v2_all": 2.8159
       }
     },
     {
@@ -50,8 +50,8 @@
         "conservative_clean": 0.6243,
         "flexible_clean": 0.6953,
         "prolific_accepted": 0.6988,
-        "v2_finished": 0.7713,
-        "v2_all": 0.773
+        "v2_finished": 0.7739,
+        "v2_all": 0.7756
       }
     },
     {
@@ -61,8 +61,8 @@
         "conservative_clean": 3.0379,
         "flexible_clean": 3.086,
         "prolific_accepted": 3.1153,
-        "v2_finished": 3.2155,
-        "v2_all": 3.2157
+        "v2_finished": 3.2162,
+        "v2_all": 3.2164
       }
     },
     {
@@ -72,8 +72,8 @@
         "conservative_clean": 0.5566,
         "flexible_clean": 0.6414,
         "prolific_accepted": 0.6656,
-        "v2_finished": 0.7157,
-        "v2_all": 0.7142
+        "v2_finished": 0.7159,
+        "v2_all": 0.7145
       }
     },
     {
@@ -83,8 +83,8 @@
         "conservative_clean": 3.0625,
         "flexible_clean": 3.077,
         "prolific_accepted": 3.1504,
-        "v2_finished": 3.2456,
-        "v2_all": 3.2458
+        "v2_finished": 3.2443,
+        "v2_all": 3.2445
       }
     },
     {
@@ -94,8 +94,8 @@
         "conservative_clean": 0.6897,
         "flexible_clean": 0.7808,
         "prolific_accepted": 0.7913,
-        "v2_finished": 0.8007,
-        "v2_all": 0.7999
+        "v2_finished": 0.8047,
+        "v2_all": 0.8038
       }
     },
     {
@@ -105,8 +105,8 @@
         "conservative_clean": -0.3704,
         "flexible_clean": -0.3978,
         "prolific_accepted": -0.3167,
-        "v2_finished": -0.282,
-        "v2_all": -0.2817
+        "v2_finished": -0.273,
+        "v2_all": -0.2727
       }
     },
     {
@@ -116,8 +116,8 @@
         "conservative_clean": -0.1378,
         "flexible_clean": -0.2724,
         "prolific_accepted": -0.252,
-        "v2_finished": -0.2891,
-        "v2_all": -0.289
+        "v2_finished": -0.272,
+        "v2_all": -0.2719
       }
     },
     {
@@ -127,8 +127,8 @@
         "conservative_clean": 0.5839,
         "flexible_clean": 0.7034,
         "prolific_accepted": 0.7269,
-        "v2_finished": 0.726,
-        "v2_all": 0.726
+        "v2_finished": 0.7248,
+        "v2_all": 0.7248
       }
     },
     {
@@ -138,8 +138,8 @@
         "conservative_clean": 0.8551,
         "flexible_clean": 0.8738,
         "prolific_accepted": 0.8745,
-        "v2_finished": 0.9026,
-        "v2_all": 0.9031
+        "v2_finished": 0.9033,
+        "v2_all": 0.9038
       }
     },
     {
@@ -149,8 +149,8 @@
         "conservative_clean": 0.8537,
         "flexible_clean": 0.9084,
         "prolific_accepted": 0.9145,
-        "v2_finished": 0.9298,
-        "v2_all": 0.9298
+        "v2_finished": 0.93,
+        "v2_all": 0.93
       }
     },
     {
@@ -160,8 +160,8 @@
         "conservative_clean": 0.825,
         "flexible_clean": 0.8798,
         "prolific_accepted": 0.8838,
-        "v2_finished": 0.889,
-        "v2_all": 0.889
+        "v2_finished": 0.8905,
+        "v2_all": 0.8905
       }
     }
   ],
@@ -1099,11 +1099,11 @@
     "v2_finished": {
       "demographics": {
         "roles": {
-          "Other": 96,
+          "Other": 97,
           "CIO": 68,
-          "CEO": 55,
+          "CEO": 56,
           "COO": 52,
-          "CTO": 43,
+          "CTO": 44,
           "CSO": 42,
           "CFO": 38,
           "CMO": 33,
@@ -1112,93 +1112,93 @@
           "CISO": 6
         },
         "org_sizes": {
-          "<100": 71,
+          "<100": 72,
           "100-499": 149,
           "500-999": 70,
-          "1000-4999": 90,
+          "1000-4999": 91,
           "5000-9999": 43,
-          "10000+": 66
+          "10000+": 67
         },
         "profit_models": {
-          "For-Profit": 359,
+          "For-Profit": 362,
           "Non-Profit": 84,
           "Government/Public Sector": 46
         },
         "tech_vs_nontech": {
-          "technical": 122,
-          "non_technical": 367,
+          "technical": 123,
+          "non_technical": 369,
           "other": 0
         },
         "other_roles": {
-          "total": 96,
+          "total": 97,
           "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 122,
-          "nontech_n": 367,
+          "tech_n": 123,
+          "nontech_n": 369,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7213,
-              "tech_mean_ci_lower": 2.5801,
-              "tech_mean_ci_upper": 2.8625,
-              "nontech_mean": 2.841,
-              "nontech_mean_ci_lower": 2.7625,
-              "nontech_mean_ci_upper": 2.9195,
-              "d": -0.1554,
-              "d_ci_lower": -0.3656,
-              "d_ci_upper": 0.0528
+              "tech_mean": 2.7349,
+              "tech_mean_ci_lower": 2.5923,
+              "tech_mean_ci_upper": 2.8774,
+              "nontech_mean": 2.8391,
+              "nontech_mean_ci_lower": 2.7608,
+              "nontech_mean_ci_upper": 2.9174,
+              "d": -0.1347,
+              "d_ci_lower": -0.347,
+              "d_ci_upper": 0.0698
             },
             "readiness": {
-              "tech_mean": 3.487,
-              "tech_mean_ci_lower": 3.3661,
-              "tech_mean_ci_upper": 3.6079,
-              "nontech_mean": 3.125,
-              "nontech_mean_ci_lower": 3.0523,
-              "nontech_mean_ci_upper": 3.1976,
-              "d": 0.518,
-              "d_ci_lower": 0.3208,
-              "d_ci_upper": 0.7207
+              "tech_mean": 3.4941,
+              "tech_mean_ci_lower": 3.3734,
+              "tech_mean_ci_upper": 3.6148,
+              "nontech_mean": 3.1234,
+              "nontech_mean_ci_lower": 3.051,
+              "nontech_mean_ci_upper": 3.1957,
+              "d": 0.5308,
+              "d_ci_lower": 0.3405,
+              "d_ci_upper": 0.7273
             },
             "maturity": {
-              "tech_mean": 3.46,
-              "tech_mean_ci_lower": 3.3255,
-              "tech_mean_ci_upper": 3.5946,
-              "nontech_mean": 3.1739,
-              "nontech_mean_ci_lower": 3.091,
-              "nontech_mean_ci_upper": 3.2568,
-              "d": 0.3613,
-              "d_ci_lower": 0.1579,
-              "d_ci_upper": 0.5639
+              "tech_mean": 3.4695,
+              "tech_mean_ci_lower": 3.3348,
+              "tech_mean_ci_upper": 3.6042,
+              "nontech_mean": 3.1689,
+              "nontech_mean_ci_lower": 3.086,
+              "nontech_mean_ci_upper": 3.2518,
+              "d": 0.3782,
+              "d_ci_lower": 0.1771,
+              "d_ci_upper": 0.5738
             }
           }
         },
         "large_vs_small": {
-          "large_n": 109,
-          "small_medium_n": 380,
+          "large_n": 110,
+          "small_medium_n": 382,
           "constructs": {
             "barriers": {
-              "large_mean": 2.8939,
-              "large_mean_ci_lower": 2.748,
-              "large_mean_ci_upper": 3.0398,
-              "small_medium_mean": 2.7874,
-              "small_medium_mean_ci_lower": 2.7096,
-              "small_medium_mean_ci_upper": 2.8652,
-              "d": 0.1382,
-              "d_ci_lower": -0.081,
-              "d_ci_upper": 0.3579
+              "large_mean": 2.8969,
+              "large_mean_ci_lower": 2.7522,
+              "large_mean_ci_upper": 3.0416,
+              "small_medium_mean": 2.7889,
+              "small_medium_mean_ci_lower": 2.7108,
+              "small_medium_mean_ci_upper": 2.8669,
+              "d": 0.1397,
+              "d_ci_lower": -0.0748,
+              "d_ci_upper": 0.3548
             },
             "readiness": {
-              "large_mean": 3.2433,
-              "large_mean_ci_lower": 3.1076,
-              "large_mean_ci_upper": 3.379,
-              "small_medium_mean": 3.2075,
-              "small_medium_mean_ci_lower": 3.1351,
-              "small_medium_mean_ci_upper": 3.2799,
-              "d": 0.05,
-              "d_ci_lower": -0.1605,
-              "d_ci_upper": 0.2816
+              "large_mean": 3.2373,
+              "large_mean_ci_lower": 3.1024,
+              "large_mean_ci_upper": 3.3723,
+              "small_medium_mean": 3.2101,
+              "small_medium_mean_ci_lower": 3.1379,
+              "small_medium_mean_ci_upper": 3.2824,
+              "d": 0.038,
+              "d_ci_lower": -0.1739,
+              "d_ci_upper": 0.2525
             }
           }
         }
@@ -1207,154 +1207,154 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 122,
-            "barrier_mean": 2.7213,
-            "readiness_mean": 3.487,
-            "maturity_mean": 3.46
+            "n": 123,
+            "barrier_mean": 2.7349,
+            "readiness_mean": 3.4941,
+            "maturity_mean": 3.4695
           },
           {
             "group": "Non-Technical",
-            "n": 367,
-            "barrier_mean": 2.841,
-            "readiness_mean": 3.125,
-            "maturity_mean": 3.1739
+            "n": 369,
+            "barrier_mean": 2.8391,
+            "readiness_mean": 3.1234,
+            "maturity_mean": 3.1689
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 220,
-            "barrier_mean": 2.7799,
-            "readiness_mean": 3.1223,
-            "maturity_mean": 3.1337
+            "n": 221,
+            "barrier_mean": 2.7752,
+            "readiness_mean": 3.122,
+            "maturity_mean": 3.1263
           },
           {
             "group": "Medium (500-4999)",
-            "n": 160,
-            "barrier_mean": 2.7977,
-            "readiness_mean": 3.3254,
-            "maturity_mean": 3.3451
+            "n": 161,
+            "barrier_mean": 2.8076,
+            "readiness_mean": 3.3319,
+            "maturity_mean": 3.3531
           },
           {
             "group": "Large (5000+)",
-            "n": 109,
-            "barrier_mean": 2.8939,
-            "readiness_mean": 3.2433,
-            "maturity_mean": 3.3251
+            "n": 110,
+            "barrier_mean": 2.8969,
+            "readiness_mean": 3.2373,
+            "maturity_mean": 3.3222
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 122,
-          "nontech_n": 367,
+          "tech_n": 123,
+          "nontech_n": 369,
           "constructs": {
             "barriers": {
-              "t": -1.4648,
-              "p": 0.1445,
-              "df": 202.12,
-              "mean_diff_ci_lower": -0.2808,
-              "mean_diff_ci_upper": 0.0414,
+              "t": -1.2665,
+              "p": 0.2068,
+              "df": 201.74,
+              "mean_diff_ci_lower": -0.2665,
+              "mean_diff_ci_upper": 0.058,
               "sig": false
             },
             "readiness": {
-              "t": 5.0725,
+              "t": 5.2059,
               "p": 0.0,
-              "df": 216.21,
-              "mean_diff_ci_lower": 0.2214,
-              "mean_diff_ci_upper": 0.5028,
+              "df": 217.35,
+              "mean_diff_ci_lower": 0.2304,
+              "mean_diff_ci_upper": 0.5111,
               "sig": true
             },
             "maturity": {
-              "t": 3.5785,
-              "p": 0.0004,
-              "df": 221.11,
-              "mean_diff_ci_lower": 0.1286,
-              "mean_diff_ci_upper": 0.4437,
+              "t": 3.7551,
+              "p": 0.0002,
+              "df": 222.68,
+              "mean_diff_ci_lower": 0.1429,
+              "mean_diff_ci_upper": 0.4584,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 109,
-          "small_medium_n": 380,
+          "large_n": 110,
+          "small_medium_n": 382,
           "constructs": {
             "barriers": {
-              "t": 1.2746,
-              "p": 0.2042,
-              "df": 175.29,
-              "mean_diff_ci_lower": -0.0584,
-              "mean_diff_ci_upper": 0.2714,
+              "t": 1.3002,
+              "p": 0.1952,
+              "df": 178.49,
+              "mean_diff_ci_lower": -0.0559,
+              "mean_diff_ci_upper": 0.272,
               "sig": false
             },
             "readiness": {
-              "t": 0.4606,
-              "p": 0.6457,
-              "df": 175.29,
-              "mean_diff_ci_lower": -0.1176,
-              "mean_diff_ci_upper": 0.1892,
+              "t": 0.3516,
+              "p": 0.7255,
+              "df": 177.39,
+              "mean_diff_ci_lower": -0.1255,
+              "mean_diff_ci_upper": 0.1799,
               "sig": false
             },
             "maturity": {
-              "t": 1.1519,
-              "p": 0.251,
-              "df": 169.69,
-              "mean_diff_ci_lower": -0.0731,
-              "mean_diff_ci_upper": 0.2781,
+              "t": 1.1345,
+              "p": 0.2581,
+              "df": 173.03,
+              "mean_diff_ci_lower": -0.0742,
+              "mean_diff_ci_upper": 0.275,
               "sig": false
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical"],
-          "group_ns": [122, 367],
+          "group_ns": [123, 369],
           "constructs": {
             "barriers": {
-              "f": 2.2106,
-              "p": 0.1377,
+              "f": 1.675,
+              "p": 0.1962,
               "df_between": 1,
-              "df_within": 487,
+              "df_within": 490,
               "sig": false
             },
             "readiness": {
-              "f": 24.5492,
+              "f": 25.9774,
               "p": 0.0,
               "df_between": 1,
-              "df_within": 486,
+              "df_within": 489,
               "sig": true
             },
             "maturity": {
-              "f": 11.9385,
-              "p": 0.0006,
+              "f": 13.1802,
+              "p": 0.0003,
               "df_between": 1,
-              "df_within": 485,
+              "df_within": 488,
               "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [220, 160, 109],
+          "group_ns": [221, 161, 110],
           "constructs": {
             "barriers": {
-              "f": 0.8319,
-              "p": 0.4358,
+              "f": 0.9131,
+              "p": 0.402,
               "df_between": 2,
-              "df_within": 486,
+              "df_within": 489,
               "sig": false
             },
             "readiness": {
-              "f": 3.87,
-              "p": 0.0215,
+              "f": 4.0995,
+              "p": 0.0172,
               "df_between": 2,
-              "df_within": 485,
+              "df_within": 488,
               "sig": true
             },
             "maturity": {
-              "f": 3.9507,
-              "p": 0.0199,
+              "f": 4.4045,
+              "p": 0.0127,
               "df_between": 2,
-              "df_within": 484,
+              "df_within": 487,
               "sig": true
             }
           }
@@ -1364,13 +1364,13 @@
     "v2_all": {
       "demographics": {
         "roles": {
-          "Other": 100,
+          "Other": 101,
           "Unknown": 72,
           "CIO": 70,
-          "CEO": 55,
+          "CEO": 56,
           "COO": 54,
           "CSO": 44,
-          "CTO": 43,
+          "CTO": 44,
           "CFO": 39,
           "CMO": 33,
           "CRO": 31,
@@ -1378,93 +1378,93 @@
           "CISO": 6
         },
         "org_sizes": {
-          "<100": 73,
+          "<100": 74,
           "100-499": 155,
           "500-999": 73,
-          "1000-4999": 91,
+          "1000-4999": 92,
           "5000-9999": 44,
-          "10000+": 67
+          "10000+": 68
         },
         "profit_models": {
-          "For-Profit": 370,
+          "For-Profit": 373,
           "Non-Profit": 87,
           "Government/Public Sector": 46
         },
         "tech_vs_nontech": {
-          "technical": 124,
-          "non_technical": 379,
+          "technical": 125,
+          "non_technical": 381,
           "other": 72
         },
         "other_roles": {
-          "total": 100,
+          "total": 101,
           "categories": {}
         }
       },
       "effect_sizes": {
         "tech_vs_nontech": {
-          "tech_n": 124,
-          "nontech_n": 379,
+          "tech_n": 125,
+          "nontech_n": 381,
           "constructs": {
             "barriers": {
-              "tech_mean": 2.7249,
-              "tech_mean_ci_lower": 2.5847,
-              "tech_mean_ci_upper": 2.8651,
-              "nontech_mean": 2.8436,
-              "nontech_mean_ci_lower": 2.7653,
-              "nontech_mean_ci_upper": 2.9218,
-              "d": -0.1537,
-              "d_ci_lower": -0.356,
-              "d_ci_upper": 0.0583
+              "tech_mean": 2.7383,
+              "tech_mean_ci_lower": 2.5968,
+              "tech_mean_ci_upper": 2.8799,
+              "nontech_mean": 2.8417,
+              "nontech_mean_ci_lower": 2.7636,
+              "nontech_mean_ci_upper": 2.9197,
+              "d": -0.1333,
+              "d_ci_lower": -0.3422,
+              "d_ci_upper": 0.0707
             },
             "readiness": {
-              "tech_mean": 3.487,
-              "tech_mean_ci_lower": 3.3661,
-              "tech_mean_ci_upper": 3.6079,
-              "nontech_mean": 3.1257,
-              "nontech_mean_ci_lower": 3.0535,
-              "nontech_mean_ci_upper": 3.198,
-              "d": 0.5179,
-              "d_ci_lower": 0.3096,
-              "d_ci_upper": 0.7173
+              "tech_mean": 3.4941,
+              "tech_mean_ci_lower": 3.3734,
+              "tech_mean_ci_upper": 3.6148,
+              "nontech_mean": 3.1241,
+              "nontech_mean_ci_lower": 3.0522,
+              "nontech_mean_ci_upper": 3.1961,
+              "d": 0.5308,
+              "d_ci_lower": 0.329,
+              "d_ci_upper": 0.7409
             },
             "maturity": {
-              "tech_mean": 3.46,
-              "tech_mean_ci_lower": 3.3255,
-              "tech_mean_ci_upper": 3.5946,
-              "nontech_mean": 3.1743,
-              "nontech_mean_ci_lower": 3.0917,
-              "nontech_mean_ci_upper": 3.257,
-              "d": 0.3611,
-              "d_ci_lower": 0.1603,
-              "d_ci_upper": 0.5657
+              "tech_mean": 3.4695,
+              "tech_mean_ci_lower": 3.3348,
+              "tech_mean_ci_upper": 3.6042,
+              "nontech_mean": 3.1693,
+              "nontech_mean_ci_lower": 3.0866,
+              "nontech_mean_ci_upper": 3.252,
+              "d": 0.3781,
+              "d_ci_lower": 0.1757,
+              "d_ci_upper": 0.5782
             }
           }
         },
         "large_vs_small": {
-          "large_n": 111,
-          "small_medium_n": 464,
+          "large_n": 112,
+          "small_medium_n": 466,
           "constructs": {
             "barriers": {
-              "large_mean": 2.9014,
-              "large_mean_ci_lower": 2.7561,
-              "large_mean_ci_upper": 3.0467,
-              "small_medium_mean": 2.7891,
-              "small_medium_mean_ci_lower": 2.7117,
-              "small_medium_mean_ci_upper": 2.8666,
-              "d": 0.1454,
-              "d_ci_lower": -0.0708,
-              "d_ci_upper": 0.3542
+              "large_mean": 2.9043,
+              "large_mean_ci_lower": 2.7602,
+              "large_mean_ci_upper": 3.0484,
+              "small_medium_mean": 2.7906,
+              "small_medium_mean_ci_lower": 2.7129,
+              "small_medium_mean_ci_upper": 2.8683,
+              "d": 0.1468,
+              "d_ci_lower": -0.0615,
+              "d_ci_upper": 0.3625
             },
             "readiness": {
-              "large_mean": 3.2433,
-              "large_mean_ci_lower": 3.1076,
-              "large_mean_ci_upper": 3.379,
-              "small_medium_mean": 3.2078,
-              "small_medium_mean_ci_lower": 3.1358,
-              "small_medium_mean_ci_upper": 3.2798,
-              "d": 0.0497,
-              "d_ci_lower": -0.1621,
-              "d_ci_upper": 0.2729
+              "large_mean": 3.2373,
+              "large_mean_ci_lower": 3.1024,
+              "large_mean_ci_upper": 3.3723,
+              "small_medium_mean": 3.2104,
+              "small_medium_mean_ci_lower": 3.1386,
+              "small_medium_mean_ci_upper": 3.2823,
+              "d": 0.0376,
+              "d_ci_lower": -0.1721,
+              "d_ci_upper": 0.2449
             }
           }
         }
@@ -1473,17 +1473,17 @@
         "by_role": [
           {
             "group": "Technical",
-            "n": 124,
-            "barrier_mean": 2.7249,
-            "readiness_mean": 3.487,
-            "maturity_mean": 3.46
+            "n": 125,
+            "barrier_mean": 2.7383,
+            "readiness_mean": 3.4941,
+            "maturity_mean": 3.4695
           },
           {
             "group": "Non-Technical",
-            "n": 379,
-            "barrier_mean": 2.8436,
-            "readiness_mean": 3.1257,
-            "maturity_mean": 3.1743
+            "n": 381,
+            "barrier_mean": 2.8417,
+            "readiness_mean": 3.1241,
+            "maturity_mean": 3.1693
           },
           {
             "group": "Unclassified",
@@ -1496,138 +1496,138 @@
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 228,
-            "barrier_mean": 2.7906,
-            "readiness_mean": 3.1229,
-            "maturity_mean": 3.1337
+            "n": 229,
+            "barrier_mean": 2.7859,
+            "readiness_mean": 3.1227,
+            "maturity_mean": 3.1263
           },
           {
             "group": "Medium (500-4999)",
-            "n": 164,
-            "barrier_mean": 2.7872,
-            "readiness_mean": 3.3251,
-            "maturity_mean": 3.3451
+            "n": 165,
+            "barrier_mean": 2.797,
+            "readiness_mean": 3.3314,
+            "maturity_mean": 3.353
           },
           {
             "group": "Large (5000+)",
-            "n": 111,
-            "barrier_mean": 2.9014,
-            "readiness_mean": 3.2433,
-            "maturity_mean": 3.3251
+            "n": 112,
+            "barrier_mean": 2.9043,
+            "readiness_mean": 3.2373,
+            "maturity_mean": 3.3222
           }
         ]
       },
       "inferential": {
         "t_tests_tech_vs_nontech": {
-          "tech_n": 124,
-          "nontech_n": 379,
+          "tech_n": 125,
+          "nontech_n": 381,
           "constructs": {
             "barriers": {
-              "t": -1.4607,
-              "p": 0.1456,
-              "df": 204.53,
-              "mean_diff_ci_lower": -0.2788,
-              "mean_diff_ci_upper": 0.0415,
+              "t": -1.2632,
+              "p": 0.208,
+              "df": 204.14,
+              "mean_diff_ci_lower": -0.2646,
+              "mean_diff_ci_upper": 0.0579,
               "sig": false
             },
             "readiness": {
-              "t": 5.0689,
+              "t": 5.2024,
               "p": 0.0,
-              "df": 215.23,
-              "mean_diff_ci_lower": 0.2208,
-              "mean_diff_ci_upper": 0.5018,
+              "df": 216.37,
+              "mean_diff_ci_lower": 0.2298,
+              "mean_diff_ci_upper": 0.5101,
               "sig": true
             },
             "maturity": {
-              "t": 3.5757,
-              "p": 0.0004,
-              "df": 220.59,
-              "mean_diff_ci_lower": 0.1282,
-              "mean_diff_ci_upper": 0.4432,
+              "t": 3.7523,
+              "p": 0.0002,
+              "df": 222.16,
+              "mean_diff_ci_lower": 0.1425,
+              "mean_diff_ci_upper": 0.4578,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
-          "large_n": 111,
-          "small_medium_n": 464,
+          "large_n": 112,
+          "small_medium_n": 466,
           "constructs": {
             "barriers": {
-              "t": 1.349,
-              "p": 0.1791,
-              "df": 176.89,
-              "mean_diff_ci_lower": -0.052,
-              "mean_diff_ci_upper": 0.2766,
+              "t": 1.3743,
+              "p": 0.1711,
+              "df": 180.09,
+              "mean_diff_ci_lower": -0.0496,
+              "mean_diff_ci_upper": 0.277,
               "sig": false
             },
             "readiness": {
-              "t": 0.4571,
-              "p": 0.6482,
-              "df": 174.58,
-              "mean_diff_ci_lower": -0.1178,
-              "mean_diff_ci_upper": 0.1887,
+              "t": 0.3482,
+              "p": 0.7281,
+              "df": 176.67,
+              "mean_diff_ci_lower": -0.1256,
+              "mean_diff_ci_upper": 0.1795,
               "sig": false
             },
             "maturity": {
-              "t": 1.1493,
-              "p": 0.2521,
-              "df": 169.36,
-              "mean_diff_ci_lower": -0.0733,
-              "mean_diff_ci_upper": 0.2777,
+              "t": 1.1319,
+              "p": 0.2593,
+              "df": 172.69,
+              "mean_diff_ci_lower": -0.0744,
+              "mean_diff_ci_upper": 0.2746,
               "sig": false
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Unclassified"],
-          "group_ns": [124, 379, 72],
+          "group_ns": [125, 381, 72],
           "constructs": {
             "barriers": {
-              "f": 2.1833,
-              "p": 0.1402,
+              "f": 1.655,
+              "p": 0.1989,
               "df_between": 1,
-              "df_within": 493,
+              "df_within": 496,
               "sig": false
             },
             "readiness": {
-              "f": 24.5747,
+              "f": 26.0055,
               "p": 0.0,
               "df_between": 1,
-              "df_within": 488,
+              "df_within": 491,
               "sig": true
             },
             "maturity": {
-              "f": 11.9339,
-              "p": 0.0006,
+              "f": 13.1758,
+              "p": 0.0003,
               "df_between": 1,
-              "df_within": 486,
+              "df_within": 489,
               "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [228, 164, 111],
+          "group_ns": [229, 165, 112],
           "constructs": {
             "barriers": {
-              "f": 0.9034,
-              "p": 0.4059,
+              "f": 0.9369,
+              "p": 0.3925,
               "df_between": 2,
-              "df_within": 492,
+              "df_within": 495,
               "sig": false
             },
             "readiness": {
-              "f": 3.8667,
-              "p": 0.0216,
+              "f": 4.096,
+              "p": 0.0172,
               "df_between": 2,
-              "df_within": 487,
+              "df_within": 490,
               "sig": true
             },
             "maturity": {
-              "f": 3.9649,
-              "p": 0.0196,
+              "f": 4.4194,
+              "p": 0.0125,
               "df_between": 2,
-              "df_within": 485,
+              "df_within": 488,
               "sig": true
             }
           }
@@ -1638,22 +1638,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 0.57,
-      "p_value": 0.9041,
+      "chi2": 0.59,
+      "p_value": 0.8978,
       "df": 3,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 8.82,
-      "p_value": 0.8865,
+      "chi2": 8.7,
+      "p_value": 0.8929,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 3.9,
-      "p_value": 0.6901,
+      "chi2": 4.06,
+      "p_value": 0.6679,
       "df": 6,
       "error": null
     },
@@ -1676,7 +1676,7 @@
           "Government/Public Sector": 32
         },
         "All V2 Finished": {
-          "For-Profit": 359,
+          "For-Profit": 362,
           "Non-Profit": 84,
           "Government/Public Sector": 46
         }
@@ -2404,6 +2404,6 @@
       }
     ]
   },
-  "last_updated": "2026-04-28T11:11:40.932946Z",
-  "extended_last_updated": "2026-04-28T11:11:40.932946Z"
+  "last_updated": "2026-04-29T11:06:26.452845Z",
+  "extended_last_updated": "2026-04-29T11:06:26.452845Z"
 }


### PR DESCRIPTION
Automated update from the unified daily pipeline.

**Data flow**: Qualtrics export → Prolific enrichment →
disposition waterfall → analysis suite → CRP dataset (N=200) →
approve CLEAN → dashboard summary.

All statistics computed across 5 sample definitions.
CRP dataset: N=200 tiered selection + NIST de-identification.