### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-10T03:16:45Z",
-  "commit_sha": "fa9b5de888a8c2096e9986ce0e0a8137e7e49da2",
-  "commit_count": 5835,
-  "lines_of_code": 227595,
+  "as_of": "2026-05-10T11:08:17Z",
+  "commit_sha": "cea1809ece9040c7bb7d7c4aec869402d1f32a5e",
+  "commit_count": 5839,
+  "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,
-  "total_lines": 266572,
+  "total_lines": 266576,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44781,
+      "code": 44785,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-10T03:16:45Z",
-  "commit_sha": "fa9b5de888a8c2096e9986ce0e0a8137e7e49da2",
-  "commit_count": 5835,
-  "lines_of_code": 227595,
+  "as_of": "2026-05-10T11:08:17Z",
+  "commit_sha": "cea1809ece9040c7bb7d7c4aec869402d1f32a5e",
+  "commit_count": 5839,
+  "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,
-  "total_lines": 266572,
+  "total_lines": 266576,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44781,
+      "code": 44785,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.