### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T14:16:26Z",
-  "commit_sha": "defa4eabca306b97599a258a69cd40f3b9852ec7",
-  "commit_count": 6620,
+  "as_of": "2026-05-15T14:21:04Z",
+  "commit_sha": "0667aec92ee2dc9f182a9a4e31e028175758fe5b",
+  "commit_count": 6622,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T14:16:26Z",
-  "commit_sha": "defa4eabca306b97599a258a69cd40f3b9852ec7",
-  "commit_count": 6620,
+  "as_of": "2026-05-15T14:21:04Z",
+  "commit_sha": "0667aec92ee2dc9f182a9a4e31e028175758fe5b",
+  "commit_count": 6622,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.