### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T08:06:15Z",
-  "commit_sha": "277ea81181a965300a5fb6fdc79a12616a6a4e0e",
-  "commit_count": 6091,
+  "as_of": "2026-05-11T08:10:20Z",
+  "commit_sha": "cc540d27ed02980bae5bb7041ad2a653fa3cd95b",
+  "commit_count": 6093,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T08:06:15Z",
-  "commit_sha": "277ea81181a965300a5fb6fdc79a12616a6a4e0e",
-  "commit_count": 6091,
+  "as_of": "2026-05-11T08:10:20Z",
+  "commit_sha": "cc540d27ed02980bae5bb7041ad2a653fa3cd95b",
+  "commit_count": 6093,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.