### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T12:06:27Z",
-  "commit_sha": "60d7c8026377c963499cb99cb9a11b60d9c5e60f",
-  "commit_count": 6207,
+  "as_of": "2026-05-11T12:10:31Z",
+  "commit_sha": "a4c062ce8ef2b1fc2114711685ccfafa1c62ee10",
+  "commit_count": 6209,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-11T12:06:27Z",
-  "commit_sha": "60d7c8026377c963499cb99cb9a11b60d9c5e60f",
-  "commit_count": 6207,
+  "as_of": "2026-05-11T12:10:31Z",
+  "commit_sha": "a4c062ce8ef2b1fc2114711685ccfafa1c62ee10",
+  "commit_count": 6209,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.