### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T02:37:37Z",
-  "commit_sha": "2f18e4812f9dde1e1042ec33ffc3065083b363db",
-  "commit_count": 5439,
+  "as_of": "2026-05-08T02:41:40Z",
+  "commit_sha": "16ef4b23d93ba80d21c577548002d54e4e7cf95d",
+  "commit_count": 5441,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T02:37:37Z",
-  "commit_sha": "2f18e4812f9dde1e1042ec33ffc3065083b363db",
-  "commit_count": 5439,
+  "as_of": "2026-05-08T02:41:40Z",
+  "commit_sha": "16ef4b23d93ba80d21c577548002d54e4e7cf95d",
+  "commit_count": 5441,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.