### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T11:45:00Z",
-  "commit_sha": "c6794f8093c1d4c597cfbe0ed0e9caf3392549a6",
-  "commit_count": 5857,
+  "as_of": "2026-05-10T11:49:24Z",
+  "commit_sha": "77a67100552b702931e9464318d30a4635f9f648",
+  "commit_count": 5859,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T11:45:00Z",
-  "commit_sha": "c6794f8093c1d4c597cfbe0ed0e9caf3392549a6",
-  "commit_count": 5857,
+  "as_of": "2026-05-10T11:49:24Z",
+  "commit_sha": "77a67100552b702931e9464318d30a4635f9f648",
+  "commit_count": 5859,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.