### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T15:20:40Z",
-  "commit_sha": "f289046aca86e7e5626db62d1da71f1b97d0dd86",
-  "commit_count": 6649,
+  "as_of": "2026-05-15T15:24:44Z",
+  "commit_sha": "d929c6b534cc30f51a5f60aff1b79a1d08668fe0",
+  "commit_count": 6651,
   "lines_of_code": 228796,
   "comments": 12954,
   "blanks": 26302,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T15:20:40Z",
-  "commit_sha": "f289046aca86e7e5626db62d1da71f1b97d0dd86",
-  "commit_count": 6649,
+  "as_of": "2026-05-15T15:24:44Z",
+  "commit_sha": "d929c6b534cc30f51a5f60aff1b79a1d08668fe0",
+  "commit_count": 6651,
   "lines_of_code": 228796,
   "comments": 12954,
   "blanks": 26302,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.