### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T06:33:13Z",
-  "commit_sha": "a0a5554e931f149b522e365035b8f5c7b9c23b4f",
-  "commit_count": 5553,
+  "as_of": "2026-05-08T06:37:23Z",
+  "commit_sha": "6a570751fa5427945742952560d0cedeee952a37",
+  "commit_count": 5555,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T06:33:13Z",
-  "commit_sha": "a0a5554e931f149b522e365035b8f5c7b9c23b4f",
-  "commit_count": 5553,
+  "as_of": "2026-05-08T06:37:23Z",
+  "commit_sha": "6a570751fa5427945742952560d0cedeee952a37",
+  "commit_count": 5555,
   "lines_of_code": 227601,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.