### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T03:57:18Z",
-  "commit_sha": "277a3bccc42480d3c6b30677e7a059d0c83cefb8",
-  "commit_count": 5971,
+  "as_of": "2026-05-11T04:01:25Z",
+  "commit_sha": "d03be48d08efb1e0ea5cd670d138ee7e9860c5c7",
+  "commit_count": 5973,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T03:57:18Z",
-  "commit_sha": "277a3bccc42480d3c6b30677e7a059d0c83cefb8",
-  "commit_count": 5971,
+  "as_of": "2026-05-11T04:01:25Z",
+  "commit_sha": "d03be48d08efb1e0ea5cd670d138ee7e9860c5c7",
+  "commit_count": 5973,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.