### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,12 +1,12 @@
 {
-  "as_of": "2026-05-15T14:33:29Z",
-  "commit_sha": "7c1623b728fc5d3c89c5741e15b4d039f999d3d0",
-  "commit_count": 6628,
-  "lines_of_code": 227616,
-  "comments": 12864,
-  "blanks": 26130,
-  "total_lines": 266610,
-  "tracked_files": 782,
+  "as_of": "2026-05-15T15:07:37Z",
+  "commit_sha": "d220452714722642dbee54e5f0201504ffeca3e5",
+  "commit_count": 6643,
+  "lines_of_code": 228796,
+  "comments": 12954,
+  "blanks": 26302,
+  "total_lines": 268052,
+  "tracked_files": 784,
   "github_workflows": 50,
   "integrations": 8,
   "development_phases": 5,
@@ -29,10 +29,10 @@
     },
     {
       "language": "Python",
-      "files": 83,
-      "code": 34998,
-      "comment": 7577,
-      "blank": 6927
+      "files": 85,
+      "code": 35907,
+      "comment": 7644,
+      "blank": 7067
     },
     {
       "language": "Markdown",
@@ -44,9 +44,9 @@
     {
       "language": "YAML",
       "files": 56,
-      "code": 6910,
-      "comment": 863,
-      "blank": 1142
+      "code": 7037,
+      "comment": 880,
+      "blank": 1152
     },
     {
       "language": "CSV",
@@ -72,9 +72,9 @@
     {
       "language": "Bourne Shell",
       "files": 4,
-      "code": 583,
-      "comment": 85,
-      "blank": 95
+      "code": 727,
+      "comment": 91,
+      "blank": 117
     },
     {
       "language": "DOS Batch",

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,12 +1,12 @@
 {
-  "as_of": "2026-05-15T14:33:29Z",
-  "commit_sha": "7c1623b728fc5d3c89c5741e15b4d039f999d3d0",
-  "commit_count": 6628,
-  "lines_of_code": 227616,
-  "comments": 12864,
-  "blanks": 26130,
-  "total_lines": 266610,
-  "tracked_files": 782,
+  "as_of": "2026-05-15T15:07:37Z",
+  "commit_sha": "d220452714722642dbee54e5f0201504ffeca3e5",
+  "commit_count": 6643,
+  "lines_of_code": 228796,
+  "comments": 12954,
+  "blanks": 26302,
+  "total_lines": 268052,
+  "tracked_files": 784,
   "github_workflows": 50,
   "integrations": 8,
   "development_phases": 5,
@@ -29,10 +29,10 @@
     },
     {
       "language": "Python",
-      "files": 83,
-      "code": 34998,
-      "comment": 7577,
-      "blank": 6927
+      "files": 85,
+      "code": 35907,
+      "comment": 7644,
+      "blank": 7067
     },
     {
       "language": "Markdown",
@@ -44,9 +44,9 @@
     {
       "language": "YAML",
       "files": 56,
-      "code": 6910,
-      "comment": 863,
-      "blank": 1142
+      "code": 7037,
+      "comment": 880,
+      "blank": 1152
     },
     {
       "language": "CSV",
@@ -72,9 +72,9 @@
     {
       "language": "Bourne Shell",
       "files": 4,
-      "code": 583,
-      "comment": 85,
-      "blank": 95
+      "code": 727,
+      "comment": 91,
+      "blank": 117
     },
     {
       "language": "DOS Batch",


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.