### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T03:02:04Z",
-  "commit_sha": "756d3e852062d8497b4ddf1cd55c012853c173a2",
-  "commit_count": 5451,
+  "as_of": "2026-05-08T03:06:17Z",
+  "commit_sha": "e118214a65fe03e1f28ad051545c261e6ecb70db",
+  "commit_count": 5453,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T03:02:04Z",
-  "commit_sha": "756d3e852062d8497b4ddf1cd55c012853c173a2",
-  "commit_count": 5451,
+  "as_of": "2026-05-08T03:06:17Z",
+  "commit_sha": "e118214a65fe03e1f28ad051545c261e6ecb70db",
+  "commit_count": 5453,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.