### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T02:07:54Z",
-  "commit_sha": "e2d94e943029b2a779331601f2a8f9be6776bd28",
-  "commit_count": 6555,
+  "as_of": "2026-05-14T02:12:01Z",
+  "commit_sha": "e15519011dcdefc101160f8aa8ee315825519b88",
+  "commit_count": 6557,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T02:07:54Z",
-  "commit_sha": "e2d94e943029b2a779331601f2a8f9be6776bd28",
-  "commit_count": 6555,
+  "as_of": "2026-05-14T02:12:01Z",
+  "commit_sha": "e15519011dcdefc101160f8aa8ee315825519b88",
+  "commit_count": 6557,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.