### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T12:46:52Z",
-  "commit_sha": "eabdd8cedcde2e87a4b9cbd00c087a50063c1c69",
-  "commit_count": 5345,
+  "as_of": "2026-05-07T12:51:24Z",
+  "commit_sha": "87ff09a6dca7c85610fb96c3db20b319ae1a29f4",
+  "commit_count": 5347,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T12:46:52Z",
-  "commit_sha": "eabdd8cedcde2e87a4b9cbd00c087a50063c1c69",
-  "commit_count": 5345,
+  "as_of": "2026-05-07T12:51:24Z",
+  "commit_sha": "87ff09a6dca7c85610fb96c3db20b319ae1a29f4",
+  "commit_count": 5347,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.