### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T11:36:54Z",
-  "commit_sha": "e02036851ed2525a150bec58b567aea60c4efb70",
-  "commit_count": 5853,
+  "as_of": "2026-05-10T11:40:44Z",
+  "commit_sha": "d25f67594f71a5d96b29b4b0ec860d11b45df513",
+  "commit_count": 5855,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T11:36:54Z",
-  "commit_sha": "e02036851ed2525a150bec58b567aea60c4efb70",
-  "commit_count": 5853,
+  "as_of": "2026-05-10T11:40:44Z",
+  "commit_sha": "d25f67594f71a5d96b29b4b0ec860d11b45df513",
+  "commit_count": 5855,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.