### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T12:17:50Z",
-  "commit_sha": "0c3e81b3c483d5b3556f6f3d2ba5307da4751ba9",
-  "commit_count": 5331,
+  "as_of": "2026-05-07T12:22:14Z",
+  "commit_sha": "48e8628140ff05dd54e283da6627c94e24f1be5e",
+  "commit_count": 5333,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T12:17:50Z",
-  "commit_sha": "0c3e81b3c483d5b3556f6f3d2ba5307da4751ba9",
-  "commit_count": 5331,
+  "as_of": "2026-05-07T12:22:14Z",
+  "commit_sha": "48e8628140ff05dd54e283da6627c94e24f1be5e",
+  "commit_count": 5333,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.