### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T01:44:13Z",
-  "commit_sha": "0908613f61cc8de3643c5a74cfb50461c3797e40",
-  "commit_count": 6543,
+  "as_of": "2026-05-14T01:48:18Z",
+  "commit_sha": "0109f7e794fecfbf4ce1623090cb8d2e2ab85a7b",
+  "commit_count": 6545,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T01:44:13Z",
-  "commit_sha": "0908613f61cc8de3643c5a74cfb50461c3797e40",
-  "commit_count": 6543,
+  "as_of": "2026-05-14T01:48:18Z",
+  "commit_sha": "0109f7e794fecfbf4ce1623090cb8d2e2ab85a7b",
+  "commit_count": 6545,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.