### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T03:10:22Z",
-  "commit_sha": "018ad95fd1c0db3b9d4b1b9428b179a39599822c",
-  "commit_count": 5455,
+  "as_of": "2026-05-08T03:14:27Z",
+  "commit_sha": "9ef7fc7fb0a86d08b281e92a99a9ef2b4d01d9a8",
+  "commit_count": 5457,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T03:10:22Z",
-  "commit_sha": "018ad95fd1c0db3b9d4b1b9428b179a39599822c",
-  "commit_count": 5455,
+  "as_of": "2026-05-08T03:14:27Z",
+  "commit_sha": "9ef7fc7fb0a86d08b281e92a99a9ef2b4d01d9a8",
+  "commit_count": 5457,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.