### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T02:08:21Z",
-  "commit_sha": "2a822b069e756e509dd2c4731cf2af45dd4bc39e",
-  "commit_count": 5917,
+  "as_of": "2026-05-11T02:12:22Z",
+  "commit_sha": "b6578fe571bf72c3dfc4c510d596f5d6eaa348b8",
+  "commit_count": 5919,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T02:08:21Z",
-  "commit_sha": "2a822b069e756e509dd2c4731cf2af45dd4bc39e",
-  "commit_count": 5917,
+  "as_of": "2026-05-11T02:12:22Z",
+  "commit_sha": "b6578fe571bf72c3dfc4c510d596f5d6eaa348b8",
+  "commit_count": 5919,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.