### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T00:59:42Z",
-  "commit_sha": "1bd18bab36e9e31710742920aeb98e79cdd4a3eb",
-  "commit_count": 6521,
+  "as_of": "2026-05-14T01:03:37Z",
+  "commit_sha": "ef4565d6389aa18a2b13dfe439351716be1ee3fa",
+  "commit_count": 6523,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T00:59:42Z",
-  "commit_sha": "1bd18bab36e9e31710742920aeb98e79cdd4a3eb",
-  "commit_count": 6521,
+  "as_of": "2026-05-14T01:03:37Z",
+  "commit_sha": "ef4565d6389aa18a2b13dfe439351716be1ee3fa",
+  "commit_count": 6523,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.