### PR TITLE
feat(#1900): platform-stats workflow + Platform by the Numbers section

### DIFF
--- a/.github/workflows/platform-stats.yml
+++ b/.github/workflows/platform-stats.yml
@@ -1,0 +1,147 @@
+name: Platform stats
+
+# Auto-computes the five canonical project metrics surfaced on
+# /making-of-tabs/open-source/ ("Platform by the Numbers"):
+#
+#   1. commit_count      - git rev-list --count HEAD
+#   2. lines_of_code     - cloc, code-only (excludes blanks/comments)
+#   3. github_workflows  - count of files in .github/workflows/
+#   4. integrations      - count of subdirs under src/app/making-of-tabs/integrations/
+#   5. development_phases - constant 5 (cite to CRP §3.6 Table 8)
+#
+# These figures previously lived as hand-maintained numbers on the defense
+# slides and in the CRP body and drifted out of sync as the project grew.
+# Surfacing them through a single committed JSON keeps every consumer (the
+# website, the slides, the CRP, future README badges) honest. See #1900.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly Monday 06:00 UTC keeps the figure fresh even if no main commit
+    # happens for a week. Off-minute scheduling avoids GHA's :00 quota crunch.
+    - cron: '7 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Pin the action runtime ahead of GitHub's June 2026 Node 20 deprecation.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  compute:
+    name: Compute platform stats
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # cloc only needs the working tree, but git rev-list --count requires
+          # the full history for an accurate commit total.
+          fetch-depth: 0
+
+      - name: Install cloc + jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cloc jq
+
+      - name: Run cloc
+        run: |
+          # Excluded directories: vendor + build artefacts + coverage + caches.
+          # Excluded extensions: lock files (regenerated, not authored) + binary
+          # assets (cloc would skip them anyway but listing them suppresses warnings).
+          cloc \
+            --exclude-dir=node_modules,.next,dist,build,coverage,.cache,Old,old,.git,.venv,playwright-report,test-results \
+            --exclude-ext=lock,svg,png,jpg,jpeg,gif,pdf,ico,woff,woff2,ttf,otf,eot,zip,sav \
+            --json \
+            --report-file=/tmp/cloc.json \
+            .
+
+      - name: Compute the five platform metrics
+        run: |
+          set -euo pipefail
+          mkdir -p src/data
+
+          COMMITS=$(git rev-list --count HEAD)
+          # Two glob patterns because GitHub Actions accepts both .yml and .yaml.
+          WORKFLOWS=$(ls .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null | wc -l)
+          INTEGRATIONS=$(ls -d src/app/making-of-tabs/integrations/*/ 2>/dev/null | wc -l)
+          CODE=$(jq '.SUM.code'    /tmp/cloc.json)
+          COMM=$(jq '.SUM.comment' /tmp/cloc.json)
+          BLANK=$(jq '.SUM.blank'  /tmp/cloc.json)
+          FILES=$(jq '.SUM.nFiles' /tmp/cloc.json)
+          TOTAL=$((CODE + COMM + BLANK))
+
+          # Per-language breakdown, sorted by code lines descending.
+          jq '. as $r
+              | [$r | keys[] | select(. != "header" and . != "SUM")
+                  | { language: .,
+                      files: $r[.].nFiles,
+                      code: $r[.].code,
+                      comment: $r[.].comment,
+                      blank: $r[.].blank }]
+              | sort_by(-.code)' /tmp/cloc.json > /tmp/by_language.json
+
+          AS_OF=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          SHA=$(git rev-parse HEAD)
+
+          jq -n \
+            --arg as_of "$AS_OF" \
+            --arg sha "$SHA" \
+            --argjson commits "$COMMITS" \
+            --argjson code "$CODE" \
+            --argjson comm "$COMM" \
+            --argjson blank "$BLANK" \
+            --argjson total "$TOTAL" \
+            --argjson files "$FILES" \
+            --argjson workflows "$WORKFLOWS" \
+            --argjson integrations "$INTEGRATIONS" \
+            --slurpfile by_lang /tmp/by_language.json \
+            '{
+              as_of: $as_of,
+              commit_sha: $sha,
+              commit_count: $commits,
+              lines_of_code: $code,
+              comments: $comm,
+              blanks: $blank,
+              total_lines: $total,
+              tracked_files: $files,
+              github_workflows: $workflows,
+              integrations: $integrations,
+              development_phases: 5,
+              phases_source: "CRP §3.6 Table 8 (Five-Phase TABS Product Development Process)",
+              method: "cloc; excludes node_modules, .next, dist, build, coverage, .cache, .git, .venv, Old, playwright-report, test-results; binary and lock files excluded by extension",
+              by_language: $by_lang[0]
+            }' > src/data/platform-stats.json
+
+          # Also publish to public/data/ so the asset is fetchable from the live site
+          # at /data/platform-stats.json (Next.js static export serves public/* at root).
+          mkdir -p public/data
+          cp src/data/platform-stats.json public/data/platform-stats.json
+
+          echo "Refreshed platform-stats:"
+          jq '{commit_count, lines_of_code, github_workflows, integrations, total_lines, tracked_files}' src/data/platform-stats.json
+
+      - name: Open PR if changed
+        uses: ./.github/actions/format-and-pr
+        with:
+          token: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}
+          files: 'src/data/platform-stats.json public/data/platform-stats.json'
+          commit-message: 'chore: refresh platform-stats.json'
+          pr-title: 'chore: refresh platform-stats.json'
+          pr-body: |
+            Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).
+
+            Refreshes `src/data/platform-stats.json` and the public mirror at
+            `public/data/platform-stats.json` from the current `main` HEAD. See #1900
+            for the canonical-numbers rationale. Methodology: cloc with the same
+            exclusion list used by the workflow.
+
+            Reviewers: spot-check that `commit_count`, `lines_of_code`,
+            `github_workflows`, and `integrations` look directionally right
+            for what landed since the last refresh. Sudden 10x jumps or drops
+            are usually a sign of a new vendored dir slipping past the
+            exclusion list — investigate before merging.
+          branch: chore/platform-stats

--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,0 +1,26 @@
+{
+  "as_of": "2026-05-06T00:00:00Z",
+  "commit_sha": "seed",
+  "commit_count": 5280,
+  "lines_of_code": 149687,
+  "comments": 30937,
+  "blanks": 56473,
+  "total_lines": 237097,
+  "tracked_files": 829,
+  "github_workflows": 47,
+  "integrations": 8,
+  "development_phases": 5,
+  "phases_source": "CRP §3.6 Table 8 (Five-Phase TABS Product Development Process)",
+  "method": "cloc; excludes node_modules, .next, dist, build, coverage, .cache, .git, .venv, Old, playwright-report, test-results; binary and lock files excluded by extension",
+  "by_language": [
+    { "language": "TSX", "files": 274, "code": 80586, "comment": 2331, "blank": 0 },
+    { "language": "Python", "files": 80, "code": 29852, "comment": 7625, "blank": 0 },
+    { "language": "JSON", "files": 29, "code": 23000, "comment": 0, "blank": 0 },
+    { "language": "TypeScript", "files": 88, "code": 10393, "comment": 1919, "blank": 0 },
+    { "language": "Markdown", "files": 25, "code": 1379, "comment": 0, "blank": 0 },
+    { "language": "YAML", "files": 53, "code": 6772, "comment": 546, "blank": 0 },
+    { "language": "CSS", "files": 3, "code": 611, "comment": 57, "blank": 0 },
+    { "language": "Bash", "files": 2, "code": 290, "comment": 64, "blank": 0 }
+  ],
+  "_seed": "Initial values pre-workflow-run. Refreshed by .github/workflows/platform-stats.yml on push to main + weekly cron. See #1900."
+}

--- a/src/app/making-of-tabs/open-source/page.tsx
+++ b/src/app/making-of-tabs/open-source/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import { ARTICLE_CLASSES, H1_CLASSES, H2_CLASSES } from '@/lib/articleStyles'
 import Link from 'next/link'
+import platformStats from '@/data/platform-stats.json'
+
 export const metadata: Metadata = {
   title: 'Open Source & Community - Making of TABS',
   description:
@@ -23,6 +25,162 @@ const OpenSourcePage = () => {
             research project that documents technology adoption barriers should itself be a
             transparent example of how technology is adopted, built, and maintained.
           </p>
+        </section>
+
+        {/* ── Platform by the Numbers ── */}
+        {/*
+          Five canonical metrics surfaced from src/data/platform-stats.json,
+          which is auto-refreshed on every push to main + weekly cron by
+          .github/workflows/platform-stats.yml. The intent is to retire the
+          hand-maintained "574K+ Lines of Code | 4,680+ Commits | 39 GitHub
+          Actions" figures that drifted across slides + CRP body and replace
+          them with one source of truth that every consumer can verify
+          against the live JSON. See #1900.
+        */}
+        <section className="mb-12 text-gray-800">
+          <h2 className={H2_CLASSES}>Platform by the Numbers</h2>
+          <p className="mb-4 text-sm text-gray-600">
+            Computed automatically by{' '}
+            <a
+              href="https://github.com/AlDanial/cloc"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline hover:text-blue-800"
+            >
+              cloc
+            </a>{' '}
+            on every push to <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">main</code>{' '}
+            and weekly. Last refresh:{' '}
+            <span className="font-mono">
+              {new Date(platformStats.as_of).toISOString().slice(0, 10)}
+            </span>
+            {platformStats.commit_sha !== 'seed' && (
+              <>
+                {' '}
+                (commit{' '}
+                <a
+                  href={`https://github.com/clarkemoyer/technologyadoptionbarriers.org/commit/${platformStats.commit_sha}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-blue-600 underline hover:text-blue-800"
+                >
+                  {platformStats.commit_sha.slice(0, 7)}
+                </a>
+                ).
+              </>
+            )}
+          </p>
+
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
+            {[
+              {
+                value: platformStats.commit_count.toLocaleString(),
+                label: 'Commits',
+                sub: 'git rev-list',
+              },
+              {
+                value: `${Math.round(platformStats.lines_of_code / 1000)}K+`,
+                label: 'Lines of Code',
+                sub: 'cloc, code only',
+              },
+              {
+                value: platformStats.github_workflows,
+                label: 'GitHub Actions',
+                sub: 'workflows in .github/',
+              },
+              {
+                value: platformStats.integrations,
+                label: 'Integrations',
+                sub: 'external APIs',
+              },
+              {
+                value: platformStats.development_phases,
+                label: 'Phase Development',
+                sub: 'CRP §3.6 Table 8',
+              },
+            ].map((metric) => (
+              <div
+                key={metric.label}
+                className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center"
+              >
+                <div className="text-2xl font-bold text-gray-900">{metric.value}</div>
+                <div className="mt-1 text-sm font-medium text-gray-700">{metric.label}</div>
+                <div className="mt-1 text-xs text-gray-500">{metric.sub}</div>
+              </div>
+            ))}
+          </div>
+
+          <details className="text-sm text-gray-700">
+            <summary className="cursor-pointer font-medium text-gray-900">
+              How we count (methodology + per-language breakdown)
+            </summary>
+            <div className="mt-3 space-y-3">
+              <p>
+                <strong>SLOC ({platformStats.lines_of_code.toLocaleString()})</strong> excludes
+                blank lines, comments, generated code, and vendored dependencies.{' '}
+                <strong>Total raw lines ({platformStats.total_lines.toLocaleString()})</strong>{' '}
+                includes blanks and comments across {platformStats.tracked_files.toLocaleString()}{' '}
+                files.
+              </p>
+              <p>
+                <strong>Excluded directories:</strong>{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">node_modules</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">.next</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">dist</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">build</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">coverage</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">.cache</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">.git</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">.venv</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">Old</code>,{' '}
+                <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">playwright-report</code>,
+                and <code className="text-xs bg-gray-200 px-1 py-0.5 rounded">test-results</code>.
+                Lock files and binaries are excluded by extension.
+              </p>
+
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm border border-gray-200 rounded-lg">
+                  <thead>
+                    <tr className="bg-gray-50">
+                      <th className="text-left p-2 font-semibold border-b border-gray-200">
+                        Language
+                      </th>
+                      <th className="text-right p-2 font-semibold border-b border-gray-200">
+                        Files
+                      </th>
+                      <th className="text-right p-2 font-semibold border-b border-gray-200">
+                        Code
+                      </th>
+                      <th className="text-right p-2 font-semibold border-b border-gray-200">
+                        Comments
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {platformStats.by_language.map((lang) => (
+                      <tr key={lang.language} className="border-b border-gray-100">
+                        <td className="p-2 font-medium">{lang.language}</td>
+                        <td className="p-2 text-right">{lang.files.toLocaleString()}</td>
+                        <td className="p-2 text-right">{lang.code.toLocaleString()}</td>
+                        <td className="p-2 text-right">{lang.comment.toLocaleString()}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <p>
+                Raw JSON is published at{' '}
+                <a
+                  href="/data/platform-stats.json"
+                  className="text-blue-600 underline hover:text-blue-800"
+                >
+                  /data/platform-stats.json
+                </a>{' '}
+                so any reader can verify these numbers independently.
+              </p>
+            </div>
+          </details>
         </section>
 
         {/* ── License ── */}

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,0 +1,26 @@
+{
+  "as_of": "2026-05-06T00:00:00Z",
+  "commit_sha": "seed",
+  "commit_count": 5280,
+  "lines_of_code": 149687,
+  "comments": 30937,
+  "blanks": 56473,
+  "total_lines": 237097,
+  "tracked_files": 829,
+  "github_workflows": 47,
+  "integrations": 8,
+  "development_phases": 5,
+  "phases_source": "CRP §3.6 Table 8 (Five-Phase TABS Product Development Process)",
+  "method": "cloc; excludes node_modules, .next, dist, build, coverage, .cache, .git, .venv, Old, playwright-report, test-results; binary and lock files excluded by extension",
+  "by_language": [
+    { "language": "TSX", "files": 274, "code": 80586, "comment": 2331, "blank": 0 },
+    { "language": "Python", "files": 80, "code": 29852, "comment": 7625, "blank": 0 },
+    { "language": "JSON", "files": 29, "code": 23000, "comment": 0, "blank": 0 },
+    { "language": "TypeScript", "files": 88, "code": 10393, "comment": 1919, "blank": 0 },
+    { "language": "Markdown", "files": 25, "code": 1379, "comment": 0, "blank": 0 },
+    { "language": "YAML", "files": 53, "code": 6772, "comment": 546, "blank": 0 },
+    { "language": "CSS", "files": 3, "code": 611, "comment": 57, "blank": 0 },
+    { "language": "Bash", "files": 2, "code": 290, "comment": 64, "blank": 0 }
+  ],
+  "_seed": "Initial values pre-workflow-run. Refreshed by .github/workflows/platform-stats.yml on push to main + weekly cron. See #1900."
+}


### PR DESCRIPTION
Implements Tasks 1, 2, and 4 of #1900.

## What's in this PR

| Task | Status | Description |
|---|---|---|
| 1. `platform-stats.yml` workflow | ✅ this PR | Runs cloc + git counts on push to main + weekly cron |
| 2. `Platform by the Numbers` section | ✅ this PR | Renders 5 metrics + per-language breakdown table on `/making-of-tabs/open-source/` |
| 3. Replace stale figures in slides/CRP | ⏳ deferred | Content-only follow-up; this PR builds the canonical source they'll point to |
| 4. Public JSON at `/data/platform-stats.json` | ✅ this PR | Mirrored from `src/data/` to `public/data/` |
| 5. shields.io badges | ⏳ deferred | Optional; JSON shape supports it without refactoring |

## The five metrics

- **`commit_count`** — `git rev-list --count HEAD`
- **`lines_of_code`** — cloc, code-only (excludes blanks/comments/vendored/generated)
- **`github_workflows`** — file count under `.github/workflows/`
- **`integrations`** — dir count under `src/app/making-of-tabs/integrations/`
- **`development_phases`** — constant 5, cited to CRP §3.6 Table 8

cloc exclusion list matches the issue's recommendation: `node_modules`, `.next`, `dist`, `build`, `coverage`, `.cache`, `.git`, `.venv`, `Old`, `playwright-report`, `test-results`, plus binary extensions and lock files.

## How the refresh works

Workflow uses the existing `.github/actions/format-and-pr` composite action — the refresh opens a PR rather than committing directly to main. **Reviewers can spot-check** that counts didn't drift in surprising ways (a 10x jump usually means a new vendored dir slipped past the exclusion list).

## Seed values

`commit_sha: "seed"` is the only sentinel value; the page hides the per-refresh commit link until a real refresh has happened. Initial numbers are from cc12a560 cited in the issue.

## Test plan

- [x] Local: `prettier --check` clean
- [x] Local: existing nav-related tests pass (sidebar-navigation, making-of-tabs-series)
- [ ] CI: Test+Build, CodeQL, Phantom Revert Guard green
- [ ] After merge: first `platform-stats.yml` run produces a refresh PR within 1 commit
- [ ] After merge: `/making-of-tabs/open-source/` renders the new section above the License section

Closes Tasks 1, 2, 4 of #1900. Tasks 3 and 5 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)