### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T13:08:06Z",
-  "commit_sha": "e48aec7c8e124d89a91543767d8d669d8a0fb117",
-  "commit_count": 5355,
+  "as_of": "2026-05-07T13:12:36Z",
+  "commit_sha": "5713c4dc892624c8e341da9d0c9f990d1213e989",
+  "commit_count": 5357,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T13:08:06Z",
-  "commit_sha": "e48aec7c8e124d89a91543767d8d669d8a0fb117",
-  "commit_count": 5355,
+  "as_of": "2026-05-07T13:12:36Z",
+  "commit_sha": "5713c4dc892624c8e341da9d0c9f990d1213e989",
+  "commit_count": 5357,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.