### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T03:16:35Z",
-  "commit_sha": "211ef681f12944c108914d29cc4a4f5fd113f2ca",
-  "commit_count": 5951,
+  "as_of": "2026-05-11T03:20:38Z",
+  "commit_sha": "7c7e4a37870456f5847b51267f199f09af8cfb4f",
+  "commit_count": 5953,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T03:16:35Z",
-  "commit_sha": "211ef681f12944c108914d29cc4a4f5fd113f2ca",
-  "commit_count": 5951,
+  "as_of": "2026-05-11T03:20:38Z",
+  "commit_sha": "7c7e4a37870456f5847b51267f199f09af8cfb4f",
+  "commit_count": 5953,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.