### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T07:36:54Z",
-  "commit_sha": "34184250e9d4ee3edf9badf2be026687f9bce40c",
-  "commit_count": 6568,
+  "as_of": "2026-05-14T07:41:00Z",
+  "commit_sha": "070835330a303448ecef4bcc6eebc76c9cdded14",
+  "commit_count": 6570,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T07:36:54Z",
-  "commit_sha": "34184250e9d4ee3edf9badf2be026687f9bce40c",
-  "commit_count": 6568,
+  "as_of": "2026-05-14T07:41:00Z",
+  "commit_sha": "070835330a303448ecef4bcc6eebc76c9cdded14",
+  "commit_count": 6570,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.