### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T14:14:17Z",
-  "commit_sha": "b45597e62c8981518366ce98d4296b341dbbaaf3",
-  "commit_count": 5383,
+  "as_of": "2026-05-07T14:18:37Z",
+  "commit_sha": "dc5aa1ad58e152affcbfcd349cbd832a939bd5bb",
+  "commit_count": 5385,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-07T14:14:17Z",
-  "commit_sha": "b45597e62c8981518366ce98d4296b341dbbaaf3",
-  "commit_count": 5383,
+  "as_of": "2026-05-07T14:18:37Z",
+  "commit_sha": "dc5aa1ad58e152affcbfcd349cbd832a939bd5bb",
+  "commit_count": 5385,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.