### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T14:03:23Z",
-  "commit_sha": "f80c7440ea1cc92a7e062cc3e81a8fe44b8cc460",
-  "commit_count": 5645,
+  "as_of": "2026-05-08T14:07:34Z",
+  "commit_sha": "e9a0b45c6dc5ff1aad0a1e1da26276bb83ff7120",
+  "commit_count": 5647,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T14:03:23Z",
-  "commit_sha": "f80c7440ea1cc92a7e062cc3e81a8fe44b8cc460",
-  "commit_count": 5645,
+  "as_of": "2026-05-08T14:07:34Z",
+  "commit_sha": "e9a0b45c6dc5ff1aad0a1e1da26276bb83ff7120",
+  "commit_count": 5647,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.