### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T11:35:08Z",
-  "commit_sha": "1258668186b5df65e47ddb2b16e7c6a101337ac9",
-  "commit_count": 5575,
+  "as_of": "2026-05-08T11:39:15Z",
+  "commit_sha": "99ff2ed99925effc03e3356f1d375c7009ae3dc7",
+  "commit_count": 5577,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T11:35:08Z",
-  "commit_sha": "1258668186b5df65e47ddb2b16e7c6a101337ac9",
-  "commit_count": 5575,
+  "as_of": "2026-05-08T11:39:15Z",
+  "commit_sha": "99ff2ed99925effc03e3356f1d375c7009ae3dc7",
+  "commit_count": 5577,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.