### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T01:11:28Z",
-  "commit_sha": "362e1d76edae2dbe03c1c4dbd598abeebe15dc4e",
-  "commit_count": 5397,
+  "as_of": "2026-05-08T01:15:38Z",
+  "commit_sha": "4a18856f5e838e09efca4690db10773414fc2173",
+  "commit_count": 5399,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T01:11:28Z",
-  "commit_sha": "362e1d76edae2dbe03c1c4dbd598abeebe15dc4e",
-  "commit_count": 5397,
+  "as_of": "2026-05-08T01:15:38Z",
+  "commit_sha": "4a18856f5e838e09efca4690db10773414fc2173",
+  "commit_count": 5399,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.