### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T01:25:07Z",
-  "commit_sha": "94ef4f87b6c47bb4b7bda5f5960cfb2c6d468dcb",
-  "commit_count": 6604,
+  "as_of": "2026-05-15T01:29:21Z",
+  "commit_sha": "5a9c439f5019d0f7ff5cd1abbc97c14940dbfadf",
+  "commit_count": 6606,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T01:25:07Z",
-  "commit_sha": "94ef4f87b6c47bb4b7bda5f5960cfb2c6d468dcb",
-  "commit_count": 6604,
+  "as_of": "2026-05-15T01:29:21Z",
+  "commit_sha": "5a9c439f5019d0f7ff5cd1abbc97c14940dbfadf",
+  "commit_count": 6606,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.