### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T04:03:30Z",
-  "commit_sha": "e194fec93644eaedbdc32d74ef6bcac0b7a01d49",
-  "commit_count": 5481,
+  "as_of": "2026-05-08T04:07:40Z",
+  "commit_sha": "b0230ffde32100698633e4a87b14961ad6234409",
+  "commit_count": 5483,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T04:03:30Z",
-  "commit_sha": "e194fec93644eaedbdc32d74ef6bcac0b7a01d49",
-  "commit_count": 5481,
+  "as_of": "2026-05-08T04:07:40Z",
+  "commit_sha": "b0230ffde32100698633e4a87b14961ad6234409",
+  "commit_count": 5483,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.