### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T02:52:38Z",
-  "commit_sha": "53782c42aa10329e471f6c37b9979e9a141b65a7",
-  "commit_count": 5939,
+  "as_of": "2026-05-11T02:56:15Z",
+  "commit_sha": "405c9134fd229651a000883aa1c5cad6cbf5fbc7",
+  "commit_count": 5941,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T02:52:38Z",
-  "commit_sha": "53782c42aa10329e471f6c37b9979e9a141b65a7",
-  "commit_count": 5939,
+  "as_of": "2026-05-11T02:56:15Z",
+  "commit_sha": "405c9134fd229651a000883aa1c5cad6cbf5fbc7",
+  "commit_count": 5941,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.