### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T01:40:06Z",
-  "commit_sha": "2824e4f964c28a360d8cac6e32159701b1c8bfd0",
-  "commit_count": 5697,
+  "as_of": "2026-05-09T01:44:22Z",
+  "commit_sha": "7ff5353393a02032a8212d8b83b70a69c4a1a912",
+  "commit_count": 5699,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T01:40:06Z",
-  "commit_sha": "2824e4f964c28a360d8cac6e32159701b1c8bfd0",
-  "commit_count": 5697,
+  "as_of": "2026-05-09T01:44:22Z",
+  "commit_sha": "7ff5353393a02032a8212d8b83b70a69c4a1a912",
+  "commit_count": 5699,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.