### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T12:50:21Z",
-  "commit_sha": "af83421aa8be08deb21ac092eb1b606d2dd62cd6",
-  "commit_count": 5753,
+  "as_of": "2026-05-09T12:54:18Z",
+  "commit_sha": "4add785cc72a88d5504f2766fbfa1665bcbac444",
+  "commit_count": 5755,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-09T12:50:21Z",
-  "commit_sha": "af83421aa8be08deb21ac092eb1b606d2dd62cd6",
-  "commit_count": 5753,
+  "as_of": "2026-05-09T12:54:18Z",
+  "commit_sha": "4add785cc72a88d5504f2766fbfa1665bcbac444",
+  "commit_count": 5755,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.