### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T02:00:06Z",
-  "commit_sha": "cd39a32e97510585c274d423b4c1dcf219aeaede",
-  "commit_count": 6551,
+  "as_of": "2026-05-14T02:04:01Z",
+  "commit_sha": "ed1e7bca646fe365719f82db911c01822fb222b3",
+  "commit_count": 6553,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T02:00:06Z",
-  "commit_sha": "cd39a32e97510585c274d423b4c1dcf219aeaede",
-  "commit_count": 6551,
+  "as_of": "2026-05-14T02:04:01Z",
+  "commit_sha": "ed1e7bca646fe365719f82db911c01822fb222b3",
+  "commit_count": 6553,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.