### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-15T19:18:12Z",
-  "commit_sha": "ab102a5b500e6d70ba242b4b9b4568eaf660a5b7",
-  "commit_count": 6692,
-  "lines_of_code": 228947,
+  "as_of": "2026-05-16T00:53:34Z",
+  "commit_sha": "0ef6e4859aaa73b63071e3d3da4df34d40dd9080",
+  "commit_count": 6698,
+  "lines_of_code": 228954,
   "comments": 12954,
   "blanks": 26304,
-  "total_lines": 268205,
+  "total_lines": 268212,
   "tracked_files": 784,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44902,
+      "code": 44909,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-15T19:18:12Z",
-  "commit_sha": "ab102a5b500e6d70ba242b4b9b4568eaf660a5b7",
-  "commit_count": 6692,
-  "lines_of_code": 228947,
+  "as_of": "2026-05-16T00:53:34Z",
+  "commit_sha": "0ef6e4859aaa73b63071e3d3da4df34d40dd9080",
+  "commit_count": 6698,
+  "lines_of_code": 228954,
   "comments": 12954,
   "blanks": 26304,
-  "total_lines": 268205,
+  "total_lines": 268212,
   "tracked_files": 784,
   "github_workflows": 50,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44902,
+      "code": 44909,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.