### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T07:45:05Z",
-  "commit_sha": "1f5ab2de6c420daf11105125d02d6a73eb6406a1",
-  "commit_count": 6572,
+  "as_of": "2026-05-14T07:49:14Z",
+  "commit_sha": "1c5e290bdca75a8922a45d056c97870fc19d01be",
+  "commit_count": 6574,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T07:45:05Z",
-  "commit_sha": "1f5ab2de6c420daf11105125d02d6a73eb6406a1",
-  "commit_count": 6572,
+  "as_of": "2026-05-14T07:49:14Z",
+  "commit_sha": "1c5e290bdca75a8922a45d056c97870fc19d01be",
+  "commit_count": 6574,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.