### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T18:04:08Z",
-  "commit_sha": "3831b6203e120c5e02998223e6924bc33dccc28f",
-  "commit_count": 6778,
+  "as_of": "2026-05-16T18:08:13Z",
+  "commit_sha": "89b106a828e46cf3538c0f3d5b9d459014933a49",
+  "commit_count": 6780,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T18:04:08Z",
-  "commit_sha": "3831b6203e120c5e02998223e6924bc33dccc28f",
-  "commit_count": 6778,
+  "as_of": "2026-05-16T18:08:13Z",
+  "commit_sha": "89b106a828e46cf3538c0f3d5b9d459014933a49",
+  "commit_count": 6780,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.