### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T19:17:27Z",
-  "commit_sha": "9ae8d2b19d7ee7803c453cdcfaefb66d7b7fbe4b",
-  "commit_count": 6816,
+  "as_of": "2026-05-16T19:20:57Z",
+  "commit_sha": "7ecfd59b92baeaaa8dad4cbfbb89e6b777a41615",
+  "commit_count": 6818,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T19:17:27Z",
-  "commit_sha": "9ae8d2b19d7ee7803c453cdcfaefb66d7b7fbe4b",
-  "commit_count": 6816,
+  "as_of": "2026-05-16T19:20:57Z",
+  "commit_sha": "7ecfd59b92baeaaa8dad4cbfbb89e6b777a41615",
+  "commit_count": 6818,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.