### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T20:41:39Z",
-  "commit_sha": "f0225a14a653e7e3ed512c3f0c1afe70782c1f98",
-  "commit_count": 6860,
+  "as_of": "2026-05-16T20:45:46Z",
+  "commit_sha": "7fe9e0c05aec254a93c8188f73fd8086a911e43b",
+  "commit_count": 6862,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T20:41:39Z",
-  "commit_sha": "f0225a14a653e7e3ed512c3f0c1afe70782c1f98",
-  "commit_count": 6860,
+  "as_of": "2026-05-16T20:45:46Z",
+  "commit_sha": "7fe9e0c05aec254a93c8188f73fd8086a911e43b",
+  "commit_count": 6862,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.