### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T02:12:59Z",
-  "commit_sha": "4bdf4f650d22e5d303c35003661aad001079d603",
-  "commit_count": 6415,
+  "as_of": "2026-05-13T02:17:10Z",
+  "commit_sha": "29bf68b84a12cbf9adf8a876bf6f7da12e6814c0",
+  "commit_count": 6417,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T02:12:59Z",
-  "commit_sha": "4bdf4f650d22e5d303c35003661aad001079d603",
-  "commit_count": 6415,
+  "as_of": "2026-05-13T02:17:10Z",
+  "commit_sha": "29bf68b84a12cbf9adf8a876bf6f7da12e6814c0",
+  "commit_count": 6417,
   "lines_of_code": 227599,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.