### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T06:15:48Z",
-  "commit_sha": "05b122a71a88c3a9e4bcb1913b0221258d385d10",
-  "commit_count": 5545,
+  "as_of": "2026-05-08T06:19:58Z",
+  "commit_sha": "db99dfa393889abecce63218dc64ea0ce4d8f5c1",
+  "commit_count": 5547,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T06:15:48Z",
-  "commit_sha": "05b122a71a88c3a9e4bcb1913b0221258d385d10",
-  "commit_count": 5545,
+  "as_of": "2026-05-08T06:19:58Z",
+  "commit_sha": "db99dfa393889abecce63218dc64ea0ce4d8f5c1",
+  "commit_count": 5547,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.