### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T11:59:11Z",
-  "commit_sha": "6765d2fd665d7e2486344a31bba28ff6da2b2154",
-  "commit_count": 5729,
+  "as_of": "2026-05-09T12:03:30Z",
+  "commit_sha": "175192c686f2c504a4fdb1426068438678a41090",
+  "commit_count": 5731,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T11:59:11Z",
-  "commit_sha": "6765d2fd665d7e2486344a31bba28ff6da2b2154",
-  "commit_count": 5729,
+  "as_of": "2026-05-09T12:03:30Z",
+  "commit_sha": "175192c686f2c504a4fdb1426068438678a41090",
+  "commit_count": 5731,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.