### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T02:17:15Z",
-  "commit_sha": "b1a13c68ea867f649a652f45d2fd710b5a617777",
-  "commit_count": 6255,
+  "as_of": "2026-05-12T02:21:18Z",
+  "commit_sha": "7de56bb9f46c54314de33350b512aa66951599e7",
+  "commit_count": 6257,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T02:17:15Z",
-  "commit_sha": "b1a13c68ea867f649a652f45d2fd710b5a617777",
-  "commit_count": 6255,
+  "as_of": "2026-05-12T02:21:18Z",
+  "commit_sha": "7de56bb9f46c54314de33350b512aa66951599e7",
+  "commit_count": 6257,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.