### PR TITLE
fix(findings): use plain dash for per-cell missing scalars (closes prod smoke incident)

### DIFF
--- a/src/components/results/findings/InferentialExtensions.tsx
+++ b/src/components/results/findings/InferentialExtensions.tsx
@@ -1,5 +1,9 @@
 import { H2_CLASSES, H3_CLASSES, PARAGRAPH_CLASSES } from '@/lib/articleStyles'
-import { DATA_UNAVAILABLE } from '@/lib/sentinelMarker'
+// Per-cell missing values render as '-' (see fmt/fmtP helpers below).
+// DATA_UNAVAILABLE sentinel is reserved for missing entire data blocks
+// (caught by the smoke test as a production incident); the
+// InferentialExtensions component uses block-level guards in the parent
+// (buildInferentialExtensionsProps) to decide whether to render at all.
 
 /**
  * "Inferential Extensions" section for /results/findings and
@@ -98,12 +102,15 @@ export type InferentialExtensionsProps = {
 }
 
 const fmt = (v: number | null | undefined, digits = 3): string => {
-  if (typeof v !== 'number' || !Number.isFinite(v)) return DATA_UNAVAILABLE
+  // Single missing scalars are normal in mediation/regression tables (some
+  // estimators don't produce bootstrap CI bounds, some lavaan-MLR outputs
+  // omit certain p-values, etc). A missing scalar gets a plain dash.
+  if (typeof v !== 'number' || !Number.isFinite(v)) return '-'
   return v.toFixed(digits)
 }
 
 const fmtP = (v: number | null | undefined): string => {
-  if (typeof v !== 'number' || !Number.isFinite(v)) return DATA_UNAVAILABLE
+  if (typeof v !== 'number' || !Number.isFinite(v)) return '-'
   if (v < 0.001) return '< .001'
   return v.toFixed(3)
 }
@@ -202,7 +209,7 @@ function MediationBlock({ data }: { data: MediationData }) {
                       ns
                     </span>
                   ) : (
-                    DATA_UNAVAILABLE
+                    '-'
                   )}
                 </td>
               </tr>
@@ -267,7 +274,7 @@ function PerFactorRegressionBlock({ data }: { data: PerFactorRegData }) {
                 <td className="border border-gray-300 px-3 py-1.5 text-right font-mono text-emerald-700 font-semibold">
                   {e.r2_lift_from_decomposition != null
                     ? `+${fmt(e.r2_lift_from_decomposition, 4)}`
-                    : DATA_UNAVAILABLE}
+                    : '-'}
                 </td>
               </tr>
             ) : null
@@ -454,7 +461,7 @@ function TOSTBlock({ data }: { data: TOSTData }) {
                       Not equivalent
                     </span>
                   ) : (
-                    DATA_UNAVAILABLE
+                    '-'
                   )}
                 </td>
               </tr>
@@ -480,13 +487,11 @@ function PowerAnalysisBlock({ data }: { data: PowerAnalysisData }) {
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
         <div>
           <div className="text-xs text-blue-800">N (SMB)</div>
-          <div className="font-mono text-blue-900 text-base">{data.n_smb ?? DATA_UNAVAILABLE}</div>
+          <div className="font-mono text-blue-900 text-base">{data.n_smb ?? '-'}</div>
         </div>
         <div>
           <div className="text-xs text-blue-800">N (Enterprise)</div>
-          <div className="font-mono text-blue-900 text-base">
-            {data.n_enterprise ?? DATA_UNAVAILABLE}
-          </div>
+          <div className="font-mono text-blue-900 text-base">{data.n_enterprise ?? '-'}</div>
         </div>
         <div>
           <div className="text-xs text-blue-800">SMB / ENT ratio</div>


### PR DESCRIPTION
## Summary

Hotfix for the post-deploy smoke failure on main commit \`8a82b1c4\`. The pages \`/results/findings\` and \`/results/crp-2026/findings\` were rendering the \`DATA_UNAVAILABLE\` sentinel ("[DATA UNAVAILABLE - pipeline error]") in mediation-table CI bound cells, which the smoke workflow correctly catches as a production-incident signal.

## Root cause

The \`InferentialExtensions\` component (introduced in PR #1853 Pass 4) used \`DATA_UNAVAILABLE\` as a fallback for SINGLE missing scalars inside \`fmt()\` and \`fmtP()\` helpers, plus four other per-cell fallbacks (SMB n, Enterprise n, sig status, equivalence status, R-squared lift).

\`DATA_UNAVAILABLE\` is a hard production-incident sentinel that the smoke workflow asserts on - it is intended ONLY for the case where an entire expected data block is missing from the pipeline JSON, not for the normal case of a single null value in a table cell. Some pipeline outputs (mediation bootstrap CI bounds in particular) legitimately have null per-cell values that are not failures.

## Changes

- \`fmt()\` returns \`'-'\` when input is null/undefined/non-finite (was: \`DATA_UNAVAILABLE\`)
- \`fmtP()\` same change
- 5 other per-cell \`DATA_UNAVAILABLE\` fallbacks replaced with \`'-'\`
- Removed the \`DATA_UNAVAILABLE\` import; replaced with a comment explaining the per-cell vs block-level distinction
- Block-level guards in \`buildInferentialExtensionsProps\` and other parent components remain unchanged - those still surface the \`DATA_UNAVAILABLE\` sentinel correctly when an entire data structure is absent

## Verification

- \`grep DATA_UNAVAILABLE InferentialExtensions.tsx\` returns only the explanatory comment
- Once this lands the post-deploy smoke \`check_no_sentinel\` for \`/results/findings\` and \`/results/crp-2026/findings\` will pass

## Test plan

- [x] Pre-commit hook ran (lint + format clean)
- [ ] CI builds successfully
- [ ] Post-deploy smoke green on the merge commit (the test that originally failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)