### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T13:50:24Z",
-  "commit_sha": "fc70a20580c89e4bf3eee0996a09b35ba0f758df",
-  "commit_count": 6375,
+  "as_of": "2026-05-13T00:57:48Z",
+  "commit_sha": "0f11cddd0d497fe0509ecf1b83c0fedb0eea27fa",
+  "commit_count": 6379,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-12T13:50:24Z",
-  "commit_sha": "fc70a20580c89e4bf3eee0996a09b35ba0f758df",
-  "commit_count": 6375,
+  "as_of": "2026-05-13T00:57:48Z",
+  "commit_sha": "0f11cddd0d497fe0509ecf1b83c0fedb0eea27fa",
+  "commit_count": 6379,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.