### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-08T06:50:28Z",
-  "commit_sha": "800cb74e80c7ea8289fb91a3c4eeb6d1fab151a7",
-  "commit_count": 5561,
-  "lines_of_code": 227601,
+  "as_of": "2026-05-08T11:15:01Z",
+  "commit_sha": "aa90669b02042249830a27aebe577e5a5cc67a8b",
+  "commit_count": 5565,
+  "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,
-  "total_lines": 266578,
+  "total_lines": 266572,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44787,
+      "code": 44781,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-08T06:50:28Z",
-  "commit_sha": "800cb74e80c7ea8289fb91a3c4eeb6d1fab151a7",
-  "commit_count": 5561,
-  "lines_of_code": 227601,
+  "as_of": "2026-05-08T11:15:01Z",
+  "commit_sha": "aa90669b02042249830a27aebe577e5a5cc67a8b",
+  "commit_count": 5565,
+  "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,
-  "total_lines": 266578,
+  "total_lines": 266572,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44787,
+      "code": 44781,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.