### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T02:25:05Z",
-  "commit_sha": "8be97c4dff53dc72ef8dee5e5761997a1c1a52cb",
-  "commit_count": 5809,
+  "as_of": "2026-05-10T02:29:24Z",
+  "commit_sha": "ce787dd22beb2135619b73a0684c22e53c652ba5",
+  "commit_count": 5811,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T02:25:05Z",
-  "commit_sha": "8be97c4dff53dc72ef8dee5e5761997a1c1a52cb",
-  "commit_count": 5809,
+  "as_of": "2026-05-10T02:29:24Z",
+  "commit_sha": "ce787dd22beb2135619b73a0684c22e53c652ba5",
+  "commit_count": 5811,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.