### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T06:07:52Z",
-  "commit_sha": "a9686a7e29589af5748555a8a7092379f44d39c3",
-  "commit_count": 5541,
+  "as_of": "2026-05-08T06:11:39Z",
+  "commit_sha": "c9fdbe74cbcdd1f75baf7579ed8e0e1bdb9d6927",
+  "commit_count": 5543,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T06:07:52Z",
-  "commit_sha": "a9686a7e29589af5748555a8a7092379f44d39c3",
-  "commit_count": 5541,
+  "as_of": "2026-05-08T06:11:39Z",
+  "commit_sha": "c9fdbe74cbcdd1f75baf7579ed8e0e1bdb9d6927",
+  "commit_count": 5543,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.