### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T03:41:10Z",
-  "commit_sha": "6a86c149e688e5857afcd9c1ce8911ec24640d43",
-  "commit_count": 5963,
+  "as_of": "2026-05-11T03:45:10Z",
+  "commit_sha": "6bc9c5bb6aadd6867a817a0489021e1ec067ab0f",
+  "commit_count": 5965,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T03:41:10Z",
-  "commit_sha": "6a86c149e688e5857afcd9c1ce8911ec24640d43",
-  "commit_count": 5963,
+  "as_of": "2026-05-11T03:45:10Z",
+  "commit_sha": "6bc9c5bb6aadd6867a817a0489021e1ec067ab0f",
+  "commit_count": 5965,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.