### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T04:16:07Z",
-  "commit_sha": "1a806d3bacff5baadd1f9018ea00d6f1cf385c16",
-  "commit_count": 5487,
+  "as_of": "2026-05-08T04:20:26Z",
+  "commit_sha": "e6aa54a6a2d7eb7b1b4e09ef77a9f528dc87ee1f",
+  "commit_count": 5489,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T04:16:07Z",
-  "commit_sha": "1a806d3bacff5baadd1f9018ea00d6f1cf385c16",
-  "commit_count": 5487,
+  "as_of": "2026-05-08T04:20:26Z",
+  "commit_sha": "e6aa54a6a2d7eb7b1b4e09ef77a9f528dc87ee1f",
+  "commit_count": 5489,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.