### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T12:20:09Z",
-  "commit_sha": "2dc101aebd5c508c6235ef7dade432a08228de02",
-  "commit_count": 5739,
+  "as_of": "2026-05-09T12:24:50Z",
+  "commit_sha": "15ed204da341f285cf4b19e0d8c2fb471aad6121",
+  "commit_count": 5741,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T12:20:09Z",
-  "commit_sha": "2dc101aebd5c508c6235ef7dade432a08228de02",
-  "commit_count": 5739,
+  "as_of": "2026-05-09T12:24:50Z",
+  "commit_sha": "15ed204da341f285cf4b19e0d8c2fb471aad6121",
+  "commit_count": 5741,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.