### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T02:16:09Z",
-  "commit_sha": "f856fdfa4cd82b347905c0347ead4997b1811e39",
-  "commit_count": 6559,
+  "as_of": "2026-05-14T02:20:16Z",
+  "commit_sha": "3628f757243879d96eb640fa8d12da4d16f034f7",
+  "commit_count": 6561,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T02:16:09Z",
-  "commit_sha": "f856fdfa4cd82b347905c0347ead4997b1811e39",
-  "commit_count": 6559,
+  "as_of": "2026-05-14T02:20:16Z",
+  "commit_sha": "3628f757243879d96eb640fa8d12da4d16f034f7",
+  "commit_count": 6561,
   "lines_of_code": 227603,
   "comments": 12848,
   "blanks": 26129,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.