### PR TITLE
feat(pipeline): 21-day auto-approve runway tracking + fix 3 daily-report regressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13813,6 +13813,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/scripts/analysis/create_crp_dataset.py
+++ b/scripts/analysis/create_crp_dataset.py
@@ -110,6 +110,11 @@ COLUMNS_TO_DROP: set[str] = {
     "Auth_LLM",
     "Auth_Bots",
     "Prolific_Status",
+    # Prolific submission timestamp anchors — pipeline-internal only.
+    # These are also caught by the PROLIFIC_DEMO_PREFIX filter in
+    # filter_columns(), but listed here explicitly so the intent is clear.
+    "Prolific_Completed_At",
+    "Prolific_Started_At",
     # Qualtrics operational fields
     "Q_RecaptchaScore",
     "Q_StraightliningCount",

--- a/scripts/analysis/disposition_triage.py
+++ b/scripts/analysis/disposition_triage.py
@@ -2,10 +2,12 @@
 """
 TABS V2 Disposition Triage CLI (Python)
 
-Drop-in replacement for scripts/disposition-triage.ts.
+Replacement for scripts/archive/disposition-triage.ts.
 Reads a Qualtrics CSV export, computes dispositions using the 10-step
-waterfall, and writes a disposition CSV with the same columns and format
-as the TypeScript version.
+waterfall, and writes a disposition CSV. The first 20 columns (through
+``Disposition``) match the archived TypeScript version; the trailing
+``Prolific_*`` columns intentionally extend that format with Prolific
+submission anchors added by enrich_qualtrics_csv.py upstream.
 
 Environment variables:
   INPUT_PATH   – Path to the raw Qualtrics CSV export (required)
@@ -23,7 +25,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 from tabs_v2_data_audit import parse_csv
 
 
-# CSV column order matching scripts/disposition-triage.ts exactly
+# CSV column definitions. The first 20 columns (through "Disposition") match
+# scripts/archive/disposition-triage.ts. The trailing Prolific_* columns
+# intentionally extend the archived TS format — they are populated by
+# enrich_qualtrics_csv.py upstream and are not present in the TS version.
 CSV_HEADERS = [
     "PROLIFIC_PID",
     "Finished",

--- a/scripts/analysis/disposition_triage.py
+++ b/scripts/analysis/disposition_triage.py
@@ -45,6 +45,12 @@ CSV_HEADERS = [
     "Partial_Straightlining_Flag",
     "Partial_Straightlining_Blocks",
     "Disposition",
+    # Prolific submission anchors (added by enrich_qualtrics_csv.py). Empty
+    # strings when no Prolific submission joins to this PID. Downstream
+    # consumers compute days-until-21-day-auto-approve from Prolific_Completed_At.
+    "Prolific_Status",
+    "Prolific_Completed_At",
+    "Prolific_Started_At",
 ]
 
 

--- a/scripts/analysis/enrich_qualtrics_csv.py
+++ b/scripts/analysis/enrich_qualtrics_csv.py
@@ -56,10 +56,34 @@ def load_auth_checks(path: str) -> dict[str, dict[str, str]]:
     return result
 
 
-def load_statuses(path: str) -> dict[str, str]:
-    """Load submission statuses JSON into {PID: status}."""
+def load_statuses(path: str) -> dict[str, dict[str, str]]:
+    """Load submission summaries JSON into {PID: {status, completed_at, started_at}}.
+
+    Accepts both the legacy shape ``{PID: status_string}`` (older
+    statuses.json artifacts) and the current shape
+    ``{PID: {status, completed_at, started_at}}`` written by
+    fetch_prolific_data.py. Older shape values are normalised so callers
+    can rely on the same dict layout regardless of source.
+    """
     with open(path, encoding="utf-8") as f:
-        return json.load(f)
+        raw = json.load(f)
+
+    normalised: dict[str, dict[str, str]] = {}
+    for pid, value in raw.items():
+        if isinstance(value, dict):
+            normalised[pid] = {
+                "status": value.get("status", "") or "",
+                "completed_at": value.get("completed_at", "") or "",
+                "started_at": value.get("started_at", "") or "",
+            }
+        else:
+            # Legacy shape: bare status string, no timestamps available.
+            normalised[pid] = {
+                "status": str(value) if value is not None else "",
+                "completed_at": "",
+                "started_at": "",
+            }
+    return normalised
 
 
 def load_demographics(path: str) -> tuple[list[str], dict[str, dict[str, str]]]:
@@ -125,7 +149,10 @@ def enrich(
     if auth_data:
         new_cols.extend(["Auth_LLM", "Auth_Bots"])
     if status_data:
-        new_cols.append("Prolific_Status")
+        # Prolific_Status keeps the existing column name for backward
+        # compatibility. Prolific_Completed_At and Prolific_Started_At are
+        # the canonical anchors for 21-day auto-approve runway calculations.
+        new_cols.extend(["Prolific_Status", "Prolific_Completed_At", "Prolific_Started_At"])
     # Prefix Prolific demographic columns to avoid collision with Qualtrics columns
     prefixed_demo_cols = [f"Prolific_{c}" for c in demo_cols]
     new_cols.extend(prefixed_demo_cols)
@@ -149,7 +176,10 @@ def enrich(
                     row.append(auth.get("Auth_LLM", ""))
                     row.append(auth.get("Auth_Bots", ""))
                 if "Prolific_Status" in new_cols:
-                    row.append(status_data.get(pid, ""))
+                    summary = status_data.get(pid, {})
+                    row.append(summary.get("status", ""))
+                    row.append(summary.get("completed_at", ""))
+                    row.append(summary.get("started_at", ""))
                 # Append demographic values in the same order as prefixed_demo_cols
                 demo = demo_data.get(pid, {})
                 for col in demo_cols:

--- a/scripts/analysis/enrich_qualtrics_csv.py
+++ b/scripts/analysis/enrich_qualtrics_csv.py
@@ -70,6 +70,8 @@ def load_statuses(path: str) -> dict[str, dict[str, str]]:
 
     normalised: dict[str, dict[str, str]] = {}
     for pid, value in raw.items():
+        if not pid or not pid.strip():
+            continue
         if isinstance(value, dict):
             normalised[pid] = {
                 "status": value.get("status", "") or "",

--- a/scripts/analysis/fetch_prolific_data.py
+++ b/scripts/analysis/fetch_prolific_data.py
@@ -6,6 +6,15 @@ Reads environment variables:
   PROLIFIC_STUDY_ID   - Study ID (required)
   AUTH_OUTPUT         - Path to write auth checks CSV (default: /tmp/auth-checks.csv)
   STATUSES_OUTPUT     - Path to write statuses JSON (default: /tmp/statuses.json)
+
+The statuses JSON now stores the full submission summary per PID:
+  {"<pid>": {"status": "...", "completed_at": "...", "started_at": "..."}, ...}
+
+The richer payload feeds the enrichment + disposition steps so every
+downstream consumer can reason about Prolific's 21-day auto-approve clock
+without making its own API call. Older callers that only read the status
+string are kept compatible by ``load_statuses`` in
+``enrich_qualtrics_csv.py``.
 """
 import json
 import os
@@ -15,7 +24,7 @@ from pathlib import Path
 # Add analysis dir to path for imports
 sys.path.insert(0, str(Path(__file__).parent))
 
-from tabs_api import prolific_auth_checks_csv, prolific_submission_statuses
+from tabs_api import prolific_auth_checks_csv, prolific_submission_summaries
 
 
 def main():
@@ -33,13 +42,13 @@ def main():
     auth_output = os.environ.get("AUTH_OUTPUT", "/tmp/auth-checks.csv")
     prolific_auth_checks_csv(study_id, api_token, auth_output)
 
-    # Submission statuses
+    # Submission summaries (status + completed_at + started_at per PID)
     statuses_output = os.environ.get("STATUSES_OUTPUT", "/tmp/statuses.json")
-    statuses = prolific_submission_statuses(study_id, api_token)
+    summaries = prolific_submission_summaries(study_id, api_token)
     Path(statuses_output).parent.mkdir(parents=True, exist_ok=True)
     with open(statuses_output, "w") as f:
-        json.dump(statuses, f)
-    print(f"Statuses: {len(statuses)} submissions → {statuses_output}")
+        json.dump(summaries, f)
+    print(f"Statuses: {len(summaries)} submissions → {statuses_output}")
 
 
 if __name__ == "__main__":

--- a/scripts/analysis/generate_disposition_summary.py
+++ b/scripts/analysis/generate_disposition_summary.py
@@ -327,6 +327,10 @@ def main():
             "denominator": finished_participants,
         },
         "autoApproveRunway": auto_approve_runway,
+        # Convenience top-level aliases: consumers (daily report, dashboards)
+        # can check these without knowing the nested autoApproveRunway layout.
+        "highRiskCount": auto_approve_runway["highRiskCount"],
+        "highRiskByDisposition": auto_approve_runway["highRiskByDisposition"],
         "studyId": study_id,
         "studyName": study_name,
     }

--- a/scripts/analysis/generate_disposition_summary.py
+++ b/scripts/analysis/generate_disposition_summary.py
@@ -205,10 +205,12 @@ def main():
                 disposition_by_pid[p] = d
 
     runway_now = datetime.now(timezone.utc)
+    total_awaiting_review = 0
     runway_evaluated = 0
     for sub in subs:
         if sub.get("status") != "AWAITING REVIEW":
             continue
+        total_awaiting_review += 1
         completed_at_raw = sub.get("completed_at") or ""
         if not completed_at_raw:
             continue
@@ -232,7 +234,12 @@ def main():
     auto_approve_runway = {
         "thresholdDays": AUTO_APPROVE_THRESHOLD_DAYS,
         "computedAt": runway_now.isoformat(),
-        "totalAwaitingReview": runway_evaluated,
+        # Total AWAITING REVIEW submissions (regardless of timestamp availability).
+        "totalAwaitingReview": total_awaiting_review,
+        # Submissions with a parseable completed_at that were placed into buckets.
+        "evaluatedCount": runway_evaluated,
+        # Submissions skipped because completed_at was absent or unparseable.
+        "skippedMissingCompletedAt": total_awaiting_review - runway_evaluated,
         "buckets": [
             {
                 "label": spec["label"],

--- a/scripts/analysis/generate_disposition_summary.py
+++ b/scripts/analysis/generate_disposition_summary.py
@@ -227,8 +227,9 @@ def main():
                 bucket_counts[idx] += 1
                 if spec["risk"] == "high":
                     pid = sub.get("participant_id", "")
-                    disp = disposition_by_pid.get(pid, "UNKNOWN")
-                    high_risk_by_disposition[disp] = high_risk_by_disposition.get(disp, 0) + 1
+                    if pid:  # skip entries without a usable PID (consistent with prolific_submission_statuses/summaries)
+                        disp = disposition_by_pid.get(pid, "UNKNOWN")
+                        high_risk_by_disposition[disp] = high_risk_by_disposition.get(disp, 0) + 1
                 break
 
     auto_approve_runway = {

--- a/scripts/analysis/generate_disposition_summary.py
+++ b/scripts/analysis/generate_disposition_summary.py
@@ -247,7 +247,9 @@ def main():
                 "risk": spec["risk"],
                 # JSON cannot represent infinity; emit null for the open ends.
                 "minDaysRemaining": None if spec["min_days"] == float("-inf") else spec["min_days"],
-                "maxDaysRemaining": spec["max_days"],
+                # Exclusive upper bound: bucket contains submissions where
+                # days_remaining < maxDaysRemainingExclusive (half-open interval).
+                "maxDaysRemainingExclusive": spec["max_days"],
                 "count": count,
             }
             for spec, count in zip(bucket_specs, bucket_counts)

--- a/scripts/analysis/generate_disposition_summary.py
+++ b/scripts/analysis/generate_disposition_summary.py
@@ -176,6 +176,86 @@ def main():
         print(f"  {d}: {c}")
     print()
 
+    # ── Prolific 21-day auto-approve runway ──────────────────────
+    # Every AWAITING REVIEW submission is on a 21-day clock anchored to its
+    # completed_at. Once 21 days pass, Prolific auto-approves and pays out
+    # automatically -- regardless of TABS quality flags. We bucket the
+    # remaining runway so the daily report and downstream scripts can
+    # surface "act now" pressure without re-querying the API.
+    AUTO_APPROVE_THRESHOLD_DAYS = 21
+    bucket_specs = [
+        {"label": "Comfortable", "min_days": 10.0, "max_days": None, "risk": "low"},
+        {"label": "Monitor", "min_days": 5.0, "max_days": 10.0, "risk": "moderate"},
+        {"label": "Act soon", "min_days": 2.0, "max_days": 5.0, "risk": "elevated"},
+        # Last bucket is intentionally HIGH RISK -- the report styles it
+        # accordingly. ``min_days = -inf`` catches anything already past
+        # the 21-day mark (Prolific would have already auto-approved).
+        {"label": "HIGH RISK", "min_days": float("-inf"), "max_days": 2.0, "risk": "high"},
+    ]
+    bucket_counts = [0] * len(bucket_specs)
+    high_risk_by_disposition: dict[str, int] = {}
+
+    # Need quick lookup of disposition by PID (built from the CSV rows above).
+    disposition_by_pid: dict[str, str] = {}
+    for row in rows[1:]:
+        if len(row) > max(pid_idx, disp_idx):
+            p = row[pid_idx].strip()
+            d = row[disp_idx].strip()
+            if p and d:
+                disposition_by_pid[p] = d
+
+    runway_now = datetime.now(timezone.utc)
+    runway_evaluated = 0
+    for sub in subs:
+        if sub.get("status") != "AWAITING REVIEW":
+            continue
+        completed_at_raw = sub.get("completed_at") or ""
+        if not completed_at_raw:
+            continue
+        try:
+            completed_at = datetime.fromisoformat(completed_at_raw.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        days_remaining = AUTO_APPROVE_THRESHOLD_DAYS - (runway_now - completed_at).total_seconds() / 86400.0
+        runway_evaluated += 1
+        for idx, spec in enumerate(bucket_specs):
+            min_d = spec["min_days"]
+            max_d = spec["max_days"]
+            if days_remaining >= min_d and (max_d is None or days_remaining < max_d):
+                bucket_counts[idx] += 1
+                if spec["risk"] == "high":
+                    pid = sub.get("participant_id", "")
+                    disp = disposition_by_pid.get(pid, "UNKNOWN")
+                    high_risk_by_disposition[disp] = high_risk_by_disposition.get(disp, 0) + 1
+                break
+
+    auto_approve_runway = {
+        "thresholdDays": AUTO_APPROVE_THRESHOLD_DAYS,
+        "computedAt": runway_now.isoformat(),
+        "totalAwaitingReview": runway_evaluated,
+        "buckets": [
+            {
+                "label": spec["label"],
+                "risk": spec["risk"],
+                # JSON cannot represent infinity; emit null for the open ends.
+                "minDaysRemaining": None if spec["min_days"] == float("-inf") else spec["min_days"],
+                "maxDaysRemaining": spec["max_days"],
+                "count": count,
+            }
+            for spec, count in zip(bucket_specs, bucket_counts)
+        ],
+        # The last bucket is, by design, the HIGH RISK bucket. Surfaced as a
+        # top-level field so downstream consumers (daily report, dashboards)
+        # don't have to know the bucket layout to render the warning.
+        "highRiskCount": bucket_counts[-1],
+        "highRiskByDisposition": high_risk_by_disposition,
+    }
+    print("Auto-approve runway (21-day Prolific clock):")
+    for spec, count in zip(bucket_specs, bucket_counts):
+        marker = " <-- HIGH RISK" if spec["risk"] == "high" else ""
+        print(f"  {spec['label']}: {count}{marker}")
+    print()
+
     print("Disposition x Prolific Status cross-reference:")
     for disp, statuses in sorted(disposition_by_status.items()):
         parts = ", ".join(f"{s}:{c}" for s, c in sorted(statuses.items(), key=lambda x: -x[1]))
@@ -239,6 +319,7 @@ def main():
             "maturity": iri_rate(iri_maturity_pass),
             "denominator": finished_participants,
         },
+        "autoApproveRunway": auto_approve_runway,
         "studyId": study_id,
         "studyName": study_name,
     }

--- a/scripts/analysis/tabs_api.py
+++ b/scripts/analysis/tabs_api.py
@@ -398,11 +398,15 @@ def prolific_submission_statuses(study_id: str, api_token: str) -> Dict[str, str
     string. New callers should prefer ``prolific_submission_summaries``,
     which also returns timestamps used for 21-day auto-approve runway
     calculations.
+
+    Submissions without a non-empty ``participant_id`` are silently skipped
+    (consistent with ``prolific_submission_summaries``).
     """
     submissions = prolific_submissions(study_id, api_token)
     return {
-        sub.get("participant_id", ""): sub.get("status", "UNKNOWN")
+        sub["participant_id"]: sub.get("status", "UNKNOWN")
         for sub in submissions
+        if sub.get("participant_id")
     }
 
 

--- a/scripts/analysis/tabs_api.py
+++ b/scripts/analysis/tabs_api.py
@@ -392,12 +392,47 @@ def prolific_demographics_csv(
 
 
 def prolific_submission_statuses(study_id: str, api_token: str) -> Dict[str, str]:
-    """Return a dict mapping PROLIFIC_PID → submission status."""
+    """Return a dict mapping PROLIFIC_PID → submission status.
+
+    Kept for backward compatibility with callers that only need the status
+    string. New callers should prefer ``prolific_submission_summaries``,
+    which also returns timestamps used for 21-day auto-approve runway
+    calculations.
+    """
     submissions = prolific_submissions(study_id, api_token)
     return {
         sub.get("participant_id", ""): sub.get("status", "UNKNOWN")
         for sub in submissions
     }
+
+
+def prolific_submission_summaries(study_id: str, api_token: str) -> Dict[str, Dict[str, str]]:
+    """Return a dict mapping PROLIFIC_PID → submission summary fields.
+
+    Each value contains the fields downstream pipeline steps need beyond
+    the status string itself:
+      - status:         submission state (APPROVED, AWAITING REVIEW, ...)
+      - completed_at:   ISO 8601 timestamp the participant submitted, or ""
+      - started_at:     ISO 8601 timestamp the participant started, or ""
+
+    ``completed_at`` is the canonical anchor for Prolific's 21-day
+    auto-approve clock: any submission still in AWAITING REVIEW longer
+    than 21 days after ``completed_at`` is auto-approved by Prolific
+    (and the participant is paid). The pipeline persists this raw
+    timestamp so consumers can compute their own "now" delta accurately.
+    """
+    submissions = prolific_submissions(study_id, api_token)
+    summaries: Dict[str, Dict[str, str]] = {}
+    for sub in submissions:
+        pid = sub.get("participant_id", "")
+        if not pid:
+            continue
+        summaries[pid] = {
+            "status": sub.get("status", "UNKNOWN") or "UNKNOWN",
+            "completed_at": sub.get("completed_at") or "",
+            "started_at": sub.get("started_at") or "",
+        }
+    return summaries
 
 
 def prolific_recent_messages(

--- a/scripts/analysis/tabs_v2_data_audit.py
+++ b/scripts/analysis/tabs_v2_data_audit.py
@@ -316,6 +316,13 @@ def parse_csv(csv_path: str) -> List[Dict[str, Any]]:
             auth_llm = row.get("Auth_LLM", "").strip()
             auth_bots = row.get("Auth_Bots", "").strip()
 
+            # Prolific submission anchors (populated by enrich_qualtrics_csv.py).
+            # Prolific_Completed_At drives the 21-day auto-approve runway calc
+            # for downstream consumers; empty string when no submission joined.
+            prolific_status = row.get("Prolific_Status", "").strip()
+            prolific_completed_at = row.get("Prolific_Completed_At", "").strip()
+            prolific_started_at = row.get("Prolific_Started_At", "").strip()
+
             # Build row dict
             disposition_row = {
                 "PROLIFIC_PID": pid,
@@ -336,6 +343,9 @@ def parse_csv(csv_path: str) -> List[Dict[str, Any]]:
                 "Straightlining_Flag": straightlining_flag,
                 "Partial_Straightlining_Flag": partial_flag,
                 "Partial_Straightlining_Blocks": partial_blocks,
+                "Prolific_Status": prolific_status,
+                "Prolific_Completed_At": prolific_completed_at,
+                "Prolific_Started_At": prolific_started_at,
             }
 
             # Compute disposition

--- a/scripts/analysis/tests/test_api.py
+++ b/scripts/analysis/tests/test_api.py
@@ -211,6 +211,22 @@ class TestProlificStatuses:
             "PID3": "AWAITING REVIEW",
         }
 
+    def test_status_mapping_skips_missing_pid(self):
+        """Submissions without a participant_id are skipped (no empty-string key)."""
+        mock_submissions = [
+            {"participant_id": "PID1", "status": "APPROVED"},
+            # missing participant_id — should be silently excluded
+            {"status": "REJECTED"},
+            # empty string participant_id — should also be excluded
+            {"participant_id": "", "status": "AWAITING REVIEW"},
+        ]
+
+        with patch("tabs_api.prolific_submissions", return_value=mock_submissions):
+            result = prolific_submission_statuses("study1", "token")
+
+        assert result == {"PID1": "APPROVED"}
+        assert "" not in result
+
     def test_summaries_include_timestamps(self):
         """prolific_submission_summaries returns the per-PID dict shape that
         carries completed_at and started_at -- needed for the 21-day

--- a/scripts/analysis/tests/test_api.py
+++ b/scripts/analysis/tests/test_api.py
@@ -211,6 +211,44 @@ class TestProlificStatuses:
             "PID3": "AWAITING REVIEW",
         }
 
+    def test_summaries_include_timestamps(self):
+        """prolific_submission_summaries returns the per-PID dict shape that
+        carries completed_at and started_at -- needed for the 21-day
+        auto-approve runway computation downstream."""
+        from tabs_api import prolific_submission_summaries
+
+        mock_submissions = [
+            {
+                "participant_id": "PID1",
+                "status": "APPROVED",
+                "completed_at": "2026-04-25T12:34:56Z",
+                "started_at": "2026-04-25T12:30:00Z",
+            },
+            {
+                "participant_id": "PID2",
+                "status": "AWAITING REVIEW",
+                # missing completed_at / started_at — should yield empty strings
+            },
+            # rows with no participant_id are skipped
+            {"status": "REJECTED"},
+        ]
+
+        with patch("tabs_api.prolific_submissions", return_value=mock_submissions):
+            result = prolific_submission_summaries("study1", "token")
+
+        assert result == {
+            "PID1": {
+                "status": "APPROVED",
+                "completed_at": "2026-04-25T12:34:56Z",
+                "started_at": "2026-04-25T12:30:00Z",
+            },
+            "PID2": {
+                "status": "AWAITING REVIEW",
+                "completed_at": "",
+                "started_at": "",
+            },
+        }
+
 
 # ── Prolific demographics (mocked) ──────────────────────────
 

--- a/scripts/analysis/tests/test_cross_validation.py
+++ b/scripts/analysis/tests/test_cross_validation.py
@@ -215,10 +215,11 @@ class TestCrossValidation:
         assert "Triaged" in result.stdout
         assert Path(output_csv).exists()
 
-        # Verify CSV headers match TS format exactly. The Prolific_* trailing
-        # columns are populated by enrich_qualtrics_csv.py upstream and pass
-        # through the triage step so downstream consumers can compute
-        # 21-day auto-approve runway from Prolific_Completed_At.
+        # Verify CSV headers. The first 20 columns (through "Disposition") match
+        # the archived scripts/archive/disposition-triage.ts format. The trailing
+        # Prolific_* columns extend the Python format with Prolific submission
+        # anchors populated by enrich_qualtrics_csv.py so downstream consumers
+        # can compute 21-day auto-approve runway from Prolific_Completed_At.
         with open(output_csv) as f:
             header = f.readline().strip()
         expected = "PROLIFIC_PID,Finished,Duration_Seconds,Auth_LLM,Auth_Bots,Auth_Flag,IRI_Barrier_Pass,IRI_Readiness_Pass,IRI_Maturity_Pass,IRI_Pass_Count,IRI_Fail_Count,Speed_Flag,Smeal_Benchmark_Flag,reCAPTCHA_Score,reCAPTCHA_Flag,Straightlining_Count,Straightlining_Flag,Partial_Straightlining_Flag,Partial_Straightlining_Blocks,Disposition,Prolific_Status,Prolific_Completed_At,Prolific_Started_At"

--- a/scripts/analysis/tests/test_cross_validation.py
+++ b/scripts/analysis/tests/test_cross_validation.py
@@ -215,10 +215,13 @@ class TestCrossValidation:
         assert "Triaged" in result.stdout
         assert Path(output_csv).exists()
 
-        # Verify CSV headers match TS format exactly
+        # Verify CSV headers match TS format exactly. The Prolific_* trailing
+        # columns are populated by enrich_qualtrics_csv.py upstream and pass
+        # through the triage step so downstream consumers can compute
+        # 21-day auto-approve runway from Prolific_Completed_At.
         with open(output_csv) as f:
             header = f.readline().strip()
-        expected = "PROLIFIC_PID,Finished,Duration_Seconds,Auth_LLM,Auth_Bots,Auth_Flag,IRI_Barrier_Pass,IRI_Readiness_Pass,IRI_Maturity_Pass,IRI_Pass_Count,IRI_Fail_Count,Speed_Flag,Smeal_Benchmark_Flag,reCAPTCHA_Score,reCAPTCHA_Flag,Straightlining_Count,Straightlining_Flag,Partial_Straightlining_Flag,Partial_Straightlining_Blocks,Disposition"
+        expected = "PROLIFIC_PID,Finished,Duration_Seconds,Auth_LLM,Auth_Bots,Auth_Flag,IRI_Barrier_Pass,IRI_Readiness_Pass,IRI_Maturity_Pass,IRI_Pass_Count,IRI_Fail_Count,Speed_Flag,Smeal_Benchmark_Flag,reCAPTCHA_Score,reCAPTCHA_Flag,Straightlining_Count,Straightlining_Flag,Partial_Straightlining_Flag,Partial_Straightlining_Blocks,Disposition,Prolific_Status,Prolific_Completed_At,Prolific_Started_At"
         assert header == expected, f"Header mismatch:\n  Got:      {header}\n  Expected: {expected}"
 
         # Verify integer floats don't have trailing .0

--- a/scripts/analysis/tests/test_enrich.py
+++ b/scripts/analysis/tests/test_enrich.py
@@ -47,11 +47,49 @@ class TestLoadAuthChecks:
 # ── load_statuses ────────────────────────────────────────────
 
 class TestLoadStatuses:
-    def test_basic(self, tmp_path):
+    def test_legacy_string_shape_normalised(self, tmp_path):
+        """Older statuses.json artifacts store a bare status string per PID;
+        the loader still has to accept that shape and zero-fill the
+        timestamps so downstream code can rely on a uniform dict layout."""
         from _helpers import make_json
         path = make_json(tmp_path, {"PID1": "APPROVED", "PID2": "REJECTED"})
         result = load_statuses(path)
-        assert result == {"PID1": "APPROVED", "PID2": "REJECTED"}
+        assert result == {
+            "PID1": {"status": "APPROVED", "completed_at": "", "started_at": ""},
+            "PID2": {"status": "REJECTED", "completed_at": "", "started_at": ""},
+        }
+
+    def test_summary_shape_passes_through(self, tmp_path):
+        """The current statuses.json shape carries status + completed_at +
+        started_at per PID. All three should round-trip."""
+        from _helpers import make_json
+        path = make_json(
+            tmp_path,
+            {
+                "PID1": {
+                    "status": "AWAITING REVIEW",
+                    "completed_at": "2026-04-25T12:34:56Z",
+                    "started_at": "2026-04-25T12:30:00Z",
+                },
+            },
+        )
+        result = load_statuses(path)
+        assert result["PID1"] == {
+            "status": "AWAITING REVIEW",
+            "completed_at": "2026-04-25T12:34:56Z",
+            "started_at": "2026-04-25T12:30:00Z",
+        }
+
+    def test_missing_fields_default_to_empty(self, tmp_path):
+        """Robust to partial dicts (e.g., older API responses that
+        don't include started_at)."""
+        from _helpers import make_json
+        path = make_json(tmp_path, {"PID1": {"status": "APPROVED"}})
+        assert load_statuses(path)["PID1"] == {
+            "status": "APPROVED",
+            "completed_at": "",
+            "started_at": "",
+        }
 
 
 # ── load_demographics ────────────────────────────────────────
@@ -139,6 +177,47 @@ class TestEnrich:
             reader = csv.reader(f)
             header = next(reader)
         assert "Prolific_Status" in header
+        assert "Prolific_Completed_At" in header
+        assert "Prolific_Started_At" in header
+
+    def test_statuses_with_timestamps_populates_columns(self, tmp_path):
+        """When statuses.json carries the new shape with completed_at and
+        started_at, those values land in the enriched CSV alongside the
+        status string."""
+        from _helpers import make_json
+        qualtrics_path = self._make_qualtrics(tmp_path)
+        statuses_path = make_json(
+            tmp_path,
+            {
+                "PID1": {
+                    "status": "AWAITING REVIEW",
+                    "completed_at": "2026-04-25T12:34:56Z",
+                    "started_at": "2026-04-25T12:30:00Z",
+                },
+                # PID2 absent on purpose — should yield empty cells.
+                "PID3": {
+                    "status": "APPROVED",
+                    "completed_at": "2026-04-20T08:00:00Z",
+                    "started_at": "2026-04-20T07:55:00Z",
+                },
+            },
+        )
+        output_path = str(tmp_path / "enriched.csv")
+
+        enrich(qualtrics_path, None, statuses_path, None, output_path)
+
+        with open(output_path) as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        header = rows[0]
+        completed_idx = header.index("Prolific_Completed_At")
+        started_idx = header.index("Prolific_Started_At")
+        # Skip the 3 Qualtrics header rows then check data rows.
+        data = rows[3:]
+        assert data[0][completed_idx] == "2026-04-25T12:34:56Z"
+        assert data[0][started_idx] == "2026-04-25T12:30:00Z"
+        assert data[1][completed_idx] == ""  # PID2 not in statuses
+        assert data[2][completed_idx] == "2026-04-20T08:00:00Z"
 
     def test_demographics(self, tmp_path):
         from _helpers import make_csv

--- a/scripts/analysis/tests/test_generate_disposition_summary.py
+++ b/scripts/analysis/tests/test_generate_disposition_summary.py
@@ -248,3 +248,101 @@ class TestGenerateDispositionSummary:
         assert data["actions"]["rejected"] == 1
         assert data["actions"]["returned"] == 1
         assert data["actions"]["awaitingReview"] == 1
+
+
+class TestAutoApproveRunway:
+    """The autoApproveRunway block buckets every AWAITING REVIEW submission
+    by days remaining before Prolific's 21-day auto-approve clock fires."""
+
+    def _run(self, tmp_path, mock_subs):
+        csv_path = _write_disposition_csv(tmp_path)
+        output_path = str(tmp_path / "summary.json")
+        with patch("generate_disposition_summary.prolific_study_info", return_value=MOCK_STUDY), \
+             patch("generate_disposition_summary.prolific_submissions", return_value=mock_subs), \
+             patch("generate_disposition_summary.prolific_recent_messages", return_value=[]):
+            from generate_disposition_summary import main
+            import os
+            old_env = os.environ.copy()
+            os.environ.update({
+                "PROLIFIC_API_TOKEN": "test_token",
+                "STUDY_ID": "STUDY_1",
+                "CSV_FILE_PATH": csv_path,
+                "OUTPUT_PATH": output_path,
+            })
+            try:
+                main()
+            finally:
+                os.environ.clear()
+                os.environ.update(old_env)
+        return json.loads(Path(output_path).read_text())
+
+    def test_block_present_with_expected_shape(self, tmp_path):
+        data = self._run(tmp_path, MOCK_SUBMISSIONS)
+        assert "autoApproveRunway" in data
+        runway = data["autoApproveRunway"]
+        assert runway["thresholdDays"] == 21
+        assert isinstance(runway["buckets"], list) and len(runway["buckets"]) == 4
+        # Last bucket is the HIGH RISK bucket -- documented in the script.
+        assert runway["buckets"][-1]["risk"] == "high"
+        assert runway["buckets"][-1]["label"] == "HIGH RISK"
+        # highRiskCount must equal the last bucket's count for downstream consumers.
+        assert runway["highRiskCount"] == runway["buckets"][-1]["count"]
+
+    def test_high_risk_picks_up_old_completion(self, tmp_path):
+        """A submission completed 20 days ago has 1 day until auto-approve →
+        belongs in the HIGH RISK (<2 days) bucket."""
+        from datetime import datetime, timezone, timedelta
+        old = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+        subs = [
+            {
+                "participant_id": "PID_C",
+                "status": "AWAITING REVIEW",
+                "completed_at": old,
+            },
+        ]
+        data = self._run(tmp_path, subs)
+        runway = data["autoApproveRunway"]
+        assert runway["highRiskCount"] == 1
+        assert runway["totalAwaitingReview"] == 1
+        assert runway["highRiskByDisposition"].get("FLAG-SPEED") == 1
+
+    def test_buckets_partitioned_by_runway_days(self, tmp_path):
+        """Each AWAITING REVIEW submission lands in exactly one bucket."""
+        from datetime import datetime, timezone, timedelta
+        now = datetime.now(timezone.utc)
+        subs = [
+            # 1 day ago → 20 days remaining → Comfortable
+            {"participant_id": "PID_A", "status": "AWAITING REVIEW",
+             "completed_at": (now - timedelta(days=1)).isoformat()},
+            # 14 days ago → 7 days remaining → Monitor
+            {"participant_id": "PID_B", "status": "AWAITING REVIEW",
+             "completed_at": (now - timedelta(days=14)).isoformat()},
+            # 18 days ago → 3 days remaining → Act soon
+            {"participant_id": "PID_C", "status": "AWAITING REVIEW",
+             "completed_at": (now - timedelta(days=18)).isoformat()},
+            # 20 days ago → 1 day remaining → HIGH RISK
+            {"participant_id": "PID_D", "status": "AWAITING REVIEW",
+             "completed_at": (now - timedelta(days=20)).isoformat()},
+            # APPROVED is excluded from runway entirely
+            {"participant_id": "PID_E", "status": "APPROVED",
+             "completed_at": (now - timedelta(days=22)).isoformat()},
+        ]
+        data = self._run(tmp_path, subs)
+        runway = data["autoApproveRunway"]
+        counts = [b["count"] for b in runway["buckets"]]
+        # Order matches bucket_specs in generate_disposition_summary.py:
+        # Comfortable (>=10), Monitor (5-10), Act soon (2-5), HIGH RISK (<2)
+        assert counts == [1, 1, 1, 1]
+        assert runway["totalAwaitingReview"] == 4
+        assert runway["highRiskCount"] == 1
+
+    def test_no_completed_at_skipped(self, tmp_path):
+        """Submissions missing completed_at are excluded -- we cannot
+        compute runway without a timestamp."""
+        subs = [
+            {"participant_id": "PID_C", "status": "AWAITING REVIEW"},
+        ]
+        data = self._run(tmp_path, subs)
+        runway = data["autoApproveRunway"]
+        assert runway["totalAwaitingReview"] == 0
+        assert all(b["count"] == 0 for b in runway["buckets"])

--- a/scripts/analysis/tests/test_generate_disposition_summary.py
+++ b/scripts/analysis/tests/test_generate_disposition_summary.py
@@ -371,3 +371,19 @@ class TestAutoApproveRunway:
         assert runway["evaluatedCount"] == 0
         assert runway["skippedMissingCompletedAt"] == 1
         assert all(b["count"] == 0 for b in runway["buckets"])
+
+    def test_high_risk_empty_pid_not_in_breakdown(self, tmp_path):
+        """A HIGH RISK submission with a missing/empty participant_id is
+        counted in the bucket total but NOT in highRiskByDisposition (consistent
+        with prolific_submission_statuses/summaries which also skip empty PIDs)."""
+        from datetime import datetime, timezone, timedelta
+        old = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+        subs = [
+            # Missing participant_id — should count in bucket, not in breakdown.
+            {"participant_id": "", "status": "AWAITING REVIEW", "completed_at": old},
+        ]
+        data = self._run(tmp_path, subs)
+        runway = data["autoApproveRunway"]
+        assert runway["highRiskCount"] == 1
+        # The breakdown should be empty (no actionable PID).
+        assert runway["highRiskByDisposition"] == {}

--- a/scripts/analysis/tests/test_generate_disposition_summary.py
+++ b/scripts/analysis/tests/test_generate_disposition_summary.py
@@ -345,7 +345,19 @@ class TestAutoApproveRunway:
         assert runway["skippedMissingCompletedAt"] == 0
         assert runway["highRiskCount"] == 1
 
-    def test_no_completed_at_skipped(self, tmp_path):
+    def test_top_level_high_risk_aliases(self, tmp_path):
+        """highRiskCount and highRiskByDisposition are mirrored as top-level
+        fields for consumers that don't want to traverse autoApproveRunway."""
+        from datetime import datetime, timezone, timedelta
+        old = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+        subs = [
+            {"participant_id": "PID_C", "status": "AWAITING REVIEW", "completed_at": old},
+        ]
+        data = self._run(tmp_path, subs)
+        # Top-level aliases must mirror the nested block exactly.
+        runway = data["autoApproveRunway"]
+        assert data.get("highRiskCount") == runway["highRiskCount"]
+        assert data.get("highRiskByDisposition") == runway["highRiskByDisposition"]
         """Submissions missing completed_at cannot be bucketed but still count
         towards totalAwaitingReview; evaluatedCount stays 0."""
         subs = [

--- a/scripts/analysis/tests/test_generate_disposition_summary.py
+++ b/scripts/analysis/tests/test_generate_disposition_summary.py
@@ -358,6 +358,8 @@ class TestAutoApproveRunway:
         runway = data["autoApproveRunway"]
         assert data.get("highRiskCount") == runway["highRiskCount"]
         assert data.get("highRiskByDisposition") == runway["highRiskByDisposition"]
+
+    def test_no_completed_at_skipped(self, tmp_path):
         """Submissions missing completed_at cannot be bucketed but still count
         towards totalAwaitingReview; evaluatedCount stays 0."""
         subs = [

--- a/scripts/analysis/tests/test_generate_disposition_summary.py
+++ b/scripts/analysis/tests/test_generate_disposition_summary.py
@@ -287,6 +287,11 @@ class TestAutoApproveRunway:
         assert runway["buckets"][-1]["label"] == "HIGH RISK"
         # highRiskCount must equal the last bucket's count for downstream consumers.
         assert runway["highRiskCount"] == runway["buckets"][-1]["count"]
+        # New fields for clarity on how many submissions were evaluated.
+        assert "totalAwaitingReview" in runway
+        assert "evaluatedCount" in runway
+        assert "skippedMissingCompletedAt" in runway
+        assert runway["evaluatedCount"] + runway["skippedMissingCompletedAt"] == runway["totalAwaitingReview"]
 
     def test_high_risk_picks_up_old_completion(self, tmp_path):
         """A submission completed 20 days ago has 1 day until auto-approve →
@@ -304,6 +309,8 @@ class TestAutoApproveRunway:
         runway = data["autoApproveRunway"]
         assert runway["highRiskCount"] == 1
         assert runway["totalAwaitingReview"] == 1
+        assert runway["evaluatedCount"] == 1
+        assert runway["skippedMissingCompletedAt"] == 0
         assert runway["highRiskByDisposition"].get("FLAG-SPEED") == 1
 
     def test_buckets_partitioned_by_runway_days(self, tmp_path):
@@ -334,15 +341,19 @@ class TestAutoApproveRunway:
         # Comfortable (>=10), Monitor (5-10), Act soon (2-5), HIGH RISK (<2)
         assert counts == [1, 1, 1, 1]
         assert runway["totalAwaitingReview"] == 4
+        assert runway["evaluatedCount"] == 4
+        assert runway["skippedMissingCompletedAt"] == 0
         assert runway["highRiskCount"] == 1
 
     def test_no_completed_at_skipped(self, tmp_path):
-        """Submissions missing completed_at are excluded -- we cannot
-        compute runway without a timestamp."""
+        """Submissions missing completed_at cannot be bucketed but still count
+        towards totalAwaitingReview; evaluatedCount stays 0."""
         subs = [
             {"participant_id": "PID_C", "status": "AWAITING REVIEW"},
         ]
         data = self._run(tmp_path, subs)
         runway = data["autoApproveRunway"]
-        assert runway["totalAwaitingReview"] == 0
+        assert runway["totalAwaitingReview"] == 1
+        assert runway["evaluatedCount"] == 0
+        assert runway["skippedMissingCompletedAt"] == 1
         assert all(b["count"] == 0 for b in runway["buckets"])

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -382,12 +382,23 @@ with open(os.environ['TODAY_FILE'], encoding='utf-8') as f:
 runway = d.get('autoApproveRunway') or {}
 buckets = runway.get('buckets') or []
 total = runway.get('totalAwaitingReview', 0)
+evaluated = runway.get('evaluatedCount', 0)
+skipped_missing_completed_at = runway.get('skippedMissingCompletedAt', 0)
 if not buckets or total == 0:
     raise SystemExit(0)
 
 threshold = runway.get('thresholdDays', 21)
 print(f'Prolific auto-approves any AWAITING REVIEW submission **{threshold} days** after `completed_at`. Buckets count remaining runway per submission.')
 print('')
+if evaluated <= 0:
+    print(f'⚠️ Runway could not be evaluated for the **{total}** AWAITING REVIEW submission(s) because no usable `completed_at` timestamps were available.')
+    if skipped_missing_completed_at:
+        print(f'- Skipped due to missing/unparseable `completed_at`: **{skipped_missing_completed_at}**')
+    raise SystemExit(0)
+
+if skipped_missing_completed_at:
+    print(f'> Evaluated **{evaluated}** of **{total}** AWAITING REVIEW submission(s); skipped **{skipped_missing_completed_at}** with missing/unparseable `completed_at`.')
+    print('')
 print('| Bucket | Days remaining | Count | Risk |')
 print('|---|---|---:|---|')
 for b in buckets:

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -59,17 +59,53 @@ fi
 dfmt() { if [ "$1" -gt 0 ]; then printf "+%d" "$1"; elif [ "$1" -eq 0 ]; then printf "0"; else printf "%d" "$1"; fi; }
 
 # --- Triage data ---
+# Preferred source: a triage-metrics artifact written by an upstream pipeline
+# step. Currently no step publishes this artifact, so the lookup silently
+# misses on every run and the Disposition Triage table renders empty. The
+# fallback below computes the same total + breakdown directly from the
+# already-downloaded dashboard-data/disposition-summary.json so the table
+# never goes blank when dashboard data is available.
 TRIAGE_TOTAL="unknown"
 TRIAGE_BREAKDOWN=""
 [ -f "$ARTIFACTS_DIR/triage-metrics/triage-total.txt" ] && TRIAGE_TOTAL=$(cat "$ARTIFACTS_DIR/triage-metrics/triage-total.txt")
 [ -f "$ARTIFACTS_DIR/triage-metrics/triage-breakdown.txt" ] && TRIAGE_BREAKDOWN=$(cat "$ARTIFACTS_DIR/triage-metrics/triage-breakdown.txt")
+if [ "$TRIAGE_TOTAL" = "unknown" ] && [ -f "$TODAY_FILE" ]; then
+  FALLBACK=$(TODAY_FILE="$TODAY_FILE" python3 << 'PYEOF'
+import json, os
+with open(os.environ['TODAY_FILE'], encoding='utf-8') as f:
+    d = json.load(f)
+disps = d.get('dispositions') or {}
+total = sum(disps.values())
+if total == 0:
+    raise SystemExit(0)
+order = ['CLEAN', 'FLAG-SINGLE-IRI', 'FLAG-SMEAL', 'FLAG-PARTIAL-STRAIGHTLINING',
+         'FLAG-SPEED', 'FLAG-RECAPTCHA', 'AUTO-EXCLUDE', 'INCOMPLETE']
+ordered = [k for k in order if k in disps] + [k for k in disps if k not in order]
+lines = [f'__TRIAGE_TOTAL__={total}']
+for k in ordered:
+    pct = (disps[k] / total * 100) if total else 0
+    lines.append(f'| {k} | {disps[k]} | {pct:.1f}% |')
+print('\n'.join(lines))
+PYEOF
+  ) || FALLBACK=""
+  if [ -n "$FALLBACK" ]; then
+    TRIAGE_TOTAL=$(printf '%s\n' "$FALLBACK" | sed -n 's/^__TRIAGE_TOTAL__=//p')
+    TRIAGE_BREAKDOWN=$(printf '%s\n' "$FALLBACK" | grep -v '^__TRIAGE_TOTAL__=')
+  fi
+fi
 
 # --- Approve data ---
+# The grep needs to cover every result phrase approve_submissions.py emits.
+# Today's script ends successful no-op runs with "Nothing to do" (not the
+# legacy "Nothing to approve"), which the original pattern missed -- so the
+# Auto-Approve CLEAN section fell back to "No data" on every run. Pattern
+# now also matches "Nothing to do" and "are already APPROVED" so the report
+# reflects what actually happened.
 APPROVE_CLEAN_COUNT="0"
 APPROVE_RESULT="No data"
 if [ -f "$ARTIFACTS_DIR/approve-metrics/approve-output.txt" ]; then
   APPROVE_CLEAN_COUNT=$(grep "CLEAN dispositions" "$ARTIFACTS_DIR/approve-metrics/approve-output.txt" | head -1 | grep -o '[0-9]*' | head -1 || echo "0")
-  APPROVE_RESULT=$(grep "Successfully approved\|No CLEAN\|No participants with CLEAN disposition found\|Nothing to approve" "$ARTIFACTS_DIR/approve-metrics/approve-output.txt" | head -1 || echo "No data")
+  APPROVE_RESULT=$(grep -E "Successfully approved|No CLEAN|No participants with CLEAN disposition found|Nothing to approve|Nothing to do|are already APPROVED" "$ARTIFACTS_DIR/approve-metrics/approve-output.txt" | head -1 || echo "No data")
 fi
 
 # --- Reconciliation cross-reference (disposition x Prolific status) ---
@@ -131,14 +167,24 @@ for f in "$ARTIFACTS_DIR"/message-metrics-*/message-output.txt; do
       ACTIONED=$(echo "$SENT_LINE" | sed -n 's/.*already actioned): \([0-9]*\).*/\1/p')
       MESSAGED=$(echo "$SENT_LINE" | sed -n 's/.*already messaged): \([0-9]*\).*/\1/p')
       FAILED=$(echo "$SENT_LINE" | sed -n 's/.*FAILED: \([0-9]*\).*/\1/p')
-      MSG_ROWS="$MSG_ROWS
-| $DISP | ${SENT:-0} | ${ACTIONED:-0} | ${MESSAGED:-0} | ${FAILED:-0} |"
+      ROW="| $DISP | ${SENT:-0} | ${ACTIONED:-0} | ${MESSAGED:-0} | ${FAILED:-0} |"
+      if [ -z "$MSG_ROWS" ]; then
+        MSG_ROWS="$ROW"
+      else
+        MSG_ROWS="$MSG_ROWS
+$ROW"
+      fi
       TOTAL_SENT=$((TOTAL_SENT + ${SENT:-0}))
       TOTAL_FAILED=$((TOTAL_FAILED + ${FAILED:-0}))
     else
       # No participants matched this disposition - show 0/0/0/0 so it still appears in report
-      MSG_ROWS="$MSG_ROWS
-| $DISP | 0 | 0 | 0 | 0 |"
+      ROW="| $DISP | 0 | 0 | 0 | 0 |"
+      if [ -z "$MSG_ROWS" ]; then
+        MSG_ROWS="$ROW"
+      else
+        MSG_ROWS="$MSG_ROWS
+$ROW"
+      fi
     fi
   fi
 done
@@ -192,6 +238,16 @@ if ae_approved > 0:
 inc_awaiting = dbs.get('INCOMPLETE', {}).get('AWAITING REVIEW', 0)
 if inc_awaiting > 0:
     recs.append(f'| 🔵 Low | **{inc_awaiting} INCOMPLETE** awaiting review | Likely abandoned - consider requesting return |')
+
+# Priority 0 (highest): submissions in the HIGH RISK auto-approve runway bucket.
+# Prepend rather than append so it lands at the top of the recommendations
+# table when present -- it's the most time-sensitive item on the report.
+runway = d.get('autoApproveRunway') or {}
+high_risk_count = runway.get('highRiskCount', 0)
+if high_risk_count > 0:
+    by_disp = runway.get('highRiskByDisposition') or {}
+    breakdown = ', '.join(f'{c} {dp}' for dp, c in sorted(by_disp.items(), key=lambda x: -x[1])) or 'unspecified'
+    recs.insert(0, f'| 🚨 HIGH RISK | **{high_risk_count} AWAITING REVIEW** within 2 days of Prolific 21-day auto-approve | Action today ({breakdown}) |')
 
 # Summary counts
 total_awaiting = sum(r.get('AWAITING REVIEW', 0) for r in dbs.values())
@@ -312,6 +368,63 @@ $RECONCILIATION_TABLE
 "
 fi
 
+# --- Auto-Approve Runway section ---
+# Renders the per-bucket counts written into disposition-summary.json by
+# generate_disposition_summary.py. The last bucket is the HIGH RISK bucket
+# (within 2 days of Prolific's 21-day auto-approve mark). Empty when
+# disposition-summary.json is missing or has no AWAITING REVIEW rows.
+RUNWAY_SECTION=""
+if [ -f "$TODAY_FILE" ]; then
+  RUNWAY_BODY=$(TODAY_FILE="$TODAY_FILE" python3 << 'RUNWAYEOF'
+import json, os
+with open(os.environ['TODAY_FILE'], encoding='utf-8') as f:
+    d = json.load(f)
+runway = d.get('autoApproveRunway') or {}
+buckets = runway.get('buckets') or []
+total = runway.get('totalAwaitingReview', 0)
+if not buckets or total == 0:
+    raise SystemExit(0)
+
+threshold = runway.get('thresholdDays', 21)
+print(f'Prolific auto-approves any AWAITING REVIEW submission **{threshold} days** after `completed_at`. Buckets count remaining runway per submission.')
+print('')
+print('| Bucket | Days remaining | Count | Risk |')
+print('|---|---|---:|---|')
+for b in buckets:
+    label = b.get('label', '?')
+    risk = b.get('risk', 'low')
+    min_d = b.get('minDaysRemaining')
+    max_d = b.get('maxDaysRemaining')
+    if min_d is None and max_d is not None:
+        rng = f'< {max_d:g}'
+    elif min_d is not None and max_d is None:
+        rng = f'>= {min_d:g}'
+    elif min_d is not None and max_d is not None:
+        rng = f'{min_d:g} - {max_d:g}'
+    else:
+        rng = '?'
+    risk_marker = {'low': '🟢', 'moderate': '🟡', 'elevated': '🟠', 'high': '🔴 **HIGH RISK**'}.get(risk, risk)
+    bold_count = f'**{b.get("count", 0)}**' if risk == 'high' else str(b.get('count', 0))
+    print(f'| {label} | {rng} | {bold_count} | {risk_marker} |')
+print('')
+high_risk = runway.get('highRiskCount', 0)
+if high_risk > 0:
+    by_disp = runway.get('highRiskByDisposition') or {}
+    breakdown = ', '.join(f'{c} {dp}' for dp, c in sorted(by_disp.items(), key=lambda x: -x[1])) or 'unspecified'
+    noun = 'submission is' if high_risk == 1 else 'submissions are'
+    print(f'> 🚨 **{high_risk} {noun} within 2 days of auto-approval** ({breakdown}). Action today.')
+else:
+    print('> ✅ No submissions in the HIGH RISK bucket.')
+RUNWAYEOF
+  ) || RUNWAY_BODY=""
+  if [ -n "$RUNWAY_BODY" ]; then
+    RUNWAY_SECTION="## Auto-Approve Runway (21-day Prolific clock)
+
+$RUNWAY_BODY
+"
+  fi
+fi
+
 # --- Build warnings for upstream failures ---
 WARNINGS=""
 if [ "${TRIAGE_RESULT:-}" = "failure" ]; then
@@ -361,6 +474,7 @@ cat >> /tmp/report-body.md << STATUSEOF
 $TRIAGE_BREAKDOWN
 
 $RECONCILIATION_SECTION
+$RUNWAY_SECTION
 $RECOMMENDATIONS_SECTION
 $STALE_TRIAGE_SECTION_FORMATTED
 ## Auto-Approve CLEAN

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -89,7 +89,7 @@ PYEOF
   ) || FALLBACK=""
   if [ -n "$FALLBACK" ]; then
     TRIAGE_TOTAL=$(printf '%s\n' "$FALLBACK" | sed -n 's/^__TRIAGE_TOTAL__=//p')
-    TRIAGE_BREAKDOWN=$(printf '%s\n' "$FALLBACK" | grep -v '^__TRIAGE_TOTAL__=')
+    TRIAGE_BREAKDOWN=$(printf '%s\n' "$FALLBACK" | grep -v '^__TRIAGE_TOTAL__=' || true)
   fi
 fi
 

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -76,15 +76,14 @@ with open(os.environ['TODAY_FILE'], encoding='utf-8') as f:
     d = json.load(f)
 disps = d.get('dispositions') or {}
 total = sum(disps.values())
-if total == 0:
-    raise SystemExit(0)
 order = ['CLEAN', 'FLAG-SINGLE-IRI', 'FLAG-SMEAL', 'FLAG-PARTIAL-STRAIGHTLINING',
          'FLAG-SPEED', 'FLAG-RECAPTCHA', 'AUTO-EXCLUDE', 'INCOMPLETE']
 ordered = [k for k in order if k in disps] + [k for k in disps if k not in order]
 lines = [f'__TRIAGE_TOTAL__={total}']
-for k in ordered:
-    pct = (disps[k] / total * 100) if total else 0
-    lines.append(f'| {k} | {disps[k]} | {pct:.1f}% |')
+if total > 0:
+    for k in ordered:
+        pct = disps[k] / total * 100
+        lines.append(f'| {k} | {disps[k]} | {pct:.1f}% |')
 print('\n'.join(lines))
 PYEOF
   ) || FALLBACK=""

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -404,13 +404,13 @@ for b in buckets:
     label = b.get('label', '?')
     risk = b.get('risk', 'low')
     min_d = b.get('minDaysRemaining')
-    max_d = b.get('maxDaysRemaining')
+    max_d = b.get('maxDaysRemainingExclusive')
     if min_d is None and max_d is not None:
         rng = f'< {max_d:g}'
     elif min_d is not None and max_d is None:
         rng = f'>= {min_d:g}'
     elif min_d is not None and max_d is not None:
-        rng = f'{min_d:g} - {max_d:g}'
+        rng = f'>= {min_d:g} and < {max_d:g}'
     else:
         rng = '?'
     risk_marker = {'low': '🟢', 'moderate': '🟡', 'elevated': '🟠', 'high': '🔴 **HIGH RISK**'}.get(risk, risk)

--- a/scripts/validate-data-schemas.ts
+++ b/scripts/validate-data-schemas.ts
@@ -46,6 +46,28 @@ export const DispositionSummarySchema = z.object({
   }),
   studyId: z.string().optional(),
   studyName: z.string().optional(),
+  autoApproveRunway: z
+    .object({
+      thresholdDays: z.number().min(0),
+      computedAt: z.string(),
+      totalAwaitingReview: z.number().min(0),
+      evaluatedCount: z.number().min(0),
+      skippedMissingCompletedAt: z.number().min(0),
+      buckets: z.array(
+        z.object({
+          label: z.string(),
+          risk: z.string(),
+          minDaysRemaining: z.number().nullable(),
+          maxDaysRemaining: z.number().nullable(),
+          count: z.number().min(0),
+        })
+      ),
+      highRiskCount: z.number().min(0),
+      highRiskByDisposition: z.record(z.string(), z.number().min(0)),
+    })
+    .optional(),
+  highRiskCount: z.number().min(0).optional(),
+  highRiskByDisposition: z.record(z.string(), z.number().min(0)).optional(),
 })
 
 // Schema for src/data/sensitivity-analysis.json

--- a/scripts/validate-data-schemas.ts
+++ b/scripts/validate-data-schemas.ts
@@ -58,7 +58,7 @@ export const DispositionSummarySchema = z.object({
           label: z.string(),
           risk: z.string(),
           minDaysRemaining: z.number().nullable(),
-          maxDaysRemaining: z.number().nullable(),
+          maxDaysRemainingExclusive: z.number().nullable(),
           count: z.number().min(0),
         })
       ),


### PR DESCRIPTION
Two related changes ship together because the daily report needs the new runway data to render the HIGH RISK section, and the report had three pre-existing render bugs that were already affecting every daily issue.

## Pipeline data additions

Prolific auto-approves any AWAITING REVIEW submission **21 days** after \`completed_at\`, regardless of TABS quality flags. Until now the pipeline discarded that timestamp, so no script could see how much runway each submission had. Threading it through the pipeline lets every consumer (messaging, rejection, triage, reports) reason about deadlines without making its own API call.

| # | File | Change |
|---|---|---|
| 1 | \`scripts/analysis/tabs_api.py\` | New \`prolific_submission_summaries()\` returns \`{PID: {status, completed_at, started_at}}\`. Existing \`prolific_submission_statuses()\` kept for backward compat. |
| 2 | \`scripts/analysis/fetch_prolific_data.py\` | Writes the richer dict to \`statuses.json\`. |
| 3 | \`scripts/analysis/enrich_qualtrics_csv.py\` | Adds \`Prolific_Completed_At\` + \`Prolific_Started_At\` columns. Loader normalises legacy + current shapes. |
| 4 | \`scripts/analysis/tabs_v2_data_audit.py\` + \`disposition_triage.py\` | New columns flow through to \`disposition.csv\`. |
| 5 | \`scripts/analysis/generate_disposition_summary.py\` | New \`autoApproveRunway\` block in \`disposition-summary.json\` with 4 buckets (Comfortable / Monitor / Act soon / **HIGH RISK**) + top-level \`highRiskCount\` and \`highRiskByDisposition\` for downstream consumers. |

**Privacy:** only aggregate counts land in the committed JSON. Per-PID \`Prolific_Completed_At\` lives only in the \`disposition-csv\` artifact (1-day retention).

## Daily report regressions fixed

Audit of issues #1823 / #1826 / #1829 / #1832 / #1835 showed three sections rendering wrong on **every daily report for >5 days**:

| Fix | Section | Root cause |
|---|---|---|
| **A** | Disposition Triage table empty | Reads \`triage-metrics/*.txt\` artifact that no pipeline step writes. Added fallback computing total + breakdown from \`dashboard-data/disposition-summary.json\`. **(Same fix as #1700 — supersedes that PR.)** |
| **B** | Auto-Approve CLEAN: 'No data' | grep pattern missed \`Nothing to do\` and \`are already APPROVED\` — both phrases the current \`approve_submissions.py\` emits on successful no-op runs. |
| **C** | Messages Sent: blank line between header and first row | \`MSG_ROWS\` was prepended with \`\n\` unconditionally; first iteration left a leading newline. Now joins lines correctly. |

## Daily report enhancement

New **'Auto-Approve Runway (21-day Prolific clock)'** section reads the new aggregate and renders a 4-bucket table with risk markers. The HIGH RISK bucket is bold and flagged with a callout that lists the disposition breakdown. A HIGH RISK recommendation row is also prepended to Recommended Actions (priority 0 — highest — so it sorts to the top).

## Smoke test (local, against current data)

Patched today's \`src/data/disposition-summary.json\` with example runway data and ran \`scripts/build-daily-report.sh\` with stubbed \`gh\`. Verified:

- Disposition Triage now populates correctly (CLEAN 107, FLAG-SINGLE-IRI 98, etc.)
- Auto-Approve CLEAN now shows \"All 112 CLEAN submissions are already APPROVED. Nothing to do.\"
- Messages Sent table has no blank line
- New runway section renders with 4 buckets, HIGH RISK in bold + 🚨 callout
- Grammar correct singular/plural (\"1 submission is\" vs \"N submissions are\")

## Test plan

- [x] \`npm run format\` — clean
- [x] \`npm run lint\` — 0 errors (3 pre-existing warnings unrelated)
- [x] \`npm test\` — 582/582 pass
- [x] \`npm run build\` — static export succeeds
- [x] \`pytest scripts/analysis/tests/\` — **8 net new passing tests**, no new failures (52 pre-existing failures are Windows-only encoding issues that don't fire in Linux CI)
- [x] Local smoke test of \`build-daily-report.sh\` against current data
- [ ] After merge: tomorrow's daily report at 09:00 UTC should show all 4 sections rendering correctly + new Auto-Approve Runway section

## Closes / supersedes

- Closes #1700 (Disposition Triage table fix is included here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)