### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T12:26:01Z",
-  "commit_sha": "7c46a7af0d7a0a85f29cc3dad490ce579581c419",
-  "commit_count": 5877,
+  "as_of": "2026-05-10T12:30:09Z",
+  "commit_sha": "a904d19131e153fc89c60d38f6f6e5746b0d5ee6",
+  "commit_count": 5879,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-10T12:26:01Z",
-  "commit_sha": "7c46a7af0d7a0a85f29cc3dad490ce579581c419",
-  "commit_count": 5877,
+  "as_of": "2026-05-10T12:30:09Z",
+  "commit_sha": "a904d19131e153fc89c60d38f6f6e5746b0d5ee6",
+  "commit_count": 5879,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.