### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T10:59:08Z",
-  "commit_sha": "51ac2b1563a4779200e2f95b09c7be5eb664d688",
-  "commit_count": 6175,
+  "as_of": "2026-05-11T11:03:29Z",
+  "commit_sha": "011d9bb03609f1f56bb0194358f778eb19f58f8c",
+  "commit_count": 6177,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T10:59:08Z",
-  "commit_sha": "51ac2b1563a4779200e2f95b09c7be5eb664d688",
-  "commit_count": 6175,
+  "as_of": "2026-05-11T11:03:29Z",
+  "commit_sha": "011d9bb03609f1f56bb0194358f778eb19f58f8c",
+  "commit_count": 6177,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.