### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-07T11:56:44Z",
-  "commit_sha": "225a6a9635409d1aa8d9ea5e58f8071f5525be66",
-  "commit_count": 5321,
-  "lines_of_code": 227498,
+  "as_of": "2026-05-07T12:00:58Z",
+  "commit_sha": "efda38d3adeabbf72e202997d325d9f02bb84c37",
+  "commit_count": 5323,
+  "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,
-  "total_lines": 266475,
+  "total_lines": 266578,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44684,
+      "code": 44787,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-07T11:56:44Z",
-  "commit_sha": "225a6a9635409d1aa8d9ea5e58f8071f5525be66",
-  "commit_count": 5321,
-  "lines_of_code": 227498,
+  "as_of": "2026-05-07T12:00:58Z",
+  "commit_sha": "efda38d3adeabbf72e202997d325d9f02bb84c37",
+  "commit_count": 5323,
+  "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,
-  "total_lines": 266475,
+  "total_lines": 266578,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44684,
+      "code": 44787,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.