### PR TITLE
fix(test): scope response-funnel value assertions to their metric cards

### DIFF
--- a/__tests__/components/survey-stats/response-funnel.test.tsx
+++ b/__tests__/components/survey-stats/response-funnel.test.tsx
@@ -50,10 +50,10 @@ describe('Response Funnel page (QualtricsSurveyStats)', () => {
       .getByRole('heading', { name: /^Items presented$/i })
       .closest('.rounded-lg') as HTMLElement
     expect(
-      within(questionIdsCard).getByText(metricsData.questionCount.toLocaleString()),
+      within(questionIdsCard).getByText(metricsData.questionCount.toLocaleString())
     ).toBeInTheDocument()
     expect(
-      within(itemsPresentedCard).getByText(TOTAL_ITEMS_PRESENTED.toLocaleString()),
+      within(itemsPresentedCard).getByText(TOTAL_ITEMS_PRESENTED.toLocaleString())
     ).toBeInTheDocument()
   })
 

--- a/__tests__/components/survey-stats/response-funnel.test.tsx
+++ b/__tests__/components/survey-stats/response-funnel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import QualtricsSurveyStats from '../../../src/components/survey-stats/qualtrics-survey-stats'
@@ -40,13 +40,21 @@ describe('Response Funnel page (QualtricsSurveyStats)', () => {
 
   it('renders Qualtrics question IDs and items presented as separate values', () => {
     render(<QualtricsSurveyStats />)
-    // Use exact match (the default): small values like 21 would otherwise
-    // substring-match larger numbers rendered by other metric cards on the
-    // page (e.g. Prolific disposition counts or Qualtrics raw-response counts
-    // that shift daily), causing this assertion to fail intermittently as
-    // pipeline data drifts.
-    expect(screen.getByText(metricsData.questionCount.toLocaleString())).toBeInTheDocument()
-    expect(screen.getByText(TOTAL_ITEMS_PRESENTED.toLocaleString())).toBeInTheDocument()
+    // Scope to each MetricCard by its label heading. Plain getByText collides
+    // whenever a daily-pipeline value (e.g. a disposition count) happens to
+    // match the items-presented instrument constant.
+    const questionIdsCard = screen
+      .getByRole('heading', { name: /Qualtrics question IDs/i })
+      .closest('.rounded-lg') as HTMLElement
+    const itemsPresentedCard = screen
+      .getByRole('heading', { name: /^Items presented$/i })
+      .closest('.rounded-lg') as HTMLElement
+    expect(
+      within(questionIdsCard).getByText(metricsData.questionCount.toLocaleString()),
+    ).toBeInTheDocument()
+    expect(
+      within(itemsPresentedCard).getByText(TOTAL_ITEMS_PRESENTED.toLocaleString()),
+    ).toBeInTheDocument()
   })
 
   it('labels each metric card with its API source via badge text', () => {

--- a/__tests__/components/survey-stats/response-funnel.test.tsx
+++ b/__tests__/components/survey-stats/response-funnel.test.tsx
@@ -40,15 +40,22 @@ describe('Response Funnel page (QualtricsSurveyStats)', () => {
 
   it('renders Qualtrics question IDs and items presented as separate values', () => {
     render(<QualtricsSurveyStats />)
+    const getMetricCard = (name: RegExp) => {
+      const heading = screen.getByRole('heading', { name, level: 4 })
+      const card = heading.parentElement?.parentElement
+
+      if (!(card instanceof HTMLElement)) {
+        throw new Error(`Expected metric card container for heading ${name.toString()}`)
+      }
+
+      return card
+    }
+
     // Scope to each MetricCard by its label heading. Plain getByText collides
     // whenever a daily-pipeline value (e.g. a disposition count) happens to
     // match the items-presented instrument constant.
-    const questionIdsCard = screen
-      .getByRole('heading', { name: /Qualtrics question IDs/i })
-      .closest('.rounded-lg') as HTMLElement
-    const itemsPresentedCard = screen
-      .getByRole('heading', { name: /^Items presented$/i })
-      .closest('.rounded-lg') as HTMLElement
+    const questionIdsCard = getMetricCard(/Qualtrics question IDs/i)
+    const itemsPresentedCard = getMetricCard(/^Items presented$/i)
     expect(
       within(questionIdsCard).getByText(metricsData.questionCount.toLocaleString())
     ).toBeInTheDocument()


### PR DESCRIPTION
## Summary

Fixes the failing Jest test `Response Funnel page (QualtricsSurveyStats) › renders Qualtrics question IDs and items presented as separate values` that has been blocking the daily-pipeline data PR (#2594) from merging.

## Root cause

The test uses `screen.getByText(...)` (single-match) with exact-match values. It still fails any day a pipeline-driven number coincidentally equals an instrument constant. Today: `TOTAL_ITEMS_PRESENTED = 57` and `dispositions["FLAG-PARTIAL-STRAIGHTLINING"] = 57` both render in `<div class="mt-2 text-3xl font-bold text-slate-900">57</div>`, so `getByText("57")` finds two matches and throws.

The author's earlier switch to exact-match avoided substring collisions (e.g. `21` matching inside `421`) but did not address full-value collisions.

## Fix

Scope each assertion to its specific `MetricCard` via the card's `<h4>` heading, then use `within(card).getByText(value)`. This makes the assertion immune to other cards' values regardless of pipeline drift.

No production code changed — test-only.

## Test plan

- [ ] Jest `response-funnel.test.tsx` passes locally and in CI
- [ ] Other 5 tests in the same file still pass (unchanged)
- [ ] Once green, PR #2594 (daily pipeline data) can re-run checks and merge

## Notes

- Discovered while triaging why `src/data/disposition-summary.json` on `main` was ~26 hours stale.
- Today's pipeline ran successfully; data is sitting on `chore/daily-pipeline-data` (PR #2594), blocked by this test plus the PII-scan false-positive that #1925 fixes.
