### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T19:39:58Z",
-  "commit_sha": "4521f0c6f214e8acd2281f85f0f4c6c08d0ef384",
-  "commit_count": 6828,
+  "as_of": "2026-05-16T19:44:00Z",
+  "commit_sha": "26c76a1375afe6a9ea9c562b9acd76bdb8465888",
+  "commit_count": 6830,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T19:39:58Z",
-  "commit_sha": "4521f0c6f214e8acd2281f85f0f4c6c08d0ef384",
-  "commit_count": 6828,
+  "as_of": "2026-05-16T19:44:00Z",
+  "commit_sha": "26c76a1375afe6a9ea9c562b9acd76bdb8465888",
+  "commit_count": 6830,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.