### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T00:54:34Z",
-  "commit_sha": "8e0ef5e8196740ac3ed0c3a50d197066bc07902e",
-  "commit_count": 5675,
+  "as_of": "2026-05-09T00:58:51Z",
+  "commit_sha": "a1c5147215d999d165682b83b82a10978dc286eb",
+  "commit_count": 5677,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T00:54:34Z",
-  "commit_sha": "8e0ef5e8196740ac3ed0c3a50d197066bc07902e",
-  "commit_count": 5675,
+  "as_of": "2026-05-09T00:58:51Z",
+  "commit_sha": "a1c5147215d999d165682b83b82a10978dc286eb",
+  "commit_count": 5677,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.