### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T06:00:39Z",
-  "commit_sha": "0d45db23e4f6ef6460bca0741f3cb8732ec06e75",
-  "commit_count": 6031,
+  "as_of": "2026-05-11T06:04:19Z",
+  "commit_sha": "3c5b1d167ca7adbf91cf1e72da2a9c257ef47589",
+  "commit_count": 6033,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T06:00:39Z",
-  "commit_sha": "0d45db23e4f6ef6460bca0741f3cb8732ec06e75",
-  "commit_count": 6031,
+  "as_of": "2026-05-11T06:04:19Z",
+  "commit_sha": "3c5b1d167ca7adbf91cf1e72da2a9c257ef47589",
+  "commit_count": 6033,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.