### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T01:16:47Z",
-  "commit_sha": "d6a31dc77872f92d3964f8ef5ab491d46b1945a9",
-  "commit_count": 6600,
+  "as_of": "2026-05-15T01:21:10Z",
+  "commit_sha": "412734b900c37a98f5f8c87b427f87056d3326ac",
+  "commit_count": 6602,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T01:16:47Z",
-  "commit_sha": "d6a31dc77872f92d3964f8ef5ab491d46b1945a9",
-  "commit_count": 6600,
+  "as_of": "2026-05-15T01:21:10Z",
+  "commit_sha": "412734b900c37a98f5f8c87b427f87056d3326ac",
+  "commit_count": 6602,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.