### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T14:05:10Z",
-  "commit_sha": "6a2691957949526af904ef3c2ac71b04a2aacbb1",
-  "commit_count": 6503,
+  "as_of": "2026-05-13T14:10:07Z",
+  "commit_sha": "42702d57ba889be3f88c30ee55a8af891fdd8200",
+  "commit_count": 6505,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-13T14:05:10Z",
-  "commit_sha": "6a2691957949526af904ef3c2ac71b04a2aacbb1",
-  "commit_count": 6503,
+  "as_of": "2026-05-13T14:10:07Z",
+  "commit_sha": "42702d57ba889be3f88c30ee55a8af891fdd8200",
+  "commit_count": 6505,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.