### PR TITLE
fix(prolific): switch message export to per-user fetch (no 30-day limit)

### DIFF
--- a/scripts/analysis/extract_prolific_messages.py
+++ b/scripts/analysis/extract_prolific_messages.py
@@ -72,7 +72,11 @@ def _check_outside_repo(env_var: str, path: Path) -> None:
 
 # Re-use the project's Prolific helpers.
 sys.path.insert(0, str(REPO_ROOT / "scripts" / "analysis"))
-from tabs_api import prolific_recent_messages  # noqa: E402
+from tabs_api import (  # noqa: E402
+    prolific_list_studies,
+    prolific_submissions,
+    prolific_user_messages,
+)
 
 # ---------------------------------------------------------------------------
 # PII risk heuristics (matches q74_full_analysis.py)
@@ -240,11 +244,63 @@ def main() -> int:
         p.parent.mkdir(parents=True, exist_ok=True)
     summary_path.parent.mkdir(parents=True, exist_ok=True)
 
-    print(f"Fetching Prolific messages since {since}")
+    print(f"Fetching Prolific messages (full history per participant)")
     print(f"  study_id   = {study_id or '(all studies)'}")
     print(f"  researcher = {researcher_id}")
+    print(f"  since filter (post-fetch) = {since}")
+    print()
 
-    messages = prolific_recent_messages(since, token, study_id)
+    # The Prolific /messages/?created_after= endpoint only returns messages
+    # from the last 30 days. To capture the full history we have to fetch
+    # per-participant via /messages/?user_id=, which has no time limit.
+    # Step 1: enumerate every participant who appears in the study's
+    # submission roster.
+    if study_id:
+        study_ids = [study_id]
+    else:
+        studies = prolific_list_studies(token)
+        study_ids = [s["id"] for s in studies if s.get("id")]
+        print(f"Discovered {len(study_ids)} studies. Iterating each.")
+
+    participant_ids: set[str] = set()
+    for sid in study_ids:
+        subs = prolific_submissions(sid, token)
+        for s in subs:
+            pid = s.get("participant_id") or s.get("participant")
+            if pid:
+                participant_ids.add(pid)
+    print(f"Found {len(participant_ids)} unique participants.")
+
+    # Step 2: fetch messages per participant. ~1 API call each. Log
+    # progress every 25 to keep the workflow log readable.
+    messages: list[dict] = []
+    seen_ids: set[str] = set()
+    for i, pid in enumerate(sorted(participant_ids), 1):
+        try:
+            msgs = prolific_user_messages(pid, token)
+        except Exception as exc:
+            print(f"  [{i}/{len(participant_ids)}] {pid}: ERROR {exc}")
+            continue
+        for m in msgs:
+            mid = m.get("id")
+            if not mid or mid in seen_ids:
+                continue
+            seen_ids.add(mid)
+            messages.append(m)
+        if i % 25 == 0 or i == len(participant_ids):
+            print(f"  [{i}/{len(participant_ids)}] cumulative messages: {len(messages)}")
+
+    # Optional post-fetch filter: keep only messages on or after `since`,
+    # so the operator can scope a re-run without re-pulling everything.
+    if since:
+        before = len(messages)
+        messages = [
+            m for m in messages
+            if (m.get("sent_at") or m.get("created_at") or "") >= since
+        ]
+        print(f"After since-filter ({since}): {len(messages)} messages "
+              f"(dropped {before - len(messages)}).")
+
     print(f"API returned {len(messages)} messages total.")
 
     with raw_path.open("w", encoding="utf-8") as f:

--- a/scripts/analysis/extract_prolific_messages.py
+++ b/scripts/analysis/extract_prolific_messages.py
@@ -214,6 +214,15 @@ def _resolve_path(env_var: str, default: str) -> Path:
     return Path(os.environ.get(env_var, default))
 
 
+def _redact_pid(pid: str) -> str:
+    """Return a redacted version of a Prolific participant ID for safe logging.
+
+    Keeps only the last 4 characters so errors are identifiable without
+    leaking the full 24-character PID into CI logs.
+    """
+    return ("****" + pid[-4:]) if len(pid) >= 4 else "****"
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -275,15 +284,15 @@ def main() -> int:
     # progress every 25 to keep the workflow log readable.
     messages: list[dict] = []
     seen_ids: set[str] = set()
-    fetch_failures = 0
+    failed_fetch_count = 0
     for i, pid in enumerate(sorted(participant_ids), 1):
         try:
             msgs = prolific_user_messages(pid, token)
         except Exception as exc:
             # Redact the participant ID so it doesn't appear in CI logs.
-            redacted = ("****" + pid[-4:]) if len(pid) >= 4 else "****"
+            redacted = _redact_pid(pid)
             print(f"  [{i}/{len(participant_ids)}] {redacted}: ERROR {exc}")
-            fetch_failures += 1
+            failed_fetch_count += 1
             continue
         for m in msgs:
             mid = m.get("id")
@@ -294,9 +303,9 @@ def main() -> int:
         if i % 25 == 0 or i == len(participant_ids):
             print(f"  [{i}/{len(participant_ids)}] cumulative messages: {len(messages)}")
 
-    if fetch_failures:
+    if failed_fetch_count:
         print(
-            f"WARNING: {fetch_failures}/{len(participant_ids)} participant fetches "
+            f"WARNING: {failed_fetch_count}/{len(participant_ids)} participant fetches "
             "failed. The export may be incomplete."
         )
 
@@ -514,9 +523,9 @@ def main() -> int:
     print(f"Inbound: {len(inbound)} | outbound: {len(outbound)}")
     print(f"Theme matches: {dict(theme_counter)}")
     print(f"PII risk: {dict(risk_counter)}")
-    if fetch_failures:
+    if failed_fetch_count:
         print(
-            f"EXITING WITH ERROR: {fetch_failures} participant fetch(es) failed. "
+            f"EXITING WITH ERROR: {failed_fetch_count} participant fetch(es) failed. "
             "Re-run or investigate the failing participants."
         )
         return 1

--- a/scripts/analysis/extract_prolific_messages.py
+++ b/scripts/analysis/extract_prolific_messages.py
@@ -275,11 +275,15 @@ def main() -> int:
     # progress every 25 to keep the workflow log readable.
     messages: list[dict] = []
     seen_ids: set[str] = set()
+    fetch_failures = 0
     for i, pid in enumerate(sorted(participant_ids), 1):
         try:
             msgs = prolific_user_messages(pid, token)
         except Exception as exc:
-            print(f"  [{i}/{len(participant_ids)}] {pid}: ERROR {exc}")
+            # Redact the participant ID so it doesn't appear in CI logs.
+            redacted = ("****" + pid[-4:]) if len(pid) >= 4 else "****"
+            print(f"  [{i}/{len(participant_ids)}] {redacted}: ERROR {exc}")
+            fetch_failures += 1
             continue
         for m in msgs:
             mid = m.get("id")
@@ -289,6 +293,25 @@ def main() -> int:
             messages.append(m)
         if i % 25 == 0 or i == len(participant_ids):
             print(f"  [{i}/{len(participant_ids)}] cumulative messages: {len(messages)}")
+
+    if fetch_failures:
+        print(
+            f"WARNING: {fetch_failures}/{len(participant_ids)} participant fetches "
+            "failed. The export may be incomplete."
+        )
+
+    # Optional post-fetch study_id filter: keep only messages associated with
+    # the requested study so unrelated conversations are excluded.
+    if study_id:
+        before = len(messages)
+        messages = [
+            m for m in messages
+            if (m.get("data") or {}).get("study_id") == study_id
+        ]
+        print(
+            f"After study_id filter ({study_id}): {len(messages)} messages "
+            f"(dropped {before - len(messages)} from other studies)."
+        )
 
     # Optional post-fetch filter: keep only messages on or after `since`,
     # so the operator can scope a re-run without re-pulling everything.
@@ -491,6 +514,12 @@ def main() -> int:
     print(f"Inbound: {len(inbound)} | outbound: {len(outbound)}")
     print(f"Theme matches: {dict(theme_counter)}")
     print(f"PII risk: {dict(risk_counter)}")
+    if fetch_failures:
+        print(
+            f"EXITING WITH ERROR: {fetch_failures} participant fetch(es) failed. "
+            "Re-run or investigate the failing participants."
+        )
+        return 1
     return 0
 
 

--- a/scripts/analysis/tests/test_extract_prolific_messages.py
+++ b/scripts/analysis/tests/test_extract_prolific_messages.py
@@ -94,7 +94,7 @@ class TestStudyIdFilter:
         assert raw[0]["id"] == "m1"
 
     def test_no_study_id_returns_all_messages(self, tmp_path):
-        """When STUDY_ID is not set all messages across studies are included."""
+        """When STUDY_ID is not set, all messages across studies are included."""
         messages_by_user = {
             "p1": [
                 _make_message("m1", sender_id="p1", study_id="STUDY_A"),
@@ -220,7 +220,7 @@ class TestFailureHandling:
             patch("extract_prolific_messages.prolific_list_studies", return_value=[{"id": "STUDY_A"}]),
             patch("extract_prolific_messages.prolific_submissions", return_value=submissions),
             patch("extract_prolific_messages.prolific_user_messages", side_effect=_side_effect),
-            # Suppress sys.stdout.reconfigure() so it doesn't fail on the real fd
+            # Suppress sys.stdout/stderr.reconfigure() so it doesn't fail on the StringIO capsys fd.
             patch("sys.stdout.reconfigure", lambda **kw: None, create=True),
             patch("sys.stderr.reconfigure", lambda **kw: None, create=True),
         ):

--- a/scripts/analysis/tests/test_extract_prolific_messages.py
+++ b/scripts/analysis/tests/test_extract_prolific_messages.py
@@ -1,0 +1,252 @@
+"""Tests for extract_prolific_messages.py - per-participant fetch strategy."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make the analysis package importable.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Import internal helpers we want to exercise directly.
+from extract_prolific_messages import main, pii_assessment, themes_for  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_message(
+    id: str,
+    sender_id: str = "participant-001",
+    body: str = "Hello",
+    study_id: str = "STUDY_A",
+    sent_at: str = "2025-03-01T10:00:00Z",
+) -> dict:
+    return {
+        "id": id,
+        "sender_id": sender_id,
+        "body": body,
+        "sent_at": sent_at,
+        "channel_id": f"ch-{sender_id}",
+        "data": {"study_id": study_id},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. study_id filter removes messages from other studies
+# ---------------------------------------------------------------------------
+
+class TestStudyIdFilter:
+    """When STUDY_ID is set, only messages for that study appear in output."""
+
+    def _run(self, tmp_path: Path, study_id: str | None, messages_by_user: dict[str, list[dict]]) -> dict:
+        """Run main() with mocked API and return the parsed aggregate JSON."""
+        raw_path = tmp_path / "raw.json"
+        csv_path = tmp_path / "inbound.csv"
+        transcripts_path = tmp_path / "transcripts.md"
+        candidates_path = tmp_path / "candidates.md"
+        summary_path = tmp_path / "summary.json"
+
+        env = {
+            "PROLIFIC_API_TOKEN": "token",
+            "RESEARCHER_ID": "researcher-999",
+            "SINCE": "",
+            "RAW_OUTPUT_PATH": str(raw_path),
+            "INBOUND_CSV_PATH": str(csv_path),
+            "TRANSCRIPTS_PATH": str(transcripts_path),
+            "CANDIDATES_PATH": str(candidates_path),
+            "SUMMARY_PATH": str(summary_path),
+        }
+        if study_id:
+            env["STUDY_ID"] = study_id
+
+        # submissions: one submission per user id key
+        submissions = [{"participant_id": uid} for uid in messages_by_user]
+
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("extract_prolific_messages.prolific_list_studies", return_value=[{"id": "STUDY_A"}, {"id": "STUDY_B"}]),
+            patch("extract_prolific_messages.prolific_submissions", return_value=submissions),
+            patch("extract_prolific_messages.prolific_user_messages", side_effect=lambda uid, _token: messages_by_user.get(uid, [])),
+        ):
+            rc = main()
+
+        import json
+        aggregate = json.loads(summary_path.read_text())
+        return {"rc": rc, "aggregate": aggregate, "raw": json.loads(raw_path.read_text())}
+
+    def test_study_id_filter_excludes_other_study(self, tmp_path):
+        """Messages from a different study are excluded when STUDY_ID is set."""
+        messages_by_user = {
+            "p1": [
+                _make_message("m1", sender_id="p1", study_id="STUDY_A"),
+                _make_message("m2", sender_id="p1", study_id="STUDY_B"),  # should be excluded
+            ],
+        }
+        result = self._run(tmp_path, study_id="STUDY_A", messages_by_user=messages_by_user)
+        assert result["rc"] == 0
+        raw = result["raw"]
+        assert len(raw) == 1
+        assert raw[0]["id"] == "m1"
+
+    def test_no_study_id_returns_all_messages(self, tmp_path):
+        """When STUDY_ID is not set all messages across studies are included."""
+        messages_by_user = {
+            "p1": [
+                _make_message("m1", sender_id="p1", study_id="STUDY_A"),
+                _make_message("m2", sender_id="p1", study_id="STUDY_B"),
+            ],
+        }
+        result = self._run(tmp_path, study_id=None, messages_by_user=messages_by_user)
+        assert result["rc"] == 0
+        assert len(result["raw"]) == 2
+
+    def test_study_id_filter_all_excluded(self, tmp_path):
+        """If no messages match the study, the export is empty but exits 0."""
+        messages_by_user = {
+            "p1": [_make_message("m1", sender_id="p1", study_id="STUDY_B")],
+        }
+        result = self._run(tmp_path, study_id="STUDY_A", messages_by_user=messages_by_user)
+        assert result["rc"] == 0
+        assert len(result["raw"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Deduplication by message id across participants
+# ---------------------------------------------------------------------------
+
+class TestDeduplication:
+    """Messages with duplicate ids (e.g. returned for multiple participants) appear once."""
+
+    def _run(self, tmp_path: Path, messages_by_user: dict[str, list[dict]]) -> list[dict]:
+        raw_path = tmp_path / "raw.json"
+        csv_path = tmp_path / "inbound.csv"
+        transcripts_path = tmp_path / "transcripts.md"
+        candidates_path = tmp_path / "candidates.md"
+        summary_path = tmp_path / "summary.json"
+
+        env = {
+            "PROLIFIC_API_TOKEN": "token",
+            "RESEARCHER_ID": "researcher-999",
+            "SINCE": "",
+            "RAW_OUTPUT_PATH": str(raw_path),
+            "INBOUND_CSV_PATH": str(csv_path),
+            "TRANSCRIPTS_PATH": str(transcripts_path),
+            "CANDIDATES_PATH": str(candidates_path),
+            "SUMMARY_PATH": str(summary_path),
+        }
+        submissions = [{"participant_id": uid} for uid in messages_by_user]
+
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("extract_prolific_messages.prolific_list_studies", return_value=[{"id": "STUDY_A"}]),
+            patch("extract_prolific_messages.prolific_submissions", return_value=submissions),
+            patch("extract_prolific_messages.prolific_user_messages", side_effect=lambda uid, _token: messages_by_user.get(uid, [])),
+        ):
+            main()
+
+        import json
+        return json.loads(raw_path.read_text())
+
+    def test_duplicate_message_ids_deduplicated(self, tmp_path):
+        """The same message id returned for two users appears exactly once."""
+        shared_msg = _make_message("shared-id", sender_id="p1")
+        messages_by_user = {
+            "p1": [shared_msg],
+            "p2": [shared_msg],  # same id, different user fetch
+        }
+        raw = self._run(tmp_path, messages_by_user)
+        assert len(raw) == 1
+        assert raw[0]["id"] == "shared-id"
+
+    def test_different_ids_not_deduplicated(self, tmp_path):
+        """Two messages with different ids both appear in output."""
+        messages_by_user = {
+            "p1": [_make_message("id-1", sender_id="p1")],
+            "p2": [_make_message("id-2", sender_id="p2")],
+        }
+        raw = self._run(tmp_path, messages_by_user)
+        ids = {m["id"] for m in raw}
+        assert ids == {"id-1", "id-2"}
+
+    def test_messages_without_id_excluded(self, tmp_path):
+        """Messages that have no 'id' field are silently skipped."""
+        messages_by_user = {
+            "p1": [{"sender_id": "p1", "body": "no id here", "data": {"study_id": "STUDY_A"}}],
+        }
+        raw = self._run(tmp_path, messages_by_user)
+        assert raw == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure handling - non-zero exit and no PID leakage
+# ---------------------------------------------------------------------------
+
+class TestFailureHandling:
+    """When prolific_user_messages raises, failures are tracked and exit is non-zero."""
+
+    def _run(self, tmp_path: Path, fail_user: str, capsys) -> tuple[int, str]:
+        raw_path = tmp_path / "raw.json"
+        csv_path = tmp_path / "inbound.csv"
+        transcripts_path = tmp_path / "transcripts.md"
+        candidates_path = tmp_path / "candidates.md"
+        summary_path = tmp_path / "summary.json"
+
+        env = {
+            "PROLIFIC_API_TOKEN": "token",
+            "RESEARCHER_ID": "researcher-999",
+            "SINCE": "",
+            "RAW_OUTPUT_PATH": str(raw_path),
+            "INBOUND_CSV_PATH": str(csv_path),
+            "TRANSCRIPTS_PATH": str(transcripts_path),
+            "CANDIDATES_PATH": str(candidates_path),
+            "SUMMARY_PATH": str(summary_path),
+        }
+
+        submissions = [{"participant_id": "aabbccddeeff112233445566"}]
+        good_msg = _make_message("good-id", sender_id="aabbccddeeff112233445566")
+
+        def _side_effect(uid: str, _token: str) -> list[dict]:
+            if uid == fail_user:
+                raise RuntimeError("API timeout")
+            return [good_msg]
+
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("extract_prolific_messages.prolific_list_studies", return_value=[{"id": "STUDY_A"}]),
+            patch("extract_prolific_messages.prolific_submissions", return_value=submissions),
+            patch("extract_prolific_messages.prolific_user_messages", side_effect=_side_effect),
+            # Suppress sys.stdout.reconfigure() so it doesn't fail on the real fd
+            patch("sys.stdout.reconfigure", lambda **kw: None, create=True),
+            patch("sys.stderr.reconfigure", lambda **kw: None, create=True),
+        ):
+            rc = main()
+
+        captured = capsys.readouterr()
+        return rc, captured.out
+
+    def test_exit_nonzero_on_fetch_failure(self, tmp_path, capsys):
+        """Script returns exit code 1 when at least one participant fetch fails."""
+        rc, _ = self._run(tmp_path, fail_user="aabbccddeeff112233445566", capsys=capsys)
+        assert rc == 1
+
+    def test_pid_not_logged_raw(self, tmp_path, capsys):
+        """The full participant ID is not printed to stdout on failure."""
+        _rc, stdout = self._run(tmp_path, fail_user="aabbccddeeff112233445566", capsys=capsys)
+        # The raw 24-char PID must not appear anywhere in the output.
+        assert "aabbccddeeff112233445566" not in stdout
+
+    def test_pid_redacted_to_last_four(self, tmp_path, capsys):
+        """Error log redacts the PID to '****<last-4>'."""
+        _rc, stdout = self._run(tmp_path, fail_user="aabbccddeeff112233445566", capsys=capsys)
+        assert "****5566" in stdout
+
+    def test_zero_on_success(self, tmp_path, capsys):
+        """Script returns 0 when all participant fetches succeed."""
+        # Use a different fail_user so the actual participant doesn't fail.
+        rc, _ = self._run(tmp_path, fail_user="nonexistent-participant", capsys=capsys)
+        assert rc == 0


### PR DESCRIPTION
## Summary

The first run of [prolific-message-export.yml](.github/workflows/prolific-message-export.yml) on main failed with HTTP 400:

> This API can only retrieve the last 30 days of messages.

The `/messages/?created_after=` endpoint has a 30-day cap that I didn't see documented when I built the workflow.

## Fix

Switch to the per-user endpoint (`/messages/?user_id=`), which has no time limit:

1. Enumerate every participant in the study's submission roster (`prolific_list_studies` + `prolific_submissions`, both already in `tabs_api.py`).
2. Fetch per-participant via `prolific_user_messages`.
3. Deduplicate by message id.
4. Apply the `SINCE` env-var filter post-fetch so the operator can still scope a run without re-pulling.

Trades 1 paginated request for ~600 individual requests (one per unique participant). This is the only path to the full history.

## Test plan

- [x] Script parses.
- [ ] CI passes.
- [ ] After merge, `gh workflow run prolific-message-export.yml` produces all 5 artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)