### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T14:53:50Z",
-  "commit_sha": "9a4795eaea3f3f9d5d0b47407a606e8e2efc6af6",
-  "commit_count": 5669,
+  "as_of": "2026-05-08T14:57:59Z",
+  "commit_sha": "20147e15ea3159be079e1fb5df02501dd93c624d",
+  "commit_count": 5671,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-08T14:53:50Z",
-  "commit_sha": "9a4795eaea3f3f9d5d0b47407a606e8e2efc6af6",
-  "commit_count": 5669,
+  "as_of": "2026-05-08T14:57:59Z",
+  "commit_sha": "20147e15ea3159be079e1fb5df02501dd93c624d",
+  "commit_count": 5671,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.