### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T12:53:44Z",
-  "commit_sha": "ece4ddffe7a450f7ea26c1028d9d9958a3ae8de3",
-  "commit_count": 6351,
+  "as_of": "2026-05-12T12:58:16Z",
+  "commit_sha": "b364566c62b57e9b4f44252083e1879a882c4dc4",
+  "commit_count": 6353,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T12:53:44Z",
-  "commit_sha": "ece4ddffe7a450f7ea26c1028d9d9958a3ae8de3",
-  "commit_count": 6351,
+  "as_of": "2026-05-12T12:58:16Z",
+  "commit_sha": "b364566c62b57e9b4f44252083e1879a882c4dc4",
+  "commit_count": 6353,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.