### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T12:17:44Z",
-  "commit_sha": "7dc4f611c1d963f8ef16e471cf26a9f2d5ad89bc",
-  "commit_count": 5873,
+  "as_of": "2026-05-10T12:21:54Z",
+  "commit_sha": "ae4c64d3f9fd3ebf7b4d327ec2e32a3c5cf4e5a1",
+  "commit_count": 5875,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T12:17:44Z",
-  "commit_sha": "7dc4f611c1d963f8ef16e471cf26a9f2d5ad89bc",
-  "commit_count": 5873,
+  "as_of": "2026-05-10T12:21:54Z",
+  "commit_sha": "ae4c64d3f9fd3ebf7b4d327ec2e32a3c5cf4e5a1",
+  "commit_count": 5875,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.