### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-17T00:25:46Z",
-  "commit_sha": "b8d8e5a8f8cb4400373bf87c9caabe9e358a54f7",
-  "commit_count": 6976,
+  "as_of": "2026-05-17T00:29:44Z",
+  "commit_sha": "1269c363a517abc2f162de7bde4c07baa8232a22",
+  "commit_count": 6978,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-17T00:25:46Z",
-  "commit_sha": "b8d8e5a8f8cb4400373bf87c9caabe9e358a54f7",
-  "commit_count": 6976,
+  "as_of": "2026-05-17T00:29:44Z",
+  "commit_sha": "1269c363a517abc2f162de7bde4c07baa8232a22",
+  "commit_count": 6978,
   "lines_of_code": 228974,
   "comments": 12954,
   "blanks": 26309,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.