### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T03:08:54Z",
-  "commit_sha": "2d6e25c96243542a584df4f5ba5f6612cd67ccd3",
-  "commit_count": 5831,
+  "as_of": "2026-05-10T03:13:01Z",
+  "commit_sha": "ba7046fcc0d6c0b12decca58397c724a17b16f4d",
+  "commit_count": 5833,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T03:08:54Z",
-  "commit_sha": "2d6e25c96243542a584df4f5ba5f6612cd67ccd3",
-  "commit_count": 5831,
+  "as_of": "2026-05-10T03:13:01Z",
+  "commit_sha": "ba7046fcc0d6c0b12decca58397c724a17b16f4d",
+  "commit_count": 5833,
   "lines_of_code": 227595,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.