### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-13T02:54:27Z",
-  "commit_sha": "feb1179ee2d3481fdc09c02671062ea26fc24dc8",
-  "commit_count": 6435,
-  "lines_of_code": 227599,
+  "as_of": "2026-05-13T11:43:16Z",
+  "commit_sha": "cb513cbf1be3bbe7de852188e8cb9aa53228cc7e",
+  "commit_count": 6439,
+  "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,
-  "total_lines": 266576,
+  "total_lines": 266580,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44785,
+      "code": 44789,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-13T02:54:27Z",
-  "commit_sha": "feb1179ee2d3481fdc09c02671062ea26fc24dc8",
-  "commit_count": 6435,
-  "lines_of_code": 227599,
+  "as_of": "2026-05-13T11:43:16Z",
+  "commit_sha": "cb513cbf1be3bbe7de852188e8cb9aa53228cc7e",
+  "commit_count": 6439,
+  "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,
-  "total_lines": 266576,
+  "total_lines": 266580,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44785,
+      "code": 44789,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.