### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T11:22:53Z",
-  "commit_sha": "7dc89fe5765262a06d6bdafa3c8bf3ec607e91cf",
-  "commit_count": 5569,
+  "as_of": "2026-05-08T11:26:47Z",
+  "commit_sha": "75ff770552cea2bfb451631eeef6b0b54b92f5b8",
+  "commit_count": 5571,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T11:22:53Z",
-  "commit_sha": "7dc89fe5765262a06d6bdafa3c8bf3ec607e91cf",
-  "commit_count": 5569,
+  "as_of": "2026-05-08T11:26:47Z",
+  "commit_sha": "75ff770552cea2bfb451631eeef6b0b54b92f5b8",
+  "commit_count": 5571,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.