### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T21:44:25Z",
-  "commit_sha": "31837d5db4b8f51b458259d23fbbc50c5edf706d",
-  "commit_count": 6892,
+  "as_of": "2026-05-16T21:48:22Z",
+  "commit_sha": "ae2f29f42ac6e3e69c9318c524b8be9c1ff79a5f",
+  "commit_count": 6894,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T21:44:25Z",
-  "commit_sha": "31837d5db4b8f51b458259d23fbbc50c5edf706d",
-  "commit_count": 6892,
+  "as_of": "2026-05-16T21:48:22Z",
+  "commit_sha": "ae2f29f42ac6e3e69c9318c524b8be9c1ff79a5f",
+  "commit_count": 6894,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.