### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T13:31:12Z",
-  "commit_sha": "22c4e95fe474efe34af29bd4d3633e1967415ece",
-  "commit_count": 6489,
+  "as_of": "2026-05-13T13:35:20Z",
+  "commit_sha": "c70f64234863acd97b4334907fc449a43b0b1cc3",
+  "commit_count": 6491,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T13:31:12Z",
-  "commit_sha": "22c4e95fe474efe34af29bd4d3633e1967415ece",
-  "commit_count": 6489,
+  "as_of": "2026-05-13T13:35:20Z",
+  "commit_sha": "c70f64234863acd97b4334907fc449a43b0b1cc3",
+  "commit_count": 6491,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.