### PR TITLE
fix(smoke): assert 'Prolific Accepted' on /results overview (closes #1849)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -473,8 +473,11 @@ jobs:
 
           : > /tmp/content-results.txt
 
-          # Results section - verify key content renders
-          check_content "${SITE_URL}/results" "Prolific Approved" "/results overview"
+          # Results section - verify key content renders.
+          # 'Prolific Accepted' replaced 'Prolific Approved' as the canonical
+          # hero-stat label in PR #1709 (commit 73b6e3b1, "Prolific Accepted
+          # label"). The /results page now uses 'Prolific Accepted'.
+          check_content "${SITE_URL}/results" "Prolific Accepted" "/results overview"
           check_content "${SITE_URL}/results" "Clean Sample" "/results hero stats"
           check_content "${SITE_URL}/results/data-quality" "Disposition Waterfall" "/results/data-quality"
           check_content "${SITE_URL}/results/descriptive" "Grand Mean" "/results/descriptive"

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -474,9 +474,8 @@ jobs:
           : > /tmp/content-results.txt
 
           # Results section - verify key content renders.
-          # 'Prolific Accepted' replaced 'Prolific Approved' as the canonical
-          # hero-stat label in PR #1709 (commit 73b6e3b1, "Prolific Accepted
-          # label"). The /results page now uses 'Prolific Accepted'.
+          # 'Prolific Accepted' replaced 'Prolific Approved' as the hero-stat label
+          # in PR #1709 (commit 73b6e3b1, "Prolific Accepted label").
           check_content "${SITE_URL}/results" "Prolific Accepted" "/results overview"
           check_content "${SITE_URL}/results" "Clean Sample" "/results hero stats"
           check_content "${SITE_URL}/results/data-quality" "Disposition Waterfall" "/results/data-quality"


### PR DESCRIPTION
Closes #1849.

## What broke

The post-deploy smoke test for the /results overview still asserts the legacy hero-stat label \`Prolific Approved\`. PR #1709 (recently merged) renamed it to \`Prolific Accepted\` (commit 73b6e3b1, \"Prolific Accepted label\"). The first deploy after #1709 (commit \`37d5558f\`) tripped the smoke test and auto-filed issue #1849.

## What this PR does

One-line change in \`.github/workflows/post-deploy-smoke.yml\`:

\`\`\`diff
- check_content \"\${SITE_URL}/results\" \"Prolific Approved\" \"/results overview\"
+ check_content \"\${SITE_URL}/results\" \"Prolific Accepted\" \"/results overview\"
\`\`\`

Plus an inline comment pointing at PR #1709 commit 73b6e3b1 so future readers see why the label changed.

## Live verification

\`\`\`
$ curl -sL https://technologyadoptionbarriers.org/results | grep -ci 'Prolific Accepted'
3
$ curl -sL https://technologyadoptionbarriers.org/results | grep -ci 'Prolific Approved'
0
\`\`\`

The new label is live; the old label no longer exists. The next post-deploy run after this merges will pass.

## Test plan

- [ ] Merge this PR -> trigger a deploy of main -> post-deploy-smoke.yml runs -> /results overview check passes -> issue #1849 auto-closes via the \"closes #1849\" trailer.

## Related

- PR #1709 (the redesign that introduced the new label)
- Issue #1839 (the larger surface-28-stats follow-up; not affected by this fix)