### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T01:19:56Z",
-  "commit_sha": "512fc0300004881385546a6da691acd1230f05fb",
-  "commit_count": 6531,
+  "as_of": "2026-05-14T01:24:04Z",
+  "commit_sha": "2d3b530b1e9f3bafdd3ed88febc4ee985a7eabb0",
+  "commit_count": 6533,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T01:19:56Z",
-  "commit_sha": "512fc0300004881385546a6da691acd1230f05fb",
-  "commit_count": 6531,
+  "as_of": "2026-05-14T01:24:04Z",
+  "commit_sha": "2d3b530b1e9f3bafdd3ed88febc4ee985a7eabb0",
+  "commit_count": 6533,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.