### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T02:00:40Z",
-  "commit_sha": "6b4c3348841c78420b173cbdfa2204155151e883",
-  "commit_count": 5421,
+  "as_of": "2026-05-08T02:04:33Z",
+  "commit_sha": "9b97399bb32594c4b3f88192b7ffcc93e12da04b",
+  "commit_count": 5423,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T02:00:40Z",
-  "commit_sha": "6b4c3348841c78420b173cbdfa2204155151e883",
-  "commit_count": 5421,
+  "as_of": "2026-05-08T02:04:33Z",
+  "commit_sha": "9b97399bb32594c4b3f88192b7ffcc93e12da04b",
+  "commit_count": 5423,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.