### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T01:41:54Z",
-  "commit_sha": "47b3f704a30a037b7ee579f147918296afaa67c1",
-  "commit_count": 5787,
+  "as_of": "2026-05-10T01:45:52Z",
+  "commit_sha": "bb84b65a79d9aeb24f02eeda5eeed64288ba3bf2",
+  "commit_count": 5789,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T01:41:54Z",
-  "commit_sha": "47b3f704a30a037b7ee579f147918296afaa67c1",
-  "commit_count": 5787,
+  "as_of": "2026-05-10T01:45:52Z",
+  "commit_sha": "bb84b65a79d9aeb24f02eeda5eeed64288ba3bf2",
+  "commit_count": 5789,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.