### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T11:57:24Z",
-  "commit_sha": "1f0768cb4f379db5a40f6d098fd5a7fd7b44f04f",
-  "commit_count": 5863,
+  "as_of": "2026-05-10T12:01:26Z",
+  "commit_sha": "d9fe1d7e379d3e11ee84cef2371e779958f15f1a",
+  "commit_count": 5865,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T11:57:24Z",
-  "commit_sha": "1f0768cb4f379db5a40f6d098fd5a7fd7b44f04f",
-  "commit_count": 5863,
+  "as_of": "2026-05-10T12:01:26Z",
+  "commit_sha": "d9fe1d7e379d3e11ee84cef2371e779958f15f1a",
+  "commit_count": 5865,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.