### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T01:52:20Z",
-  "commit_sha": "17e17eafe5cffb836614c143df8b5b3ccc8e5ce2",
-  "commit_count": 6547,
+  "as_of": "2026-05-14T01:56:17Z",
+  "commit_sha": "6b168bdcf7b5d81ab99bc804ea42e52f1d9508df",
+  "commit_count": 6549,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T01:52:20Z",
-  "commit_sha": "17e17eafe5cffb836614c143df8b5b3ccc8e5ce2",
-  "commit_count": 6547,
+  "as_of": "2026-05-14T01:56:17Z",
+  "commit_sha": "6b168bdcf7b5d81ab99bc804ea42e52f1d9508df",
+  "commit_count": 6549,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.