### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T04:20:27Z",
-  "commit_sha": "047ee095716c2555a3c1968742a74933ace9aef5",
-  "commit_count": 6315,
+  "as_of": "2026-05-12T11:37:23Z",
+  "commit_sha": "f10a0f057f8d463e4cf4f235b61d0aaeb276a0ef",
+  "commit_count": 6319,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T04:20:27Z",
-  "commit_sha": "047ee095716c2555a3c1968742a74933ace9aef5",
-  "commit_count": 6315,
+  "as_of": "2026-05-12T11:37:23Z",
+  "commit_sha": "f10a0f057f8d463e4cf4f235b61d0aaeb276a0ef",
+  "commit_count": 6319,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.