### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T11:49:28Z",
-  "commit_sha": "30643749a4de02e847de60338f6bf565f16eda61",
-  "commit_count": 6199,
+  "as_of": "2026-05-11T11:53:48Z",
+  "commit_sha": "ce0a3f9a657591e595b3dfbe9c99d89cd59a235d",
+  "commit_count": 6201,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T11:49:28Z",
-  "commit_sha": "30643749a4de02e847de60338f6bf565f16eda61",
-  "commit_count": 6199,
+  "as_of": "2026-05-11T11:53:48Z",
+  "commit_sha": "ce0a3f9a657591e595b3dfbe9c99d89cd59a235d",
+  "commit_count": 6201,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.