### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T17:56:18Z",
-  "commit_sha": "36cee947d9d0859b63386795ae9fcf4d217485ef",
-  "commit_count": 6774,
+  "as_of": "2026-05-16T18:00:15Z",
+  "commit_sha": "5fea504a334e579a5ca18d043e56dc26ce49b1d6",
+  "commit_count": 6776,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T17:56:18Z",
-  "commit_sha": "36cee947d9d0859b63386795ae9fcf4d217485ef",
-  "commit_count": 6774,
+  "as_of": "2026-05-16T18:00:15Z",
+  "commit_sha": "5fea504a334e579a5ca18d043e56dc26ce49b1d6",
+  "commit_count": 6776,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.