### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T13:55:52Z",
-  "commit_sha": "0929ddd984150c432b1489ff1d43ebad3edcb663",
-  "commit_count": 6499,
+  "as_of": "2026-05-13T14:00:43Z",
+  "commit_sha": "72be470737949551e8c8891f25f83e503f97e85f",
+  "commit_count": 6501,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T13:55:52Z",
-  "commit_sha": "0929ddd984150c432b1489ff1d43ebad3edcb663",
-  "commit_count": 6499,
+  "as_of": "2026-05-13T14:00:43Z",
+  "commit_sha": "72be470737949551e8c8891f25f83e503f97e85f",
+  "commit_count": 6501,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.