### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T12:33:29Z",
-  "commit_sha": "a737f8ef551acb83a8e1557ff85d95a50c9916a6",
-  "commit_count": 5745,
+  "as_of": "2026-05-09T12:37:42Z",
+  "commit_sha": "ce907d3d774687ec5ac2d4a8521253ec5d176f29",
+  "commit_count": 5747,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T12:33:29Z",
-  "commit_sha": "a737f8ef551acb83a8e1557ff85d95a50c9916a6",
-  "commit_count": 5745,
+  "as_of": "2026-05-09T12:37:42Z",
+  "commit_sha": "ce907d3d774687ec5ac2d4a8521253ec5d176f29",
+  "commit_count": 5747,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.