### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-16T09:38:34Z",
-  "commit_sha": "7cd21a4547320b5e8b85b0720533e9983e8cae66",
-  "commit_count": 6702,
-  "lines_of_code": 228961,
+  "as_of": "2026-05-16T16:14:46Z",
+  "commit_sha": "26cf2dee20bbe9fb11b92f2a3d98f29b93aabd9c",
+  "commit_count": 6722,
+  "lines_of_code": 228974,
   "comments": 12954,
-  "blanks": 26304,
-  "total_lines": 268219,
+  "blanks": 26309,
+  "total_lines": 268237,
   "tracked_files": 784,
   "github_workflows": 50,
   "integrations": 8,
@@ -16,23 +16,23 @@
     {
       "language": "TypeScript",
       "files": 460,
-      "code": 111953,
-      "comment": 3921,
-      "blank": 7959
+      "code": 111967,
+      "comment": 3919,
+      "blank": 7962
     },
     {
       "language": "JSON",
       "files": 41,
-      "code": 44916,
+      "code": 44914,
       "comment": 0,
       "blank": 0
     },
     {
       "language": "Python",
       "files": 85,
-      "code": 35907,
-      "comment": 7644,
-      "blank": 7067
+      "code": 35908,
+      "comment": 7646,
+      "blank": 7069
     },
     {
       "language": "Markdown",

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-16T09:38:34Z",
-  "commit_sha": "7cd21a4547320b5e8b85b0720533e9983e8cae66",
-  "commit_count": 6702,
-  "lines_of_code": 228961,
+  "as_of": "2026-05-16T16:14:46Z",
+  "commit_sha": "26cf2dee20bbe9fb11b92f2a3d98f29b93aabd9c",
+  "commit_count": 6722,
+  "lines_of_code": 228974,
   "comments": 12954,
-  "blanks": 26304,
-  "total_lines": 268219,
+  "blanks": 26309,
+  "total_lines": 268237,
   "tracked_files": 784,
   "github_workflows": 50,
   "integrations": 8,
@@ -16,23 +16,23 @@
     {
       "language": "TypeScript",
       "files": 460,
-      "code": 111953,
-      "comment": 3921,
-      "blank": 7959
+      "code": 111967,
+      "comment": 3919,
+      "blank": 7962
     },
     {
       "language": "JSON",
       "files": 41,
-      "code": 44916,
+      "code": 44914,
       "comment": 0,
       "blank": 0
     },
     {
       "language": "Python",
       "files": 85,
-      "code": 35907,
-      "comment": 7644,
-      "blank": 7067
+      "code": 35908,
+      "comment": 7646,
+      "blank": 7069
     },
     {
       "language": "Markdown",


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.