### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T04:39:47Z",
-  "commit_sha": "5ef2d03ac636f37f4680948d46f31eb131dca6d8",
-  "commit_count": 5499,
+  "as_of": "2026-05-08T04:44:22Z",
+  "commit_sha": "0e4e9d0289c8a60d513972275ebee8144c432bb5",
+  "commit_count": 5501,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T04:39:47Z",
-  "commit_sha": "5ef2d03ac636f37f4680948d46f31eb131dca6d8",
-  "commit_count": 5499,
+  "as_of": "2026-05-08T04:44:22Z",
+  "commit_sha": "0e4e9d0289c8a60d513972275ebee8144c432bb5",
+  "commit_count": 5501,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.