### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T17:21:28Z",
-  "commit_sha": "cfd004b497d45ef8998793303cb1a8ebaa0da611",
-  "commit_count": 6756,
+  "as_of": "2026-05-16T17:25:30Z",
+  "commit_sha": "5be8cbd1fbdd93ee28d48c60947a6688fc2053b2",
+  "commit_count": 6758,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T17:21:28Z",
-  "commit_sha": "cfd004b497d45ef8998793303cb1a8ebaa0da611",
-  "commit_count": 6756,
+  "as_of": "2026-05-16T17:25:30Z",
+  "commit_sha": "5be8cbd1fbdd93ee28d48c60947a6688fc2053b2",
+  "commit_count": 6758,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.