### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T23:05:23Z",
-  "commit_sha": "26b056f25ce8527ed57c1dd2bca9b9aafb2ed845",
-  "commit_count": 6934,
+  "as_of": "2026-05-16T23:09:23Z",
+  "commit_sha": "bf90ed19f1358f34be30de331807f8b157b80b21",
+  "commit_count": 6936,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T23:05:23Z",
-  "commit_sha": "26b056f25ce8527ed57c1dd2bca9b9aafb2ed845",
-  "commit_count": 6934,
+  "as_of": "2026-05-16T23:09:23Z",
+  "commit_sha": "bf90ed19f1358f34be30de331807f8b157b80b21",
+  "commit_count": 6936,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.