### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T12:22:38Z",
-  "commit_sha": "4c8ce5938938c0c1a96f1b693a740ae2ac037fc6",
-  "commit_count": 6337,
+  "as_of": "2026-05-12T12:27:33Z",
+  "commit_sha": "17a20ae29ec17aea32cb1c36dd0dd08872bd66d2",
+  "commit_count": 6339,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T12:22:38Z",
-  "commit_sha": "4c8ce5938938c0c1a96f1b693a740ae2ac037fc6",
-  "commit_count": 6337,
+  "as_of": "2026-05-12T12:27:33Z",
+  "commit_sha": "17a20ae29ec17aea32cb1c36dd0dd08872bd66d2",
+  "commit_count": 6339,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.