### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T17:05:33Z",
-  "commit_sha": "2b6fa31f2011b389654576d2c8d64a6dcc8b6709",
-  "commit_count": 6748,
+  "as_of": "2026-05-16T17:09:22Z",
+  "commit_sha": "7fded32d8e0f950f7baf379f4ebd6a769a7b1293",
+  "commit_count": 6750,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T17:05:33Z",
-  "commit_sha": "2b6fa31f2011b389654576d2c8d64a6dcc8b6709",
-  "commit_count": 6748,
+  "as_of": "2026-05-16T17:09:22Z",
+  "commit_sha": "7fded32d8e0f950f7baf379f4ebd6a769a7b1293",
+  "commit_count": 6750,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.