### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T01:44:49Z",
-  "commit_sha": "981c5fa73e210547628b552dd97ce3c2ac4577b1",
-  "commit_count": 5413,
+  "as_of": "2026-05-08T01:48:27Z",
+  "commit_sha": "ccb9de560020a74fee4e7d6e6b76a53b36b43f4e",
+  "commit_count": 5415,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T01:44:49Z",
-  "commit_sha": "981c5fa73e210547628b552dd97ce3c2ac4577b1",
-  "commit_count": 5413,
+  "as_of": "2026-05-08T01:48:27Z",
+  "commit_sha": "ccb9de560020a74fee4e7d6e6b76a53b36b43f4e",
+  "commit_count": 5415,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.