### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T11:55:57Z",
-  "commit_sha": "f723a236b6a51c4bdf63dfb699aba0a176d23e50",
-  "commit_count": 5585,
+  "as_of": "2026-05-08T11:59:54Z",
+  "commit_sha": "f69b3b27d8164fa86d587bdc52c5cd43c32eefbd",
+  "commit_count": 5587,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T11:55:57Z",
-  "commit_sha": "f723a236b6a51c4bdf63dfb699aba0a176d23e50",
-  "commit_count": 5585,
+  "as_of": "2026-05-08T11:59:54Z",
+  "commit_sha": "f69b3b27d8164fa86d587bdc52c5cd43c32eefbd",
+  "commit_count": 5587,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.