### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T14:32:43Z",
-  "commit_sha": "5e2bd2f2b6d0061831ee74fc7a5788b2ab6bc5b8",
-  "commit_count": 5659,
+  "as_of": "2026-05-08T14:37:12Z",
+  "commit_sha": "09ed772925a38e9281f6a9230fb9776282b7f279",
+  "commit_count": 5661,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T14:32:43Z",
-  "commit_sha": "5e2bd2f2b6d0061831ee74fc7a5788b2ab6bc5b8",
-  "commit_count": 5659,
+  "as_of": "2026-05-08T14:37:12Z",
+  "commit_sha": "09ed772925a38e9281f6a9230fb9776282b7f279",
+  "commit_count": 5661,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.