### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T03:54:37Z",
-  "commit_sha": "fda30f28334a3185627905f00d856b71fb6f391f",
-  "commit_count": 5477,
+  "as_of": "2026-05-08T03:59:01Z",
+  "commit_sha": "b5a663a38ff34a267e75b4f6259a22af148bc526",
+  "commit_count": 5479,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T03:54:37Z",
-  "commit_sha": "fda30f28334a3185627905f00d856b71fb6f391f",
-  "commit_count": 5477,
+  "as_of": "2026-05-08T03:59:01Z",
+  "commit_sha": "b5a663a38ff34a267e75b4f6259a22af148bc526",
+  "commit_count": 5479,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.