### PR TITLE
fix(platform-stats): replace pipefail-fatal ls globs with find

### DIFF
--- a/.github/workflows/platform-stats.yml
+++ b/.github/workflows/platform-stats.yml
@@ -65,9 +65,12 @@ jobs:
           mkdir -p src/data
 
           COMMITS=$(git rev-list --count HEAD)
-          # Two glob patterns because GitHub Actions accepts both .yml and .yaml.
-          WORKFLOWS=$(ls .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null | wc -l)
-          INTEGRATIONS=$(ls -d src/app/making-of-tabs/integrations/*/ 2>/dev/null | wc -l)
+          # `ls A B` returns nonzero when one pattern matches nothing. Combined
+          # with `set -o pipefail` that kills the script even when 2>/dev/null
+          # hides the warning. Use `find` instead - it returns 0 for
+          # both-found and neither-found, and we count its output.
+          WORKFLOWS=$(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | wc -l)
+          INTEGRATIONS=$(find src/app/making-of-tabs/integrations -maxdepth 1 -mindepth 1 -type d | wc -l)
           CODE=$(jq '.SUM.code'    /tmp/cloc.json)
           COMM=$(jq '.SUM.comment' /tmp/cloc.json)
           BLANK=$(jq '.SUM.blank'  /tmp/cloc.json)


### PR DESCRIPTION
## Summary

The platform-stats workflow has been failing the compute step on every commit since #1903 landed (verified across [a0bd327d](https://github.com/clarkemoyer/technologyadoptionbarriers.org/runs/25464681101), [b58336ed](https://github.com/clarkemoyer/technologyadoptionbarriers.org/runs/25465056048), and [81297fba](https://github.com/clarkemoyer/technologyadoptionbarriers.org/runs/25467865895)). It exits 2 with no visible output, before any of the script's echo lines fire.

## Root cause

Reproduced locally:

```bash
bash -c 'set -euo pipefail; ls .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null | wc -l'
# -> exit code 2
```

When `ls` is called with two glob patterns and only one matches, `ls` exits non-zero. `2>/dev/null` hides the stderr message but `set -o pipefail` still propagates the nonzero exit through `wc -l`, and `set -e` kills the script. There are no `.yaml` workflow files in this repo (only `.yml`), so the second glob has been silently breaking the script the entire time.

Same hazard would apply to the `INTEGRATIONS=$(ls -d src/app/.../integrations/*/)` line if that dir were ever empty.

## Fix

Switch both counters to `find ... | wc -l`. `find` returns 0 whether the search matches or not, and `wc -l` accurately counts the lines it printed.

```bash
WORKFLOWS=$(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | wc -l)
INTEGRATIONS=$(find src/app/making-of-tabs/integrations -maxdepth 1 -mindepth 1 -type d | wc -l)
```

## Test plan

- [x] Local reproduction confirms exit-2 with the original line, exit-0 with the fix.
- [x] Local counts: workflows=50, integrations=8 (matches `ls` output).
- [ ] CI passes (the workflow itself, plus the rest of the pipeline).
- [ ] After merge, the daily push trigger should produce a `chore: refresh platform-stats.json` PR for the first time since the workflow shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)