### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T14:29:15Z",
-  "commit_sha": "f749d82960465f7832b2365da60a08d92a627e43",
-  "commit_count": 6626,
+  "as_of": "2026-05-15T14:33:29Z",
+  "commit_sha": "7c1623b728fc5d3c89c5741e15b4d039f999d3d0",
+  "commit_count": 6628,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T14:29:15Z",
-  "commit_sha": "f749d82960465f7832b2365da60a08d92a627e43",
-  "commit_count": 6626,
+  "as_of": "2026-05-15T14:33:29Z",
+  "commit_sha": "7c1623b728fc5d3c89c5741e15b4d039f999d3d0",
+  "commit_count": 6628,
   "lines_of_code": 227616,
   "comments": 12864,
   "blanks": 26130,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.