### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T11:16:03Z",
-  "commit_sha": "ada5daf34ea26537f4b3c969348b8770d4090c7f",
-  "commit_count": 6183,
+  "as_of": "2026-05-11T11:20:12Z",
+  "commit_sha": "81f385887f196cf41f83dae4b77e1edc39b43c42",
+  "commit_count": 6185,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T11:16:03Z",
-  "commit_sha": "ada5daf34ea26537f4b3c969348b8770d4090c7f",
-  "commit_count": 6183,
+  "as_of": "2026-05-11T11:20:12Z",
+  "commit_sha": "81f385887f196cf41f83dae4b77e1edc39b43c42",
+  "commit_count": 6185,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.