### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T11:15:04Z",
-  "commit_sha": "00a914a43e0324e63b8f0e1a12f90f8c151e2b00",
-  "commit_count": 5707,
+  "as_of": "2026-05-09T11:19:17Z",
+  "commit_sha": "0e79b8b25487ac1916ae62ca42504680a9a6d2b3",
+  "commit_count": 5709,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T11:15:04Z",
-  "commit_sha": "00a914a43e0324e63b8f0e1a12f90f8c151e2b00",
-  "commit_count": 5707,
+  "as_of": "2026-05-09T11:19:17Z",
+  "commit_sha": "0e79b8b25487ac1916ae62ca42504680a9a6d2b3",
+  "commit_count": 5709,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.