### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T13:50:05Z",
-  "commit_sha": "48f306a1f992ee6c7b58b6d52351a49f80f71d6e",
-  "commit_count": 5639,
+  "as_of": "2026-05-08T13:54:37Z",
+  "commit_sha": "7b194d383bba3a25c549ef8047498257054d8e6a",
+  "commit_count": 5641,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T13:50:05Z",
-  "commit_sha": "48f306a1f992ee6c7b58b6d52351a49f80f71d6e",
-  "commit_count": 5639,
+  "as_of": "2026-05-08T13:54:37Z",
+  "commit_sha": "7b194d383bba3a25c549ef8047498257054d8e6a",
+  "commit_count": 5641,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.