### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T15:37:15Z",
-  "commit_sha": "0e411130495d804bc5718af93b7beeb798f91199",
-  "commit_count": 6657,
+  "as_of": "2026-05-15T15:41:25Z",
+  "commit_sha": "4cceb5cd0b84aeea1708c5a835905a53a87cba3a",
+  "commit_count": 6659,
   "lines_of_code": 228796,
   "comments": 12954,
   "blanks": 26302,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-15T15:37:15Z",
-  "commit_sha": "0e411130495d804bc5718af93b7beeb798f91199",
-  "commit_count": 6657,
+  "as_of": "2026-05-15T15:41:25Z",
+  "commit_sha": "4cceb5cd0b84aeea1708c5a835905a53a87cba3a",
+  "commit_count": 6659,
   "lines_of_code": 228796,
   "comments": 12954,
   "blanks": 26302,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.