### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T01:10:23Z",
-  "commit_sha": "d5b411c4a853a4b7add9a1da0fc1515a575f1c77",
-  "commit_count": 5889,
+  "as_of": "2026-05-11T01:14:33Z",
+  "commit_sha": "f26ceca7b01950d83f14535a6e7cda6ded0f4970",
+  "commit_count": 5891,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T01:10:23Z",
-  "commit_sha": "d5b411c4a853a4b7add9a1da0fc1515a575f1c77",
-  "commit_count": 5889,
+  "as_of": "2026-05-11T01:14:33Z",
+  "commit_sha": "f26ceca7b01950d83f14535a6e7cda6ded0f4970",
+  "commit_count": 5891,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.