### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T04:46:58Z",
-  "commit_sha": "8d293b2a9daf304ca243b4b426e02ee7f6c216ce",
-  "commit_count": 5995,
+  "as_of": "2026-05-11T04:51:03Z",
+  "commit_sha": "3406287b9e07cd452fd127cda184f2e607de021c",
+  "commit_count": 5997,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T04:46:58Z",
-  "commit_sha": "8d293b2a9daf304ca243b4b426e02ee7f6c216ce",
-  "commit_count": 5995,
+  "as_of": "2026-05-11T04:51:03Z",
+  "commit_sha": "3406287b9e07cd452fd127cda184f2e607de021c",
+  "commit_count": 5997,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.