### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T14:24:59Z",
-  "commit_sha": "d006d029d7585ca3042e317a7e3ce6d26571659b",
-  "commit_count": 6624,
+  "as_of": "2026-05-15T14:29:15Z",
+  "commit_sha": "f749d82960465f7832b2365da60a08d92a627e43",
+  "commit_count": 6626,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T14:24:59Z",
-  "commit_sha": "d006d029d7585ca3042e317a7e3ce6d26571659b",
-  "commit_count": 6624,
+  "as_of": "2026-05-15T14:29:15Z",
+  "commit_sha": "f749d82960465f7832b2365da60a08d92a627e43",
+  "commit_count": 6626,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.