### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T01:31:22Z",
-  "commit_sha": "8343cb32536961a83d7524858be87af252cb9cdb",
-  "commit_count": 6395,
+  "as_of": "2026-05-13T01:35:36Z",
+  "commit_sha": "e4709ea4e8befb2b926ab41745672fcf35a15aeb",
+  "commit_count": 6397,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T01:31:22Z",
-  "commit_sha": "8343cb32536961a83d7524858be87af252cb9cdb",
-  "commit_count": 6395,
+  "as_of": "2026-05-13T01:35:36Z",
+  "commit_sha": "e4709ea4e8befb2b926ab41745672fcf35a15aeb",
+  "commit_count": 6397,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.