### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T04:26:28Z",
-  "commit_sha": "37b557935d7b79f8f2c12851a46249e34ff8a2be",
-  "commit_count": 5985,
+  "as_of": "2026-05-11T04:30:41Z",
+  "commit_sha": "c627d94bfa7f8793b168db06f6c2f8b9ae2a44fb",
+  "commit_count": 5987,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T04:26:28Z",
-  "commit_sha": "37b557935d7b79f8f2c12851a46249e34ff8a2be",
-  "commit_count": 5985,
+  "as_of": "2026-05-11T04:30:41Z",
+  "commit_sha": "c627d94bfa7f8793b168db06f6c2f8b9ae2a44fb",
+  "commit_count": 5987,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.