### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T03:49:15Z",
-  "commit_sha": "79171e417e01152fa1911e2734dd9b64b78fecff",
-  "commit_count": 5967,
+  "as_of": "2026-05-11T03:53:08Z",
+  "commit_sha": "e0c68a974bdc2f279b2e5cf11ea32d6f69133943",
+  "commit_count": 5969,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T03:49:15Z",
-  "commit_sha": "79171e417e01152fa1911e2734dd9b64b78fecff",
-  "commit_count": 5967,
+  "as_of": "2026-05-11T03:53:08Z",
+  "commit_sha": "e0c68a974bdc2f279b2e5cf11ea32d6f69133943",
+  "commit_count": 5969,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.