### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T23:47:50Z",
-  "commit_sha": "e7a3e96a2bc18c2133e5ff21d1411bb321340ce5",
-  "commit_count": 6956,
+  "as_of": "2026-05-16T23:51:38Z",
+  "commit_sha": "5485cba94787da26afa5fd8416f94dbf28501273",
+  "commit_count": 6958,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-16T23:47:50Z",
-  "commit_sha": "e7a3e96a2bc18c2133e5ff21d1411bb321340ce5",
-  "commit_count": 6956,
+  "as_of": "2026-05-16T23:51:38Z",
+  "commit_sha": "5485cba94787da26afa5fd8416f94dbf28501273",
+  "commit_count": 6958,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.