### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T04:04:14Z",
-  "commit_sha": "d02790fcdcff7eba85c1f56b7e8c25264e089671",
-  "commit_count": 6307,
+  "as_of": "2026-05-12T04:08:23Z",
+  "commit_sha": "1d2c739ba8bfc8ecf913ea844f2bb9024b321a6e",
+  "commit_count": 6309,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T04:04:14Z",
-  "commit_sha": "d02790fcdcff7eba85c1f56b7e8c25264e089671",
-  "commit_count": 6307,
+  "as_of": "2026-05-12T04:08:23Z",
+  "commit_sha": "1d2c739ba8bfc8ecf913ea844f2bb9024b321a6e",
+  "commit_count": 6309,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.