### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T11:47:23Z",
-  "commit_sha": "32a230939f3ed128306d244303abc677df8dac2a",
-  "commit_count": 5581,
+  "as_of": "2026-05-08T11:51:40Z",
+  "commit_sha": "994105242f690690cf2a0d2ae6de1505472d7a28",
+  "commit_count": 5583,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T11:47:23Z",
-  "commit_sha": "32a230939f3ed128306d244303abc677df8dac2a",
-  "commit_count": 5581,
+  "as_of": "2026-05-08T11:51:40Z",
+  "commit_sha": "994105242f690690cf2a0d2ae6de1505472d7a28",
+  "commit_count": 5583,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.