### PR TITLE
Update daily pipeline data

### DIFF
--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -2394,6 +2394,6 @@
       }
     ]
   },
-  "last_updated": "2026-05-01T11:07:33.432442Z",
-  "extended_last_updated": "2026-05-01T11:07:33.432442Z"
+  "last_updated": "2026-05-01T17:25:50.875297Z",
+  "extended_last_updated": "2026-05-01T17:25:50.875297Z"
 }

--- a/src/data/data-audit.json
+++ b/src/data/data-audit.json
@@ -2,21 +2,21 @@
   "disposition_counts": {
     "INCOMPLETE": 89,
     "CLEAN": 113,
-    "FLAG-SMEAL": 68,
+    "FLAG-SMEAL": 69,
     "FLAG-SPEED": 10,
     "FLAG-PARTIAL-STRAIGHTLINING": 42,
-    "FLAG-SINGLE-IRI": 105,
+    "FLAG-SINGLE-IRI": 106,
     "AUTO-EXCLUDE": 158,
     "FLAG-RECAPTCHA": 4
   },
   "iri_pass_rates": {
-    "barrier": 0.499151103565365,
-    "readiness": 0.5857385398981324,
-    "maturity": 0.7028862478777589
+    "barrier": 0.5008460236886633,
+    "readiness": 0.5854483925549916,
+    "maturity": 0.7038917089678511
   },
   "duration_stats": {
-    "mean": 630.0611205432937,
-    "median": 531,
+    "mean": 629.6666666666666,
+    "median": 530,
     "q25": 320,
     "q75": 781,
     "min": 2,
@@ -27,8 +27,8 @@
     "partial_flagged": 178
   },
   "sample_sizes": {
-    "total": 589,
-    "complete": 500,
+    "total": 591,
+    "complete": 502,
     "clean": 113
   },
   "waterfall_steps": [
@@ -65,32 +65,32 @@
     {
       "step": 5,
       "name": "FLAG-SINGLE-IRI",
-      "count": 105,
-      "cumulative_excluded": 362
+      "count": 106,
+      "cumulative_excluded": 363
     },
     {
       "step": 6,
       "name": "FLAG-SMEAL",
-      "count": 68,
-      "cumulative_excluded": 430
+      "count": 69,
+      "cumulative_excluded": 432
     },
     {
       "step": 7,
       "name": "FLAG-RECAPTCHA",
       "count": 4,
-      "cumulative_excluded": 434
+      "cumulative_excluded": 436
     },
     {
       "step": 8,
       "name": "FLAG-STRAIGHTLINING",
       "count": 0,
-      "cumulative_excluded": 434
+      "cumulative_excluded": 436
     },
     {
       "step": 9,
       "name": "FLAG-PARTIAL-STRAIGHTLINING",
       "count": 42,
-      "cumulative_excluded": 476
+      "cumulative_excluded": 478
     },
     {
       "step": 10,

--- a/src/data/disposition-summary.json
+++ b/src/data/disposition-summary.json
@@ -1,34 +1,34 @@
 {
-  "updatedAt": "2026-05-01T11:11:54.117768+00:00",
-  "last_updated": "2026-05-01T11:11:54.117783+00:00",
+  "updatedAt": "2026-05-01T17:30:19.862356+00:00",
+  "last_updated": "2026-05-01T17:30:19.862359+00:00",
   "study": {
     "id": "69c17630acada6abeead2da5",
     "name": "Technology Adoption Barriers Survey (2026)",
     "status": "ACTIVE",
     "totalAvailablePlaces": 500,
-    "placesTaken": 357,
-    "averageRewardPerHour": 4013.55,
+    "placesTaken": 351,
+    "averageRewardPerHour": 3986.55,
     "averageTimeTaken": 10,
     "reward": 700,
     "publishedAt": "2026-03-23T18:00:28.650000Z"
   },
   "completionProgress": {
     "target": 500,
-    "completed": 357,
+    "completed": 351,
     "approved": 308,
-    "awaitingReview": 49,
-    "percentComplete": 71.4
+    "awaitingReview": 43,
+    "percentComplete": 70.2
   },
-  "totalResponses": 598,
-  "uniqueParticipants": 589,
+  "totalResponses": 600,
+  "uniqueParticipants": 591,
   "duplicatesRemoved": 0,
   "dispositions": {
     "INCOMPLETE": 89,
     "CLEAN": 113,
-    "FLAG-SMEAL": 68,
+    "FLAG-SMEAL": 69,
     "FLAG-SPEED": 10,
     "FLAG-PARTIAL-STRAIGHTLINING": 42,
-    "FLAG-SINGLE-IRI": 105,
+    "FLAG-SINGLE-IRI": 106,
     "AUTO-EXCLUDE": 158,
     "FLAG-RECAPTCHA": 4
   },
@@ -44,7 +44,7 @@
     },
     "FLAG-SMEAL": {
       "APPROVED": 52,
-      "AWAITING REVIEW": 9,
+      "AWAITING REVIEW": 10,
       "RETURNED": 7
     },
     "FLAG-SPEED": {
@@ -59,13 +59,13 @@
     "FLAG-SINGLE-IRI": {
       "RETURNED": 7,
       "APPROVED": 80,
-      "AWAITING REVIEW": 18
+      "AWAITING REVIEW": 19
     },
     "AUTO-EXCLUDE": {
-      "REJECTED": 35,
+      "REJECTED": 43,
       "APPROVED": 14,
-      "AWAITING REVIEW": 17,
-      "RETURNED": 92
+      "RETURNED": 92,
+      "AWAITING REVIEW": 9
     },
     "FLAG-RECAPTCHA": {
       "APPROVED": 4
@@ -80,19 +80,60 @@
   },
   "actions": {
     "approved": 308,
-    "rejected": 35,
+    "rejected": 43,
     "returned": 200,
     "timedOut": 6,
-    "awaitingReview": 49,
+    "awaitingReview": 43,
     "active": 0,
     "messaged": 0
   },
   "iriPassRates": {
-    "barrier": 58.4,
-    "readiness": 68.6,
-    "maturity": 82.6,
-    "denominator": 500
+    "barrier": 58.6,
+    "readiness": 68.5,
+    "maturity": 82.7,
+    "denominator": 502
   },
+  "autoApproveRunway": {
+    "thresholdDays": 21,
+    "computedAt": "2026-05-01T17:30:19.862200+00:00",
+    "totalAwaitingReview": 43,
+    "evaluatedCount": 43,
+    "skippedMissingCompletedAt": 0,
+    "buckets": [
+      {
+        "label": "Comfortable",
+        "risk": "low",
+        "minDaysRemaining": 10.0,
+        "maxDaysRemainingExclusive": null,
+        "count": 37
+      },
+      {
+        "label": "Monitor",
+        "risk": "moderate",
+        "minDaysRemaining": 5.0,
+        "maxDaysRemainingExclusive": 10.0,
+        "count": 3
+      },
+      {
+        "label": "Act soon",
+        "risk": "elevated",
+        "minDaysRemaining": 2.0,
+        "maxDaysRemainingExclusive": 5.0,
+        "count": 3
+      },
+      {
+        "label": "HIGH RISK",
+        "risk": "high",
+        "minDaysRemaining": null,
+        "maxDaysRemainingExclusive": 2.0,
+        "count": 0
+      }
+    ],
+    "highRiskCount": 0,
+    "highRiskByDisposition": {}
+  },
+  "highRiskCount": 0,
+  "highRiskByDisposition": {},
   "studyId": "69c17630acada6abeead2da5",
   "studyName": "Technology Adoption Barriers Survey (2026)"
 }

--- a/src/data/live-validation.json
+++ b/src/data/live-validation.json
@@ -1452,133 +1452,133 @@
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 500,
+      "n": 502,
       "n_to_param_ratio": 10.9,
       "adequacy": "good",
       "adequacy_note": "N:parameter ratio 10.9:1 meets the recommended 10:1 threshold for stable CFA estimation.",
       "Barriers": {
-        "cronbach_alpha": 0.9034,
-        "cronbach_alpha_ci": [0.8903, 0.9157],
-        "n_listwise": 470,
-        "mcdonalds_omega": 0.9038,
-        "composite_reliability": 0.9038,
-        "ave": 0.3483,
-        "split_half": 0.9204,
+        "cronbach_alpha": 0.9032,
+        "cronbach_alpha_ci": [0.89, 0.9154],
+        "n_listwise": 472,
+        "mcdonalds_omega": 0.9035,
+        "composite_reliability": 0.9035,
+        "ave": 0.3475,
+        "split_half": 0.9203,
         "kmo_bartlett": {
-          "kmo_overall": 0.9303,
-          "bartlett_chi2": 3114.76,
+          "kmo_overall": 0.9306,
+          "bartlett_chi2": 3119.1,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 2,
-          "eigenvalues_real": [6.9066, 1.5992, 0.9727, 0.9119]
+          "eigenvalues_real": [6.8933, 1.6098, 0.9706, 0.9094]
         },
         "efa": {
           "construct": "Barriers",
           "n_factors": 2,
-          "variance_explained": [0.3232, 0.1038],
+          "variance_explained": [0.3222, 0.1047],
           "total_variance": 0.427,
           "factor_correlations": [
             [1.0, 0.5695],
             [0.5695, 1.0]
           ],
           "loadings": {
-            "B1": [0.7568, -0.1798],
-            "B2": [0.7832, -0.1311],
-            "B3": [0.6998, -0.1009],
-            "B4": [0.7265, -0.0773],
-            "B5": [0.6817, -0.0549],
-            "B6": [0.4925, 0.0438],
-            "B7": [0.5553, 0.0622],
-            "B8": [0.5847, 0.0638],
-            "B9": [0.5751, 0.0191],
-            "B10": [0.7624, -0.0441],
-            "B11": [0.5525, 0.1049],
-            "B12": [0.5674, 0.0599],
-            "B13": [-0.1659, 0.8872],
-            "B14": [-0.1206, 0.8537],
-            "B15": [0.4662, 0.1915],
-            "B16": [0.2201, 0.4205],
-            "B17": [0.4959, 0.0983],
-            "B18": [0.4043, 0.1847]
+            "B1": [0.753, -0.1775],
+            "B2": [0.7844, -0.1348],
+            "B3": [0.7018, -0.1029],
+            "B4": [0.7274, -0.077],
+            "B5": [0.6813, -0.0565],
+            "B6": [0.4891, 0.0491],
+            "B7": [0.5552, 0.0613],
+            "B8": [0.5874, 0.0578],
+            "B9": [0.5737, 0.0221],
+            "B10": [0.7614, -0.0439],
+            "B11": [0.5487, 0.1098],
+            "B12": [0.5689, 0.058],
+            "B13": [-0.166, 0.8852],
+            "B14": [-0.1264, 0.8583],
+            "B15": [0.4582, 0.2006],
+            "B16": [0.2139, 0.4276],
+            "B17": [0.4932, 0.102],
+            "B18": [0.4044, 0.1863]
           }
         },
         "cfa": {
           "construct": "Barriers",
-          "chi2": 586.952,
+          "chi2": 589.58,
           "df": 135,
           "chi2_p": 0.0,
-          "cfi": 0.8501,
-          "tli": 0.8301,
-          "rmsea": 0.0845,
+          "cfi": 0.8494,
+          "tli": 0.8293,
+          "rmsea": 0.0846,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.3426,
-          "min_r": 0.1243,
-          "max_r": 0.6496,
-          "sd_r": 0.091
+          "mean_r": 0.3418,
+          "min_r": 0.1233,
+          "max_r": 0.6501,
+          "sd_r": 0.0911
         },
         "itc_min": 0.4,
         "itc_all_above_030": true
       },
       "Readiness": {
-        "cronbach_alpha": 0.9301,
-        "cronbach_alpha_ci": [0.9203, 0.9392],
-        "n_listwise": 449,
-        "mcdonalds_omega": 0.9308,
-        "composite_reliability": 0.9308,
-        "ave": 0.443,
+        "cronbach_alpha": 0.9298,
+        "cronbach_alpha_ci": [0.92, 0.9389],
+        "n_listwise": 451,
+        "mcdonalds_omega": 0.9305,
+        "composite_reliability": 0.9305,
+        "ave": 0.4418,
         "split_half": 0.9356,
         "kmo_bartlett": {
-          "kmo_overall": 0.961,
-          "bartlett_chi2": 3516.55,
+          "kmo_overall": 0.9605,
+          "bartlett_chi2": 3521.39,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [8.0803, 0.9645, 0.777, 0.768]
+          "eigenvalues_real": [8.0619, 0.967, 0.7798, 0.766]
         },
         "efa": {
           "construct": "Readiness",
           "n_factors": 1,
-          "variance_explained": [0.443],
-          "total_variance": 0.443,
+          "variance_explained": [0.4418],
+          "total_variance": 0.4418,
           "factor_correlations": null,
           "loadings": {
-            "R1": [0.7231],
-            "R2": [0.6718],
-            "R3": [0.7037],
+            "R1": [0.7234],
+            "R2": [0.6723],
+            "R3": [0.7027],
             "R4": [0.5868],
-            "R5": [0.5987],
-            "R6": [0.6921],
-            "R7": [0.7094],
-            "R8": [0.6831],
-            "R9": [0.6634],
-            "R10": [0.6678],
-            "R11": [0.6728],
-            "R12": [0.6433],
-            "R13": [0.6888],
+            "R5": [0.5969],
+            "R6": [0.6917],
+            "R7": [0.7087],
+            "R8": [0.6788],
+            "R9": [0.6639],
+            "R10": [0.6646],
+            "R11": [0.6724],
+            "R12": [0.644],
+            "R13": [0.6868],
             "R14": [0.627],
-            "R15": [0.6691],
-            "R16": [0.7314],
-            "R17": [0.5536]
+            "R15": [0.6688],
+            "R16": [0.7295],
+            "R17": [0.5532]
           }
         },
         "cfa": {
           "construct": "Readiness",
-          "chi2": 277.806,
+          "chi2": 282.248,
           "df": 119,
           "chi2_p": 0.0,
-          "cfi": 0.9538,
-          "tli": 0.9472,
-          "rmsea": 0.0546,
+          "cfi": 0.9526,
+          "tli": 0.9458,
+          "rmsea": 0.0552,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.4407,
-          "min_r": 0.2719,
-          "max_r": 0.5834,
+          "mean_r": 0.4396,
+          "min_r": 0.2697,
+          "max_r": 0.5858,
           "sd_r": 0.0574
         },
         "itc_min": 0.53,
@@ -1587,52 +1587,52 @@
       "Maturity": {
         "cronbach_alpha": 0.8887,
         "cronbach_alpha_ci": [0.8728, 0.9033],
-        "n_listwise": 467,
-        "mcdonalds_omega": 0.8892,
-        "composite_reliability": 0.8892,
-        "ave": 0.5024,
-        "split_half": 0.9128,
+        "n_listwise": 469,
+        "mcdonalds_omega": 0.8893,
+        "composite_reliability": 0.8893,
+        "ave": 0.5025,
+        "split_half": 0.9125,
         "kmo_bartlett": {
-          "kmo_overall": 0.9246,
-          "bartlett_chi2": 1631.11,
+          "kmo_overall": 0.9253,
+          "bartlett_chi2": 1637.05,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [4.5082, 0.6611, 0.58, 0.5365]
+          "eigenvalues_real": [4.5086, 0.6588, 0.5812, 0.5355]
         },
         "efa": {
           "construct": "Maturity",
           "n_factors": 1,
-          "variance_explained": [0.5024],
-          "total_variance": 0.5024,
+          "variance_explained": [0.5025],
+          "total_variance": 0.5025,
           "factor_correlations": null,
           "loadings": {
             "M1": [0.7657],
-            "M2": [0.7802],
-            "M3": [0.6521],
-            "M4": [0.6746],
-            "M5": [0.6547],
+            "M2": [0.7803],
+            "M3": [0.652],
+            "M4": [0.6718],
+            "M5": [0.656],
             "M6": [0.7754],
-            "M7": [0.7083],
-            "M8": [0.6423]
+            "M7": [0.7096],
+            "M8": [0.6428]
           }
         },
         "cfa": {
           "construct": "Maturity",
-          "chi2": 42.248,
+          "chi2": 40.827,
           "df": 20,
-          "chi2_p": 0.0026,
-          "cfi": 0.9863,
-          "tli": 0.9808,
-          "rmsea": 0.0489,
+          "chi2_p": 0.0039,
+          "cfi": 0.9872,
+          "tli": 0.9821,
+          "rmsea": 0.0472,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.4994,
-          "min_r": 0.4013,
-          "max_r": 0.6418,
-          "sd_r": 0.0557
+          "mean_r": 0.4995,
+          "min_r": 0.4027,
+          "max_r": 0.641,
+          "sd_r": 0.0555
         },
         "itc_min": 0.6,
         "itc_all_above_030": true
@@ -1640,25 +1640,25 @@
       "htmt": [
         {
           "pair": "Barriers vs Readiness",
-          "htmt": 0.3146,
-          "ci_lower": 0.2463,
-          "ci_upper": 0.4273,
+          "htmt": 0.3155,
+          "ci_lower": 0.2465,
+          "ci_upper": 0.4252,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "htmt": 0.3354,
-          "ci_lower": 0.2632,
-          "ci_upper": 0.4322,
+          "htmt": 0.3351,
+          "ci_lower": 0.2605,
+          "ci_upper": 0.4334,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "htmt": 0.8176,
-          "ci_lower": 0.7484,
-          "ci_upper": 0.8731,
+          "htmt": 0.8137,
+          "ci_lower": 0.7444,
+          "ci_upper": 0.8692,
           "below_085": true,
           "below_090": true
         }
@@ -1666,66 +1666,66 @@
       "fornell_larcker": [
         {
           "pair": "Barriers vs Readiness",
-          "sqrt_ave1": 0.5902,
-          "sqrt_ave2": 0.6656,
-          "abs_r": 0.2576,
+          "sqrt_ave1": 0.5895,
+          "sqrt_ave2": 0.6647,
+          "abs_r": 0.2578,
           "pass": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "sqrt_ave1": 0.5902,
-          "sqrt_ave2": 0.7088,
-          "abs_r": 0.2634,
+          "sqrt_ave1": 0.5895,
+          "sqrt_ave2": 0.7089,
+          "abs_r": 0.2636,
           "pass": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "sqrt_ave1": 0.6656,
-          "sqrt_ave2": 0.7088,
-          "abs_r": 0.725,
+          "sqrt_ave1": 0.6647,
+          "sqrt_ave2": 0.7089,
+          "abs_r": 0.7217,
           "pass": false
         }
       ],
       "construct_correlations": {
         "Barriers": {
           "Barriers": 1.0,
-          "Readiness": -0.2576,
-          "Maturity": -0.2634
+          "Readiness": -0.2578,
+          "Maturity": -0.2636
         },
         "Readiness": {
-          "Barriers": -0.2576,
+          "Barriers": -0.2578,
           "Readiness": 1.0,
-          "Maturity": 0.725
+          "Maturity": 0.7217
         },
         "Maturity": {
-          "Barriers": -0.2634,
-          "Readiness": 0.725,
+          "Barriers": -0.2636,
+          "Readiness": 0.7217,
           "Maturity": 1.0
         }
       },
       "barriers_4f_cfa": {
-        "chi2": 463.37,
+        "chi2": 461.857,
         "df": 129,
         "chi2_p": 0.0,
-        "cfi": 0.8891,
-        "tli": 0.8684,
-        "rmsea": 0.0743,
-        "aic": 82.03,
-        "bic": 256.44
+        "cfi": 0.8897,
+        "tli": 0.8692,
+        "rmsea": 0.074,
+        "aic": 82.04,
+        "bic": 256.64
       },
       "factor_analysis": {
         "efa_factors": [
           {
             "name": "F1",
             "items": 15,
-            "eigenvalue": 6.9066,
-            "variance_pct": 32.3
+            "eigenvalue": 6.8933,
+            "variance_pct": 32.2
           },
           {
             "name": "F2",
             "items": 3,
-            "eigenvalue": 1.5992,
-            "variance_pct": 10.4
+            "eigenvalue": 1.6098,
+            "variance_pct": 10.5
           }
         ],
         "three_groups": [
@@ -1733,25 +1733,25 @@
             "name": "F1a \u2014 Strategy & Culture",
             "item_ids": ["B1", "B2", "B3", "B5", "B9", "B10", "B11", "B15", "B17"],
             "items": 9,
-            "alpha": 0.8621,
-            "cr": 0.8655,
-            "ave": 0.4246
+            "alpha": 0.8608,
+            "cr": 0.8644,
+            "ave": 0.4225
           },
           {
             "name": "F1b \u2014 Resources & Operations",
             "item_ids": ["B4", "B6", "B7", "B8", "B12"],
             "items": 5,
-            "alpha": 0.7213,
-            "cr": 0.7244,
-            "ave": 0.3485
+            "alpha": 0.7216,
+            "cr": 0.7248,
+            "ave": 0.3491
           },
           {
             "name": "F2 \u2014 External & Compliance",
             "item_ids": ["B13", "B14", "B16", "B18"],
             "items": 4,
-            "alpha": 0.6476,
-            "cr": 0.7077,
-            "ave": 0.4317
+            "alpha": 0.6513,
+            "cr": 0.7107,
+            "ave": 0.4345
           }
         ],
         "factor_correlation": 0.5695,
@@ -1778,110 +1778,110 @@
         "loadings_matrix": [
           {
             "id": "B1",
-            "f1": 0.7568,
-            "f2": -0.1798,
+            "f1": 0.753,
+            "f2": -0.1775,
             "assigned": "F1"
           },
           {
             "id": "B2",
-            "f1": 0.7832,
-            "f2": -0.1311,
+            "f1": 0.7844,
+            "f2": -0.1348,
             "assigned": "F1"
           },
           {
             "id": "B3",
-            "f1": 0.6998,
-            "f2": -0.1009,
+            "f1": 0.7018,
+            "f2": -0.1029,
             "assigned": "F1"
           },
           {
             "id": "B4",
-            "f1": 0.7265,
-            "f2": -0.0773,
+            "f1": 0.7274,
+            "f2": -0.077,
             "assigned": "F1"
           },
           {
             "id": "B5",
-            "f1": 0.6817,
-            "f2": -0.0549,
+            "f1": 0.6813,
+            "f2": -0.0565,
             "assigned": "F1"
           },
           {
             "id": "B6",
-            "f1": 0.4925,
-            "f2": 0.0438,
+            "f1": 0.4891,
+            "f2": 0.0491,
             "assigned": "F1"
           },
           {
             "id": "B7",
-            "f1": 0.5553,
-            "f2": 0.0622,
+            "f1": 0.5552,
+            "f2": 0.0613,
             "assigned": "F1"
           },
           {
             "id": "B8",
-            "f1": 0.5847,
-            "f2": 0.0638,
+            "f1": 0.5874,
+            "f2": 0.0578,
             "assigned": "F1"
           },
           {
             "id": "B9",
-            "f1": 0.5751,
-            "f2": 0.0191,
+            "f1": 0.5737,
+            "f2": 0.0221,
             "assigned": "F1"
           },
           {
             "id": "B10",
-            "f1": 0.7624,
-            "f2": -0.0441,
+            "f1": 0.7614,
+            "f2": -0.0439,
             "assigned": "F1"
           },
           {
             "id": "B11",
-            "f1": 0.5525,
-            "f2": 0.1049,
+            "f1": 0.5487,
+            "f2": 0.1098,
             "assigned": "F1"
           },
           {
             "id": "B12",
-            "f1": 0.5674,
-            "f2": 0.0599,
+            "f1": 0.5689,
+            "f2": 0.058,
             "assigned": "F1"
           },
           {
             "id": "B13",
-            "f1": -0.1659,
-            "f2": 0.8872,
+            "f1": -0.166,
+            "f2": 0.8852,
             "assigned": "F2"
           },
           {
             "id": "B14",
-            "f1": -0.1206,
-            "f2": 0.8537,
+            "f1": -0.1264,
+            "f2": 0.8583,
             "assigned": "F2"
           },
           {
             "id": "B15",
-            "f1": 0.4662,
-            "f2": 0.1915,
+            "f1": 0.4582,
+            "f2": 0.2006,
             "assigned": "F1"
           },
           {
             "id": "B16",
-            "f1": 0.2201,
-            "f2": 0.4205,
+            "f1": 0.2139,
+            "f2": 0.4276,
             "assigned": "F2"
           },
           {
             "id": "B17",
-            "f1": 0.4959,
-            "f2": 0.0983,
+            "f1": 0.4932,
+            "f2": 0.102,
             "assigned": "F1"
           },
           {
             "id": "B18",
-            "f1": 0.4043,
-            "f2": 0.1847,
+            "f1": 0.4044,
+            "f2": 0.1863,
             "assigned": "F1"
           }
         ]
@@ -1931,7 +1931,7 @@
         }
       },
       "metadata": {
-        "n_total": 500,
+        "n_total": 502,
         "crp200_mode": false,
         "constructs": ["Barriers", "Readiness", "Maturity"],
         "n_barriers": 18,
@@ -1943,133 +1943,133 @@
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 589,
+      "n": 591,
       "n_to_param_ratio": 12.8,
       "adequacy": "good",
       "adequacy_note": "N:parameter ratio 12.8:1 meets the recommended 10:1 threshold for stable CFA estimation.",
       "Barriers": {
-        "cronbach_alpha": 0.9039,
-        "cronbach_alpha_ci": [0.8909, 0.916],
-        "n_listwise": 476,
-        "mcdonalds_omega": 0.9043,
-        "composite_reliability": 0.9043,
-        "ave": 0.3494,
-        "split_half": 0.9211,
+        "cronbach_alpha": 0.9036,
+        "cronbach_alpha_ci": [0.8906, 0.9158],
+        "n_listwise": 478,
+        "mcdonalds_omega": 0.904,
+        "composite_reliability": 0.904,
+        "ave": 0.3486,
+        "split_half": 0.921,
         "kmo_bartlett": {
-          "kmo_overall": 0.9305,
-          "bartlett_chi2": 3167.94,
+          "kmo_overall": 0.9308,
+          "bartlett_chi2": 3172.03,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 2,
-          "eigenvalues_real": [6.9259, 1.6036, 0.9638, 0.9106]
+          "eigenvalues_real": [6.9126, 1.6138, 0.9617, 0.9084]
         },
         "efa": {
           "construct": "Barriers",
           "n_factors": 2,
-          "variance_explained": [0.3234, 0.1047],
-          "total_variance": 0.4282,
+          "variance_explained": [0.3225, 0.1056],
+          "total_variance": 0.4281,
           "factor_correlations": [
             [1.0, 0.5727],
             [0.5727, 1.0]
           ],
           "loadings": {
-            "B1": [0.7502, -0.1839],
-            "B2": [0.7842, -0.1368],
-            "B3": [0.6992, -0.0925],
-            "B4": [0.7334, -0.0802],
-            "B5": [0.6882, -0.0617],
-            "B6": [0.4983, 0.0399],
-            "B7": [0.552, 0.0723],
-            "B8": [0.5817, 0.074],
-            "B9": [0.5721, 0.0182],
-            "B10": [0.7693, -0.056],
-            "B11": [0.5469, 0.1176],
-            "B12": [0.56, 0.0711],
-            "B13": [-0.1716, 0.8864],
-            "B14": [-0.1212, 0.8553],
-            "B15": [0.4704, 0.192],
-            "B16": [0.2172, 0.4226],
-            "B17": [0.4971, 0.1043],
-            "B18": [0.4012, 0.1886]
+            "B1": [0.7464, -0.1816],
+            "B2": [0.7854, -0.1406],
+            "B3": [0.7011, -0.0946],
+            "B4": [0.7342, -0.0799],
+            "B5": [0.6878, -0.0631],
+            "B6": [0.4948, 0.0452],
+            "B7": [0.5519, 0.0714],
+            "B8": [0.5845, 0.0679],
+            "B9": [0.5707, 0.0211],
+            "B10": [0.7681, -0.0556],
+            "B11": [0.5431, 0.1224],
+            "B12": [0.5615, 0.0691],
+            "B13": [-0.1717, 0.8846],
+            "B14": [-0.1269, 0.8598],
+            "B15": [0.4625, 0.201],
+            "B16": [0.2111, 0.4295],
+            "B17": [0.4944, 0.1079],
+            "B18": [0.4012, 0.1901]
           }
         },
         "cfa": {
           "construct": "Barriers",
-          "chi2": 595.607,
+          "chi2": 597.934,
           "df": 135,
           "chi2_p": 0.0,
-          "cfi": 0.8499,
-          "tli": 0.8298,
+          "cfi": 0.8493,
+          "tli": 0.8292,
           "rmsea": 0.0848,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.3437,
-          "min_r": 0.1199,
-          "max_r": 0.6483,
+          "mean_r": 0.343,
+          "min_r": 0.1189,
+          "max_r": 0.6488,
           "sd_r": 0.091
         },
         "itc_min": 0.4,
         "itc_all_above_030": true
       },
       "Readiness": {
-        "cronbach_alpha": 0.9301,
-        "cronbach_alpha_ci": [0.9203, 0.9392],
-        "n_listwise": 449,
-        "mcdonalds_omega": 0.9308,
-        "composite_reliability": 0.9308,
-        "ave": 0.443,
+        "cronbach_alpha": 0.9298,
+        "cronbach_alpha_ci": [0.92, 0.9389],
+        "n_listwise": 451,
+        "mcdonalds_omega": 0.9305,
+        "composite_reliability": 0.9305,
+        "ave": 0.4418,
         "split_half": 0.9356,
         "kmo_bartlett": {
-          "kmo_overall": 0.961,
-          "bartlett_chi2": 3516.55,
+          "kmo_overall": 0.9605,
+          "bartlett_chi2": 3521.39,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [8.0803, 0.9645, 0.777, 0.768]
+          "eigenvalues_real": [8.0619, 0.967, 0.7798, 0.766]
         },
         "efa": {
           "construct": "Readiness",
           "n_factors": 1,
-          "variance_explained": [0.443],
-          "total_variance": 0.443,
+          "variance_explained": [0.4418],
+          "total_variance": 0.4418,
           "factor_correlations": null,
           "loadings": {
-            "R1": [0.7231],
-            "R2": [0.6718],
-            "R3": [0.7037],
+            "R1": [0.7234],
+            "R2": [0.6723],
+            "R3": [0.7027],
             "R4": [0.5868],
-            "R5": [0.5987],
-            "R6": [0.6921],
-            "R7": [0.7094],
-            "R8": [0.6831],
-            "R9": [0.6634],
-            "R10": [0.6678],
-            "R11": [0.6728],
-            "R12": [0.6433],
-            "R13": [0.6888],
+            "R5": [0.5969],
+            "R6": [0.6917],
+            "R7": [0.7087],
+            "R8": [0.6788],
+            "R9": [0.6639],
+            "R10": [0.6646],
+            "R11": [0.6724],
+            "R12": [0.644],
+            "R13": [0.6868],
             "R14": [0.627],
-            "R15": [0.6691],
-            "R16": [0.7314],
-            "R17": [0.5536]
+            "R15": [0.6688],
+            "R16": [0.7295],
+            "R17": [0.5532]
           }
         },
         "cfa": {
           "construct": "Readiness",
-          "chi2": 277.806,
+          "chi2": 282.248,
           "df": 119,
           "chi2_p": 0.0,
-          "cfi": 0.9538,
-          "tli": 0.9472,
-          "rmsea": 0.0546,
+          "cfi": 0.9526,
+          "tli": 0.9458,
+          "rmsea": 0.0552,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.4407,
-          "min_r": 0.2719,
-          "max_r": 0.5834,
+          "mean_r": 0.4396,
+          "min_r": 0.2697,
+          "max_r": 0.5858,
           "sd_r": 0.0574
         },
         "itc_min": 0.53,
@@ -2078,52 +2078,52 @@
       "Maturity": {
         "cronbach_alpha": 0.8887,
         "cronbach_alpha_ci": [0.8728, 0.9033],
-        "n_listwise": 467,
-        "mcdonalds_omega": 0.8892,
-        "composite_reliability": 0.8892,
-        "ave": 0.5024,
-        "split_half": 0.9128,
+        "n_listwise": 469,
+        "mcdonalds_omega": 0.8893,
+        "composite_reliability": 0.8893,
+        "ave": 0.5025,
+        "split_half": 0.9125,
         "kmo_bartlett": {
-          "kmo_overall": 0.9246,
-          "bartlett_chi2": 1631.11,
+          "kmo_overall": 0.9253,
+          "bartlett_chi2": 1637.05,
           "bartlett_p": 0.0
         },
         "parallel_analysis": {
           "n_factors": 1,
-          "eigenvalues_real": [4.5082, 0.6611, 0.58, 0.5365]
+          "eigenvalues_real": [4.5086, 0.6588, 0.5812, 0.5355]
         },
         "efa": {
           "construct": "Maturity",
           "n_factors": 1,
-          "variance_explained": [0.5024],
-          "total_variance": 0.5024,
+          "variance_explained": [0.5025],
+          "total_variance": 0.5025,
           "factor_correlations": null,
           "loadings": {
             "M1": [0.7657],
-            "M2": [0.7802],
-            "M3": [0.6521],
-            "M4": [0.6746],
-            "M5": [0.6547],
+            "M2": [0.7803],
+            "M3": [0.652],
+            "M4": [0.6718],
+            "M5": [0.656],
             "M6": [0.7754],
-            "M7": [0.7083],
-            "M8": [0.6423]
+            "M7": [0.7096],
+            "M8": [0.6428]
           }
         },
         "cfa": {
           "construct": "Maturity",
-          "chi2": 42.248,
+          "chi2": 40.827,
           "df": 20,
-          "chi2_p": 0.0026,
-          "cfi": 0.9863,
-          "tli": 0.9808,
-          "rmsea": 0.0489,
+          "chi2_p": 0.0039,
+          "cfi": 0.9872,
+          "tli": 0.9821,
+          "rmsea": 0.0472,
           "srmr": null
         },
         "inter_item": {
-          "mean_r": 0.4994,
-          "min_r": 0.4013,
-          "max_r": 0.6418,
-          "sd_r": 0.0557
+          "mean_r": 0.4995,
+          "min_r": 0.4027,
+          "max_r": 0.641,
+          "sd_r": 0.0555
         },
         "itc_min": 0.6,
         "itc_all_above_030": true
@@ -2131,25 +2131,25 @@
       "htmt": [
         {
           "pair": "Barriers vs Readiness",
-          "htmt": 0.3146,
-          "ci_lower": 0.2463,
-          "ci_upper": 0.4273,
+          "htmt": 0.3155,
+          "ci_lower": 0.2465,
+          "ci_upper": 0.4252,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "htmt": 0.3354,
-          "ci_lower": 0.2632,
-          "ci_upper": 0.4322,
+          "htmt": 0.3351,
+          "ci_lower": 0.2605,
+          "ci_upper": 0.4334,
           "below_085": true,
           "below_090": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "htmt": 0.8176,
-          "ci_lower": 0.7484,
-          "ci_upper": 0.8731,
+          "htmt": 0.8137,
+          "ci_lower": 0.7444,
+          "ci_upper": 0.8692,
           "below_085": true,
           "below_090": true
         }
@@ -2157,66 +2157,66 @@
       "fornell_larcker": [
         {
           "pair": "Barriers vs Readiness",
-          "sqrt_ave1": 0.5911,
-          "sqrt_ave2": 0.6656,
-          "abs_r": 0.2573,
+          "sqrt_ave1": 0.5904,
+          "sqrt_ave2": 0.6647,
+          "abs_r": 0.2575,
           "pass": true
         },
         {
           "pair": "Barriers vs Maturity",
-          "sqrt_ave1": 0.5911,
-          "sqrt_ave2": 0.7088,
-          "abs_r": 0.2634,
+          "sqrt_ave1": 0.5904,
+          "sqrt_ave2": 0.7089,
+          "abs_r": 0.2636,
           "pass": true
         },
         {
           "pair": "Readiness vs Maturity",
-          "sqrt_ave1": 0.6656,
-          "sqrt_ave2": 0.7088,
-          "abs_r": 0.725,
+          "sqrt_ave1": 0.6647,
+          "sqrt_ave2": 0.7089,
+          "abs_r": 0.7217,
           "pass": false
         }
       ],
       "construct_correlations": {
         "Barriers": {
           "Barriers": 1.0,
-          "Readiness": -0.2573,
-          "Maturity": -0.2634
+          "Readiness": -0.2575,
+          "Maturity": -0.2636
         },
         "Readiness": {
-          "Barriers": -0.2573,
+          "Barriers": -0.2575,
           "Readiness": 1.0,
-          "Maturity": 0.725
+          "Maturity": 0.7217
         },
         "Maturity": {
-          "Barriers": -0.2634,
-          "Readiness": 0.725,
+          "Barriers": -0.2636,
+          "Readiness": 0.7217,
           "Maturity": 1.0
         }
       },
       "barriers_4f_cfa": {
-        "chi2": 474.49,
+        "chi2": 472.66,
         "df": 129,
         "chi2_p": 0.0,
-        "cfi": 0.8874,
-        "tli": 0.8664,
-        "rmsea": 0.0751,
-        "aic": 82.01,
-        "bic": 256.95
+        "cfi": 0.8881,
+        "tli": 0.8673,
+        "rmsea": 0.0747,
+        "aic": 82.02,
+        "bic": 257.15
       },
       "factor_analysis": {
         "efa_factors": [
           {
             "name": "F1",
             "items": 15,
-            "eigenvalue": 6.9259,
-            "variance_pct": 32.3
+            "eigenvalue": 6.9126,
+            "variance_pct": 32.2
           },
           {
             "name": "F2",
             "items": 3,
-            "eigenvalue": 1.6036,
-            "variance_pct": 10.5
+            "eigenvalue": 1.6138,
+            "variance_pct": 10.6
           }
         ],
         "three_groups": [
@@ -2224,25 +2224,25 @@
             "name": "F1a \u2014 Strategy & Culture",
             "item_ids": ["B1", "B2", "B3", "B5", "B9", "B10", "B11", "B15", "B17"],
             "items": 9,
-            "alpha": 0.8624,
-            "cr": 0.8658,
-            "ave": 0.4252
+            "alpha": 0.8611,
+            "cr": 0.8647,
+            "ave": 0.4231
           },
           {
             "name": "F1b \u2014 Resources & Operations",
             "item_ids": ["B4", "B6", "B7", "B8", "B12"],
             "items": 5,
-            "alpha": 0.721,
-            "cr": 0.7243,
-            "ave": 0.3486
+            "alpha": 0.7213,
+            "cr": 0.7247,
+            "ave": 0.3491
           },
           {
             "name": "F2 \u2014 External & Compliance",
             "item_ids": ["B13", "B14", "B16", "B18"],
             "items": 4,
-            "alpha": 0.65,
-            "cr": 0.7093,
-            "ave": 0.4329
+            "alpha": 0.6536,
+            "cr": 0.7123,
+            "ave": 0.4356
           }
         ],
         "factor_correlation": 0.5727,
@@ -2269,110 +2269,110 @@
         "loadings_matrix": [
           {
             "id": "B1",
-            "f1": 0.7502,
-            "f2": -0.1839,
+            "f1": 0.7464,
+            "f2": -0.1816,
             "assigned": "F1"
           },
           {
             "id": "B2",
-            "f1": 0.7842,
-            "f2": -0.1368,
+            "f1": 0.7854,
+            "f2": -0.1406,
             "assigned": "F1"
           },
           {
             "id": "B3",
-            "f1": 0.6992,
-            "f2": -0.0925,
+            "f1": 0.7011,
+            "f2": -0.0946,
             "assigned": "F1"
           },
           {
             "id": "B4",
-            "f1": 0.7334,
-            "f2": -0.0802,
+            "f1": 0.7342,
+            "f2": -0.0799,
             "assigned": "F1"
           },
           {
             "id": "B5",
-            "f1": 0.6882,
-            "f2": -0.0617,
+            "f1": 0.6878,
+            "f2": -0.0631,
             "assigned": "F1"
           },
           {
             "id": "B6",
-            "f1": 0.4983,
-            "f2": 0.0399,
+            "f1": 0.4948,
+            "f2": 0.0452,
             "assigned": "F1"
           },
           {
             "id": "B7",
-            "f1": 0.552,
-            "f2": 0.0723,
+            "f1": 0.5519,
+            "f2": 0.0714,
             "assigned": "F1"
           },
           {
             "id": "B8",
-            "f1": 0.5817,
-            "f2": 0.074,
+            "f1": 0.5845,
+            "f2": 0.0679,
             "assigned": "F1"
           },
           {
             "id": "B9",
-            "f1": 0.5721,
-            "f2": 0.0182,
+            "f1": 0.5707,
+            "f2": 0.0211,
             "assigned": "F1"
           },
           {
             "id": "B10",
-            "f1": 0.7693,
-            "f2": -0.056,
+            "f1": 0.7681,
+            "f2": -0.0556,
             "assigned": "F1"
           },
           {
             "id": "B11",
-            "f1": 0.5469,
-            "f2": 0.1176,
+            "f1": 0.5431,
+            "f2": 0.1224,
             "assigned": "F1"
           },
           {
             "id": "B12",
-            "f1": 0.56,
-            "f2": 0.0711,
+            "f1": 0.5615,
+            "f2": 0.0691,
             "assigned": "F1"
           },
           {
             "id": "B13",
-            "f1": -0.1716,
-            "f2": 0.8864,
+            "f1": -0.1717,
+            "f2": 0.8846,
             "assigned": "F2"
           },
           {
             "id": "B14",
-            "f1": -0.1212,
-            "f2": 0.8553,
+            "f1": -0.1269,
+            "f2": 0.8598,
             "assigned": "F2"
           },
           {
             "id": "B15",
-            "f1": 0.4704,
-            "f2": 0.192,
+            "f1": 0.4625,
+            "f2": 0.201,
             "assigned": "F1"
           },
           {
             "id": "B16",
-            "f1": 0.2172,
-            "f2": 0.4226,
+            "f1": 0.2111,
+            "f2": 0.4295,
             "assigned": "F2"
           },
           {
             "id": "B17",
-            "f1": 0.4971,
-            "f2": 0.1043,
+            "f1": 0.4944,
+            "f2": 0.1079,
             "assigned": "F1"
           },
           {
             "id": "B18",
             "f1": 0.4012,
-            "f2": 0.1886,
+            "f2": 0.1901,
             "assigned": "F1"
           }
         ]
@@ -2422,7 +2422,7 @@
         }
       },
       "metadata": {
-        "n_total": 589,
+        "n_total": 591,
         "crp200_mode": false,
         "constructs": ["Barriers", "Readiness", "Maturity"],
         "n_barriers": 18,

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -22,13 +22,13 @@
       "key": "v2_finished",
       "label": "All V2 Finished",
       "description": "Finished + duration >= 120s (extreme speeders excluded)",
-      "n": 500
+      "n": 502
     },
     {
       "key": "v2_all",
       "label": "All V2",
       "description": "All V2 responses including incomplete",
-      "n": 589
+      "n": 591
     }
   ],
   "metrics": [
@@ -39,8 +39,8 @@
         "conservative_clean": 2.8546,
         "flexible_clean": 2.8423,
         "prolific_accepted": 2.8326,
-        "v2_finished": 2.8233,
-        "v2_all": 2.8261
+        "v2_finished": 2.8242,
+        "v2_all": 2.8269
       }
     },
     {
@@ -50,8 +50,8 @@
         "conservative_clean": 0.6257,
         "flexible_clean": 0.6949,
         "prolific_accepted": 0.6985,
-        "v2_finished": 0.7737,
-        "v2_all": 0.7753
+        "v2_finished": 0.7727,
+        "v2_all": 0.7743
       }
     },
     {
@@ -61,8 +61,8 @@
         "conservative_clean": 3.0428,
         "flexible_clean": 3.0884,
         "prolific_accepted": 3.1163,
-        "v2_finished": 3.226,
-        "v2_all": 3.2261
+        "v2_finished": 3.2272,
+        "v2_all": 3.2274
       }
     },
     {
@@ -72,8 +72,8 @@
         "conservative_clean": 0.5582,
         "flexible_clean": 0.6407,
         "prolific_accepted": 0.6649,
-        "v2_finished": 0.7161,
-        "v2_all": 0.7147
+        "v2_finished": 0.7153,
+        "v2_all": 0.7139
       }
     },
     {
@@ -83,8 +83,8 @@
         "conservative_clean": 3.0518,
         "flexible_clean": 3.0698,
         "prolific_accepted": 3.1457,
-        "v2_finished": 3.2505,
-        "v2_all": 3.2506
+        "v2_finished": 3.2477,
+        "v2_all": 3.2479
       }
     },
     {
@@ -94,8 +94,8 @@
         "conservative_clean": 0.6975,
         "flexible_clean": 0.784,
         "prolific_accepted": 0.7933,
-        "v2_finished": 0.8012,
-        "v2_all": 0.8004
+        "v2_finished": 0.8008,
+        "v2_all": 0.8
       }
     },
     {
@@ -105,8 +105,8 @@
         "conservative_clean": -0.3614,
         "flexible_clean": -0.3924,
         "prolific_accepted": -0.3144,
-        "v2_finished": -0.2576,
-        "v2_all": -0.2573
+        "v2_finished": -0.2578,
+        "v2_all": -0.2575
       }
     },
     {
@@ -116,8 +116,8 @@
         "conservative_clean": -0.0964,
         "flexible_clean": -0.248,
         "prolific_accepted": -0.2386,
-        "v2_finished": -0.2634,
-        "v2_all": -0.2634
+        "v2_finished": -0.2636,
+        "v2_all": -0.2636
       }
     },
     {
@@ -127,8 +127,8 @@
         "conservative_clean": 0.5697,
         "flexible_clean": 0.6944,
         "prolific_accepted": 0.7216,
-        "v2_finished": 0.725,
-        "v2_all": 0.725
+        "v2_finished": 0.7217,
+        "v2_all": 0.7217
       }
     },
     {
@@ -138,8 +138,8 @@
         "conservative_clean": 0.8521,
         "flexible_clean": 0.8722,
         "prolific_accepted": 0.8737,
-        "v2_finished": 0.9034,
-        "v2_all": 0.9039
+        "v2_finished": 0.9032,
+        "v2_all": 0.9036
       }
     },
     {
@@ -149,8 +149,8 @@
         "conservative_clean": 0.8561,
         "flexible_clean": 0.9085,
         "prolific_accepted": 0.9145,
-        "v2_finished": 0.9301,
-        "v2_all": 0.9301
+        "v2_finished": 0.9298,
+        "v2_all": 0.9298
       }
     },
     {
@@ -1101,18 +1101,18 @@
         "roles": {
           "Other": 100,
           "CIO": 69,
-          "CEO": 57,
+          "CEO": 58,
           "COO": 53,
           "CTO": 44,
           "CSO": 43,
           "CFO": 38,
           "CMO": 33,
-          "CRO": 31,
+          "CRO": 32,
           "CHRO": 26,
           "CISO": 6
         },
         "org_sizes": {
-          "<100": 72,
+          "<100": 74,
           "100-499": 152,
           "500-999": 72,
           "1000-4999": 92,
@@ -1120,13 +1120,13 @@
           "10000+": 69
         },
         "profit_models": {
-          "For-Profit": 367,
+          "For-Profit": 369,
           "Non-Profit": 86,
           "Government/Public Sector": 47
         },
         "tech_vs_nontech": {
           "technical": 125,
-          "non_technical": 375,
+          "non_technical": 377,
           "other": 0
         },
         "other_roles": {
@@ -1137,68 +1137,68 @@
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 125,
-          "nontech_n": 375,
+          "nontech_n": 377,
           "constructs": {
             "barriers": {
               "tech_mean": 2.7395,
               "tech_mean_ci_lower": 2.5991,
               "tech_mean_ci_upper": 2.8799,
-              "nontech_mean": 2.8513,
-              "nontech_mean_ci_lower": 2.7735,
-              "nontech_mean_ci_upper": 2.9291,
-              "d": -0.1445,
-              "d_ci_lower": -0.3518,
-              "d_ci_upper": 0.0544
+              "nontech_mean": 2.8522,
+              "nontech_mean_ci_lower": 2.7748,
+              "nontech_mean_ci_upper": 2.9297,
+              "d": -0.1459,
+              "d_ci_lower": -0.3537,
+              "d_ci_upper": 0.0564
             },
             "readiness": {
               "tech_mean": 3.5041,
               "tech_mean_ci_lower": 3.3845,
               "tech_mean_ci_upper": 3.6236,
-              "nontech_mean": 3.1331,
-              "nontech_mean_ci_lower": 3.0613,
-              "nontech_mean_ci_upper": 3.2048,
-              "d": 0.5311,
-              "d_ci_lower": 0.3303,
-              "d_ci_upper": 0.7222
+              "nontech_mean": 3.1352,
+              "nontech_mean_ci_lower": 3.0637,
+              "nontech_mean_ci_upper": 3.2067,
+              "d": 0.5286,
+              "d_ci_lower": 0.3305,
+              "d_ci_upper": 0.722
             },
             "maturity": {
               "tech_mean": 3.477,
               "tech_mean_ci_lower": 3.3437,
               "tech_mean_ci_upper": 3.6103,
-              "nontech_mean": 3.1745,
-              "nontech_mean_ci_lower": 3.0927,
-              "nontech_mean_ci_upper": 3.2563,
-              "d": 0.3823,
-              "d_ci_lower": 0.1817,
-              "d_ci_upper": 0.5773
+              "nontech_mean": 3.1713,
+              "nontech_mean_ci_lower": 3.0898,
+              "nontech_mean_ci_upper": 3.2528,
+              "d": 0.3867,
+              "d_ci_lower": 0.1897,
+              "d_ci_upper": 0.5805
             }
           }
         },
         "large_vs_small": {
           "large_n": 112,
-          "small_medium_n": 388,
+          "small_medium_n": 390,
           "constructs": {
             "barriers": {
               "large_mean": 2.8992,
               "large_mean_ci_lower": 2.7571,
               "large_mean_ci_upper": 3.0413,
-              "small_medium_mean": 2.8014,
-              "small_medium_mean_ci_lower": 2.7238,
-              "small_medium_mean_ci_upper": 2.879,
-              "d": 0.1264,
-              "d_ci_lower": -0.076,
-              "d_ci_upper": 0.3486
+              "small_medium_mean": 2.8026,
+              "small_medium_mean_ci_lower": 2.7253,
+              "small_medium_mean_ci_upper": 2.8799,
+              "d": 0.1251,
+              "d_ci_lower": -0.0814,
+              "d_ci_upper": 0.3363
             },
             "readiness": {
               "large_mean": 3.2531,
               "large_mean_ci_lower": 3.1187,
               "large_mean_ci_upper": 3.3874,
-              "small_medium_mean": 3.2182,
-              "small_medium_mean_ci_lower": 3.1466,
-              "small_medium_mean_ci_upper": 3.2898,
-              "d": 0.0487,
-              "d_ci_lower": -0.1679,
-              "d_ci_upper": 0.2592
+              "small_medium_mean": 3.2198,
+              "small_medium_mean_ci_lower": 3.1484,
+              "small_medium_mean_ci_upper": 3.2911,
+              "d": 0.0465,
+              "d_ci_lower": -0.1492,
+              "d_ci_upper": 0.2727
             }
           }
         }
@@ -1214,19 +1214,19 @@
           },
           {
             "group": "Non-Technical",
-            "n": 375,
-            "barrier_mean": 2.8513,
-            "readiness_mean": 3.1331,
-            "maturity_mean": 3.1745
+            "n": 377,
+            "barrier_mean": 2.8522,
+            "readiness_mean": 3.1352,
+            "maturity_mean": 3.1713
           }
         ],
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 224,
-            "barrier_mean": 2.7854,
-            "readiness_mean": 3.1301,
-            "maturity_mean": 3.1302
+            "n": 226,
+            "barrier_mean": 2.7876,
+            "readiness_mean": 3.1336,
+            "maturity_mean": 3.1252
           },
           {
             "group": "Medium (500-4999)",
@@ -1247,114 +1247,114 @@
       "inferential": {
         "t_tests_tech_vs_nontech": {
           "tech_n": 125,
-          "nontech_n": 375,
+          "nontech_n": 377,
           "constructs": {
             "barriers": {
-              "t": -1.3755,
-              "p": 0.1705,
-              "df": 206.52,
-              "mean_diff_ci_lower": -0.2719,
-              "mean_diff_ci_upper": 0.0484,
+              "t": -1.3885,
+              "p": 0.1665,
+              "df": 205.81,
+              "mean_diff_ci_lower": -0.2726,
+              "mean_diff_ci_upper": 0.0473,
               "sig": false
             },
             "readiness": {
-              "t": 5.2555,
+              "t": 5.231,
               "p": 0.0,
-              "df": 221.24,
-              "mean_diff_ci_lower": 0.2319,
-              "mean_diff_ci_upper": 0.5101,
+              "df": 220.53,
+              "mean_diff_ci_lower": 0.2299,
+              "mean_diff_ci_upper": 0.5079,
               "sig": true
             },
             "maturity": {
-              "t": 3.8205,
-              "p": 0.0002,
-              "df": 225.7,
-              "mean_diff_ci_lower": 0.1465,
-              "mean_diff_ci_upper": 0.4585,
+              "t": 3.8658,
+              "p": 0.0001,
+              "df": 224.97,
+              "mean_diff_ci_lower": 0.1499,
+              "mean_diff_ci_upper": 0.4616,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 112,
-          "small_medium_n": 388,
+          "small_medium_n": 390,
           "constructs": {
             "barriers": {
-              "t": 1.1946,
-              "p": 0.2338,
-              "df": 183.61,
-              "mean_diff_ci_lower": -0.0637,
-              "mean_diff_ci_upper": 0.2593,
+              "t": 1.1816,
+              "p": 0.2389,
+              "df": 183.0,
+              "mean_diff_ci_lower": -0.0647,
+              "mean_diff_ci_upper": 0.258,
               "sig": false
             },
             "readiness": {
-              "t": 0.4536,
-              "p": 0.6507,
-              "df": 179.97,
-              "mean_diff_ci_lower": -0.117,
-              "mean_diff_ci_upper": 0.1868,
+              "t": 0.4332,
+              "p": 0.6654,
+              "df": 179.41,
+              "mean_diff_ci_lower": -0.1184,
+              "mean_diff_ci_upper": 0.1851,
               "sig": false
             },
             "maturity": {
-              "t": 1.2197,
-              "p": 0.2242,
-              "df": 175.82,
-              "mean_diff_ci_lower": -0.066,
-              "mean_diff_ci_upper": 0.2794,
+              "t": 1.2597,
+              "p": 0.2095,
+              "df": 175.38,
+              "mean_diff_ci_lower": -0.0624,
+              "mean_diff_ci_upper": 0.2827,
               "sig": false
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical"],
-          "group_ns": [125, 375],
+          "group_ns": [125, 377],
           "constructs": {
             "barriers": {
-              "f": 1.9588,
-              "p": 0.1623,
+              "f": 1.9996,
+              "p": 0.158,
               "df_between": 1,
-              "df_within": 498,
+              "df_within": 500,
               "sig": false
             },
             "readiness": {
-              "f": 26.4308,
+              "f": 26.2107,
               "p": 0.0,
               "df_between": 1,
-              "df_within": 497,
+              "df_within": 499,
               "sig": true
             },
             "maturity": {
-              "f": 13.6834,
+              "f": 14.0215,
               "p": 0.0002,
               "df_between": 1,
-              "df_within": 496,
+              "df_within": 498,
               "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [224, 164, 112],
+          "group_ns": [226, 164, 112],
           "constructs": {
             "barriers": {
-              "f": 0.807,
-              "p": 0.4468,
+              "f": 0.7812,
+              "p": 0.4584,
               "df_between": 2,
-              "df_within": 497,
+              "df_within": 499,
               "sig": false
             },
             "readiness": {
-              "f": 4.1771,
-              "p": 0.0159,
+              "f": 4.0533,
+              "p": 0.0179,
               "df_between": 2,
-              "df_within": 496,
+              "df_within": 498,
               "sig": true
             },
             "maturity": {
-              "f": 4.6475,
-              "p": 0.01,
+              "f": 4.8974,
+              "p": 0.0078,
               "df_between": 2,
-              "df_within": 495,
+              "df_within": 497,
               "sig": true
             }
           }
@@ -1367,18 +1367,18 @@
           "Other": 104,
           "Unknown": 75,
           "CIO": 71,
-          "CEO": 57,
+          "CEO": 58,
           "COO": 55,
           "CSO": 45,
           "CTO": 44,
           "CFO": 39,
           "CMO": 33,
-          "CRO": 32,
+          "CRO": 33,
           "CHRO": 28,
           "CISO": 6
         },
         "org_sizes": {
-          "<100": 74,
+          "<100": 76,
           "100-499": 158,
           "500-999": 75,
           "1000-4999": 93,
@@ -1386,13 +1386,13 @@
           "10000+": 70
         },
         "profit_models": {
-          "For-Profit": 378,
+          "For-Profit": 380,
           "Non-Profit": 89,
           "Government/Public Sector": 47
         },
         "tech_vs_nontech": {
           "technical": 127,
-          "non_technical": 387,
+          "non_technical": 389,
           "other": 75
         },
         "other_roles": {
@@ -1403,68 +1403,68 @@
       "effect_sizes": {
         "tech_vs_nontech": {
           "tech_n": 127,
-          "nontech_n": 387,
+          "nontech_n": 389,
           "constructs": {
             "barriers": {
               "tech_mean": 2.7429,
               "tech_mean_ci_lower": 2.6035,
               "tech_mean_ci_upper": 2.8824,
-              "nontech_mean": 2.8537,
-              "nontech_mean_ci_lower": 2.7761,
-              "nontech_mean_ci_upper": 2.9312,
-              "d": -0.143,
-              "d_ci_lower": -0.3463,
-              "d_ci_upper": 0.0641
+              "nontech_mean": 2.8546,
+              "nontech_mean_ci_lower": 2.7773,
+              "nontech_mean_ci_upper": 2.9318,
+              "d": -0.1443,
+              "d_ci_lower": -0.3464,
+              "d_ci_upper": 0.0555
             },
             "readiness": {
               "tech_mean": 3.5041,
               "tech_mean_ci_lower": 3.3845,
               "tech_mean_ci_upper": 3.6236,
-              "nontech_mean": 3.1338,
-              "nontech_mean_ci_lower": 3.0624,
-              "nontech_mean_ci_upper": 3.2052,
-              "d": 0.5312,
-              "d_ci_lower": 0.3284,
-              "d_ci_upper": 0.7272
+              "nontech_mean": 3.1359,
+              "nontech_mean_ci_lower": 3.0647,
+              "nontech_mean_ci_upper": 3.207,
+              "d": 0.5286,
+              "d_ci_lower": 0.3261,
+              "d_ci_upper": 0.7341
             },
             "maturity": {
               "tech_mean": 3.477,
               "tech_mean_ci_lower": 3.3437,
               "tech_mean_ci_upper": 3.6103,
-              "nontech_mean": 3.175,
-              "nontech_mean_ci_lower": 3.0934,
-              "nontech_mean_ci_upper": 3.2565,
-              "d": 0.3821,
-              "d_ci_lower": 0.1928,
-              "d_ci_upper": 0.574
+              "nontech_mean": 3.1717,
+              "nontech_mean_ci_lower": 3.0904,
+              "nontech_mean_ci_upper": 3.253,
+              "d": 0.3866,
+              "d_ci_lower": 0.1876,
+              "d_ci_upper": 0.5783
             }
           }
         },
         "large_vs_small": {
           "large_n": 114,
-          "small_medium_n": 475,
+          "small_medium_n": 477,
           "constructs": {
             "barriers": {
               "large_mean": 2.9065,
               "large_mean_ci_lower": 2.7649,
               "large_mean_ci_upper": 3.0481,
-              "small_medium_mean": 2.803,
-              "small_medium_mean_ci_lower": 2.7257,
-              "small_medium_mean_ci_upper": 2.8802,
-              "d": 0.1336,
-              "d_ci_lower": -0.0794,
-              "d_ci_upper": 0.3429
+              "small_medium_mean": 2.8041,
+              "small_medium_mean_ci_lower": 2.7272,
+              "small_medium_mean_ci_upper": 2.8811,
+              "d": 0.1323,
+              "d_ci_lower": -0.065,
+              "d_ci_upper": 0.3363
             },
             "readiness": {
               "large_mean": 3.2531,
               "large_mean_ci_lower": 3.1187,
               "large_mean_ci_upper": 3.3874,
-              "small_medium_mean": 3.2184,
-              "small_medium_mean_ci_lower": 3.1472,
-              "small_medium_mean_ci_upper": 3.2896,
-              "d": 0.0485,
-              "d_ci_lower": -0.1482,
-              "d_ci_upper": 0.2694
+              "small_medium_mean": 3.22,
+              "small_medium_mean_ci_lower": 3.149,
+              "small_medium_mean_ci_upper": 3.2909,
+              "d": 0.0463,
+              "d_ci_lower": -0.1763,
+              "d_ci_upper": 0.2536
             }
           }
         }
@@ -1480,10 +1480,10 @@
           },
           {
             "group": "Non-Technical",
-            "n": 387,
-            "barrier_mean": 2.8537,
-            "readiness_mean": 3.1338,
-            "maturity_mean": 3.175
+            "n": 389,
+            "barrier_mean": 2.8546,
+            "readiness_mean": 3.1359,
+            "maturity_mean": 3.1717
           },
           {
             "group": "Unclassified",
@@ -1496,10 +1496,10 @@
         "by_org_size": [
           {
             "group": "Small (<500)",
-            "n": 232,
-            "barrier_mean": 2.7959,
-            "readiness_mean": 3.1307,
-            "maturity_mean": 3.1302
+            "n": 234,
+            "barrier_mean": 2.7979,
+            "readiness_mean": 3.1342,
+            "maturity_mean": 3.1252
           },
           {
             "group": "Medium (500-4999)",
@@ -1520,114 +1520,114 @@
       "inferential": {
         "t_tests_tech_vs_nontech": {
           "tech_n": 127,
-          "nontech_n": 387,
+          "nontech_n": 389,
           "constructs": {
             "barriers": {
-              "t": -1.3713,
-              "p": 0.1717,
-              "df": 208.93,
-              "mean_diff_ci_lower": -0.2699,
-              "mean_diff_ci_upper": 0.0485,
+              "t": -1.384,
+              "p": 0.1678,
+              "df": 208.21,
+              "mean_diff_ci_lower": -0.2707,
+              "mean_diff_ci_upper": 0.0474,
               "sig": false
             },
             "readiness": {
-              "t": 5.2527,
+              "t": 5.2283,
               "p": 0.0,
-              "df": 220.25,
-              "mean_diff_ci_lower": 0.2314,
-              "mean_diff_ci_upper": 0.5092,
+              "df": 219.55,
+              "mean_diff_ci_lower": 0.2294,
+              "mean_diff_ci_upper": 0.507,
               "sig": true
             },
             "maturity": {
-              "t": 3.8179,
-              "p": 0.0002,
-              "df": 225.19,
-              "mean_diff_ci_lower": 0.1462,
-              "mean_diff_ci_upper": 0.4579,
+              "t": 3.8631,
+              "p": 0.0001,
+              "df": 224.46,
+              "mean_diff_ci_lower": 0.1496,
+              "mean_diff_ci_upper": 0.461,
               "sig": true
             }
           }
         },
         "t_tests_large_vs_small": {
           "large_n": 114,
-          "small_medium_n": 475,
+          "small_medium_n": 477,
           "constructs": {
             "barriers": {
-              "t": 1.2697,
-              "p": 0.2058,
-              "df": 185.2,
-              "mean_diff_ci_lower": -0.0573,
-              "mean_diff_ci_upper": 0.2644,
+              "t": 1.2569,
+              "p": 0.2104,
+              "df": 184.6,
+              "mean_diff_ci_lower": -0.0583,
+              "mean_diff_ci_upper": 0.2631,
               "sig": false
             },
             "readiness": {
-              "t": 0.4509,
-              "p": 0.6526,
-              "df": 179.25,
-              "mean_diff_ci_lower": -0.117,
-              "mean_diff_ci_upper": 0.1864,
+              "t": 0.4305,
+              "p": 0.6673,
+              "df": 178.7,
+              "mean_diff_ci_lower": -0.1185,
+              "mean_diff_ci_upper": 0.1846,
               "sig": false
             },
             "maturity": {
-              "t": 1.2172,
-              "p": 0.2252,
-              "df": 175.48,
-              "mean_diff_ci_lower": -0.0661,
-              "mean_diff_ci_upper": 0.279,
+              "t": 1.2571,
+              "p": 0.2104,
+              "df": 175.05,
+              "mean_diff_ci_lower": -0.0626,
+              "mean_diff_ci_upper": 0.2823,
               "sig": false
             }
           }
         },
         "anova_by_role": {
           "groups": ["Technical", "Non-Technical", "Unclassified"],
-          "group_ns": [127, 387, 75],
+          "group_ns": [127, 389, 75],
           "constructs": {
             "barriers": {
-              "f": 1.9339,
-              "p": 0.165,
+              "f": 1.9735,
+              "p": 0.1607,
               "df_between": 1,
-              "df_within": 504,
+              "df_within": 506,
               "sig": false
             },
             "readiness": {
-              "f": 26.467,
+              "f": 26.2475,
               "p": 0.0,
               "df_between": 1,
-              "df_within": 499,
+              "df_within": 501,
               "sig": true
             },
             "maturity": {
-              "f": 13.6806,
+              "f": 14.0182,
               "p": 0.0002,
               "df_between": 1,
-              "df_within": 497,
+              "df_within": 499,
               "sig": true
             }
           }
         },
         "anova_by_org_size": {
           "groups": ["Small (<500)", "Medium (500-4999)", "Large (5000+)"],
-          "group_ns": [232, 168, 114],
+          "group_ns": [234, 168, 114],
           "constructs": {
             "barriers": {
-              "f": 0.8046,
-              "p": 0.4478,
+              "f": 0.7853,
+              "p": 0.4566,
               "df_between": 2,
-              "df_within": 503,
+              "df_within": 505,
               "sig": false
             },
             "readiness": {
-              "f": 4.1732,
-              "p": 0.0159,
+              "f": 4.0496,
+              "p": 0.018,
               "df_between": 2,
-              "df_within": 498,
+              "df_within": 500,
               "sig": true
             },
             "maturity": {
-              "f": 4.6619,
-              "p": 0.0099,
+              "f": 4.9126,
+              "p": 0.0077,
               "df_between": 2,
-              "df_within": 496,
+              "df_within": 498,
               "sig": true
             }
           }
@@ -1638,22 +1638,22 @@
   "filter_bias_analysis": {
     "role": {
       "ok": true,
-      "chi2": 0.5,
-      "p_value": 0.9179,
+      "chi2": 0.46,
+      "p_value": 0.9279,
       "df": 3,
       "error": null
     },
     "organization_size": {
       "ok": true,
-      "chi2": 8.2,
-      "p_value": 0.9157,
+      "chi2": 8.09,
+      "p_value": 0.92,
       "df": 15,
       "error": null
     },
     "profit_model": {
       "ok": true,
-      "chi2": 3.49,
-      "p_value": 0.745,
+      "chi2": 3.59,
+      "p_value": 0.7325,
       "df": 6,
       "error": null
     },
@@ -1676,7 +1676,7 @@
           "Government/Public Sector": 32
         },
         "All V2 Finished": {
-          "For-Profit": 367,
+          "For-Profit": 369,
           "Non-Profit": 86,
           "Government/Public Sector": 47
         }
@@ -2404,6 +2404,6 @@
       }
     ]
   },
-  "last_updated": "2026-05-01T10:55:41.794822Z",
-  "extended_last_updated": "2026-05-01T10:55:41.794822Z"
+  "last_updated": "2026-05-01T17:13:49.184794Z",
+  "extended_last_updated": "2026-05-01T17:13:49.184794Z"
 }


### PR DESCRIPTION
Automated update from the unified daily pipeline.

**Data flow**: Qualtrics export → Prolific enrichment →
disposition waterfall → analysis suite → CRP dataset (N=200) →
approve CLEAN → dashboard summary.

All statistics computed across 5 sample definitions.
CRP dataset: N=200 tiered selection + NIST de-identification.