### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T07:03:40Z",
-  "commit_sha": "e2b1ecaf628480268fc822f885c3bb2ebd07433d",
-  "commit_count": 6061,
+  "as_of": "2026-05-11T07:07:51Z",
+  "commit_sha": "eaff9161e7831251f522dcbdec954032d76f61c5",
+  "commit_count": 6063,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T07:03:40Z",
-  "commit_sha": "e2b1ecaf628480268fc822f885c3bb2ebd07433d",
-  "commit_count": 6061,
+  "as_of": "2026-05-11T07:07:51Z",
+  "commit_sha": "eaff9161e7831251f522dcbdec954032d76f61c5",
+  "commit_count": 6063,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.