### PR TITLE
fix(test): use exact match for questionCount in response-funnel test

### DIFF
--- a/__tests__/components/survey-stats/response-funnel.test.tsx
+++ b/__tests__/components/survey-stats/response-funnel.test.tsx
@@ -40,8 +40,11 @@ describe('Response Funnel page (QualtricsSurveyStats)', () => {
 
   it('renders Qualtrics question IDs and items presented as separate values', () => {
     render(<QualtricsSurveyStats />)
+    // Use exact match: small values like 21 would otherwise substring-match
+    // larger numbers (e.g. 321 appears in audit duration_stats), making this
+    // assertion fail intermittently as the daily pipeline data drifts.
     expect(
-      screen.getByText(metricsData.questionCount.toLocaleString(), { exact: false })
+      screen.getByText(metricsData.questionCount.toLocaleString(), { exact: true })
     ).toBeInTheDocument()
     expect(screen.getByText(TOTAL_ITEMS_PRESENTED.toLocaleString())).toBeInTheDocument()
   })

--- a/__tests__/components/survey-stats/response-funnel.test.tsx
+++ b/__tests__/components/survey-stats/response-funnel.test.tsx
@@ -41,8 +41,9 @@ describe('Response Funnel page (QualtricsSurveyStats)', () => {
   it('renders Qualtrics question IDs and items presented as separate values', () => {
     render(<QualtricsSurveyStats />)
     // Use exact match: small values like 21 would otherwise substring-match
-    // larger numbers (e.g. 321 appears in audit duration_stats), making this
-    // assertion fail intermittently as the daily pipeline data drifts.
+    // larger numbers rendered by other metric cards on the page (e.g. Prolific
+    // disposition counts or Qualtrics raw-response counts that shift daily),
+    // causing this assertion to fail intermittently as pipeline data drifts.
     expect(
       screen.getByText(metricsData.questionCount.toLocaleString(), { exact: true })
     ).toBeInTheDocument()


### PR DESCRIPTION
## Summary

- The `response-funnel.test.tsx` assertion for `metricsData.questionCount` used `{ exact: false }`, causing the rendered '21' to substring-match any number containing '21' (e.g. '321' from `audit.duration_stats.q25` in the live data-audit JSON).
- This made the test fail intermittently as daily-pipeline data shifted. PR #1877 (today's pipeline-data update) and PR #1876 (pipeline-gap statistics) both hit this failure on otherwise-clean branches.
- One-line change: `{ exact: false }` -> `{ exact: true }`. Companion `TOTAL_ITEMS_PRESENTED` assertion already uses exact matching by default.

## Test plan

- [x] Local: `npx jest __tests__/components/survey-stats/response-funnel.test.tsx` -- 6/6 pass
- [ ] CI: Test and Build green
- [ ] Confirm #1876 and #1877 unblock once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)