### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-14T02:20:16Z",
-  "commit_sha": "3628f757243879d96eb640fa8d12da4d16f034f7",
-  "commit_count": 6561,
-  "lines_of_code": 227603,
-  "comments": 12848,
-  "blanks": 26129,
-  "total_lines": 266580,
+  "as_of": "2026-05-14T07:36:54Z",
+  "commit_sha": "34184250e9d4ee3edf9badf2be026687f9bce40c",
+  "commit_count": 6568,
+  "lines_of_code": 227616,
+  "comments": 12864,
+  "blanks": 26130,
+  "total_lines": 266610,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -30,9 +30,9 @@
     {
       "language": "Python",
       "files": 83,
-      "code": 34985,
-      "comment": 7561,
-      "blank": 6926
+      "code": 34998,
+      "comment": 7577,
+      "blank": 6927
     },
     {
       "language": "Markdown",

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-14T02:20:16Z",
-  "commit_sha": "3628f757243879d96eb640fa8d12da4d16f034f7",
-  "commit_count": 6561,
-  "lines_of_code": 227603,
-  "comments": 12848,
-  "blanks": 26129,
-  "total_lines": 266580,
+  "as_of": "2026-05-14T07:36:54Z",
+  "commit_sha": "34184250e9d4ee3edf9badf2be026687f9bce40c",
+  "commit_count": 6568,
+  "lines_of_code": 227616,
+  "comments": 12864,
+  "blanks": 26130,
+  "total_lines": 266610,
   "tracked_files": 782,
   "github_workflows": 50,
   "integrations": 8,
@@ -30,9 +30,9 @@
     {
       "language": "Python",
       "files": 83,
-      "code": 34985,
-      "comment": 7561,
-      "blank": 6926
+      "code": 34998,
+      "comment": 7577,
+      "blank": 6927
     },
     {
       "language": "Markdown",


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.