### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T06:38:21Z",
-  "commit_sha": "227d9a84c2c0ad51a021140b55f43a5f5f380566",
-  "commit_count": 6049,
+  "as_of": "2026-05-11T06:42:23Z",
+  "commit_sha": "8120e1283635d3b77536ecda783eacc05de9f32a",
+  "commit_count": 6051,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T06:38:21Z",
-  "commit_sha": "227d9a84c2c0ad51a021140b55f43a5f5f380566",
-  "commit_count": 6049,
+  "as_of": "2026-05-11T06:42:23Z",
+  "commit_sha": "8120e1283635d3b77536ecda783eacc05de9f32a",
+  "commit_count": 6051,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.