### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T02:49:00Z",
-  "commit_sha": "1bc2a273843d6ed4d3ba2797c349d6cf560ca122",
-  "commit_count": 5821,
+  "as_of": "2026-05-10T02:53:13Z",
+  "commit_sha": "87a4685858c97783dcc5eac4f7665b623e06b7a6",
+  "commit_count": 5823,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T02:49:00Z",
-  "commit_sha": "1bc2a273843d6ed4d3ba2797c349d6cf560ca122",
-  "commit_count": 5821,
+  "as_of": "2026-05-10T02:53:13Z",
+  "commit_sha": "87a4685858c97783dcc5eac4f7665b623e06b7a6",
+  "commit_count": 5823,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.