### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-17T00:03:02Z",
-  "commit_sha": "7f0f21626e647ec6647bbbd3311e0b7d6e71642e",
-  "commit_count": 6964,
+  "as_of": "2026-05-17T00:06:46Z",
+  "commit_sha": "08c68aa9670498868979b5f4ca2fb3fe7d85541d",
+  "commit_count": 6966,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-17T00:03:02Z",
-  "commit_sha": "7f0f21626e647ec6647bbbd3311e0b7d6e71642e",
-  "commit_count": 6964,
+  "as_of": "2026-05-17T00:06:46Z",
+  "commit_sha": "08c68aa9670498868979b5f4ca2fb3fe7d85541d",
+  "commit_count": 6966,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.