### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T01:07:17Z",
-  "commit_sha": "7d1457d095df3f64e2596de53584bee7f9fc76e7",
-  "commit_count": 5681,
+  "as_of": "2026-05-09T01:11:16Z",
+  "commit_sha": "fc27e9597bc6b32ca2c14c2a052502d5947c255b",
+  "commit_count": 5683,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T01:07:17Z",
-  "commit_sha": "7d1457d095df3f64e2596de53584bee7f9fc76e7",
-  "commit_count": 5681,
+  "as_of": "2026-05-09T01:11:16Z",
+  "commit_sha": "fc27e9597bc6b32ca2c14c2a052502d5947c255b",
+  "commit_count": 5683,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.