### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T12:00:00Z",
-  "commit_sha": "dea895d0d1523ac23971d306e0eddadb76e515da",
-  "commit_count": 6447,
+  "as_of": "2026-05-13T12:04:02Z",
+  "commit_sha": "5acf164f35da2932554018b4d53f9e3e37c31a1a",
+  "commit_count": 6449,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T12:00:00Z",
-  "commit_sha": "dea895d0d1523ac23971d306e0eddadb76e515da",
-  "commit_count": 6447,
+  "as_of": "2026-05-13T12:04:02Z",
+  "commit_sha": "5acf164f35da2932554018b4d53f9e3e37c31a1a",
+  "commit_count": 6449,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.