### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T01:53:51Z",
-  "commit_sha": "303dff595640c10dd425382f5779acfbbb1e8f43",
-  "commit_count": 5793,
+  "as_of": "2026-05-10T01:58:01Z",
+  "commit_sha": "56b29daf12f4c2d5163017edee5a8a7933b4ab5d",
+  "commit_count": 5795,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T01:53:51Z",
-  "commit_sha": "303dff595640c10dd425382f5779acfbbb1e8f43",
-  "commit_count": 5793,
+  "as_of": "2026-05-10T01:58:01Z",
+  "commit_sha": "56b29daf12f4c2d5163017edee5a8a7933b4ab5d",
+  "commit_count": 5795,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.