### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T05:38:00Z",
-  "commit_sha": "73c6f518e3a790ea9008176c3ba8634e0a632b62",
-  "commit_count": 5527,
+  "as_of": "2026-05-08T05:42:12Z",
+  "commit_sha": "8ca250ba2d1f8c13f62706d9dde9a71a65f787ae",
+  "commit_count": 5529,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T05:38:00Z",
-  "commit_sha": "73c6f518e3a790ea9008176c3ba8634e0a632b62",
-  "commit_count": 5527,
+  "as_of": "2026-05-08T05:42:12Z",
+  "commit_sha": "8ca250ba2d1f8c13f62706d9dde9a71a65f787ae",
+  "commit_count": 5529,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.