### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-15T15:49:51Z",
-  "commit_sha": "0fed8749547b5e36daf3ae8b83c45f0821bea26f",
-  "commit_count": 6663,
-  "lines_of_code": 228796,
+  "as_of": "2026-05-15T17:12:01Z",
+  "commit_sha": "50b8f52d902fa0a1151cd35e5686a617177a9203",
+  "commit_count": 6669,
+  "lines_of_code": 228834,
   "comments": 12954,
-  "blanks": 26302,
-  "total_lines": 268052,
+  "blanks": 26304,
+  "total_lines": 268092,
   "tracked_files": 784,
   "github_workflows": 50,
   "integrations": 8,
@@ -16,7 +16,7 @@
     {
       "language": "TypeScript",
       "files": 460,
-      "code": 111928,
+      "code": 111953,
       "comment": 3921,
       "blank": 7959
     },
@@ -37,9 +37,9 @@
     {
       "language": "Markdown",
       "files": 102,
-      "code": 24036,
+      "code": 24049,
       "comment": 39,
-      "blank": 9554
+      "blank": 9556
     },
     {
       "language": "YAML",

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-15T15:49:51Z",
-  "commit_sha": "0fed8749547b5e36daf3ae8b83c45f0821bea26f",
-  "commit_count": 6663,
-  "lines_of_code": 228796,
+  "as_of": "2026-05-15T17:12:01Z",
+  "commit_sha": "50b8f52d902fa0a1151cd35e5686a617177a9203",
+  "commit_count": 6669,
+  "lines_of_code": 228834,
   "comments": 12954,
-  "blanks": 26302,
-  "total_lines": 268052,
+  "blanks": 26304,
+  "total_lines": 268092,
   "tracked_files": 784,
   "github_workflows": 50,
   "integrations": 8,
@@ -16,7 +16,7 @@
     {
       "language": "TypeScript",
       "files": 460,
-      "code": 111928,
+      "code": 111953,
       "comment": 3921,
       "blank": 7959
     },
@@ -37,9 +37,9 @@
     {
       "language": "Markdown",
       "files": 102,
-      "code": 24036,
+      "code": 24049,
       "comment": 39,
-      "blank": 9554
+      "blank": 9556
     },
     {
       "language": "YAML",


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.