### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T01:27:55Z",
-  "commit_sha": "079d15547146eddf1c2af684233a29f402479407",
-  "commit_count": 5691,
+  "as_of": "2026-05-09T01:31:59Z",
+  "commit_sha": "d5231d16070f8834d88ec51360600abe6231d2ec",
+  "commit_count": 5693,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T01:27:55Z",
-  "commit_sha": "079d15547146eddf1c2af684233a29f402479407",
-  "commit_count": 5691,
+  "as_of": "2026-05-09T01:31:59Z",
+  "commit_sha": "d5231d16070f8834d88ec51360600abe6231d2ec",
+  "commit_count": 5693,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.