### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T14:15:43Z",
-  "commit_sha": "96f13267f4fb71ffab3d15e8854a02b47e6248d5",
-  "commit_count": 5651,
+  "as_of": "2026-05-08T14:19:52Z",
+  "commit_sha": "eca37ae2390f665b5e9a56bd4f6cba0b2d76a6cf",
+  "commit_count": 5653,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T14:15:43Z",
-  "commit_sha": "96f13267f4fb71ffab3d15e8854a02b47e6248d5",
-  "commit_count": 5651,
+  "as_of": "2026-05-08T14:19:52Z",
+  "commit_sha": "eca37ae2390f665b5e9a56bd4f6cba0b2d76a6cf",
+  "commit_count": 5653,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.