### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T11:42:51Z",
-  "commit_sha": "675754e154a4a37b4a8395de66c7d5ca04fe8db0",
-  "commit_count": 6582,
+  "as_of": "2026-05-14T11:46:57Z",
+  "commit_sha": "adf5916f4dd4ad44ca12b8d619dc73e5b853410f",
+  "commit_count": 6584,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-14T11:42:51Z",
-  "commit_sha": "675754e154a4a37b4a8395de66c7d5ca04fe8db0",
-  "commit_count": 6582,
+  "as_of": "2026-05-14T11:46:57Z",
+  "commit_sha": "adf5916f4dd4ad44ca12b8d619dc73e5b853410f",
+  "commit_count": 6584,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.