### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T01:26:36Z",
-  "commit_sha": "2ceae0ac61340263f3c3e9f370c0e6d1c323f71b",
-  "commit_count": 6231,
+  "as_of": "2026-05-12T01:30:55Z",
+  "commit_sha": "f0b1da02acb2037269ad72d3a9521d667bbb6cde",
+  "commit_count": 6233,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T01:26:36Z",
-  "commit_sha": "2ceae0ac61340263f3c3e9f370c0e6d1c323f71b",
-  "commit_count": 6231,
+  "as_of": "2026-05-12T01:30:55Z",
+  "commit_sha": "f0b1da02acb2037269ad72d3a9521d667bbb6cde",
+  "commit_count": 6233,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.