### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T04:34:13Z",
-  "commit_sha": "bc32f9d9b8466b8a74f1ca0fd628e17871388b31",
-  "commit_count": 5989,
+  "as_of": "2026-05-11T04:38:12Z",
+  "commit_sha": "f504323544e58fada2fbcf13f58db309ecae9bf4",
+  "commit_count": 5991,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T04:34:13Z",
-  "commit_sha": "bc32f9d9b8466b8a74f1ca0fd628e17871388b31",
-  "commit_count": 5989,
+  "as_of": "2026-05-11T04:38:12Z",
+  "commit_sha": "f504323544e58fada2fbcf13f58db309ecae9bf4",
+  "commit_count": 5991,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.