### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T02:20:45Z",
-  "commit_sha": "f81b8f379def7d7c8b9922dee599843798eaafab",
-  "commit_count": 5431,
+  "as_of": "2026-05-08T02:25:21Z",
+  "commit_sha": "c7b7c9e1790536a4632d713c3b95a4796e2bfee6",
+  "commit_count": 5433,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T02:20:45Z",
-  "commit_sha": "f81b8f379def7d7c8b9922dee599843798eaafab",
-  "commit_count": 5431,
+  "as_of": "2026-05-08T02:25:21Z",
+  "commit_sha": "c7b7c9e1790536a4632d713c3b95a4796e2bfee6",
+  "commit_count": 5433,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.