### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T12:47:07Z",
-  "commit_sha": "c7db9fd1524e379256ec899df898c88353e3d6d9",
-  "commit_count": 6469,
+  "as_of": "2026-05-13T12:51:24Z",
+  "commit_sha": "8c2eeb8495a3434106cb2b4d8900b713cb2d88bf",
+  "commit_count": 6471,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T12:47:07Z",
-  "commit_sha": "c7db9fd1524e379256ec899df898c88353e3d6d9",
-  "commit_count": 6469,
+  "as_of": "2026-05-13T12:51:24Z",
+  "commit_sha": "8c2eeb8495a3434106cb2b4d8900b713cb2d88bf",
+  "commit_count": 6471,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.