### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T14:01:57Z",
-  "commit_sha": "67555150b86e57571ddf9c602dfded8a8a0f1cbf",
-  "commit_count": 5379,
+  "as_of": "2026-05-07T14:09:03Z",
+  "commit_sha": "17da877b413113c45429ca5e76c8d9058c6a5009",
+  "commit_count": 5381,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T14:01:57Z",
-  "commit_sha": "67555150b86e57571ddf9c602dfded8a8a0f1cbf",
-  "commit_count": 5379,
+  "as_of": "2026-05-07T14:09:03Z",
+  "commit_sha": "17da877b413113c45429ca5e76c8d9058c6a5009",
+  "commit_count": 5381,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.