### PR TITLE
fix(platform-stats): declare environment: copilot so the PR-token secret resolves

### DIFF
--- a/.github/workflows/platform-stats.yml
+++ b/.github/workflows/platform-stats.yml
@@ -34,6 +34,11 @@ jobs:
   compute:
     name: Compute platform stats
     runs-on: ubuntu-latest
+    # The "Open PR if changed" step needs the COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN
+    # secret, which lives in the `copilot` environment. Without this declaration
+    # the secret resolves to "" and create-pull-request fails with
+    # "Input 'token' not supplied". Matches ga-report.yml / prettier-autofix.yml.
+    environment: copilot
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Follow-up to #1914

The compute step now succeeds (after the `find` fix), but the next step **\"Open PR if changed\"** fails:

> ##[error]Input 'token' not supplied. Unable to continue.

## Root cause

The token reference is `secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN`. That secret lives in the **`copilot` GitHub environment**, not at the repo level. The job had no `environment:` declaration, so the secret resolved to empty string, and the create-pull-request action treated it as missing.

Confirmed via `gh secret list --env copilot` — the secret is there. The other workflows that consume the same token (`ga-report.yml`, `prettier-autofix.yml`, `daily-pipeline.yml`, `analysis-pipeline.yml`, `qualtrics-metrics-update.yml`, `daily-disposition-processing.yml`) all declare `environment: copilot`.

## Fix

```yaml
jobs:
  compute:
    name: Compute platform stats
    runs-on: ubuntu-latest
    environment: copilot
    timeout-minutes: 5
```

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, the workflow's push trigger fires on the merge commit and the format-and-pr step opens the first `chore: refresh platform-stats.json` auto-PR (the figures should differ from the seeded baseline by now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)