### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T02:17:13Z",
-  "commit_sha": "e965830bd83990814be15c5f333795f416804d58",
-  "commit_count": 5805,
+  "as_of": "2026-05-10T02:21:11Z",
+  "commit_sha": "b9829d8e66871525466188d465ae47cef9c06ce3",
+  "commit_count": 5807,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T02:17:13Z",
-  "commit_sha": "e965830bd83990814be15c5f333795f416804d58",
-  "commit_count": 5805,
+  "as_of": "2026-05-10T02:21:11Z",
+  "commit_sha": "b9829d8e66871525466188d465ae47cef9c06ce3",
+  "commit_count": 5807,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.