### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T11:35:13Z",
-  "commit_sha": "631f8f7a8118122e771cb365e4c7a5d62c64cf93",
-  "commit_count": 5717,
+  "as_of": "2026-05-09T11:39:16Z",
+  "commit_sha": "72ff9c09b64c39b45227c010b238b6fe0136fc88",
+  "commit_count": 5719,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T11:35:13Z",
-  "commit_sha": "631f8f7a8118122e771cb365e4c7a5d62c64cf93",
-  "commit_count": 5717,
+  "as_of": "2026-05-09T11:39:16Z",
+  "commit_sha": "72ff9c09b64c39b45227c010b238b6fe0136fc88",
+  "commit_count": 5719,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.