### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T11:08:17Z",
-  "commit_sha": "cea1809ece9040c7bb7d7c4aec869402d1f32a5e",
-  "commit_count": 5839,
+  "as_of": "2026-05-10T11:12:17Z",
+  "commit_sha": "33dc3e1d339d0992ad83ecf440fc314bb6b07b72",
+  "commit_count": 5841,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T11:08:17Z",
-  "commit_sha": "cea1809ece9040c7bb7d7c4aec869402d1f32a5e",
-  "commit_count": 5839,
+  "as_of": "2026-05-10T11:12:17Z",
+  "commit_sha": "33dc3e1d339d0992ad83ecf440fc314bb6b07b72",
+  "commit_count": 5841,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.