### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T01:47:40Z",
-  "commit_sha": "b9695fb7fe794c348e914132335691a43fee1015",
-  "commit_count": 5907,
+  "as_of": "2026-05-11T01:51:49Z",
+  "commit_sha": "2c8cd6cdbc3e18734417b9ee5ecc41b5026d5a1f",
+  "commit_count": 5909,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T01:47:40Z",
-  "commit_sha": "b9695fb7fe794c348e914132335691a43fee1015",
-  "commit_count": 5907,
+  "as_of": "2026-05-11T01:51:49Z",
+  "commit_sha": "2c8cd6cdbc3e18734417b9ee5ecc41b5026d5a1f",
+  "commit_count": 5909,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.