### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T02:28:28Z",
-  "commit_sha": "de449a813619ce0c3e590c4755af84787687283f",
-  "commit_count": 5927,
+  "as_of": "2026-05-11T02:32:33Z",
+  "commit_sha": "e64890980d73be857889ef7cd9f2b2f23c427cf4",
+  "commit_count": 5929,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T02:28:28Z",
-  "commit_sha": "de449a813619ce0c3e590c4755af84787687283f",
-  "commit_count": 5927,
+  "as_of": "2026-05-11T02:32:33Z",
+  "commit_sha": "e64890980d73be857889ef7cd9f2b2f23c427cf4",
+  "commit_count": 5929,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.