### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T13:38:21Z",
-  "commit_sha": "691c4dd64b52bf5ec0b2d9fe4bc16d33a58a2273",
-  "commit_count": 6371,
+  "as_of": "2026-05-12T13:42:14Z",
+  "commit_sha": "670c91a5afbec066d910090263b1b5157ab7d35c",
+  "commit_count": 6373,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T13:38:21Z",
-  "commit_sha": "691c4dd64b52bf5ec0b2d9fe4bc16d33a58a2273",
-  "commit_count": 6371,
+  "as_of": "2026-05-12T13:42:14Z",
+  "commit_sha": "670c91a5afbec066d910090263b1b5157ab7d35c",
+  "commit_count": 6373,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.