### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T12:08:19Z",
-  "commit_sha": "e1230fa6a2803e7868f35c0a26bdcd1762275b4d",
-  "commit_count": 5591,
+  "as_of": "2026-05-08T12:12:35Z",
+  "commit_sha": "7e9b77f17333cf8b48cb241444eafec5956341b4",
+  "commit_count": 5593,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T12:08:19Z",
-  "commit_sha": "e1230fa6a2803e7868f35c0a26bdcd1762275b4d",
-  "commit_count": 5591,
+  "as_of": "2026-05-08T12:12:35Z",
+  "commit_sha": "7e9b77f17333cf8b48cb241444eafec5956341b4",
+  "commit_count": 5593,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.