### PR TITLE
fix(#1858): surface Tech/Non-Tech classification depth on CRP-2026 sample page

### DIFF
--- a/scripts/analysis/tabs_v2_unified_data_analysis.py
+++ b/scripts/analysis/tabs_v2_unified_data_analysis.py
@@ -1560,8 +1560,11 @@ def sensitivity_to_json(cuts, idx):
                 nontech_n += 1
             else:
                 other_n += 1
-                if role == 'Other':
-                    other_cats[categorize_other_role(other_text)] += 1
+            # Categorize Other free-text via regex bucket regardless of binary
+            # classification, so the Other Role Categories table is always
+            # populated when role == 'Other'. Fix for #1858.
+            if role == 'Other':
+                other_cats[categorize_other_role(other_text)] += 1
             org_sizes[r[idx['Q4_OrgSize']].strip()] += 1
             profit_models[r[idx['Q5_ProfitModel']].strip()] += 1
         return {

--- a/scripts/analysis/tests/test_analysis.py
+++ b/scripts/analysis/tests/test_analysis.py
@@ -1493,3 +1493,163 @@ class TestExtendedOutputBlocks:
             assert entry["n"] == 0
             assert entry["mean"] is None
             assert entry["sd"] is None
+
+
+# ── TestOtherRolesCategoriesRegression ──────────────────────────────────────
+
+class TestOtherRolesCategoriesRegression:
+    """Regression guard for other_roles.categories in demographics_for().
+
+    Prior to the fix in #1858, the categorize_other_role() call was placed
+    inside the ``else`` branch of the binary-classification if/else, which
+    was unreachable because classify_role_binary() never returns None for
+    role == 'Other' (it always falls through to the 'Non-Technical' default).
+    This caused other_roles.categories to always emit {} even when Other
+    respondents were present.
+
+    These tests assert:
+    1. categories is non-empty when Other rows are present.
+    2. Cells with count < 5 are emitted as the string "<5" (k-anonymity).
+    3. Cells with count >= 5 are emitted as plain integers.
+    """
+
+    @staticmethod
+    def _build_rows_with_other_roles():
+        """Return (idx, rows) for a synthetic 11-row dataset that includes:
+
+        - 2 CIO rows  (Technical, non-Other)
+        - 2 CEO rows  (Non-Technical, non-Other)
+        - 5 "Director of IT" Other rows  → categories["Director"] = 5
+        - 2 "VP of Finance" Other rows   → categories["VP / SVP"] = 2 (→ "<5")
+
+        All rows include the full column set required by sensitivity_to_json().
+        """
+        from tabs_v2_unified_data_analysis import (
+            BARRIER_COLS, READINESS_COLS, MATURITY_COLS,
+            BARRIER_IRI, READINESS_IRI, MATURITY_IRI,
+            BARRIER_ITEM_TEXT,
+        )
+
+        top3_cols = [f"Q29-46_Top3Barriers_{i}" for i in range(1, 19)]
+        demo_cols = [
+            "Q1_Role", "Q1_Role_11_TEXT",
+            "Q2_DecisionAuth", "Q4_OrgSize", "Q5_ProfitModel",
+        ]
+        other_cols = [
+            "ResponseId", "StartDate", "Duration (in seconds)", "Finished",
+            "PROLIFIC_PID", "Q_RecaptchaScore", "Q_StraightliningCount",
+            BARRIER_IRI, READINESS_IRI, MATURITY_IRI,
+        ]
+        all_cols = other_cols + demo_cols + BARRIER_COLS + READINESS_COLS + MATURITY_COLS + top3_cols
+        idx = {col: i for i, col in enumerate(all_cols)}
+        ncols = len(all_cols)
+
+        def make_row(pid, role, other_text, barrier_val, readiness_val, maturity_val):
+            row = [""] * ncols
+            row[idx["ResponseId"]] = pid
+            row[idx["StartDate"]] = "2026-01-01 10:00:00"
+            row[idx["Duration (in seconds)"]] = "600"
+            row[idx["Finished"]] = "TRUE"
+            row[idx["PROLIFIC_PID"]] = pid
+            row[idx["Q_RecaptchaScore"]] = "0.9"
+            row[idx["Q_StraightliningCount"]] = "0"
+            row[idx[BARRIER_IRI]] = "Major Barrier"
+            row[idx[READINESS_IRI]] = "Low Readiness/Capability"
+            row[idx[MATURITY_IRI]] = "Level 2: Developing/Repeatable"
+            row[idx["Q1_Role"]] = role
+            row[idx["Q1_Role_11_TEXT"]] = other_text
+            row[idx["Q2_DecisionAuth"]] = "High"
+            row[idx["Q4_OrgSize"]] = "10000+"
+            row[idx["Q5_ProfitModel"]] = "For-Profit"
+            for col in BARRIER_COLS:
+                row[idx[col]] = barrier_val
+            for col in READINESS_COLS:
+                row[idx[col]] = readiness_val
+            for col in MATURITY_COLS:
+                row[idx[col]] = maturity_val
+            row[idx["Q29-46_Top3Barriers_1"]] = BARRIER_ITEM_TEXT[1]
+            return row
+
+        rows = []
+        # 2 CIO rows (Technical, non-Other)
+        for i in range(2):
+            rows.append(make_row(
+                f"CIO_{i}", "CIO (e.g., Director of IT)", "",
+                "Major Barrier", "High Readiness/Capability",
+                "Level 3: Defined/Standardized",
+            ))
+        # 2 CEO rows (Non-Technical, non-Other)
+        for i in range(2):
+            rows.append(make_row(
+                f"CEO_{i}",
+                "CEO (e.g., Agency Director, Secretary, Administrator, City/County Manager)", "",
+                "Major Barrier", "High Readiness/Capability",
+                "Level 3: Defined/Standardized",
+            ))
+        # 5 "Director of IT" Other rows  → categories["Director"] = 5 (not suppressed)
+        for i in range(5):
+            rows.append(make_row(
+                f"DIR_{i}", "Other (please specify)", "Director of IT",
+                "Major Barrier", "High Readiness/Capability",
+                "Level 3: Defined/Standardized",
+            ))
+        # 2 "VP of Finance" Other rows  → categories["VP / SVP"] = 2 → "<5" suppressed
+        for i in range(2):
+            rows.append(make_row(
+                f"VP_{i}", "Other (please specify)", "VP of Finance",
+                "Major Barrier", "High Readiness/Capability",
+                "Level 3: Defined/Standardized",
+            ))
+        return idx, rows
+
+    def test_other_roles_categories_non_empty(self):
+        """Regression: categories must be non-empty when Other rows are present.
+
+        Prior to #1858 fix this always emitted {}.
+        """
+        from tabs_v2_unified_data_analysis import sensitivity_to_json
+
+        idx, rows = self._build_rows_with_other_roles()
+        result = sensitivity_to_json([("Prolific Accepted", rows)], idx)
+
+        demo = result["sample_details"]["prolific_accepted"]["demographics"]
+        cats = demo["other_roles"]["categories"]
+
+        assert cats, (
+            "other_roles.categories is empty even though Other rows are present; "
+            "likely the categorize_other_role() call is still inside an unreachable branch."
+        )
+
+    def test_other_roles_categories_no_suppression_for_count_gte_5(self):
+        """Cells with count >= 5 must be plain integers, not suppressed."""
+        from tabs_v2_unified_data_analysis import sensitivity_to_json
+
+        idx, rows = self._build_rows_with_other_roles()
+        result = sensitivity_to_json([("Prolific Accepted", rows)], idx)
+
+        demo = result["sample_details"]["prolific_accepted"]["demographics"]
+        cats = demo["other_roles"]["categories"]
+
+        assert "Director" in cats, f"'Director' key missing from categories: {cats}"
+        director_count = cats["Director"]
+        assert isinstance(director_count, int), (
+            f"Expected integer for Director count (5 rows), got {director_count!r}"
+        )
+        assert director_count == 5
+
+    def test_other_roles_categories_suppression_for_count_lt_5(self):
+        """Cells with count < 5 must be emitted as the string '<5'."""
+        from tabs_v2_unified_data_analysis import sensitivity_to_json
+
+        idx, rows = self._build_rows_with_other_roles()
+        result = sensitivity_to_json([("Prolific Accepted", rows)], idx)
+
+        demo = result["sample_details"]["prolific_accepted"]["demographics"]
+        cats = demo["other_roles"]["categories"]
+
+        assert "VP / SVP" in cats, f"'VP / SVP' key missing from categories: {cats}"
+        vp_count = cats["VP / SVP"]
+        assert vp_count == "<5", (
+            f"Expected '<5' for VP / SVP count (2 rows, below k-anonymity threshold), "
+            f"got {vp_count!r}"
+        )

--- a/src/app/results/crp-2026/sample/page.tsx
+++ b/src/app/results/crp-2026/sample/page.tsx
@@ -516,7 +516,7 @@ const CrpSamplePage = () => {
                                     className="inline-block w-2 h-2 rounded-full bg-blue-500 mr-1.5"
                                     aria-hidden="true"
                                   />
-                                  Technical (CIO, CTO)
+                                  Technical (CIO, CTO, CISO + reclassified Other)
                                 </td>
                                 <td className="py-1.5 text-right font-mono">
                                   {demo.tech_vs_nontech.technical}
@@ -567,6 +567,45 @@ const CrpSamplePage = () => {
                             </Link>{' '}
                             page.
                           </p>
+                          <details className="mt-3 text-[11px] text-gray-600">
+                            <summary className="cursor-pointer font-medium text-gray-700 hover:text-blue-600">
+                              How is this classification computed? (open for details)
+                            </summary>
+                            <div className="mt-2 pl-3 border-l-2 border-blue-200 space-y-1.5">
+                              <p>
+                                <span className="font-semibold">Technical bucket</span> = the three IT-leadership C-suite titles{' '}
+                                <span className="font-mono">CIO + CTO + CISO</span> (named role count), plus any{' '}
+                                <em>Other (please specify)</em> free-text response that matches a technical-role regex
+                                (e.g.,{' '}
+                                <span className="font-mono">director of IT</span>,{' '}
+                                <span className="font-mono">VP of engineering</span>,{' '}
+                                <span className="font-mono">software architect</span>,{' '}
+                                <span className="font-mono">cybersecurity</span>).
+                              </p>
+                              <p>
+                                <span className="font-semibold">Non-Technical bucket</span> = the seven non-IT C-suite titles{' '}
+                                <span className="font-mono">CEO + CFO + COO + CHRO + CMO + CSO + CRO</span>, plus any{' '}
+                                <em>Other</em> free-text matching a non-technical regex
+                                (e.g., president, founder, finance manager), plus unmatched{' '}
+                                <em>Other</em> responses (conservative default: assigned to Non-Technical when
+                                no clear technology signal is present).
+                              </p>
+                              <p>
+                                Source: <span className="font-mono">classify_role_binary()</span> in{' '}
+                                <Link
+                                  href="https://github.com/clarkemoyer/technologyadoptionbarriers.org/blob/main/scripts/analysis/tabs_v2_unified_data_analysis.py"
+                                  className="text-blue-500 hover:underline"
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  scripts/analysis/tabs_v2_unified_data_analysis.py
+                                </Link>{' '}
+                                (TECH_TITLES, NONTECH_TITLES, _OTHER_ROLE_PATTERNS). The{' '}
+                                <em>Other Role Categories</em> table to the right shows the regex-bucket
+                                breakdown of every <em>Other</em> respondent.
+                              </p>
+                            </div>
+                          </details>
                         </div>
                       )}
 

--- a/src/app/results/crp-2026/sample/page.tsx
+++ b/src/app/results/crp-2026/sample/page.tsx
@@ -573,22 +573,26 @@ const CrpSamplePage = () => {
                             </summary>
                             <div className="mt-2 pl-3 border-l-2 border-blue-200 space-y-1.5">
                               <p>
-                                <span className="font-semibold">Technical bucket</span> = the three IT-leadership C-suite titles{' '}
-                                <span className="font-mono">CIO + CTO + CISO</span> (named role count), plus any{' '}
-                                <em>Other (please specify)</em> free-text response that matches a technical-role regex
-                                (e.g.,{' '}
+                                <span className="font-semibold">Technical bucket</span> = the three
+                                IT-leadership C-suite titles{' '}
+                                <span className="font-mono">CIO + CTO + CISO</span> (named role
+                                count), plus any <em>Other (please specify)</em> free-text response
+                                that matches a technical-role regex (e.g.,{' '}
                                 <span className="font-mono">director of IT</span>,{' '}
                                 <span className="font-mono">VP of engineering</span>,{' '}
                                 <span className="font-mono">software architect</span>,{' '}
                                 <span className="font-mono">cybersecurity</span>).
                               </p>
                               <p>
-                                <span className="font-semibold">Non-Technical bucket</span> = the seven non-IT C-suite titles{' '}
-                                <span className="font-mono">CEO + CFO + COO + CHRO + CMO + CSO + CRO</span>, plus any{' '}
-                                <em>Other</em> free-text matching a non-technical regex
+                                <span className="font-semibold">Non-Technical bucket</span> = the
+                                seven non-IT C-suite titles{' '}
+                                <span className="font-mono">
+                                  CEO + CFO + COO + CHRO + CMO + CSO + CRO
+                                </span>
+                                , plus any <em>Other</em> free-text matching a non-technical regex
                                 (e.g., president, founder, finance manager), plus unmatched{' '}
-                                <em>Other</em> responses (conservative default: assigned to Non-Technical when
-                                no clear technology signal is present).
+                                <em>Other</em> responses (conservative default: assigned to
+                                Non-Technical when no clear technology signal is present).
                               </p>
                               <p>
                                 Source: <span className="font-mono">classify_role_binary()</span> in{' '}
@@ -601,8 +605,8 @@ const CrpSamplePage = () => {
                                   scripts/analysis/tabs_v2_unified_data_analysis.py
                                 </Link>{' '}
                                 (TECH_TITLES, NONTECH_TITLES, _OTHER_ROLE_PATTERNS). The{' '}
-                                <em>Other Role Categories</em> table to the right shows the regex-bucket
-                                breakdown of every <em>Other</em> respondent.
+                                <em>Other Role Categories</em> table to the right shows the
+                                regex-bucket breakdown of every <em>Other</em> respondent.
                               </p>
                             </div>
                           </details>

--- a/src/app/results/crp-2026/sample/page.tsx
+++ b/src/app/results/crp-2026/sample/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 
 interface OtherRolesData {
   total: number
-  categories: Record<string, number>
+  categories: Record<string, number | string>
 }
 
 interface RoleCategoryInfo {
@@ -605,8 +605,10 @@ const CrpSamplePage = () => {
                                   scripts/analysis/tabs_v2_unified_data_analysis.py
                                 </Link>{' '}
                                 (TECH_TITLES, NONTECH_TITLES, _OTHER_ROLE_PATTERNS). The{' '}
-                                <em>Other Role Categories</em> table to the right shows the
-                                regex-bucket breakdown of every <em>Other</em> respondent.
+                                <em>Other Role Categories</em> table uses{' '}
+                                <span className="font-mono">categorize_other_role()</span> /{' '}
+                                <span className="font-mono">OTHER_ROLE_CATEGORIES_PATTERNS</span>;
+                                counts shown as &ldquo;&lt;5&rdquo; are k-anonymity suppressed.
                               </p>
                             </div>
                           </details>

--- a/src/app/results/crp-2026/sample/page.tsx
+++ b/src/app/results/crp-2026/sample/page.tsx
@@ -590,7 +590,9 @@ const CrpSamplePage = () => {
                                   CEO + CFO + COO + CHRO + CMO + CSO + CRO
                                 </span>
                                 , plus any <em>Other</em> free-text matching a non-technical regex
-                                (e.g., president, founder, finance manager), plus unmatched{' '}
+                                (e.g., <span className="font-mono">president</span>,{' '}
+                                <span className="font-mono">founder</span>,{' '}
+                                <span className="font-mono">finance manager</span>), plus unmatched{' '}
                                 <em>Other</em> responses (conservative default: assigned to
                                 Non-Technical when no clear technology signal is present).
                               </p>

--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -599,7 +599,13 @@
         },
         "other_roles": {
           "total": 18,
-          "categories": {}
+          "categories": {
+            "Director": 9,
+            "VP / SVP": "<5",
+            "Uncategorized": "<5",
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5"
+          }
         }
       },
       "effect_sizes": {
@@ -864,7 +870,14 @@
         },
         "other_roles": {
           "total": 38,
-          "categories": {}
+          "categories": {
+            "Director": 20,
+            "VP / SVP": 6,
+            "Uncategorized": 5,
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5",
+            "Owner / Founder / President": "<5"
+          }
         }
       },
       "effect_sizes": {
@@ -1129,7 +1142,14 @@
         },
         "other_roles": {
           "total": 38,
-          "categories": {}
+          "categories": {
+            "Director": 20,
+            "VP / SVP": 6,
+            "Uncategorized": 5,
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5",
+            "Owner / Founder / President": "<5"
+          }
         }
       },
       "effect_sizes": {
@@ -1394,7 +1414,14 @@
         },
         "other_roles": {
           "total": 38,
-          "categories": {}
+          "categories": {
+            "Director": 20,
+            "VP / SVP": 6,
+            "Uncategorized": 5,
+            "Manager / Program Lead": "<5",
+            "C-Suite Adjacent": "<5",
+            "Owner / Founder / President": "<5"
+          }
         }
       },
       "effect_sizes": {


### PR DESCRIPTION
Closes #1858.

## Summary
Surfaces the full Tech vs Non-Tech classification depth on the CRP-2026 sample page so the website matches what the deck, talk track, handout, and analysis scripts actually compute. Three coordinated changes.

## Change 1: TSX label + methodology disclosure (`src/app/results/crp-2026/sample/page.tsx`)

- Renamed label from `Technical (CIO, CTO)` to `Technical (CIO, CTO, CISO + reclassified Other)`. The previous label omitted CISO entirely and gave no signal that free-text `Other (please specify)` responses also flow into the bucket via regex reclassification.
- Added an expandable `<details>` block under the Tech vs Non-Tech card that documents:
  - Tech bucket = `CIO + CTO + CISO` named roles plus regex-matched Other free-text (e.g., `director of IT`, `VP of engineering`, `software architect`, `cybersecurity`).
  - Non-Tech bucket = the seven non-IT C-suite titles plus regex-matched Other free-text plus the conservative default for unmatched Other (assigned to Non-Technical when no technology signal is present).
  - Source link to `classify_role_binary()` in `scripts/analysis/tabs_v2_unified_data_analysis.py`.

## Change 2: Pipeline bug — `other_roles.categories` always emits `{}` (`scripts/analysis/tabs_v2_unified_data_analysis.py`)

The categorization counter was placed inside the `else:` branch that runs only when `binary == None`. But `classify_role_binary()` never returns `None` for `role == 'Other'` — it falls through to the conservative default of `'Non-Technical'`. So the counter was never incremented, and the JSON always emitted `categories: {}` even though the categorization function exists and works.

Fix: move the categorization call out of the binary-classification if/else so it runs for every `role == 'Other'` respondent regardless of how the binary classifier resolves them. K-anonymity suppression (`<5`) preserved.

```python
# Before
if binary == 'Technical':
    tech_n += 1
elif binary == 'Non-Technical':
    nontech_n += 1
else:
    other_n += 1
    if role == 'Other':
        other_cats[categorize_other_role(other_text)] += 1   # unreachable!

# After
if binary == 'Technical':
    tech_n += 1
elif binary == 'Non-Technical':
    nontech_n += 1
else:
    other_n += 1
if role == 'Other':                                          # always runs
    other_cats[categorize_other_role(other_text)] += 1
```

## Change 3: JSON populated directly (`src/data/crp-sensitivity-analysis.json`)

Categories populated for all four tiers we can derive deterministically from the frozen N=200 public dataset:

| Tier | Total Other | Director | VP/SVP | Uncategorized | Manager | C-Suite Adj | Owner/Founder |
|---|---|---|---|---|---|---|---|
| `prolific_accepted` | 38 | 20 | 6 | 5 | <5 | <5 | <5 |
| `v2_finished` | 38 | 20 | 6 | 5 | <5 | <5 | <5 |
| `v2_all` | 38 | 20 | 6 | 5 | <5 | <5 | <5 |
| `flexible_clean` | 18 | 9 | <5 | <5 | <5 | <5 | - |
| `conservative_clean` | 13 | (left empty - daily pipeline regen will fill) | | | | | |

`conservative_clean` requires the SMEAL-threshold + reCAPTCHA scoring path that I cannot reproduce locally without the PII pipeline, so it is left empty until the next daily-pipeline run regenerates it with the corrected emit logic.

## Acceptance criteria (from #1858)

- [x] Sample page label includes CISO + reclassified Other framing
- [x] Methodology disclosure block surfaces the regex reclassification rules
- [x] `classify_role_binary()` source is linked from the page
- [x] Pipeline emits `other_roles.categories` for every Other respondent (not just unclassified ones)
- [x] JSON contains category breakdown for `prolific_accepted` (canonical CRP tier)
- [x] K-anonymity suppression preserved (`<5` for cells under 5)
- [x] Branch parent is `main`, no placeholder content, no extraneous files
- [ ] Daily-pipeline regenerates `conservative_clean.categories` (will happen on next CI run)

## Companion artifact

Tech vs Non-Tech Classification Audit (5-2-2026 1130 EST) at `03 Defense Presentation/Briefs and Audits/` documents the full role-by-role assignment that drove this PR.

## Verification

- All three files compile / parse: `py_compile` clean for the pipeline; valid JSON; TSX builds locally.
- Branch state verified via Git Data API after force-push (cleared a stray placeholder commit from an earlier MCP push attempt).
- Pushed via the Git Data API (blobs -> tree -> commit -> ref) rather than the Contents API to avoid the corruption pattern that produced the placeholder.
