### PR TITLE
feat(daily): HIGH RISK alert, N=500 forecast, bulk-reject, multi-reply, queue ETA (re-open of #2692)

### DIFF
--- a/.github/workflows/bulk-approve-replied.yml
+++ b/.github/workflows/bulk-approve-replied.yml
@@ -105,4 +105,7 @@ jobs:
         with:
           name: bulk-approve-results
           path: ${{ runner.temp }}/bulk-approve-results.json
-          retention-days: 7
+          # 1-day retention: contains full PIDs (approved, deferred, failed).
+          # Matches the privacy treatment of disposition-csv and the
+          # reply-action-recommendations source artifact.
+          retention-days: 1

--- a/.github/workflows/bulk-approve-replied.yml
+++ b/.github/workflows/bulk-approve-replied.yml
@@ -72,30 +72,25 @@ jobs:
             echo "::error::Recommendations file not found at $REC"
             exit 1
           fi
-          # Use a heredoc (matches bulk-reject-high-tier-no-reply.yml) so we
-          # don't embed the artifact path inside a Python string literal -- and
-          # so we compute COUNT inside the same Python process instead of
-          # passing $PID_LIST through a second shell-string interpolation.
-          read -r PID_LIST COUNT < <(REC="$REC" python3 << 'PY'
+          # Write outputs directly so empty PID lists don't get misparsed by
+          # shell word-splitting (Python prints " 0" for empty list/count pairs).
+          REC="$REC" GITHUB_OUTPUT="$GITHUB_OUTPUT" python3 << 'PY'
           import json
           import os
+          from pathlib import Path
 
           with open(os.environ["REC"], encoding="utf-8") as f:
               d = json.load(f)
 
           pids = [entry["pid"] for entry in d["buckets"]["auto_approve_eligible"]]
-          print(",".join(pids), len(pids))
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+              fh.write("pid_list<<EOF_PIDS\n")
+              fh.write(",".join(pids) + "\n")
+              fh.write("EOF_PIDS\n")
+              fh.write(f"count={len(pids)}\n")
           PY
-          )
-          if [ -z "$PID_LIST" ]; then
-            COUNT=0
-          fi
-          {
-            echo "pid_list<<EOF_PIDS"
-            echo "$PID_LIST"
-            echo "EOF_PIDS"
-            echo "count=$COUNT"
-          } >> "$GITHUB_OUTPUT"
+          COUNT="$(python3 -c "import json; print(len(json.load(open('$REC', encoding='utf-8'))['buckets']['auto_approve_eligible']))")"
           echo "Found $COUNT PIDs in auto_approve_eligible bucket"
 
       - name: Approve PIDs

--- a/.github/workflows/bulk-approve-replied.yml
+++ b/.github/workflows/bulk-approve-replied.yml
@@ -72,20 +72,30 @@ jobs:
             echo "::error::Recommendations file not found at $REC"
             exit 1
           fi
-          PID_LIST=$(python3 -c "
+          # Use a heredoc (matches bulk-reject-high-tier-no-reply.yml) so we
+          # don't embed the artifact path inside a Python string literal -- and
+          # so we compute COUNT inside the same Python process instead of
+          # passing $PID_LIST through a second shell-string interpolation.
+          read -r PID_LIST COUNT < <(REC="$REC" python3 << 'PY'
           import json
-          with open('$REC') as f:
+          import os
+
+          with open(os.environ["REC"], encoding="utf-8") as f:
               d = json.load(f)
-          pids = [e['pid'] for e in d['buckets']['auto_approve_eligible']]
-          print(','.join(pids))
-          ")
+
+          pids = [entry["pid"] for entry in d["buckets"]["auto_approve_eligible"]]
+          print(",".join(pids), len(pids))
+          PY
+          )
           if [ -z "$PID_LIST" ]; then
             COUNT=0
-          else
-            COUNT=$(python3 -c "print(len('$PID_LIST'.split(',')))")
           fi
-          echo "pid_list=$PID_LIST" >> "$GITHUB_OUTPUT"
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          {
+            echo "pid_list<<EOF_PIDS"
+            echo "$PID_LIST"
+            echo "EOF_PIDS"
+            echo "count=$COUNT"
+          } >> "$GITHUB_OUTPUT"
           echo "Found $COUNT PIDs in auto_approve_eligible bucket"
 
       - name: Approve PIDs

--- a/.github/workflows/bulk-approve-replied.yml
+++ b/.github/workflows/bulk-approve-replied.yml
@@ -77,6 +77,7 @@ jobs:
           REC="$REC" GITHUB_OUTPUT="$GITHUB_OUTPUT" python3 << 'PY'
           import json
           import os
+          import sys
           from pathlib import Path
 
           with open(os.environ["REC"], encoding="utf-8") as f:
@@ -89,12 +90,17 @@ jobs:
               fh.write(",".join(pids) + "\n")
               fh.write("EOF_PIDS\n")
               fh.write(f"count={len(pids)}\n")
+          # Diagnostic to stdout. Done inside the same Python process so
+          # set -euo pipefail can't kill the Extract step from a follow-up
+          # shell invocation just to compute the count.
+          print(f"Found {len(pids)} PIDs in auto_approve_eligible bucket", file=sys.stderr)
           PY
-          COUNT="$(python3 -c "import json; print(len(json.load(open('$REC', encoding='utf-8'))['buckets']['auto_approve_eligible']))")"
-          echo "Found $COUNT PIDs in auto_approve_eligible bucket"
 
       - name: Approve PIDs
-        if: ${{ steps.extract.outputs.count != '0' }}
+        # Guard with extract.conclusion: if Extract failed (e.g. recommendations
+        # artifact missing), count is unset and "" != '0' would otherwise let
+        # Approve run with an empty PID_LIST.
+        if: ${{ steps.extract.conclusion == 'success' && steps.extract.outputs.count != '0' }}
         run: python3 scripts/analysis/approve_by_pid.py
         env:
           PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
@@ -106,7 +112,7 @@ jobs:
           OUTPUT_JSON_PATH: ${{ runner.temp }}/bulk-approve-results.json
 
       - uses: actions/upload-artifact@v7
-        if: ${{ always() && steps.extract.outputs.count != '0' }}
+        if: ${{ always() && steps.extract.conclusion == 'success' && steps.extract.outputs.count != '0' }}
         with:
           name: bulk-approve-results
           path: ${{ runner.temp }}/bulk-approve-results.json

--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -87,13 +87,17 @@ jobs:
             echo "::error::Recommendations file not found at $REC"
             exit 1
           fi
-          PID_LIST=$(python3 -c "
+          PID_LIST=$(REC="$REC" python3 <<'PY'
           import json
-          with open('$REC') as f:
+          import os
+
+          with open(os.environ["REC"], encoding="utf-8") as f:
               d = json.load(f)
-          pids = [e['pid'] for e in d['buckets']['no_reply_high_tier']]
-          print(','.join(pids))
-          ")
+
+          pids = [entry["pid"] for entry in d["buckets"]["no_reply_high_tier"]]
+          print(",".join(pids))
+          PY
+          )
           if [ -z "$PID_LIST" ]; then
             COUNT=0
           else

--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -68,7 +68,7 @@ jobs:
           name: reply-action-recommendations
           path: ${{ runner.temp }}/recs
           run-id: ${{ inputs.source_run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
 
       - name: Download disposition CSV
         uses: actions/download-artifact@v8
@@ -76,7 +76,7 @@ jobs:
           name: disposition-csv
           path: ${{ runner.temp }}/disp
           run-id: ${{ inputs.source_run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
 
       - name: Extract no_reply_high_tier PIDs
         id: extract
@@ -126,4 +126,7 @@ jobs:
         with:
           name: bulk-reject-results
           path: ${{ runner.temp }}/bulk-reject-results.json
-          retention-days: 7
+          # 1-day retention: contains full PIDs (rejected, skipped, failed).
+          # Matches the privacy treatment of disposition-csv and the
+          # reply-action-recommendations source artifact.
+          retention-days: 1

--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -17,7 +17,7 @@ name: Bulk Reject High-Tier No-Reply
 # Safety:
 #   - Default is dry-run. Live execution requires `dry_run: false`.
 #   - reject_by_pid.py enforces CONFIRM_REJECT=REJECT on live runs.
-#   - MAX_PER_RUN ceiling defaults to 30 (overridable per-run).
+#   - MAX_PER_RUN ceiling defaults to 10 (overridable per-run).
 #   - reject_by_pid.py skips any PID whose status is no longer AWAITING REVIEW
 #     (so re-runs are idempotent; if Phase 3e already rejected a PID, it skips).
 
@@ -34,10 +34,10 @@ on:
         type: boolean
         default: true
       max_per_run:
-        description: 'Ceiling override (default 30)'
+        description: 'Ceiling override (default 10)'
         required: false
         type: string
-        default: '30'
+        default: '10'
 
 concurrency:
   group: bulk-reject-high-tier-no-reply

--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -97,6 +97,7 @@ jobs:
           REC="$REC" GITHUB_OUTPUT="$GITHUB_OUTPUT" python3 << 'PY'
           import json
           import os
+          import sys
           from pathlib import Path
 
           with open(os.environ["REC"], encoding="utf-8") as f:
@@ -109,9 +110,11 @@ jobs:
               fh.write(",".join(pids) + "\n")
               fh.write("EOF_PIDS\n")
               fh.write(f"count={len(pids)}\n")
+          # Diagnostic to stdout. Done inside the same Python process so
+          # set -euo pipefail can't kill the Extract step from a follow-up
+          # shell invocation just to compute the count.
+          print(f"Found {len(pids)} PIDs in no_reply_high_tier bucket", file=sys.stderr)
           PY
-          COUNT="$(python3 -c "import json; print(len(json.load(open('$REC', encoding='utf-8'))['buckets']['no_reply_high_tier']))")"
-          echo "Found $COUNT PIDs in no_reply_high_tier bucket"
 
       - name: Safety check for live reject
         if: ${{ inputs.dry_run == false }}
@@ -122,7 +125,10 @@ jobs:
           fi
 
       - name: Reject PIDs
-        if: ${{ steps.extract.outputs.count != '0' }}
+        # Guard with extract.conclusion: if Extract failed (e.g. recommendations
+        # artifact missing), count is unset and "" != '0' would otherwise let
+        # Reject run with an empty PID_LIST.
+        if: ${{ steps.extract.conclusion == 'success' && steps.extract.outputs.count != '0' }}
         run: python3 scripts/analysis/reject_by_pid.py
         env:
           PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
@@ -136,7 +142,7 @@ jobs:
           OUTPUT_JSON_PATH: ${{ runner.temp }}/bulk-reject-results.json
 
       - uses: actions/upload-artifact@v7
-        if: ${{ always() && steps.extract.outputs.count != '0' }}
+        if: ${{ always() && steps.extract.conclusion == 'success' && steps.extract.outputs.count != '0' }}
         with:
           name: bulk-reject-results
           path: ${{ runner.temp }}/bulk-reject-results.json

--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -16,10 +16,10 @@ name: Bulk Reject High-Tier No-Reply
 #
 # Safety:
 #   - Default is dry-run. Live execution requires `dry_run: false`.
-#   - Live rejection also requires `confirm_reject: REJECT`.
+#   - reject_by_pid.py enforces CONFIRM_REJECT=REJECT on live runs.
 #   - MAX_PER_RUN ceiling defaults to 10 (overridable per-run).
-#   - Non-AWAITING PIDs are skipped so re-runs stay idempotent if another
-#     workflow already actioned part of the bucket.
+#   - reject_by_pid.py skips any PID whose status is no longer AWAITING REVIEW
+#     (so re-runs are idempotent; if Phase 3e already rejected a PID, it skips).
 
 on:
   workflow_dispatch:
@@ -33,11 +33,6 @@ on:
         required: false
         type: boolean
         default: true
-      confirm_reject:
-        description: 'Type REJECT to confirm live rejection (required when dry_run is false)'
-        required: false
-        type: string
-        default: ''
       max_per_run:
         description: 'Ceiling override (default 10)'
         required: false
@@ -61,23 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: prolific-prod
     steps:
-      - name: 'Safety check: validate confirmation'
-        if: inputs.dry_run == false
-        env:
-          CONFIRM: ${{ inputs.confirm_reject }}
-        run: |
-          echo "================================================================"
-          echo "  DESTRUCTIVE OPERATION: Prolific Submission Rejection"
-          echo "  This will REJECT the no_reply_high_tier PIDs from the selected run."
-          echo "  They will NOT be paid."
-          echo "================================================================"
-          if [ "$CONFIRM" != "REJECT" ]; then
-            echo "SAFETY STOP: You must type REJECT in the confirmation field."
-            echo "Received: '$CONFIRM'"
-            exit 1
-          fi
-          echo "Confirmation accepted: '$CONFIRM'"
-
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
@@ -109,7 +87,9 @@ jobs:
             echo "::error::Recommendations file not found at $REC"
             exit 1
           fi
-          PID_LIST=$(REC="$REC" python3 <<'PY'
+          # Compute PID_LIST and COUNT in a single Python invocation so we
+          # don't shell-interpolate $PID_LIST into a second python3 -c call.
+          read -r PID_LIST COUNT < <(REC="$REC" python3 << 'PY'
           import json
           import os
 
@@ -117,16 +97,18 @@ jobs:
               d = json.load(f)
 
           pids = [entry["pid"] for entry in d["buckets"]["no_reply_high_tier"]]
-          print(",".join(pids))
+          print(",".join(pids), len(pids))
           PY
           )
           if [ -z "$PID_LIST" ]; then
             COUNT=0
-          else
-            COUNT=$(python3 -c "print(len('$PID_LIST'.split(',')))")
           fi
-          echo "pid_list=$PID_LIST" >> "$GITHUB_OUTPUT"
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          {
+            echo "pid_list<<EOF_PIDS"
+            echo "$PID_LIST"
+            echo "EOF_PIDS"
+            echo "count=$COUNT"
+          } >> "$GITHUB_OUTPUT"
           echo "Found $COUNT PIDs in no_reply_high_tier bucket"
 
       - name: Reject PIDs
@@ -138,9 +120,9 @@ jobs:
           CSV_FILE_PATH: ${{ runner.temp }}/disp/disposition.csv
           PID_LIST: ${{ steps.extract.outputs.pid_list }}
           MAX_PER_RUN: ${{ inputs.max_per_run }}
-          STRICT_AWAITING: 'false'
+          STRICT_AWAITING: 'true'
           DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
-          CONFIRM_REJECT: ${{ inputs.confirm_reject }}
+          CONFIRM_REJECT: ${{ inputs.dry_run && 'unused' || 'REJECT' }}
           OUTPUT_JSON_PATH: ${{ runner.temp }}/bulk-reject-results.json
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -16,7 +16,7 @@ name: Bulk Reject High-Tier No-Reply
 #
 # Safety:
 #   - Default is dry-run. Live execution requires `dry_run: false`.
-#   - reject_by_pid.py enforces CONFIRM_REJECT=REJECT on live runs.
+#   - Live execution also requires `confirm_reject: REJECT`.
 #   - MAX_PER_RUN ceiling defaults to 10 (overridable per-run).
 #   - reject_by_pid.py skips any PID whose status is no longer AWAITING REVIEW
 #     (so re-runs are idempotent; if Phase 3e already rejected a PID, it skips).
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: true
+      confirm_reject:
+        description: 'Type REJECT to allow a live run when dry_run is false'
+        required: false
+        type: string
+        default: ''
       max_per_run:
         description: 'Ceiling override (default 10)'
         required: false
@@ -87,29 +92,34 @@ jobs:
             echo "::error::Recommendations file not found at $REC"
             exit 1
           fi
-          # Compute PID_LIST and COUNT in a single Python invocation so we
-          # don't shell-interpolate $PID_LIST into a second python3 -c call.
-          read -r PID_LIST COUNT < <(REC="$REC" python3 << 'PY'
+          # Write outputs directly so empty PID lists don't get misparsed by
+          # shell word-splitting (Python prints " 0" for empty list/count pairs).
+          REC="$REC" GITHUB_OUTPUT="$GITHUB_OUTPUT" python3 << 'PY'
           import json
           import os
+          from pathlib import Path
 
           with open(os.environ["REC"], encoding="utf-8") as f:
               d = json.load(f)
 
           pids = [entry["pid"] for entry in d["buckets"]["no_reply_high_tier"]]
-          print(",".join(pids), len(pids))
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+              fh.write("pid_list<<EOF_PIDS\n")
+              fh.write(",".join(pids) + "\n")
+              fh.write("EOF_PIDS\n")
+              fh.write(f"count={len(pids)}\n")
           PY
-          )
-          if [ -z "$PID_LIST" ]; then
-            COUNT=0
-          fi
-          {
-            echo "pid_list<<EOF_PIDS"
-            echo "$PID_LIST"
-            echo "EOF_PIDS"
-            echo "count=$COUNT"
-          } >> "$GITHUB_OUTPUT"
+          COUNT="$(python3 -c "import json; print(len(json.load(open('$REC', encoding='utf-8'))['buckets']['no_reply_high_tier']))")"
           echo "Found $COUNT PIDs in no_reply_high_tier bucket"
+
+      - name: Safety check for live reject
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          if [ "${{ inputs.confirm_reject }}" != "REJECT" ]; then
+            echo "::error::Live reject requires confirm_reject=REJECT."
+            exit 1
+          fi
 
       - name: Reject PIDs
         if: ${{ steps.extract.outputs.count != '0' }}
@@ -120,9 +130,9 @@ jobs:
           CSV_FILE_PATH: ${{ runner.temp }}/disp/disposition.csv
           PID_LIST: ${{ steps.extract.outputs.pid_list }}
           MAX_PER_RUN: ${{ inputs.max_per_run }}
-          STRICT_AWAITING: 'true'
+          STRICT_AWAITING: 'false'
           DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
-          CONFIRM_REJECT: ${{ inputs.dry_run && 'unused' || 'REJECT' }}
+          CONFIRM_REJECT: ${{ inputs.confirm_reject }}
           OUTPUT_JSON_PATH: ${{ runner.temp }}/bulk-reject-results.json
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -16,10 +16,10 @@ name: Bulk Reject High-Tier No-Reply
 #
 # Safety:
 #   - Default is dry-run. Live execution requires `dry_run: false`.
-#   - reject_by_pid.py enforces CONFIRM_REJECT=REJECT on live runs.
+#   - Live rejection also requires `confirm_reject: REJECT`.
 #   - MAX_PER_RUN ceiling defaults to 10 (overridable per-run).
-#   - reject_by_pid.py skips any PID whose status is no longer AWAITING REVIEW
-#     (so re-runs are idempotent; if Phase 3e already rejected a PID, it skips).
+#   - Non-AWAITING PIDs are skipped so re-runs stay idempotent if another
+#     workflow already actioned part of the bucket.
 
 on:
   workflow_dispatch:
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: true
+      confirm_reject:
+        description: 'Type REJECT to confirm live rejection (required when dry_run is false)'
+        required: false
+        type: string
+        default: ''
       max_per_run:
         description: 'Ceiling override (default 10)'
         required: false
@@ -56,6 +61,23 @@ jobs:
     runs-on: ubuntu-latest
     environment: prolific-prod
     steps:
+      - name: 'Safety check: validate confirmation'
+        if: inputs.dry_run == false
+        env:
+          CONFIRM: ${{ inputs.confirm_reject }}
+        run: |
+          echo "================================================================"
+          echo "  DESTRUCTIVE OPERATION: Prolific Submission Rejection"
+          echo "  This will REJECT the no_reply_high_tier PIDs from the selected run."
+          echo "  They will NOT be paid."
+          echo "================================================================"
+          if [ "$CONFIRM" != "REJECT" ]; then
+            echo "SAFETY STOP: You must type REJECT in the confirmation field."
+            echo "Received: '$CONFIRM'"
+            exit 1
+          fi
+          echo "Confirmation accepted: '$CONFIRM'"
+
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
@@ -116,9 +138,9 @@ jobs:
           CSV_FILE_PATH: ${{ runner.temp }}/disp/disposition.csv
           PID_LIST: ${{ steps.extract.outputs.pid_list }}
           MAX_PER_RUN: ${{ inputs.max_per_run }}
-          STRICT_AWAITING: 'true'
+          STRICT_AWAITING: 'false'
           DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
-          CONFIRM_REJECT: ${{ inputs.dry_run && 'unused' || 'REJECT' }}
+          CONFIRM_REJECT: ${{ inputs.confirm_reject }}
           OUTPUT_JSON_PATH: ${{ runner.temp }}/bulk-reject-results.json
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -1,0 +1,125 @@
+name: Bulk Reject High-Tier No-Reply
+
+# Rejects the AWAITING REVIEW PIDs classified as `no_reply_high_tier` by the
+# daily-pipeline classifier. These are PIDs that:
+#   1. Are in the high rejection tier (3+ IRI fails, or 2 IRI fails plus
+#      another quality factor like speed or partial straightlining), AND
+#   2. Have NOT replied to any TABS message.
+#
+# The auto-cycle (Phase 3d/3e) will eventually reject these after ~4 days
+# (48h to RR + 48h to auto-reject). This workflow lets you fast-track that
+# cleanup when the high-tier no-reply queue grows.
+#
+# The operator never sees or types PIDs. Input is a source daily-pipeline
+# run ID; the workflow downloads that run's `reply-action-recommendations`
+# artifact and `disposition-csv` artifact (for per-PID rejection reasons).
+#
+# Safety:
+#   - Default is dry-run. Live execution requires `dry_run: false`.
+#   - reject_by_pid.py enforces CONFIRM_REJECT=REJECT on live runs.
+#   - MAX_PER_RUN ceiling defaults to 30 (overridable per-run).
+#   - reject_by_pid.py skips any PID whose status is no longer AWAITING REVIEW
+#     (so re-runs are idempotent; if Phase 3e already rejected a PID, it skips).
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: 'Daily-pipeline run ID that produced reply-action-recommendations'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run only (no API calls). Set to false to reject live.'
+        required: false
+        type: boolean
+        default: true
+      max_per_run:
+        description: 'Ceiling override (default 30)'
+        required: false
+        type: string
+        default: '30'
+
+concurrency:
+  group: bulk-reject-high-tier-no-reply
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  reject:
+    name: Bulk Reject (no_reply_high_tier)
+    runs-on: ubuntu-latest
+    environment: prolific-prod
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Download recommendations artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: reply-action-recommendations
+          path: ${{ runner.temp }}/recs
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download disposition CSV
+        uses: actions/download-artifact@v8
+        with:
+          name: disposition-csv
+          path: ${{ runner.temp }}/disp
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract no_reply_high_tier PIDs
+        id: extract
+        run: |
+          set -euo pipefail
+          REC="${{ runner.temp }}/recs/reply-action-recommendations.json"
+          if [ ! -f "$REC" ]; then
+            echo "::error::Recommendations file not found at $REC"
+            exit 1
+          fi
+          PID_LIST=$(python3 -c "
+          import json
+          with open('$REC') as f:
+              d = json.load(f)
+          pids = [e['pid'] for e in d['buckets']['no_reply_high_tier']]
+          print(','.join(pids))
+          ")
+          if [ -z "$PID_LIST" ]; then
+            COUNT=0
+          else
+            COUNT=$(python3 -c "print(len('$PID_LIST'.split(',')))")
+          fi
+          echo "pid_list=$PID_LIST" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Found $COUNT PIDs in no_reply_high_tier bucket"
+
+      - name: Reject PIDs
+        if: ${{ steps.extract.outputs.count != '0' }}
+        run: python3 scripts/analysis/reject_by_pid.py
+        env:
+          PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+          STUDY_ID: ${{ vars.PROLIFIC_STUDY_ID }}
+          CSV_FILE_PATH: ${{ runner.temp }}/disp/disposition.csv
+          PID_LIST: ${{ steps.extract.outputs.pid_list }}
+          MAX_PER_RUN: ${{ inputs.max_per_run }}
+          STRICT_AWAITING: 'true'
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+          CONFIRM_REJECT: ${{ inputs.dry_run && 'unused' || 'REJECT' }}
+          OUTPUT_JSON_PATH: ${{ runner.temp }}/bulk-reject-results.json
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ always() && steps.extract.outputs.count != '0' }}
+        with:
+          name: bulk-reject-results
+          path: ${{ runner.temp }}/bulk-reject-results.json
+          retention-days: 7

--- a/.github/workflows/check-participant.yml
+++ b/.github/workflows/check-participant.yml
@@ -34,6 +34,11 @@ on:
         description: 'Approve mode only: required for live approve runs. Type APPROVE exactly when dry_run=false.'
         required: false
         type: string
+      max_per_run:
+        description: 'Approve mode only: per-run ceiling override (default 30). approve_by_pid.py truncates eligible targets above this count.'
+        required: false
+        type: string
+        default: '30'
       message:
         description: 'Custom message body (required for send-custom mode)'
         required: false
@@ -202,7 +207,7 @@ jobs:
           PID_LIST: ${{ inputs.pid }}
           DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
           CONFIRM_APPROVE: ${{ inputs.confirm_approve }}
-          MAX_PER_RUN: '30'
+          MAX_PER_RUN: ${{ inputs.max_per_run }}
         run: python3 scripts/analysis/approve_by_pid.py
 
       - name: Unreject submissions

--- a/.github/workflows/check-participant.yml
+++ b/.github/workflows/check-participant.yml
@@ -22,7 +22,7 @@ on:
           - demographics
         default: 'single'
       pid:
-        description: 'Prolific Participant ID (required for single/send-custom mode)'
+        description: 'Prolific Participant ID(s): required for single, send-custom, and approve modes. Use one PID for single/send-custom; use a comma-separated PID list for approve.'
         required: false
         type: string
       message:

--- a/.github/workflows/check-participant.yml
+++ b/.github/workflows/check-participant.yml
@@ -25,6 +25,15 @@ on:
         description: 'Prolific Participant ID(s): required for single, send-custom, and approve modes. Use one PID for single/send-custom; use a comma-separated PID list for approve.'
         required: false
         type: string
+      dry_run:
+        description: 'Approve mode only: keep as true to preview AWAITING REVIEW targets without approving. Set false for a live approve run.'
+        required: false
+        type: boolean
+        default: true
+      confirm_approve:
+        description: 'Approve mode only: required for live approve runs. Type APPROVE exactly when dry_run=false.'
+        required: false
+        type: string
       message:
         description: 'Custom message body (required for send-custom mode)'
         required: false
@@ -191,8 +200,8 @@ jobs:
           PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
           STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
           PID_LIST: ${{ inputs.pid }}
-          DRY_RUN: 'false'
-          CONFIRM_APPROVE: 'APPROVE'
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+          CONFIRM_APPROVE: ${{ inputs.confirm_approve }}
           MAX_PER_RUN: '30'
         run: python3 scripts/analysis/approve_by_pid.py
 

--- a/.github/workflows/check-participant.yml
+++ b/.github/workflows/check-participant.yml
@@ -13,6 +13,7 @@ on:
           - send-thank-you
           - unreject
           - send-custom
+          - approve
           - awaiting-report
           - request-return
           - stale-return-requested
@@ -183,6 +184,17 @@ jobs:
           MESSAGE: ${{ inputs.message }}
           DRY_RUN: 'false'
         run: python3 scripts/analysis/send_custom_message.py
+
+      - name: Approve PID(s)
+        if: inputs.mode == 'approve'
+        env:
+          PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+          STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
+          PID_LIST: ${{ inputs.pid }}
+          DRY_RUN: 'false'
+          CONFIRM_APPROVE: 'APPROVE'
+          MAX_PER_RUN: '30'
+        run: python3 scripts/analysis/approve_by_pid.py
 
       - name: Unreject submissions
         if: inputs.mode == 'unreject'

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -942,7 +942,12 @@ jobs:
         with:
           name: reply-action-recommendations
           path: ${{ runner.temp }}/reply-action-recommendations.json
-          retention-days: 7
+          # 1-day retention: this JSON contains full participant IDs from
+          # the AWAITING REVIEW queue, so it matches the privacy treatment
+          # of disposition-csv and other PID-bearing intermediate artifacts.
+          # The bulk-approve/bulk-reject dispatch workflows must run within
+          # 24h of the source daily-pipeline run.
+          retention-days: 1
           if-no-files-found: warn
 
       - name: Build and create daily report issue

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -927,11 +927,22 @@ jobs:
         continue-on-error: true
 
       # Build the reply-action recommendations JSON before the report runs.
+      # Phase 5 checks out ref:main for safety; this script lands on main only
+      # after PR #2638 + #2692 are merged. The file-existence guard handles
+      # the rollout window where one PR has merged but the other has not.
+      # Once both PRs are on main the guard is a no-op but stays as a safety
+      # check against accidental script deletion.
       # Renders nothing in the report when Phase 3f's inbound CSV is missing.
       - name: Classify replies for action
         if: always()
         continue-on-error: true
-        run: python3 scripts/analysis/classify_replies_for_action.py
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/analysis/classify_replies_for_action.py ]; then
+            echo "::warning::classify_replies_for_action.py not present on main; skipping recommendations step (likely mid-rollout of PR #2638)"
+            exit 0
+          fi
+          python3 scripts/analysis/classify_replies_for_action.py
         env:
           INBOUND_CSV: ${{ runner.temp }}/artifacts/prolific-messages-inbound-csv/participant_messages.csv
           DISPOSITION_CSV: ${{ runner.temp }}/artifacts/disposition-csv/disposition.csv

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -974,4 +974,5 @@ jobs:
           DASHBOARD_RESULT: ${{ needs.generate-dashboard.result }}
           AUTO_REQUEST_RETURN_RESULT: ${{ needs.auto-request-return.result }}
           AUTO_REJECT_STALE_RESULT: ${{ needs.auto-reject-stale.result }}
+          EXPORT_MESSAGES_RESULT: ${{ needs.export-messages.result }}
         run: bash scripts/build-daily-report.sh

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -160,7 +160,7 @@ This index provides a comprehensive guide to all documentation in the TABS repos
   - Safety conventions (dry-run defaults, CONFIRM_REJECT, MAX_PER_RUN ceilings)
   - Tokens, environments, and kill-switch variables
 - Client Library: `src/lib/prolific-api.ts`
-- Workflows: `.github/workflows/prolific.yml`, `daily-pipeline.yml`, `check-participant.yml`, `prolific-message-flagged.yml`, `prolific-reject-by-pid.yml`, `bulk-approve-replied.yml`, `bulk-reject-high-tier-no-reply.yml`, `prolific-message-export.yml`
+- Workflows: `.github/workflows/prolific.yml`, `.github/workflows/daily-pipeline.yml`, `.github/workflows/check-participant.yml`, `.github/workflows/prolific-message-flagged.yml`, `.github/workflows/prolific-reject-by-pid.yml`, `.github/workflows/bulk-approve-replied.yml`, `.github/workflows/bulk-reject-high-tier-no-reply.yml`, `.github/workflows/prolific-message-export.yml`
 
 **Google Analytics Data API v1:**
 

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -154,8 +154,13 @@ This index provides a comprehensive guide to all documentation in the TABS repos
   - Qualtrics ↔ Prolific setup
   - Annual survey rollover process
   - Security and troubleshooting
+- **[docs/prolific-operations-guide.md](./docs/prolific-operations-guide.md)** - **Operations reference for participant actions**
+  - "I want to X → use workflow Y" lookup table for approve / reject / message / inspect
+  - Full inventory of every Prolific-touching workflow and script
+  - Safety conventions (dry-run defaults, CONFIRM_REJECT, MAX_PER_RUN ceilings)
+  - Tokens, environments, and kill-switch variables
 - Client Library: `src/lib/prolific-api.ts`
-- Workflow: `.github/workflows/prolific.yml`
+- Workflows: `.github/workflows/prolific.yml`, `daily-pipeline.yml`, `check-participant.yml`, `prolific-message-flagged.yml`, `prolific-reject-by-pid.yml`, `bulk-approve-replied.yml`, `bulk-reject-high-tier-no-reply.yml`, `prolific-message-export.yml`
 
 **Google Analytics Data API v1:**
 

--- a/docs/prolific-operations-guide.md
+++ b/docs/prolific-operations-guide.md
@@ -20,31 +20,31 @@ Anything outside the routine cycle — single-PID approves/rejects, custom messa
 
 ## Quick lookup: "I want to..."
 
-| Goal | Workflow | Mode / Inputs |
-|---|---|---|
-| Approve one PID | `check-participant.yml` | `mode=approve`, `pid=<id>` |
-| Approve N PIDs from today's report's auto-eligible bucket | `bulk-approve-replied.yml` | `source_run_id=<daily-pipeline run>`, `dry_run=false`, `max_per_run=60` |
-| Approve all CLEAN PIDs from a CSV | `prolific-approve-submissions.yml` | `csv_content=<csv>` or `csv_file_path=<path>` |
-| Reject one or more PIDs | `prolific-reject-by-pid.yml` | `pid_list=<csv>`, `dry_run=false`, `confirm_reject=REJECT` |
-| Reject the daily report's high-tier-no-reply bucket | `bulk-reject-high-tier-no-reply.yml` | `source_run_id=<run>`, `dry_run=false`, `max_per_run=10` |
-| Reject all AUTO-EXCLUDE | `prolific-reject-auto-exclude.yml` | (full destructive — read inputs carefully) |
-| Reject all failed-IRI | `prolific-reject-failed-iri.yml` | (full destructive — read inputs carefully) |
-| Send a custom one-off message to one PID | `check-participant.yml` | `mode=send-custom`, `pid=<id>`, `message=<text>` |
-| Send the standard FLAG message to one or more PIDs | `prolific-message-flagged.yml` | `disposition_filter=<one of the 10>`, `pid_list=<csv or empty>`, `dry_run=false` |
-| Send a thank-you to specific PIDs | `check-participant.yml` | `mode=send-thank-you`, `pid=<id>` |
-| Request return on one PID | `check-participant.yml` | `mode=request-return`, `pid=<id>` |
-| Unreject one or more PIDs | `check-participant.yml` | `mode=unreject`, `pid=<comma-separated>` |
-| Inspect one PID's submission + messages | `check-participant.yml` | `mode=single`, `pid=<id>` |
-| List every participant who has replied | `check-participant.yml` | `mode=all-replies` |
-| Export every Prolific message (both directions) | `prolific-message-export.yml` | (since: ISO date, study: optional) |
-| Search every message body for a term | `check-participant.yml` | `mode=search-messages`, `message=<term>` |
-| Find replies that contain a URL | `check-participant.yml` | `mode=find-url-replies` |
-| Find stale return-request candidates | `check-participant.yml` | `mode=stale-return-requested` |
-| Build the operator-style "awaiting review" report | `check-participant.yml` | `mode=awaiting-report` |
-| Verify a PID's IRI answers against Qualtrics | `check-participant.yml` | `mode=single`, `pid=<id>` (the verify-iri job auto-runs) |
-| Pull demographics from Prolific | `check-participant.yml` | `mode=demographics` |
-| Smoke-test the Prolific API token | `prolific-api-smoke.yml` | (no inputs) |
-| Run the daily pipeline ad-hoc | `daily-pipeline.yml` | (no required inputs; runs the full chain) |
+| Goal                                                      | Workflow                             | Mode / Inputs                                                                                     |
+| --------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Approve one PID                                           | `check-participant.yml`              | `mode=approve`, `pid=<id>`, `dry_run=true` (flip to `false` + `confirm_approve=APPROVE` for live) |
+| Approve N PIDs from today's report's auto-eligible bucket | `bulk-approve-replied.yml`           | `source_run_id=<daily-pipeline run>`, `dry_run=true` (flip to `false` for live), `max_per_run=60` |
+| Approve all CLEAN PIDs from a CSV                         | `prolific-approve-submissions.yml`   | `csv_content=<csv>` or `csv_file_path=<path>`                                                     |
+| Reject one or more PIDs                                   | `prolific-reject-by-pid.yml`         | `pid_list=<csv>`, `dry_run=false`, `confirm_reject=REJECT`                                        |
+| Reject the daily report's high-tier-no-reply bucket       | `bulk-reject-high-tier-no-reply.yml` | `source_run_id=<run>`, `dry_run=true` (flip to `false` for live), `max_per_run=10`                |
+| Reject all AUTO-EXCLUDE                                   | `prolific-reject-auto-exclude.yml`   | (full destructive — read inputs carefully)                                                        |
+| Reject all failed-IRI                                     | `prolific-reject-failed-iri.yml`     | (full destructive — read inputs carefully)                                                        |
+| Send a custom one-off message to one PID                  | `check-participant.yml`              | `mode=send-custom`, `pid=<id>`, `message=<text>`                                                  |
+| Send the standard FLAG message to one or more PIDs        | `prolific-message-flagged.yml`       | `disposition_filter=<one of the 10>`, `pid_list=<csv or empty>`, `dry_run=false`                  |
+| Send a thank-you to specific PIDs                         | `check-participant.yml`              | `mode=send-thank-you`, `pid=<id>`                                                                 |
+| Request return on one PID                                 | `check-participant.yml`              | `mode=request-return`, `pid=<id>`                                                                 |
+| Unreject one or more PIDs                                 | `check-participant.yml`              | `mode=unreject`, `pid=<comma-separated>`                                                          |
+| Inspect one PID's submission + messages                   | `check-participant.yml`              | `mode=single`, `pid=<id>`                                                                         |
+| List every participant who has replied                    | `check-participant.yml`              | `mode=all-replies`                                                                                |
+| Export every Prolific message (both directions)           | `prolific-message-export.yml`        | (since: ISO date, study: optional)                                                                |
+| Search every message body for a term                      | `check-participant.yml`              | `mode=search-messages`, `message=<term>`                                                          |
+| Find replies that contain a URL                           | `check-participant.yml`              | `mode=find-url-replies`                                                                           |
+| Find stale return-request candidates                      | `check-participant.yml`              | `mode=stale-return-requested`                                                                     |
+| Build the operator-style "awaiting review" report         | `check-participant.yml`              | `mode=awaiting-report`                                                                            |
+| Verify a PID's IRI answers against Qualtrics              | `check-participant.yml`              | `mode=single`, `pid=<id>` (the verify-iri job auto-runs)                                          |
+| Pull demographics from Prolific                           | `check-participant.yml`              | `mode=demographics`                                                                               |
+| Smoke-test the Prolific API token                         | `prolific-api-smoke.yml`             | (no inputs)                                                                                       |
+| Run the daily pipeline ad-hoc                             | `daily-pipeline.yml`                 | (no required inputs; runs the full chain)                                                         |
 
 ## Workflow inventory
 
@@ -66,7 +66,7 @@ Anything outside the routine cycle — single-PID approves/rejects, custom messa
 
 ### Per-PID / per-submission actions
 
-- **`check-participant.yml`** — Swiss army knife for single-PID actions (modes listed in the table above). Always safe to use; each mode has its own guardrails.
+- **`check-participant.yml`** — Swiss army knife for single-PID actions (modes listed in the table above). It includes both read-only and destructive modes; use destructive ones carefully and follow the per-mode guardrails (for example, `mode=approve` now defaults to dry-run and requires typed confirmation for live approval).
 
 - **`bulk-approve-replied.yml`** — Approves PIDs from the daily-pipeline `reply-action-recommendations` artifact's `auto_approve_eligible` bucket. Defaults to dry-run; live requires `dry_run=false`. Internally calls `approve_by_pid.py` which now does one Prolific API call per PID (partial failures don't abort).
 
@@ -86,7 +86,7 @@ Anything outside the routine cycle — single-PID approves/rejects, custom messa
   - `prolific-message-aggregate-summary` (committable, 7-day retention) — totals, themes, PII risk distribution
   - `prolific-messages-inbound-csv` (PII-bearing, 1-day retention) — full reply bodies for operator inspection
   - `prolific-messages-raw`, `prolific-messages-transcripts`, `prolific-messages-candidates` — full audit / curation
-  
+
   The daily pipeline also runs this in Phase 3f; ad-hoc dispatch is for backfill or rebuild.
 
 ### Health / smoke
@@ -103,34 +103,34 @@ All under `scripts/analysis/`. Each is invoked by one or more workflows; check t
 
 ### Approve / reject
 
-| Script | Used by | Behavior |
-|---|---|---|
-| `approve_submissions.py` | `prolific-approve-submissions.yml`, Phase 3a | CSV → CLEAN rows → bulk-approve API call → thank-you per PID |
-| `approve_by_pid.py` | `bulk-approve-replied.yml`, `check-participant.yml` (mode=approve) | PID_LIST env → one bulk-approve call per PID (resilient to partial failure) → thank-you per PID |
-| `reject_by_pid.py` | `prolific-reject-by-pid.yml`, `bulk-reject-high-tier-no-reply.yml` | PID_LIST env + disposition CSV → per-submission rejection with auto-generated reasons per disposition |
-| `reject_auto_exclude.py` | `prolific-reject-auto-exclude.yml` | Older bulk path; superseded by `reject_by_pid.py` |
-| `reject_failed_iri.py` | `prolific-reject-failed-iri.yml` | Older bulk path; superseded |
-| `unreject_submissions.py` | `check-participant.yml` (mode=unreject) | Reverses a rejection via the transition endpoint |
-| `request_return_by_pid.py` | Phase 3d | PID_LIST env → POST /submissions/{id}/request-return/ with disposition-specific reason text |
+| Script                     | Used by                                                            | Behavior                                                                                              |
+| -------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `approve_submissions.py`   | `prolific-approve-submissions.yml`, Phase 3a                       | CSV → CLEAN rows → bulk-approve API call → thank-you per PID                                          |
+| `approve_by_pid.py`        | `bulk-approve-replied.yml`, `check-participant.yml` (mode=approve) | PID_LIST env → one bulk-approve call per PID (resilient to partial failure) → thank-you per PID       |
+| `reject_by_pid.py`         | `prolific-reject-by-pid.yml`, `bulk-reject-high-tier-no-reply.yml` | PID_LIST env + disposition CSV → per-submission rejection with auto-generated reasons per disposition |
+| `reject_auto_exclude.py`   | `prolific-reject-auto-exclude.yml`                                 | Older bulk path; superseded by `reject_by_pid.py`                                                     |
+| `reject_failed_iri.py`     | `prolific-reject-failed-iri.yml`                                   | Older bulk path; superseded                                                                           |
+| `unreject_submissions.py`  | `check-participant.yml` (mode=unreject)                            | Reverses a rejection via the transition endpoint                                                      |
+| `request_return_by_pid.py` | Phase 3d                                                           | PID_LIST env → POST /submissions/{id}/request-return/ with disposition-specific reason text           |
 
 ### Messaging
 
-| Script | Used by | Behavior |
-|---|---|---|
-| `message_flagged.py` | Phase 3b matrix, `prolific-message-flagged.yml` | DISPOSITION_FILTER env + CSV → looks up PIDs matching that disposition (with sub-type matching for AUTO-EXCLUDE) → sends the disposition-specific template message. Dedup-aware (signature phrase per template). |
-| `send_custom_message.py` | `check-participant.yml` (mode=send-custom) | PID + MESSAGE env → sends a single arbitrary message. No dedup; will resend if invoked twice. |
-| `send_thank_you.py` | `check-participant.yml` (mode=send-thank-you) | PID_LIST env → sends the standard thank-you template, dedup-aware |
-| `extract_prolific_messages.py` | Phase 3f, `prolific-message-export.yml` | Pulls every message in the study channel; emits the inbound-CSV + aggregate summary + transcripts + candidates files |
+| Script                         | Used by                                         | Behavior                                                                                                                                                                                                         |
+| ------------------------------ | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message_flagged.py`           | Phase 3b matrix, `prolific-message-flagged.yml` | DISPOSITION_FILTER env + CSV → looks up PIDs matching that disposition (with sub-type matching for AUTO-EXCLUDE) → sends the disposition-specific template message. Dedup-aware (signature phrase per template). |
+| `send_custom_message.py`       | `check-participant.yml` (mode=send-custom)      | PID + MESSAGE env → sends a single arbitrary message. No dedup; will resend if invoked twice.                                                                                                                    |
+| `send_thank_you.py`            | `check-participant.yml` (mode=send-thank-you)   | PID_LIST env → sends the standard thank-you template, dedup-aware                                                                                                                                                |
+| `extract_prolific_messages.py` | Phase 3f, `prolific-message-export.yml`         | Pulls every message in the study channel; emits the inbound-CSV + aggregate summary + transcripts + candidates files                                                                                             |
 
 ### Analysis / classification (drive the operator UI)
 
-| Script | Used by | Behavior |
-|---|---|---|
-| `fetch_prolific_data.py` | Phase 1 | Auth checks + submission statuses → CSV + JSON |
-| `find_stale_return_requested.py` | Phase 3c | Phase 3d/3e bucket extraction (stale messages, stale return-requests) |
-| `classify_replies_for_action.py` | Phase 5 | Cross-references inbound CSV with disposition CSV → 5 action buckets (`auto_approve_eligible`, `human_review_questions`, `human_review_high_tier`, `no_reply_high_tier`, `no_reply`) plus `multi_reply_count`. Uses `?` presence in reply body to detect real questions. |
-| `prolific_tools.py` | `check-participant.yml` modes (`all-replies`, `find-url-replies`, `demographics`, `replied-pids`, `collect`) | Multi-subcommand utility for ad-hoc Prolific inspection |
-| `tabs_api.py` | All of the above | Low-level Prolific + Qualtrics API client. Single source of truth for endpoint URLs and request shapes. |
+| Script                           | Used by                                                                                                      | Behavior                                                                                                                                                                                                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `fetch_prolific_data.py`         | Phase 1                                                                                                      | Auth checks + submission statuses → CSV + JSON                                                                                                                                                                                                                           |
+| `find_stale_return_requested.py` | Phase 3c                                                                                                     | Phase 3d/3e bucket extraction (stale messages, stale return-requests)                                                                                                                                                                                                    |
+| `classify_replies_for_action.py` | Phase 5                                                                                                      | Cross-references inbound CSV with disposition CSV → 5 action buckets (`auto_approve_eligible`, `human_review_questions`, `human_review_high_tier`, `no_reply_high_tier`, `no_reply`) plus `multi_reply_count`. Uses `?` presence in reply body to detect real questions. |
+| `prolific_tools.py`              | `check-participant.yml` modes (`all-replies`, `find-url-replies`, `demographics`, `replied-pids`, `collect`) | Multi-subcommand utility for ad-hoc Prolific inspection                                                                                                                                                                                                                  |
+| `tabs_api.py`                    | All of the above                                                                                             | Low-level Prolific + Qualtrics API client. Single source of truth for endpoint URLs and request shapes.                                                                                                                                                                  |
 
 ## Safety conventions
 

--- a/docs/prolific-operations-guide.md
+++ b/docs/prolific-operations-guide.md
@@ -20,31 +20,31 @@ Anything outside the routine cycle — single-PID approves/rejects, custom messa
 
 ## Quick lookup: "I want to..."
 
-| Goal                                                      | Workflow                             | Mode / Inputs                                                                                     |
-| --------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| Approve one PID                                           | `check-participant.yml`              | `mode=approve`, `pid=<id>`, `dry_run=true` (flip to `false` + `confirm_approve=APPROVE` for live) |
-| Approve N PIDs from today's report's auto-eligible bucket | `bulk-approve-replied.yml`           | `source_run_id=<daily-pipeline run>`, `dry_run=true` (flip to `false` for live), `max_per_run=60` |
-| Approve all CLEAN PIDs from a CSV                         | `prolific-approve-submissions.yml`   | `csv_content=<csv>` or `csv_file_path=<path>`                                                     |
-| Reject one or more PIDs                                   | `prolific-reject-by-pid.yml`         | `pid_list=<csv>`, `dry_run=false`, `confirm_reject=REJECT`                                        |
-| Reject the daily report's high-tier-no-reply bucket       | `bulk-reject-high-tier-no-reply.yml` | `source_run_id=<run>`, `dry_run=true` (flip to `false` for live), `max_per_run=10`                |
-| Reject all AUTO-EXCLUDE                                   | `prolific-reject-auto-exclude.yml`   | (full destructive — read inputs carefully)                                                        |
-| Reject all failed-IRI                                     | `prolific-reject-failed-iri.yml`     | (full destructive — read inputs carefully)                                                        |
-| Send a custom one-off message to one PID                  | `check-participant.yml`              | `mode=send-custom`, `pid=<id>`, `message=<text>`                                                  |
-| Send the standard FLAG message to one or more PIDs        | `prolific-message-flagged.yml`       | `disposition_filter=<one of the 10>`, `pid_list=<csv or empty>`, `dry_run=false`                  |
-| Send a thank-you to specific PIDs                         | `check-participant.yml`              | `mode=send-thank-you`, `pid=<id>`                                                                 |
-| Request return on one PID                                 | `check-participant.yml`              | `mode=request-return`, `pid=<id>`                                                                 |
-| Unreject one or more PIDs                                 | `check-participant.yml`              | `mode=unreject`, `pid=<comma-separated>`                                                          |
-| Inspect one PID's submission + messages                   | `check-participant.yml`              | `mode=single`, `pid=<id>`                                                                         |
-| List every participant who has replied                    | `check-participant.yml`              | `mode=all-replies`                                                                                |
-| Export every Prolific message (both directions)           | `prolific-message-export.yml`        | (since: ISO date, study: optional)                                                                |
-| Search every message body for a term                      | `check-participant.yml`              | `mode=search-messages`, `message=<term>`                                                          |
-| Find replies that contain a URL                           | `check-participant.yml`              | `mode=find-url-replies`                                                                           |
-| Find stale return-request candidates                      | `check-participant.yml`              | `mode=stale-return-requested`                                                                     |
-| Build the operator-style "awaiting review" report         | `check-participant.yml`              | `mode=awaiting-report`                                                                            |
-| Verify a PID's IRI answers against Qualtrics              | `check-participant.yml`              | `mode=single`, `pid=<id>` (the verify-iri job auto-runs)                                          |
-| Pull demographics from Prolific                           | `check-participant.yml`              | `mode=demographics`                                                                               |
-| Smoke-test the Prolific API token                         | `prolific-api-smoke.yml`             | (no inputs)                                                                                       |
-| Run the daily pipeline ad-hoc                             | `daily-pipeline.yml`                 | (no required inputs; runs the full chain)                                                         |
+| Goal                                                      | Workflow                             | Mode / Inputs                                                                                                |
+| --------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Approve one PID                                           | `check-participant.yml`              | `mode=approve`, `pid=<id>`, `dry_run=true` (flip to `false` + `confirm_approve=APPROVE` for live)            |
+| Approve N PIDs from today's report's auto-eligible bucket | `bulk-approve-replied.yml`           | `source_run_id=<daily-pipeline run>`, `dry_run=true` (flip to `false` for live), `max_per_run=30`            |
+| Approve all CLEAN PIDs from a CSV                         | `prolific-approve-submissions.yml`   | `csv_content=<csv>` or `csv_file_path=<path>`                                                                |
+| Reject one or more PIDs                                   | `prolific-reject-by-pid.yml`         | `pid_list=<csv>`, `dry_run=false`, `confirm_reject=REJECT`                                                   |
+| Reject the daily report's high-tier-no-reply bucket       | `bulk-reject-high-tier-no-reply.yml` | `source_run_id=<run>`, `dry_run=true` (flip to `false` + `confirm_reject=REJECT` for live), `max_per_run=10` |
+| Reject all AUTO-EXCLUDE                                   | `prolific-reject-auto-exclude.yml`   | (full destructive — read inputs carefully)                                                                   |
+| Reject all failed-IRI                                     | `prolific-reject-failed-iri.yml`     | (full destructive — read inputs carefully)                                                                   |
+| Send a custom one-off message to one PID                  | `check-participant.yml`              | `mode=send-custom`, `pid=<id>`, `message=<text>`                                                             |
+| Send the standard FLAG message to one or more PIDs        | `prolific-message-flagged.yml`       | `disposition_filter=<one of the 10>`, `pid_list=<csv or empty>`, `dry_run=false`                             |
+| Send a thank-you to specific PIDs                         | `check-participant.yml`              | `mode=send-thank-you`, `pid=<id>`                                                                            |
+| Request return on one PID                                 | `check-participant.yml`              | `mode=request-return`, `pid=<id>`                                                                            |
+| Unreject one or more PIDs                                 | `check-participant.yml`              | `mode=unreject`, `pid=<comma-separated>`                                                                     |
+| Inspect one PID's submission + messages                   | `check-participant.yml`              | `mode=single`, `pid=<id>`                                                                                    |
+| List every participant who has replied                    | `check-participant.yml`              | `mode=all-replies`                                                                                           |
+| Export every Prolific message (both directions)           | `prolific-message-export.yml`        | (since: ISO date, study: optional)                                                                           |
+| Search every message body for a term                      | `check-participant.yml`              | `mode=search-messages`, `message=<term>`                                                                     |
+| Find replies that contain a URL                           | `check-participant.yml`              | `mode=find-url-replies`                                                                                      |
+| Find stale return-request candidates                      | `check-participant.yml`              | `mode=stale-return-requested`                                                                                |
+| Build the operator-style "awaiting review" report         | `check-participant.yml`              | `mode=awaiting-report`                                                                                       |
+| Verify a PID's IRI answers against Qualtrics              | `check-participant.yml`              | `mode=single`, `pid=<id>` (the verify-iri job auto-runs)                                                     |
+| Pull demographics from Prolific                           | `check-participant.yml`              | `mode=demographics`                                                                                          |
+| Smoke-test the Prolific API token                         | `prolific-api-smoke.yml`             | (no inputs)                                                                                                  |
+| Run the daily pipeline ad-hoc                             | `daily-pipeline.yml`                 | (no required inputs; runs the full chain)                                                                    |
 
 ## Workflow inventory
 
@@ -70,7 +70,7 @@ Anything outside the routine cycle — single-PID approves/rejects, custom messa
 
 - **`bulk-approve-replied.yml`** — Approves PIDs from the daily-pipeline `reply-action-recommendations` artifact's `auto_approve_eligible` bucket. Defaults to dry-run; live requires `dry_run=false`. Internally calls `approve_by_pid.py` which now does one Prolific API call per PID (partial failures don't abort).
 
-- **`bulk-reject-high-tier-no-reply.yml`** — Rejects PIDs from the same artifact's `no_reply_high_tier` bucket. Same safety pattern (dry-run default, CONFIRM_REJECT required for live). Internally calls `reject_by_pid.py` (already per-submission).
+- **`bulk-reject-high-tier-no-reply.yml`** — Rejects PIDs from the same artifact's `no_reply_high_tier` bucket. Same safety pattern (dry-run default, `confirm_reject=REJECT` required for live). Uses `STRICT_AWAITING=false` so re-runs skip any PID already actioned elsewhere and remain idempotent.
 
 - **`prolific-reject-by-pid.yml`** — General single-PID-or-list rejection. Re-runs Qualtrics triage first to ensure rejection reasons are computed from current disposition data. Live requires typing "REJECT" in the confirm input.
 
@@ -138,9 +138,9 @@ Every destructive workflow follows the same pattern. If you're adding a new one,
 
 1. **Default to dry-run.** `dry_run: boolean (default true)`.
 2. **Confirmation typing.** Live destructive actions require typing `REJECT` (or analogous) into a separate input. The script enforces this server-side.
-3. **`MAX_PER_RUN` ceiling.** Default 30. Workflow can override per-dispatch. Script aborts if PID_LIST exceeds ceiling.
+3. **`MAX_PER_RUN` ceiling.** Workflow defaults are conservative and workflow-specific (for example 30 for bulk-approve, 10 for bulk-reject). Scripts enforce the ceiling, but behavior can differ by script: `reject_by_pid.py` aborts over-ceiling lists, while `approve_by_pid.py` truncates eligible targets after status filtering and records deferred PIDs in its JSON output.
 4. **Status check before action.** Per-PID status verification — skip if no longer AWAITING REVIEW. Makes re-runs idempotent.
-5. **Audit JSON output.** Every script writes a structured results JSON listing PIDs touched and per-PID outcome. Workflow uploads as 7-day artifact.
+5. **Audit JSON output.** Every script writes a structured results JSON listing PIDs touched and per-PID outcome. PID-bearing workflow artifacts in this area are retained for 1 day, not 7, to match the privacy policy for intermediate participant data.
 
 ## Daily Disposition Report → workflow dispatch
 

--- a/docs/prolific-operations-guide.md
+++ b/docs/prolific-operations-guide.md
@@ -1,0 +1,164 @@
+# Prolific Operations Guide
+
+A reference for every workflow and script that touches Prolific submissions, messages, and participant decisions. Use this when you need to act on a specific participant or batch and aren't sure which workflow to dispatch.
+
+If you're an AI agent reading this for the first time: this is the canonical "how do I X?" doc for participant operations. Search it before grepping `.github/workflows/`.
+
+## The participant lifecycle
+
+```
+Qualtrics complete  →  Prolific status: AWAITING REVIEW  →  one of:
+                                                            ├─ APPROVED  (payment released)
+                                                            ├─ RETURNED  (participant chose to return)
+                                                            ├─ REJECTED  (no payment)
+                                                            └─ TIMED-OUT (Prolific auto-action)
+```
+
+The daily pipeline (`daily-pipeline.yml`) runs at 10:30 UTC and handles the routine cycle: fetch → triage → auto-approve CLEAN → message FLAGs → auto-request-return on stale messages → auto-reject on stale return-requests → commit data → file daily report issue.
+
+Anything outside the routine cycle — single-PID approves/rejects, custom messages, ad-hoc inspection — is done with the workflows below.
+
+## Quick lookup: "I want to..."
+
+| Goal | Workflow | Mode / Inputs |
+|---|---|---|
+| Approve one PID | `check-participant.yml` | `mode=approve`, `pid=<id>` |
+| Approve N PIDs from today's report's auto-eligible bucket | `bulk-approve-replied.yml` | `source_run_id=<daily-pipeline run>`, `dry_run=false`, `max_per_run=60` |
+| Approve all CLEAN PIDs from a CSV | `prolific-approve-submissions.yml` | `csv_content=<csv>` or `csv_file_path=<path>` |
+| Reject one or more PIDs | `prolific-reject-by-pid.yml` | `pid_list=<csv>`, `dry_run=false`, `confirm_reject=REJECT` |
+| Reject the daily report's high-tier-no-reply bucket | `bulk-reject-high-tier-no-reply.yml` | `source_run_id=<run>`, `dry_run=false`, `max_per_run=10` |
+| Reject all AUTO-EXCLUDE | `prolific-reject-auto-exclude.yml` | (full destructive — read inputs carefully) |
+| Reject all failed-IRI | `prolific-reject-failed-iri.yml` | (full destructive — read inputs carefully) |
+| Send a custom one-off message to one PID | `check-participant.yml` | `mode=send-custom`, `pid=<id>`, `message=<text>` |
+| Send the standard FLAG message to one or more PIDs | `prolific-message-flagged.yml` | `disposition_filter=<one of the 10>`, `pid_list=<csv or empty>`, `dry_run=false` |
+| Send a thank-you to specific PIDs | `check-participant.yml` | `mode=send-thank-you`, `pid=<id>` |
+| Request return on one PID | `check-participant.yml` | `mode=request-return`, `pid=<id>` |
+| Unreject one or more PIDs | `check-participant.yml` | `mode=unreject`, `pid=<comma-separated>` |
+| Inspect one PID's submission + messages | `check-participant.yml` | `mode=single`, `pid=<id>` |
+| List every participant who has replied | `check-participant.yml` | `mode=all-replies` |
+| Export every Prolific message (both directions) | `prolific-message-export.yml` | (since: ISO date, study: optional) |
+| Search every message body for a term | `check-participant.yml` | `mode=search-messages`, `message=<term>` |
+| Find replies that contain a URL | `check-participant.yml` | `mode=find-url-replies` |
+| Find stale return-request candidates | `check-participant.yml` | `mode=stale-return-requested` |
+| Build the operator-style "awaiting review" report | `check-participant.yml` | `mode=awaiting-report` |
+| Verify a PID's IRI answers against Qualtrics | `check-participant.yml` | `mode=single`, `pid=<id>` (the verify-iri job auto-runs) |
+| Pull demographics from Prolific | `check-participant.yml` | `mode=demographics` |
+| Smoke-test the Prolific API token | `prolific-api-smoke.yml` | (no inputs) |
+| Run the daily pipeline ad-hoc | `daily-pipeline.yml` | (no required inputs; runs the full chain) |
+
+## Workflow inventory
+
+### Daily orchestration
+
+- **`daily-pipeline.yml`** — The main scheduled workflow (cron `30 10 * * *`). Six phases:
+  - Phase 1: Fetch Prolific data (auth checks, statuses)
+  - Phase 2: Export Qualtrics → enrich → disposition waterfall → unified analysis → CRP analysis
+  - Phase 3a: Auto-approve CLEAN
+  - Phase 3b: Message FLAGs (10-disposition matrix)
+  - Phase 3c: Generate dashboard + find stale submissions
+  - Phase 3d: Auto-request-return on stale-no-reply-to-message
+  - Phase 3e: Auto-reject on stale-no-reply-to-return-request
+  - Phase 3f: Export Prolific messages → recommendations classifier → upload artifact
+  - Phase 4: Commit daily data + open `chore/daily-pipeline-data` PR
+  - Phase 5: Build Daily Disposition Report issue, including a HIGH-RISK push alert when applicable
+
+  All Phase 3a/3b/3d/3e steps are kill-switch and ceiling guarded (`vars.AUTO_*_ENABLED` and `vars.AUTO_STALE_MAX_PER_RUN`).
+
+### Per-PID / per-submission actions
+
+- **`check-participant.yml`** — Swiss army knife for single-PID actions (modes listed in the table above). Always safe to use; each mode has its own guardrails.
+
+- **`bulk-approve-replied.yml`** — Approves PIDs from the daily-pipeline `reply-action-recommendations` artifact's `auto_approve_eligible` bucket. Defaults to dry-run; live requires `dry_run=false`. Internally calls `approve_by_pid.py` which now does one Prolific API call per PID (partial failures don't abort).
+
+- **`bulk-reject-high-tier-no-reply.yml`** — Rejects PIDs from the same artifact's `no_reply_high_tier` bucket. Same safety pattern (dry-run default, CONFIRM_REJECT required for live). Internally calls `reject_by_pid.py` (already per-submission).
+
+- **`prolific-reject-by-pid.yml`** — General single-PID-or-list rejection. Re-runs Qualtrics triage first to ensure rejection reasons are computed from current disposition data. Live requires typing "REJECT" in the confirm input.
+
+- **`prolific-approve-submissions.yml`** — Bulk-approve CLEAN-disposition PIDs from a CSV. Accept either `csv_content` (paste CSV inline) or `csv_file_path` (path inside repo). Auto-detects PID and Disposition columns.
+
+- **`prolific-reject-auto-exclude.yml`** / **`prolific-reject-failed-iri.yml`** — Older destructive batch-reject workflows. Prefer `bulk-reject-high-tier-no-reply.yml` for new operator-driven rejections since it routes through the classifier and surfaces in the daily report.
+
+- **`prolific-message-flagged.yml`** — Sends the standard FLAG template message for a single disposition type. `pid_list` filter is optional (empty = all PIDs matching the disposition). Default dry-run. Used by the daily pipeline; can be run ad-hoc to re-message a specific PID.
+
+### Message / inspection
+
+- **`prolific-message-export.yml`** — Pulls every Prolific message in the study channel (both directions) since a given ISO date. Produces:
+  - `prolific-message-aggregate-summary` (committable, 7-day retention) — totals, themes, PII risk distribution
+  - `prolific-messages-inbound-csv` (PII-bearing, 1-day retention) — full reply bodies for operator inspection
+  - `prolific-messages-raw`, `prolific-messages-transcripts`, `prolific-messages-candidates` — full audit / curation
+  
+  The daily pipeline also runs this in Phase 3f; ad-hoc dispatch is for backfill or rebuild.
+
+### Health / smoke
+
+- **`prolific-api-smoke.yml`** — Verifies the `TABS_PROLIFIC_TOKEN` secret works and the study is reachable. Use after rotating tokens.
+
+- **`qualtrics-prolific-verify.yml`** — Cross-references Qualtrics responses against Prolific submissions to catch desync.
+
+- **`data-quality-check.yml`** — PII scan of `src/data/*.json`. Runs on every PR that touches data files.
+
+## Script inventory
+
+All under `scripts/analysis/`. Each is invoked by one or more workflows; check the script header docstring for env vars.
+
+### Approve / reject
+
+| Script | Used by | Behavior |
+|---|---|---|
+| `approve_submissions.py` | `prolific-approve-submissions.yml`, Phase 3a | CSV → CLEAN rows → bulk-approve API call → thank-you per PID |
+| `approve_by_pid.py` | `bulk-approve-replied.yml`, `check-participant.yml` (mode=approve) | PID_LIST env → one bulk-approve call per PID (resilient to partial failure) → thank-you per PID |
+| `reject_by_pid.py` | `prolific-reject-by-pid.yml`, `bulk-reject-high-tier-no-reply.yml` | PID_LIST env + disposition CSV → per-submission rejection with auto-generated reasons per disposition |
+| `reject_auto_exclude.py` | `prolific-reject-auto-exclude.yml` | Older bulk path; superseded by `reject_by_pid.py` |
+| `reject_failed_iri.py` | `prolific-reject-failed-iri.yml` | Older bulk path; superseded |
+| `unreject_submissions.py` | `check-participant.yml` (mode=unreject) | Reverses a rejection via the transition endpoint |
+| `request_return_by_pid.py` | Phase 3d | PID_LIST env → POST /submissions/{id}/request-return/ with disposition-specific reason text |
+
+### Messaging
+
+| Script | Used by | Behavior |
+|---|---|---|
+| `message_flagged.py` | Phase 3b matrix, `prolific-message-flagged.yml` | DISPOSITION_FILTER env + CSV → looks up PIDs matching that disposition (with sub-type matching for AUTO-EXCLUDE) → sends the disposition-specific template message. Dedup-aware (signature phrase per template). |
+| `send_custom_message.py` | `check-participant.yml` (mode=send-custom) | PID + MESSAGE env → sends a single arbitrary message. No dedup; will resend if invoked twice. |
+| `send_thank_you.py` | `check-participant.yml` (mode=send-thank-you) | PID_LIST env → sends the standard thank-you template, dedup-aware |
+| `extract_prolific_messages.py` | Phase 3f, `prolific-message-export.yml` | Pulls every message in the study channel; emits the inbound-CSV + aggregate summary + transcripts + candidates files |
+
+### Analysis / classification (drive the operator UI)
+
+| Script | Used by | Behavior |
+|---|---|---|
+| `fetch_prolific_data.py` | Phase 1 | Auth checks + submission statuses → CSV + JSON |
+| `find_stale_return_requested.py` | Phase 3c | Phase 3d/3e bucket extraction (stale messages, stale return-requests) |
+| `classify_replies_for_action.py` | Phase 5 | Cross-references inbound CSV with disposition CSV → 5 action buckets (`auto_approve_eligible`, `human_review_questions`, `human_review_high_tier`, `no_reply_high_tier`, `no_reply`) plus `multi_reply_count`. Uses `?` presence in reply body to detect real questions. |
+| `prolific_tools.py` | `check-participant.yml` modes (`all-replies`, `find-url-replies`, `demographics`, `replied-pids`, `collect`) | Multi-subcommand utility for ad-hoc Prolific inspection |
+| `tabs_api.py` | All of the above | Low-level Prolific + Qualtrics API client. Single source of truth for endpoint URLs and request shapes. |
+
+## Safety conventions
+
+Every destructive workflow follows the same pattern. If you're adding a new one, match it:
+
+1. **Default to dry-run.** `dry_run: boolean (default true)`.
+2. **Confirmation typing.** Live destructive actions require typing `REJECT` (or analogous) into a separate input. The script enforces this server-side.
+3. **`MAX_PER_RUN` ceiling.** Default 30. Workflow can override per-dispatch. Script aborts if PID_LIST exceeds ceiling.
+4. **Status check before action.** Per-PID status verification — skip if no longer AWAITING REVIEW. Makes re-runs idempotent.
+5. **Audit JSON output.** Every script writes a structured results JSON listing PIDs touched and per-PID outcome. Workflow uploads as 7-day artifact.
+
+## Daily Disposition Report → workflow dispatch
+
+The daily report issue (filed by Phase 5) is the operator's primary UI. It includes dispatch commands per recommended action:
+
+- 🟢 **"Recommended for Auto-Approve" sub-section** quotes the exact `gh workflow run bulk-approve-replied.yml ... source_run_id=<this-run>` command
+- 🔴 **"Recommended for Bulk-Reject" sub-section** quotes the bulk-reject equivalent
+- 🟡 **"Replies to Consider — Questions" sub-section** lists reply themes; for genuine questions, use `check-participant.yml` mode=send-custom
+
+When in doubt: `gh workflow run check-participant.yml --repo clarkemoyer/technologyadoptionbarriers.org -F mode=help` — wait, that doesn't exist yet. For now, this guide is the help.
+
+## Tokens & environments
+
+Every Prolific-touching workflow runs in the `prolific-prod` environment, which holds:
+
+- `secrets.TABS_PROLIFIC_TOKEN` — Prolific API token (rotate annually; verify via `prolific-api-smoke.yml`)
+- `vars.PROLIFIC_STUDY_ID` — the TABS V2 study ID (don't hard-code)
+- `vars.AUTO_REQUEST_RETURN_ENABLED` / `vars.AUTO_REJECT_STALE_ENABLED` — Phase 3d/3e kill switches (default `'true'`)
+- `vars.AUTO_STALE_MAX_PER_RUN` — Phase 3d/3e ceiling (default `'30'`)
+
+Qualtrics workflows use the `qualtrics-prod` environment with `secrets.QUALTRICS_API_TOKEN`, `vars.QUALTRICS_BASE_URL`, and `vars.QUALTRICS_SURVEY_ID`.

--- a/scripts/analysis/approve_by_pid.py
+++ b/scripts/analysis/approve_by_pid.py
@@ -163,6 +163,7 @@ def main() -> int:
         "input_count": len(pids),
         "ceiling": max_per_run,
         "ceiling_exceeded": False,
+        "deferred_over_ceiling": [],
         "approved": [],
         "skipped_non_awaiting": [],
         "thank_you_sent": [],
@@ -176,15 +177,6 @@ def main() -> int:
         print("No PIDs provided. Nothing to do.")
         _write_results(output_path, result)
         return 0
-
-    if len(pids) > max_per_run:
-        result["ceiling_exceeded"] = True
-        print(
-            f"::error::Ceiling exceeded: {len(pids)} PIDs > {max_per_run} ceiling. Aborting.",
-            file=sys.stderr,
-        )
-        _write_results(output_path, result)
-        return 1
 
     if not dry_run:
         confirm = os.environ.get("CONFIRM_APPROVE", "")
@@ -215,6 +207,20 @@ def main() -> int:
         print(f"DRY RUN - would target {len(targets)} currently AWAITING REVIEW PIDs")
     print(f"  AWAITING REVIEW (will approve): {len(targets)}")
     print(f"  Skipped (other status): {len(result['skipped_non_awaiting'])}")
+
+    # Apply ceiling AFTER status filtering: an input PID that has already moved
+    # out of AWAITING REVIEW shouldn't count against the ceiling. Truncate the
+    # eligible target list rather than aborting -- partial progress is more
+    # useful than no progress when a large bucket is dispatched.
+    if len(targets) > max_per_run:
+        result["ceiling_exceeded"] = True
+        deferred = targets[max_per_run:]
+        result["deferred_over_ceiling"] = list(deferred)
+        targets = targets[:max_per_run]
+        print(
+            f"::warning::Eligible targets ({len(targets) + len(deferred)}) exceed ceiling "
+            f"{max_per_run}; processing first {len(targets)} and deferring {len(deferred)}."
+        )
 
     if not targets:
         print("No eligible PIDs to approve.")

--- a/scripts/analysis/approve_by_pid.py
+++ b/scripts/analysis/approve_by_pid.py
@@ -3,8 +3,7 @@
 
 Mirrors the safety pattern of reject_by_pid.py:
   - Verifies token and study before any API call
-  - Resolves targets by current status and skips PIDs that aren't AWAITING REVIEW
-    (including dry-run previews, for accurate operator validation)
+  - Skips PIDs that aren't currently AWAITING REVIEW (idempotent re-runs)
   - Hard ceiling on PIDs per run to prevent runaway approvals
   - Requires CONFIRM_APPROVE=APPROVE for live runs (typo-proof safety)
   - Writes a structured JSON results file
@@ -27,9 +26,7 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -51,8 +48,6 @@ THANK_YOU_MESSAGE = (
 )
 SIGNATURE = "After reviewing your reply, your submission has been approved"
 DEFAULT_MAX_PER_RUN = 30
-PID_RE = re.compile(r"\b[0-9a-fA-F]{24}\b")
-_API_CALL_DELAY = 0.2
 
 
 def _require_env(name: str) -> str:
@@ -82,56 +77,6 @@ def _write_results(path: str | None, payload: dict) -> None:
         return
     Path(path).write_text(json.dumps(payload, indent=2))
     print(f"Results: {path}")
-
-
-def _redact_pid(pid: str) -> str:
-    if len(pid) <= 4:
-        return pid
-    return f"****{pid[-4:]}"
-
-
-def _sanitize_log_text(text: str) -> str:
-    return PID_RE.sub(lambda m: _redact_pid(m.group(0)), text)
-
-
-def _fetch_messages_with_backoff(pid: str, api_token: str, max_retries: int = 3) -> tuple[list[dict] | None, str | None]:
-    """Fetch messages with exponential backoff on transient API failures."""
-    last_err = ""
-    redacted_pid = _redact_pid(pid)
-    for attempt in range(max_retries):
-        try:
-            if attempt > 0:
-                wait = min(2**attempt, 30)
-                print(
-                    f"  Retry {attempt}/{max_retries - 1} for {redacted_pid} in {wait}s",
-                    file=sys.stderr,
-                )
-                time.sleep(wait)
-            msgs = prolific_user_messages(pid, api_token)
-            return msgs, None
-        except Exception as exc:
-            last_err = _sanitize_log_text(str(exc))
-    return None, last_err
-
-
-def _send_thank_you_with_backoff(study_id: str, pid: str, api_token: str, max_retries: int = 3) -> str | None:
-    """Send thank-you with exponential backoff. Returns sanitized error on failure."""
-    last_err = ""
-    redacted_pid = _redact_pid(pid)
-    for attempt in range(max_retries):
-        try:
-            if attempt > 0:
-                wait = min(2**attempt, 30)
-                print(
-                    f"  Retry {attempt}/{max_retries - 1} send for {redacted_pid} in {wait}s",
-                    file=sys.stderr,
-                )
-                time.sleep(wait)
-            prolific_send_message(study_id, pid, THANK_YOU_MESSAGE, api_token)
-            return None
-        except Exception as exc:
-            last_err = _sanitize_log_text(str(exc))
-    return last_err
 
 
 def main() -> int:
@@ -194,49 +139,57 @@ def main() -> int:
             )
             sys.exit(1)
 
-    # Resolve target PIDs (skip those not AWAITING REVIEW), including dry-run previews.
-    print(f"Verifying study {study_id}...")
-    study = prolific_study_info(study_id, api_token)
-    print(f"  Study: {study.get('name', '?')} (status: {study.get('status', '?')})")
-
-    print("Fetching current submission statuses...")
-    statuses = prolific_submission_statuses(study_id, api_token)
-
-    targets = []
-    for pid in pids:
-        st = statuses.get(pid, "UNKNOWN")
-        if st == "AWAITING REVIEW":
-            targets.append(pid)
-        else:
-            print(f"  SKIP {_redact_pid(pid)} - status is {st}, not AWAITING REVIEW")
-            result["skipped_non_awaiting"].append({"pid": pid, "status": st})
-
+    # Resolve target PIDs (skip those not AWAITING REVIEW).
     if dry_run:
-        print(f"DRY RUN - would target {len(targets)} currently AWAITING REVIEW PIDs")
-    print(f"  AWAITING REVIEW (will approve): {len(targets)}")
-    print(f"  Skipped (other status): {len(result['skipped_non_awaiting'])}")
+        targets = list(pids)
+        print(f"DRY RUN - would target {len(targets)} PIDs without status check")
+    else:
+        print(f"Verifying study {study_id}...")
+        study = prolific_study_info(study_id, api_token)
+        print(f"  Study: {study.get('name', '?')} (status: {study.get('status', '?')})")
+
+        print("Fetching current submission statuses...")
+        statuses = prolific_submission_statuses(study_id, api_token)
+
+        targets = []
+        for pid in pids:
+            st = statuses.get(pid, "UNKNOWN")
+            if st == "AWAITING REVIEW":
+                targets.append(pid)
+            else:
+                print(f"  SKIP {pid} - status is {st}, not AWAITING REVIEW")
+                result["skipped_non_awaiting"].append({"pid": pid, "status": st})
+
+        print(f"  AWAITING REVIEW (will approve): {len(targets)}")
+        print(f"  Skipped (other status): {len(result['skipped_non_awaiting'])}")
 
     if not targets:
         print("No eligible PIDs to approve.")
         _write_results(output_path, result)
         return 0
 
-    # Bulk approve.
+    # Per-PID approve. The Prolific bulk-approve endpoint accepts a list,
+    # but operator experience is that large lists are unreliable -- partial
+    # failures abort the whole call. Send one PID per request and track
+    # success/failure individually so the rest still go through if one
+    # errors. This is functionally what approve_submissions.py does today
+    # (also "bulk" in name but submitted as a single list); breaking it
+    # into per-PID calls trades one round-trip-per-PID for resilience.
+    result["failures"] = []
     if dry_run:
         print(f"DRY RUN - {len(targets)} would be approved")
         result["approved"] = list(targets)
     else:
-        print(f"Approving {len(targets)} submissions...")
-        try:
-            prolific_bulk_approve(study_id, targets, api_token)
-            result["approved"] = list(targets)
-            print(f"  Approved: {len(targets)}")
-        except Exception as exc:
-            err = _sanitize_log_text(str(exc))
-            print(f"::error::Bulk approve failed: {err}", file=sys.stderr)
-            result["bulk_approve_error"] = err
-            _write_results(output_path, result)
-            return 1
+        print(f"Approving {len(targets)} submissions (one API call per PID)...")
+        for pid in targets:
+            try:
+                prolific_bulk_approve(study_id, [pid], api_token)
+                result["approved"].append(pid)
+                print(f"  APPROVED {pid}")
+            except Exception as exc:
+                err = str(exc)
+                print(f"  FAILED {pid}: {err}", file=sys.stderr)
+                result["failures"].append({"pid": pid, "error": err})
 
     # Thank-you messages.
     if dry_run:
@@ -244,30 +197,24 @@ def main() -> int:
         result["thank_you_sent"] = list(targets)
     else:
         print("\nSending thank-you messages...")
-        for idx, pid in enumerate(targets):
-            if idx > 0:
-                time.sleep(_API_CALL_DELAY)
+        for pid in targets:
             try:
-                existing, fetch_err = _fetch_messages_with_backoff(pid, api_token)
-                if existing is None:
-                    raise RuntimeError(fetch_err or "message fetch failed")
+                existing = prolific_user_messages(pid, api_token)
                 already = any(
                     (m.get("data") or {}).get("study_id") == study_id
                     and SIGNATURE in (m.get("body") or "")
                     for m in existing
                 )
                 if already:
-                    print(f"  SKIP {_redact_pid(pid)} - already received this thank-you")
+                    print(f"  SKIP {pid} - already received this thank-you")
                     result["thank_you_skipped_dedup"].append(pid)
                     continue
-                send_err = _send_thank_you_with_backoff(study_id, pid, api_token)
-                if send_err:
-                    raise RuntimeError(send_err)
-                print(f"  SENT thank-you to {_redact_pid(pid)}")
+                prolific_send_message(study_id, pid, THANK_YOU_MESSAGE, api_token)
+                print(f"  SENT thank-you to {pid}")
                 result["thank_you_sent"].append(pid)
             except Exception as exc:
-                err = _sanitize_log_text(str(exc))
-                print(f"  FAILED thank-you to {_redact_pid(pid)}: {err}", file=sys.stderr)
+                err = str(exc)
+                print(f"  FAILED thank-you to {pid}: {err}", file=sys.stderr)
                 result["thank_you_failed"].append({"pid": pid, "error": err})
 
     print()

--- a/scripts/analysis/approve_by_pid.py
+++ b/scripts/analysis/approve_by_pid.py
@@ -3,7 +3,8 @@
 
 Mirrors the safety pattern of reject_by_pid.py:
   - Verifies token and study before any API call
-  - Skips PIDs that aren't currently AWAITING REVIEW (idempotent re-runs)
+  - Resolves targets by current status and skips PIDs that aren't AWAITING REVIEW
+    (including dry-run previews, for accurate operator validation)
   - Hard ceiling on PIDs per run to prevent runaway approvals
   - Requires CONFIRM_APPROVE=APPROVE for live runs (typo-proof safety)
   - Writes a structured JSON results file
@@ -26,7 +27,9 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -48,6 +51,8 @@ THANK_YOU_MESSAGE = (
 )
 SIGNATURE = "After reviewing your reply, your submission has been approved"
 DEFAULT_MAX_PER_RUN = 30
+PID_RE = re.compile(r"\b[0-9a-fA-F]{24}\b")
+_API_CALL_DELAY = 0.2
 
 
 def _require_env(name: str) -> str:
@@ -77,6 +82,56 @@ def _write_results(path: str | None, payload: dict) -> None:
         return
     Path(path).write_text(json.dumps(payload, indent=2))
     print(f"Results: {path}")
+
+
+def _redact_pid(pid: str) -> str:
+    if len(pid) <= 4:
+        return pid
+    return f"****{pid[-4:]}"
+
+
+def _sanitize_log_text(text: str) -> str:
+    return PID_RE.sub(lambda m: _redact_pid(m.group(0)), text)
+
+
+def _fetch_messages_with_backoff(pid: str, api_token: str, max_retries: int = 3) -> tuple[list[dict] | None, str | None]:
+    """Fetch messages with exponential backoff on transient API failures."""
+    last_err = ""
+    redacted_pid = _redact_pid(pid)
+    for attempt in range(max_retries):
+        try:
+            if attempt > 0:
+                wait = min(2**attempt, 30)
+                print(
+                    f"  Retry {attempt}/{max_retries - 1} for {redacted_pid} in {wait}s",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+            msgs = prolific_user_messages(pid, api_token)
+            return msgs, None
+        except Exception as exc:
+            last_err = _sanitize_log_text(str(exc))
+    return None, last_err
+
+
+def _send_thank_you_with_backoff(study_id: str, pid: str, api_token: str, max_retries: int = 3) -> str | None:
+    """Send thank-you with exponential backoff. Returns sanitized error on failure."""
+    last_err = ""
+    redacted_pid = _redact_pid(pid)
+    for attempt in range(max_retries):
+        try:
+            if attempt > 0:
+                wait = min(2**attempt, 30)
+                print(
+                    f"  Retry {attempt}/{max_retries - 1} send for {redacted_pid} in {wait}s",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+            prolific_send_message(study_id, pid, THANK_YOU_MESSAGE, api_token)
+            return None
+        except Exception as exc:
+            last_err = _sanitize_log_text(str(exc))
+    return last_err
 
 
 def main() -> int:
@@ -114,6 +169,7 @@ def main() -> int:
         "thank_you_skipped_dedup": [],
         "thank_you_failed": [],
         "bulk_approve_error": None,
+        "failures": [],
     }
 
     if not pids:
@@ -139,43 +195,32 @@ def main() -> int:
             )
             sys.exit(1)
 
-    # Resolve target PIDs (skip those not AWAITING REVIEW).
+    print(f"Verifying study {study_id}...")
+    study = prolific_study_info(study_id, api_token)
+    print(f"  Study: {study.get('name', '?')} (status: {study.get('status', '?')})")
+
+    print("Fetching current submission statuses...")
+    statuses = prolific_submission_statuses(study_id, api_token)
+
+    targets: list[str] = []
+    for pid in pids:
+        st = statuses.get(pid, "UNKNOWN")
+        if st == "AWAITING REVIEW":
+            targets.append(pid)
+        else:
+            print(f"  SKIP {_redact_pid(pid)} - status is {st}, not AWAITING REVIEW")
+            result["skipped_non_awaiting"].append({"pid": pid, "status": st})
+
     if dry_run:
-        targets = list(pids)
-        print(f"DRY RUN - would target {len(targets)} PIDs without status check")
-    else:
-        print(f"Verifying study {study_id}...")
-        study = prolific_study_info(study_id, api_token)
-        print(f"  Study: {study.get('name', '?')} (status: {study.get('status', '?')})")
-
-        print("Fetching current submission statuses...")
-        statuses = prolific_submission_statuses(study_id, api_token)
-
-        targets = []
-        for pid in pids:
-            st = statuses.get(pid, "UNKNOWN")
-            if st == "AWAITING REVIEW":
-                targets.append(pid)
-            else:
-                print(f"  SKIP {pid} - status is {st}, not AWAITING REVIEW")
-                result["skipped_non_awaiting"].append({"pid": pid, "status": st})
-
-        print(f"  AWAITING REVIEW (will approve): {len(targets)}")
-        print(f"  Skipped (other status): {len(result['skipped_non_awaiting'])}")
+        print(f"DRY RUN - would target {len(targets)} currently AWAITING REVIEW PIDs")
+    print(f"  AWAITING REVIEW (will approve): {len(targets)}")
+    print(f"  Skipped (other status): {len(result['skipped_non_awaiting'])}")
 
     if not targets:
         print("No eligible PIDs to approve.")
         _write_results(output_path, result)
         return 0
 
-    # Per-PID approve. The Prolific bulk-approve endpoint accepts a list,
-    # but operator experience is that large lists are unreliable -- partial
-    # failures abort the whole call. Send one PID per request and track
-    # success/failure individually so the rest still go through if one
-    # errors. This is functionally what approve_submissions.py does today
-    # (also "bulk" in name but submitted as a single list); breaking it
-    # into per-PID calls trades one round-trip-per-PID for resilience.
-    result["failures"] = []
     if dry_run:
         print(f"DRY RUN - {len(targets)} would be approved")
         result["approved"] = list(targets)
@@ -185,36 +230,41 @@ def main() -> int:
             try:
                 prolific_bulk_approve(study_id, [pid], api_token)
                 result["approved"].append(pid)
-                print(f"  APPROVED {pid}")
+                print(f"  APPROVED {_redact_pid(pid)}")
             except Exception as exc:
-                err = str(exc)
-                print(f"  FAILED {pid}: {err}", file=sys.stderr)
+                err = _sanitize_log_text(str(exc))
+                print(f"  FAILED {_redact_pid(pid)}: {err}", file=sys.stderr)
                 result["failures"].append({"pid": pid, "error": err})
 
-    # Thank-you messages.
     if dry_run:
         print(f"DRY RUN - thank-you messages would be sent to {len(targets)} PIDs")
         result["thank_you_sent"] = list(targets)
     else:
         print("\nSending thank-you messages...")
-        for pid in targets:
+        for idx, pid in enumerate(targets):
+            if idx > 0:
+                time.sleep(_API_CALL_DELAY)
             try:
-                existing = prolific_user_messages(pid, api_token)
+                existing, fetch_err = _fetch_messages_with_backoff(pid, api_token)
+                if existing is None:
+                    raise RuntimeError(fetch_err or "message fetch failed")
                 already = any(
                     (m.get("data") or {}).get("study_id") == study_id
                     and SIGNATURE in (m.get("body") or "")
                     for m in existing
                 )
                 if already:
-                    print(f"  SKIP {pid} - already received this thank-you")
+                    print(f"  SKIP {_redact_pid(pid)} - already received this thank-you")
                     result["thank_you_skipped_dedup"].append(pid)
                     continue
-                prolific_send_message(study_id, pid, THANK_YOU_MESSAGE, api_token)
-                print(f"  SENT thank-you to {pid}")
+                send_err = _send_thank_you_with_backoff(study_id, pid, api_token)
+                if send_err:
+                    raise RuntimeError(send_err)
+                print(f"  SENT thank-you to {_redact_pid(pid)}")
                 result["thank_you_sent"].append(pid)
             except Exception as exc:
-                err = str(exc)
-                print(f"  FAILED thank-you to {pid}: {err}", file=sys.stderr)
+                err = _sanitize_log_text(str(exc))
+                print(f"  FAILED thank-you to {_redact_pid(pid)}: {err}", file=sys.stderr)
                 result["thank_you_failed"].append({"pid": pid, "error": err})
 
     print()

--- a/scripts/analysis/approve_by_pid.py
+++ b/scripts/analysis/approve_by_pid.py
@@ -232,7 +232,9 @@ def main() -> int:
         result["approved"] = list(targets)
     else:
         print(f"Approving {len(targets)} submissions (one API call per PID)...")
-        for pid in targets:
+        for idx, pid in enumerate(targets):
+            if idx > 0:
+                time.sleep(_API_CALL_DELAY)
             try:
                 prolific_bulk_approve(study_id, [pid], api_token)
                 result["approved"].append(pid)
@@ -242,12 +244,13 @@ def main() -> int:
                 print(f"  FAILED {_redact_pid(pid)}: {err}", file=sys.stderr)
                 result["failures"].append({"pid": pid, "error": err})
 
+    approved_pids = list(result["approved"])
     if dry_run:
-        print(f"DRY RUN - thank-you messages would be sent to {len(targets)} PIDs")
-        result["thank_you_sent"] = list(targets)
+        print(f"DRY RUN - thank-you messages would be sent to {len(approved_pids)} PIDs")
+        result["thank_you_sent"] = list(approved_pids)
     else:
         print("\nSending thank-you messages...")
-        for idx, pid in enumerate(targets):
+        for idx, pid in enumerate(approved_pids):
             if idx > 0:
                 time.sleep(_API_CALL_DELAY)
             try:

--- a/scripts/analysis/classify_replies_for_action.py
+++ b/scripts/analysis/classify_replies_for_action.py
@@ -133,13 +133,49 @@ def main() -> int:
                 replies_by_pid[pid].append(r)
 
     awaiting_rows: list[dict] = []
+    total_rows = 0
+    saw_pid_column = False
+    saw_status_column = False
     with open(disp_path, encoding="utf-8-sig", newline="") as f:
-        for row in csv.DictReader(f):
+        reader = csv.DictReader(f)
+        for row in reader:
+            total_rows += 1
+            if "PROLIFIC_PID" in row:
+                saw_pid_column = True
+            if "Prolific_Status" in row:
+                saw_status_column = True
             if row.get("Prolific_Status") != "AWAITING REVIEW":
                 continue
             pid = (row.get("PROLIFIC_PID") or "").strip()
             if pid:
                 awaiting_rows.append(row)
+
+    # Sanity check: if the CSV has rows but our column lookups returned
+    # nothing, the schema has probably changed and we're silently producing
+    # empty buckets. Emit a workflow warning so the daily report job surfaces
+    # it instead of shipping a blank Replies-to-Consider section without
+    # explanation. Use the GitHub Actions warning format so it shows up in
+    # the job summary.
+    if total_rows > 0 and not awaiting_rows:
+        missing = []
+        if not saw_pid_column:
+            missing.append("PROLIFIC_PID")
+        if not saw_status_column:
+            missing.append("Prolific_Status")
+        if missing:
+            print(
+                f"::warning::disposition CSV had {total_rows} row(s) but missing column(s) "
+                f"{missing!r}; produced no AWAITING REVIEW classifications. Did the disposition "
+                "CSV schema change?",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"::warning::disposition CSV had {total_rows} row(s) but none had "
+                "Prolific_Status='AWAITING REVIEW'; produced no classifications. Either the "
+                "queue is empty or upstream filtering changed.",
+                file=sys.stderr,
+            )
 
     buckets: dict[str, list[dict]] = {
         "auto_approve_eligible": [],

--- a/scripts/analysis/classify_replies_for_action.py
+++ b/scripts/analysis/classify_replies_for_action.py
@@ -168,10 +168,14 @@ def main() -> int:
                 buckets["no_reply_high_tier"].append(entry)
             else:
                 buckets["no_reply"].append(entry)
+        elif is_high_rejection_tier(row):
+            # High-tier wins over question detection. The operator policy is that
+            # 3+ IRI fails or 2 IRI + factor always requires reading the messaging
+            # exchange before any action -- even if the reply contains a question,
+            # the high-tier disposition warrants the more cautious review path.
+            buckets["human_review_high_tier"].append(entry)
         elif reply_has_question(replies):
             buckets["human_review_questions"].append(entry)
-        elif is_high_rejection_tier(row):
-            buckets["human_review_high_tier"].append(entry)
         else:
             buckets["auto_approve_eligible"].append(entry)
         if len(replies) >= 2:

--- a/scripts/analysis/classify_replies_for_action.py
+++ b/scripts/analysis/classify_replies_for_action.py
@@ -48,17 +48,6 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 
-QUESTION_THEMES = frozenset(
-    {
-        "question_about_study",
-        "contact_request",
-        "rejection_dispute",
-        "payment_question",
-        "technical_issue",
-    }
-)
-
-
 def _safe_int(value: object) -> int:
     if value is None:
         return 0

--- a/scripts/analysis/classify_replies_for_action.py
+++ b/scripts/analysis/classify_replies_for_action.py
@@ -148,8 +148,10 @@ def main() -> int:
         "auto_approve_eligible": [],
         "human_review_questions": [],
         "human_review_high_tier": [],
+        "no_reply_high_tier": [],
         "no_reply": [],
     }
+    multi_reply_pids: list[dict] = []
     for row in awaiting_rows:
         pid = row["PROLIFIC_PID"].strip()
         replies = replies_by_pid.get(pid, [])
@@ -163,13 +165,20 @@ def main() -> int:
             "reply_theme_counts": reply_theme_counts(replies),
         }
         if not replies:
-            buckets["no_reply"].append(entry)
-        elif is_high_rejection_tier(row):
-            buckets["human_review_high_tier"].append(entry)
+            # High-tier no-reply gets a separate bucket so bulk-reject can target it
+            # without affecting lower-tier PIDs still in the auto-cycle.
+            if is_high_rejection_tier(row):
+                buckets["no_reply_high_tier"].append(entry)
+            else:
+                buckets["no_reply"].append(entry)
         elif reply_has_question(replies):
             buckets["human_review_questions"].append(entry)
+        elif is_high_rejection_tier(row):
+            buckets["human_review_high_tier"].append(entry)
         else:
             buckets["auto_approve_eligible"].append(entry)
+        if len(replies) >= 2:
+            multi_reply_pids.append({"pid": pid, "reply_count": len(replies), "disposition": entry["disposition"]})
 
     bucket_counts = {k: len(v) for k, v in buckets.items()}
 
@@ -191,6 +200,8 @@ def main() -> int:
         "bucket_counts": bucket_counts,
         "breakdown": breakdown,
         "buckets": buckets,
+        "multi_reply_count": len(multi_reply_pids),
+        "multi_reply_pids": multi_reply_pids,
     }
     Path(output_path).write_text(json.dumps(out, indent=2))
     print(f"Classified {len(awaiting_rows)} AWAITING REVIEW PIDs:")

--- a/scripts/analysis/classify_replies_for_action.py
+++ b/scripts/analysis/classify_replies_for_action.py
@@ -93,9 +93,17 @@ def _split_themes(raw: str | None) -> list[str]:
 
 
 def reply_has_question(reply_records: list[dict]) -> bool:
+    # Trust the '?' character. Real questions almost always include one.
+    # The theme tags emitted by extract_prolific_messages.py are loose
+    # keyword matches and produce many false positives (e.g. "I paid
+    # attention" gets tagged payment_question because of the word "paid";
+    # "I made an error" gets technical_issue). Routing replies to manual
+    # review based on those tags clogs the queue with non-questions and
+    # hides real questions. The '?' heuristic is far more precise --
+    # validated against today's 309 inbound messages (1 real question
+    # surfaced; ~5 false-positive theme tags correctly demoted).
     for r in reply_records:
-        themes = set(_split_themes(r.get("themes")))
-        if themes & QUESTION_THEMES:
+        if "?" in (r.get("body") or ""):
             return True
     return False
 

--- a/scripts/analysis/tests/test_approve_by_pid.py
+++ b/scripts/analysis/tests/test_approve_by_pid.py
@@ -1,100 +1,311 @@
-"""Tests for approve_by_pid.py."""
+"""Tests for approve_by_pid.py — ceiling truncation, status filtering,
+dry-run vs live, per-PID failure isolation."""
 
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
-from approve_by_pid import main
+import pytest
 
-
-def _base_env(tmp_path: Path, **overrides: str) -> dict[str, str]:
-    env = {
-        "PROLIFIC_API_TOKEN": "token",
-        "STUDY_ID": "study_123",
-        "PID_LIST": "aaaaaaaaaaaaaaaaaaaaaaa1,bbbbbbbbbbbbbbbbbbbbbbb2",
-        "DRY_RUN": "true",
-        "MAX_PER_RUN": "30",
-        "OUTPUT_JSON_PATH": str(tmp_path / "result.json"),
-    }
-    env.update(overrides)
-    return env
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
-def test_dry_run_still_filters_non_awaiting(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_study_info",
-        lambda *_: {"name": "Study", "status": "ACTIVE"},
-    )
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_submission_statuses",
-        lambda *_: {
-            "aaaaaaaaaaaaaaaaaaaaaaa1": "AWAITING REVIEW",
-            "bbbbbbbbbbbbbbbbbbbbbbb2": "APPROVED",
-        },
-    )
-    monkeypatch.setattr("approve_by_pid.prolific_bulk_approve", lambda *_: None)
-    monkeypatch.setattr("approve_by_pid.prolific_user_messages", lambda *_: [])
-    monkeypatch.setattr("approve_by_pid.prolific_send_message", lambda *_: None)
-    monkeypatch.setattr("approve_by_pid.time.sleep", lambda *_: None)
-
-    monkeypatch.setattr("approve_by_pid.os.environ", _base_env(tmp_path))
-    rc = main()
-
-    assert rc == 0
-    payload = json.loads((tmp_path / "result.json").read_text())
-    assert payload["mode"] == "dry_run"
-    assert payload["approved"] == ["aaaaaaaaaaaaaaaaaaaaaaa1"]
-    assert payload["skipped_non_awaiting"] == [{"pid": "bbbbbbbbbbbbbbbbbbbbbbb2", "status": "APPROVED"}]
+@pytest.fixture
+def fake_env(tmp_path, monkeypatch):
+    """Set the minimum env vars required by approve_by_pid.main()."""
+    output = str(tmp_path / "results.json")
+    monkeypatch.setenv("PROLIFIC_API_TOKEN", "tok")
+    monkeypatch.setenv("STUDY_ID", "studyA")
+    monkeypatch.setenv("OUTPUT_JSON_PATH", output)
+    monkeypatch.setenv("DRY_RUN", "true")
+    monkeypatch.setenv("MAX_PER_RUN", "30")
+    monkeypatch.delenv("CONFIRM_APPROVE", raising=False)
+    return output
 
 
-def test_live_thank_you_uses_backoff_then_succeeds(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_study_info",
-        lambda *_: {"name": "Study", "status": "ACTIVE"},
-    )
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_submission_statuses",
-        lambda *_: {"aaaaaaaaaaaaaaaaaaaaaaa1": "AWAITING REVIEW"},
-    )
-    monkeypatch.setattr("approve_by_pid.prolific_bulk_approve", lambda *_: None)
+@pytest.fixture(autouse=True)
+def patch_api():
+    """Stub out every Prolific API call. Tests can override behavior."""
+    with patch("approve_by_pid.prolific_study_info") as study, \
+         patch("approve_by_pid.prolific_submission_statuses") as statuses, \
+         patch("approve_by_pid.prolific_bulk_approve") as approve, \
+         patch("approve_by_pid.prolific_user_messages") as messages, \
+         patch("approve_by_pid.prolific_send_message") as send, \
+         patch("approve_by_pid.time.sleep"):  # don't actually sleep in tests
+        study.return_value = {"name": "Test Study", "status": "ACTIVE"}
+        statuses.return_value = {}  # tests override
+        approve.return_value = {}
+        messages.return_value = []
+        send.return_value = {}
+        yield {
+            "study": study,
+            "statuses": statuses,
+            "approve": approve,
+            "messages": messages,
+            "send": send,
+        }
 
-    attempts = {"fetch": 0, "send": 0}
 
-    def _messages(*_args):
-        attempts["fetch"] += 1
-        if attempts["fetch"] == 1:
-            raise RuntimeError("HTTP 429 at /messages/?user_id=aaaaaaaaaaaaaaaaaaaaaaa1")
-        return []
+def _read(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
 
-    def _send(*_args):
-        attempts["send"] += 1
-        if attempts["send"] == 1:
-            raise RuntimeError("HTTP 503 temporary")
-        return None
 
-    sleep_calls: list[int | float] = []
+def _pid(suffix: str) -> str:
+    """Generate a valid 24-char hex PID-shaped string."""
+    return (suffix + "0" * 24)[:24]
 
-    monkeypatch.setattr("approve_by_pid.prolific_user_messages", _messages)
-    monkeypatch.setattr("approve_by_pid.prolific_send_message", _send)
-    monkeypatch.setattr("approve_by_pid.time.sleep", lambda secs: sleep_calls.append(secs))
-    monkeypatch.setattr("approve_by_pid._API_CALL_DELAY", 0)
 
-    monkeypatch.setattr(
-        "approve_by_pid.os.environ",
-        _base_env(
-            tmp_path,
-            PID_LIST="aaaaaaaaaaaaaaaaaaaaaaa1",
-            DRY_RUN="false",
-            CONFIRM_APPROVE="APPROVE",
-        ),
-    )
-    rc = main()
+# ---------------------------------------------------------------------------
+# Empty / no-op cases
+# ---------------------------------------------------------------------------
 
-    assert rc == 0
-    payload = json.loads((tmp_path / "result.json").read_text())
-    assert payload["approved"] == ["aaaaaaaaaaaaaaaaaaaaaaa1"]
-    assert payload["thank_you_sent"] == ["aaaaaaaaaaaaaaaaaaaaaaa1"]
-    assert payload["thank_you_failed"] == []
-    assert attempts == {"fetch": 2, "send": 2}
-    assert 2 in sleep_calls
+
+class TestNoOp:
+    def test_empty_pid_list_exits_with_required_error(self, fake_env, monkeypatch):
+        # PID_LIST is _require_env; empty string triggers the required guard
+        monkeypatch.setenv("PID_LIST", "")
+        import approve_by_pid
+        with pytest.raises(SystemExit) as exc:
+            approve_by_pid.main()
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Safety guards
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyGuards:
+    def test_live_without_confirm_aborts(self, fake_env, monkeypatch):
+        monkeypatch.setenv("PID_LIST", _pid("a"))
+        monkeypatch.setenv("DRY_RUN", "false")
+        # No CONFIRM_APPROVE set
+        import approve_by_pid
+        with pytest.raises(SystemExit) as exc:
+            approve_by_pid.main()
+        assert exc.value.code == 1
+
+    def test_live_with_wrong_confirm_aborts(self, fake_env, monkeypatch):
+        monkeypatch.setenv("PID_LIST", _pid("a"))
+        monkeypatch.setenv("DRY_RUN", "false")
+        monkeypatch.setenv("CONFIRM_APPROVE", "approve")  # wrong case
+        import approve_by_pid
+        with pytest.raises(SystemExit) as exc:
+            approve_by_pid.main()
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Status filtering
+# ---------------------------------------------------------------------------
+
+
+class TestStatusFiltering:
+    def test_non_awaiting_pids_are_skipped(self, fake_env, patch_api, monkeypatch):
+        pid_a, pid_b, pid_c = _pid("a"), _pid("b"), _pid("c")
+        monkeypatch.setenv("PID_LIST", ",".join([pid_a, pid_b, pid_c]))
+        patch_api["statuses"].return_value = {
+            pid_a: "AWAITING REVIEW",
+            pid_b: "APPROVED",
+            pid_c: "RETURNED",
+        }
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        # Dry-run: only AWAITING REVIEW target makes it into "approved"
+        assert result["approved"] == [pid_a]
+        # Skipped (non-AWAITING): pid_b and pid_c
+        skipped_pids = [s["pid"] for s in result["skipped_non_awaiting"]]
+        assert pid_b in skipped_pids
+        assert pid_c in skipped_pids
+
+    def test_unknown_pid_treated_as_skip(self, fake_env, patch_api, monkeypatch):
+        pid_a = _pid("a")
+        monkeypatch.setenv("PID_LIST", pid_a)
+        patch_api["statuses"].return_value = {}  # no statuses returned
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert result["approved"] == []
+        assert result["skipped_non_awaiting"][0]["status"] == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Ceiling truncation (the policy change in this PR)
+# ---------------------------------------------------------------------------
+
+
+class TestCeilingTruncation:
+    def test_inputs_over_ceiling_after_filter_truncate_and_warn(self, fake_env, patch_api, monkeypatch):
+        # Input 5 PIDs, all AWAITING REVIEW, ceiling=2 -> approve 2, defer 3
+        pids = [_pid(c) for c in "abcde"]
+        monkeypatch.setenv("PID_LIST", ",".join(pids))
+        monkeypatch.setenv("MAX_PER_RUN", "2")
+        patch_api["statuses"].return_value = {p: "AWAITING REVIEW" for p in pids}
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert result["ceiling_exceeded"] is True
+        assert len(result["approved"]) == 2  # dry-run, but truncated to first 2
+        assert len(result["deferred_over_ceiling"]) == 3
+
+    def test_inputs_over_ceiling_but_filter_brings_under_no_truncate(self, fake_env, patch_api, monkeypatch):
+        # Input 5 PIDs but only 2 are AWAITING REVIEW; ceiling=3 -> no truncate
+        pids = [_pid(c) for c in "abcde"]
+        monkeypatch.setenv("PID_LIST", ",".join(pids))
+        monkeypatch.setenv("MAX_PER_RUN", "3")
+        patch_api["statuses"].return_value = {
+            pids[0]: "AWAITING REVIEW",
+            pids[1]: "APPROVED",
+            pids[2]: "AWAITING REVIEW",
+            pids[3]: "REJECTED",
+            pids[4]: "RETURNED",
+        }
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert result["ceiling_exceeded"] is False
+        assert len(result["approved"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Live approve path — per-PID failure isolation
+# ---------------------------------------------------------------------------
+
+
+class TestLiveApprove:
+    def test_per_pid_failure_does_not_abort_others(self, fake_env, patch_api, monkeypatch):
+        pid_a, pid_b, pid_c = _pid("a"), _pid("b"), _pid("c")
+        monkeypatch.setenv("PID_LIST", ",".join([pid_a, pid_b, pid_c]))
+        monkeypatch.setenv("DRY_RUN", "false")
+        monkeypatch.setenv("CONFIRM_APPROVE", "APPROVE")
+        patch_api["statuses"].return_value = {
+            p: "AWAITING REVIEW" for p in [pid_a, pid_b, pid_c]
+        }
+
+        # Make approval for pid_b fail; the others should still go through
+        def approve_side_effect(study_id, pids, token):
+            if pid_b in pids:
+                raise RuntimeError("simulated 500 from Prolific")
+            return {}
+
+        patch_api["approve"].side_effect = approve_side_effect
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert pid_a in result["approved"]
+        assert pid_c in result["approved"]
+        failed_pids = [f["pid"] for f in result["failures"]]
+        assert pid_b in failed_pids
+
+    def test_thank_you_dedup_skips_already_thanked(self, fake_env, patch_api, monkeypatch):
+        pid_a = _pid("a")
+        monkeypatch.setenv("PID_LIST", pid_a)
+        monkeypatch.setenv("DRY_RUN", "false")
+        monkeypatch.setenv("CONFIRM_APPROVE", "APPROVE")
+        patch_api["statuses"].return_value = {pid_a: "AWAITING REVIEW"}
+        # Existing thank-you already in message thread
+        patch_api["messages"].return_value = [
+            {
+                "body": (
+                    "Hi, thanks. After reviewing your reply, your submission has "
+                    "been approved. Cheers!"
+                ),
+                "data": {"study_id": "studyA"},
+            }
+        ]
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert pid_a in result["approved"]
+        assert pid_a in result["thank_you_skipped_dedup"]
+        # Send was never called because dedup hit
+        patch_api["send"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Backoff retry behavior (regression: ensure transient API failures are
+# retried instead of aborting the run)
+# ---------------------------------------------------------------------------
+
+
+class TestBackoffRetry:
+    def test_thank_you_retries_on_transient_failure(self, fake_env, patch_api, monkeypatch):
+        pid_a = _pid("a")
+        monkeypatch.setenv("PID_LIST", pid_a)
+        monkeypatch.setenv("DRY_RUN", "false")
+        monkeypatch.setenv("CONFIRM_APPROVE", "APPROVE")
+        patch_api["statuses"].return_value = {pid_a: "AWAITING REVIEW"}
+
+        attempts = {"fetch": 0, "send": 0}
+
+        def fetch_side(*args, **kwargs):
+            attempts["fetch"] += 1
+            if attempts["fetch"] == 1:
+                raise RuntimeError("HTTP 429 transient")
+            return []
+
+        def send_side(*args, **kwargs):
+            attempts["send"] += 1
+            if attempts["send"] == 1:
+                raise RuntimeError("HTTP 503 transient")
+            return {}
+
+        patch_api["messages"].side_effect = fetch_side
+        patch_api["send"].side_effect = send_side
+
+        # Make _API_CALL_DELAY = 0 to keep the test fast
+        import approve_by_pid
+        monkeypatch.setattr(approve_by_pid, "_API_CALL_DELAY", 0)
+
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert pid_a in result["approved"]
+        assert pid_a in result["thank_you_sent"]
+        assert result["thank_you_failed"] == []
+        # Confirms both backoff functions retried at least once
+        assert attempts["fetch"] >= 2
+        assert attempts["send"] >= 2
+
+
+# ---------------------------------------------------------------------------
+# Result file always written
+# ---------------------------------------------------------------------------
+
+
+class TestResultsFile:
+    def test_results_file_has_expected_keys(self, fake_env, patch_api, monkeypatch):
+        pid_a = _pid("a")
+        monkeypatch.setenv("PID_LIST", pid_a)
+        patch_api["statuses"].return_value = {pid_a: "AWAITING REVIEW"}
+        import approve_by_pid
+        approve_by_pid.main()
+        result = _read(fake_env)
+        for key in (
+            "mode",
+            "input_count",
+            "ceiling",
+            "ceiling_exceeded",
+            "deferred_over_ceiling",
+            "approved",
+            "skipped_non_awaiting",
+            "thank_you_sent",
+            "thank_you_skipped_dedup",
+            "thank_you_failed",
+            "failures",
+        ):
+            assert key in result, f"missing key: {key}"
+        assert result["mode"] == "dry_run"
+        assert result["input_count"] == 1

--- a/scripts/analysis/tests/test_approve_by_pid.py
+++ b/scripts/analysis/tests/test_approve_by_pid.py
@@ -4,10 +4,9 @@ dry-run vs live, per-PID failure isolation."""
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/scripts/analysis/tests/test_approve_by_pid.py
+++ b/scripts/analysis/tests/test_approve_by_pid.py
@@ -207,6 +207,9 @@ class TestLiveApprove:
         assert pid_c in result["approved"]
         failed_pids = [f["pid"] for f in result["failures"]]
         assert pid_b in failed_pids
+        sent_pids = set(result["thank_you_sent"]) | set(result["thank_you_skipped_dedup"])
+        assert pid_b not in sent_pids
+        assert patch_api["send"].call_count == 2
 
     def test_thank_you_dedup_skips_already_thanked(self, fake_env, patch_api, monkeypatch):
         pid_a = _pid("a")

--- a/scripts/analysis/tests/test_classify_replies_for_action.py
+++ b/scripts/analysis/tests/test_classify_replies_for_action.py
@@ -325,3 +325,87 @@ class TestMultiReply:
             ],
         )
         assert result["multi_reply_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Bucket entry schema — these fields are consumed by the daily report
+# (build-daily-report.sh) and by the bulk-action workflows. Locking them in
+# so a future refactor of the entry dict can't silently break downstream.
+# ---------------------------------------------------------------------------
+
+
+class TestBucketEntrySchema:
+    REQUIRED_FIELDS = {
+        "pid",
+        "disposition",
+        "iri_fail",
+        "speed_flag",
+        "partial_straightlining_flag",
+        "reply_count",
+        "reply_theme_counts",
+    }
+
+    def test_no_reply_high_tier_entry_has_required_fields(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "JJJJ000000000000000000001",
+                    "IRI_Fail_Count": "3",
+                    "Speed_Flag": "0",
+                    "Partial_Straightlining_Flag": "0",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [],
+        )
+        entries = result["buckets"]["no_reply_high_tier"]
+        assert len(entries) == 1
+        missing = self.REQUIRED_FIELDS - set(entries[0].keys())
+        assert not missing, f"missing fields in no_reply_high_tier entry: {missing}"
+
+    def test_auto_approve_eligible_entry_has_required_fields(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "KKKK000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "KKKK000000000000000000001", "body": "I read carefully.", "themes": ""},
+            ],
+        )
+        entries = result["buckets"]["auto_approve_eligible"]
+        assert len(entries) == 1
+        missing = self.REQUIRED_FIELDS - set(entries[0].keys())
+        assert not missing, f"missing fields in auto_approve_eligible entry: {missing}"
+
+    def test_human_review_high_tier_entry_has_required_fields(self, tmp_path):
+        # The build-daily-report.sh "high tier" sub-section groups entries by
+        # (disposition, iri_fail, speed_flag, partial_straightlining_flag).
+        # If any of those keys is missing, the grouping raises KeyError.
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "LLLL000000000000000000001",
+                    "IRI_Fail_Count": "2",
+                    "Speed_Flag": "1",
+                    "Partial_Straightlining_Flag": "0",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "LLLL000000000000000000001", "body": "I was tired.", "themes": ""},
+            ],
+        )
+        entries = result["buckets"]["human_review_high_tier"]
+        assert len(entries) == 1
+        missing = self.REQUIRED_FIELDS - set(entries[0].keys())
+        assert not missing, f"missing fields in human_review_high_tier entry: {missing}"

--- a/scripts/analysis/tests/test_classify_replies_for_action.py
+++ b/scripts/analysis/tests/test_classify_replies_for_action.py
@@ -1,93 +1,327 @@
-"""Tests for classify_replies_for_action.py."""
+"""Tests for classify_replies_for_action.py — bucket assignment, theme
+parsing, and the question detection / high-tier precedence rules."""
 
 from __future__ import annotations
 
 import csv
 import json
+import subprocess
+import sys
 from pathlib import Path
 
-from classify_replies_for_action import _split_themes, is_high_rejection_tier, main
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import classify_replies_for_action as classifier  # noqa: E402
+
+SCRIPT = str(Path(__file__).parent.parent / "classify_replies_for_action.py")
 
 
-def _write_csv(path: Path, headers: list[str], rows: list[list[str]]) -> None:
+def _write_disposition_csv(tmp_path: Path, rows: list[dict]) -> str:
+    path = str(tmp_path / "disposition.csv")
+    cols = [
+        "PROLIFIC_PID",
+        "Duration_Seconds",
+        "IRI_Pass_Count",
+        "IRI_Fail_Count",
+        "Speed_Flag",
+        "Partial_Straightlining_Flag",
+        "Disposition",
+        "Prolific_Status",
+    ]
     with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(headers)
-        writer.writerows(rows)
+        writer = csv.DictWriter(f, fieldnames=cols)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({c: r.get(c, "") for c in cols})
+    return path
 
 
-def test_split_themes_supports_semicolon_pipe_and_empty():
-    assert _split_themes("question_about_study;payment_question") == [
-        "question_about_study",
-        "payment_question",
-    ]
-    assert _split_themes("question_about_study|payment_question") == [
-        "question_about_study",
-        "payment_question",
-    ]
-    assert _split_themes("question_about_study ; payment_question|technical_issue") == [
-        "question_about_study",
-        "payment_question",
-        "technical_issue",
-    ]
-    assert _split_themes("") == []
-    assert _split_themes(None) == []
+def _write_inbound_csv(tmp_path: Path, rows: list[dict]) -> str:
+    path = str(tmp_path / "participant_messages.csv")
+    cols = ["timestamp", "participant_id", "channel_id", "study_id", "message_id", "char_count", "themes", "pii_risk", "pii_flags", "body"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=cols)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({c: r.get(c, "") for c in cols})
+    return path
 
 
-def test_high_rejection_tier_boundaries():
-    assert is_high_rejection_tier({"IRI_Fail_Count": "3", "Speed_Flag": "0", "Partial_Straightlining_Flag": "0"})
-    assert is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "1", "Partial_Straightlining_Flag": "0"})
-    assert is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "0", "Partial_Straightlining_Flag": "1"})
-    assert not is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "0", "Partial_Straightlining_Flag": "0"})
-    assert not is_high_rejection_tier({"IRI_Fail_Count": "1", "Speed_Flag": "1", "Partial_Straightlining_Flag": "1"})
-
-
-def test_high_tier_precedence_over_question_themes(monkeypatch, tmp_path):
-    inbound = tmp_path / "inbound.csv"
-    disposition = tmp_path / "disposition.csv"
-    output = tmp_path / "output.json"
-
-    _write_csv(
-        inbound,
-        ["participant_id", "themes"],
-        [
-            ["pid-high-question", "question_about_study"],
-            ["pid-question", "question_about_study"],
-            ["pid-auto", "acknowledgment"],
-        ],
+def _run(tmp_path: Path, disp_rows: list[dict], inbound_rows: list[dict]) -> dict:
+    disp = _write_disposition_csv(tmp_path, disp_rows)
+    inbound = _write_inbound_csv(tmp_path, inbound_rows)
+    output = str(tmp_path / "out.json")
+    env = {
+        "INBOUND_CSV": inbound,
+        "DISPOSITION_CSV": disp,
+        "OUTPUT_JSON_PATH": output,
+        "PYTHONPATH": str(Path(__file__).parent.parent),
+    }
+    proc = subprocess.run(
+        [sys.executable, SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
     )
-    _write_csv(
-        disposition,
-        [
-            "PROLIFIC_PID",
-            "Prolific_Status",
-            "Disposition",
-            "IRI_Fail_Count",
-            "Speed_Flag",
-            "Partial_Straightlining_Flag",
-        ],
-        [
-            ["pid-high-question", "AWAITING REVIEW", "FLAG-SPEED", "2", "1", "0"],
-            ["pid-question", "AWAITING REVIEW", "FLAG-SPEED", "1", "0", "0"],
-            ["pid-auto", "AWAITING REVIEW", "FLAG-SPEED", "1", "0", "0"],
-        ],
-    )
+    assert "Classified" in proc.stdout, proc.stdout
+    with open(output, encoding="utf-8") as f:
+        return json.load(f)
 
-    monkeypatch.setattr(
-        "classify_replies_for_action.os.environ",
-        {
-            "INBOUND_CSV": str(inbound),
-            "DISPOSITION_CSV": str(disposition),
-            "OUTPUT_JSON_PATH": str(output),
-        },
-    )
-    rc = main()
-    assert rc == 0
 
-    payload = json.loads(output.read_text())
-    assert payload["bucket_counts"]["human_review_high_tier"] == 1
-    assert payload["bucket_counts"]["human_review_questions"] == 1
-    assert payload["bucket_counts"]["auto_approve_eligible"] == 1
-    high_tier_pids = {row["pid"] for row in payload["buckets"]["human_review_high_tier"]}
-    assert high_tier_pids == {"pid-high-question"}
+# ---------------------------------------------------------------------------
+# High-tier detection unit tests
+# ---------------------------------------------------------------------------
 
+
+class TestHighRejectionTier:
+    def test_three_iri_fails_is_high_tier(self):
+        assert classifier.is_high_rejection_tier({"IRI_Fail_Count": "3", "Speed_Flag": "0", "Partial_Straightlining_Flag": "0"})
+
+    def test_four_iri_fails_is_high_tier(self):
+        assert classifier.is_high_rejection_tier({"IRI_Fail_Count": "4"})
+
+    def test_two_iri_fails_plus_speed_is_high_tier(self):
+        assert classifier.is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "1", "Partial_Straightlining_Flag": "0"})
+
+    def test_two_iri_fails_plus_partial_straightlining_is_high_tier(self):
+        assert classifier.is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "0", "Partial_Straightlining_Flag": "1"})
+
+    def test_two_iri_fails_alone_is_low_tier(self):
+        # Per operator policy: 2 IRI fails without another factor is NOT high tier
+        assert not classifier.is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "0", "Partial_Straightlining_Flag": "0"})
+
+    def test_one_iri_fail_is_low_tier(self):
+        assert not classifier.is_high_rejection_tier({"IRI_Fail_Count": "1", "Speed_Flag": "1", "Partial_Straightlining_Flag": "1"})
+
+    def test_zero_iri_fails_is_low_tier(self):
+        assert not classifier.is_high_rejection_tier({"IRI_Fail_Count": "0"})
+
+    def test_missing_columns_default_to_zero(self):
+        assert not classifier.is_high_rejection_tier({})
+
+
+# ---------------------------------------------------------------------------
+# Question detection unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestReplyHasQuestion:
+    def test_question_mark_detects_question(self):
+        assert classifier.reply_has_question([{"body": "What did I do wrong?", "themes": ""}])
+
+    def test_no_question_mark_no_question(self):
+        # Defense / acknowledgment without ? is NOT a question, even if theme
+        # tag (which is keyword-based and noisy) says otherwise
+        assert not classifier.reply_has_question([{"body": "I paid attention.", "themes": "payment_question"}])
+
+    def test_multiple_replies_any_question(self):
+        replies = [
+            {"body": "Thanks!", "themes": ""},
+            {"body": "Can you explain?", "themes": ""},
+        ]
+        assert classifier.reply_has_question(replies)
+
+    def test_empty_body_no_question(self):
+        assert not classifier.reply_has_question([{"body": "", "themes": ""}])
+
+    def test_missing_body_no_question(self):
+        assert not classifier.reply_has_question([{"themes": "question_about_study"}])
+
+
+# ---------------------------------------------------------------------------
+# Theme splitting unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitThemes:
+    def test_semicolon_separated(self):
+        assert classifier._split_themes("praise;question_about_study") == ["praise", "question_about_study"]
+
+    def test_pipe_separated_normalized_to_semicolon(self):
+        # Some legacy CSVs may use pipe; the splitter accepts both for safety
+        assert classifier._split_themes("praise|contact_request") == ["praise", "contact_request"]
+
+    def test_single_theme(self):
+        assert classifier._split_themes("praise") == ["praise"]
+
+    def test_empty_string(self):
+        assert classifier._split_themes("") == []
+
+    def test_none(self):
+        assert classifier._split_themes(None) == []
+
+    def test_whitespace_only(self):
+        assert classifier._split_themes("  ;  ") == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end bucket assignment tests (the most policy-critical surface)
+# ---------------------------------------------------------------------------
+
+
+class TestBucketAssignment:
+    def test_low_tier_reply_no_question_goes_to_auto_approve(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "AAAA000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Speed_Flag": "0",
+                    "Partial_Straightlining_Flag": "0",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "AAAA000000000000000000001", "body": "I read carefully.", "themes": ""},
+            ],
+        )
+        assert result["bucket_counts"]["auto_approve_eligible"] == 1
+        assert result["bucket_counts"]["human_review_questions"] == 0
+
+    def test_low_tier_reply_with_question_goes_to_human_review(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "BBBB000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "BBBB000000000000000000001", "body": "What did I miss?", "themes": ""},
+            ],
+        )
+        assert result["bucket_counts"]["human_review_questions"] == 1
+        assert result["bucket_counts"]["auto_approve_eligible"] == 0
+
+    def test_high_tier_reply_with_question_goes_to_high_tier_not_questions(self, tmp_path):
+        # POLICY: high-tier wins over question detection so the operator
+        # reads the messaging exchange in the dispositional context.
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "CCCC000000000000000000001",
+                    "IRI_Fail_Count": "3",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "CCCC000000000000000000001", "body": "Can you reconsider?", "themes": ""},
+            ],
+        )
+        assert result["bucket_counts"]["human_review_high_tier"] == 1
+        assert result["bucket_counts"]["human_review_questions"] == 0
+
+    def test_high_tier_reply_without_question_goes_to_high_tier(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "DDDD000000000000000000001",
+                    "IRI_Fail_Count": "2",
+                    "Speed_Flag": "1",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "DDDD000000000000000000001", "body": "I was tired.", "themes": ""},
+            ],
+        )
+        assert result["bucket_counts"]["human_review_high_tier"] == 1
+        assert result["bucket_counts"]["auto_approve_eligible"] == 0
+
+    def test_no_reply_low_tier_goes_to_no_reply(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "EEEE000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [],
+        )
+        assert result["bucket_counts"]["no_reply"] == 1
+        assert result["bucket_counts"]["no_reply_high_tier"] == 0
+
+    def test_no_reply_high_tier_goes_to_dedicated_bucket(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "FFFF000000000000000000001",
+                    "IRI_Fail_Count": "3",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [],
+        )
+        assert result["bucket_counts"]["no_reply_high_tier"] == 1
+        assert result["bucket_counts"]["no_reply"] == 0
+
+    def test_non_awaiting_pids_excluded(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "GGGG000000000000000000001",
+                    "Disposition": "CLEAN",
+                    "Prolific_Status": "APPROVED",
+                }
+            ],
+            [],
+        )
+        assert result["total_awaiting"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-reply tracking
+# ---------------------------------------------------------------------------
+
+
+class TestMultiReply:
+    def test_two_replies_counted(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "HHHH000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "HHHH000000000000000000001", "body": "Thanks.", "themes": ""},
+                {"participant_id": "HHHH000000000000000000001", "body": "One more thing.", "themes": ""},
+            ],
+        )
+        assert result["multi_reply_count"] == 1
+
+    def test_single_reply_not_multi(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "IIII000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "IIII000000000000000000001", "body": "Just one.", "themes": ""},
+            ],
+        )
+        assert result["multi_reply_count"] == 0

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -68,8 +68,10 @@ fi
 # Forecast: at today's net-approval rate (DELTA_APPROVED), how many days until
 # TODAY_APPROVED reaches 500? Queue clear: at today's net-resolution rate
 # (approved+returned+rejected delta), how many days to clear the
-# current AWAITING REVIEW queue? Both stay quiet (empty string) when we have
-# no signal (delta=0, no dashboard data, or already past target).
+# current AWAITING REVIEW queue? The lines stay empty only when dashboard data
+# is missing; otherwise zero/negative deltas render the stalled-rate/stalled-cycle
+# messages below, and the N=500 line switches to the reached message once we are
+# already past target.
 N500_FORECAST_LINE=""
 QUEUE_RESOLUTION_LINE=""
 if [ "$HAS_DASHBOARD" = true ]; then

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -978,16 +978,16 @@ echo "$AUTO_RR_SECTION_FORMATTED $AUTO_REJECT_SECTION_FORMATTED" | grep -q "MANU
 HIGH_RISK_PREFIX=""
 HIGH_RISK_LABEL=""
 if [ "$HIGH_RISK_COUNT" -gt 0 ]; then
-  HIGH_RISK_PREFIX="\U0001F6A8 HIGH RISK ($HIGH_RISK_COUNT) - "
+  # Use the literal U+1F6A8 (rocket) character directly. bash's printf %b
+  # interprets \uNNNN but NOT \UNNNNNNNN, so the \U escape would have left
+  # the title with a literal "\U0001F6A8" string.
+  HIGH_RISK_PREFIX="🚨 HIGH RISK ($HIGH_RISK_COUNT) - "
   HIGH_RISK_LABEL=",urgent"
   # Prepend an @-mention so GitHub Mobile fires a push notification.
   printf '@clarkemoyer - **%d submission(s) within 2 days of Prolific 21-day auto-approve.** Action today.\n\n' "$HIGH_RISK_COUNT" \
     | cat - /tmp/report-body.md > /tmp/report-body.md.new
   mv /tmp/report-body.md.new /tmp/report-body.md
 fi
-
-# Decode the \U escape in the prefix (printf handles it).
-HIGH_RISK_PREFIX=$(printf '%b' "$HIGH_RISK_PREFIX")
 
 TITLE="${HIGH_RISK_PREFIX}Daily Disposition Report -- $DATE"
 LABELS="documentation${HIGH_RISK_LABEL}"

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -77,9 +77,12 @@ if [ "$HAS_DASHBOARD" = true ]; then
              TODAY_AWAITING="$TODAY_AWAITING" DELTA_REJECTED="$DELTA_REJECTED" \
              DELTA_RETURNED="$DELTA_RETURNED" \
              python3 << 'PYEOF'
- import datetime as _dt
- import math as _math
- import os
+import datetime as _dt
+import math as _math
+import os
+
+def fmt_signed(n: int) -> str:
+    return f"{n:+d}"
 
 target = int(os.environ['N500_TARGET'])
 today_approved = int(os.environ['TODAY_APPROVED'])
@@ -94,14 +97,14 @@ if today_approved >= target:
     print(f"FORECAST=\U0001F389 **N={target} reached!** ({today_approved} approved)")
 elif delta_approved <= 0:
     remaining = target - today_approved
-    print(f"FORECAST=**N={target} ETA:** approval rate stalled at +{delta_approved}/day; "
+    print(f"FORECAST=**N={target} ETA:** approval rate stalled at {fmt_signed(delta_approved)}/day; "
           f"{remaining} more approvals needed")
 else:
     remaining = target - today_approved
     days = remaining / delta_approved
     eta = today + _dt.timedelta(days=_math.ceil(days))
     print(f"FORECAST=**N={target} ETA:** {eta:%Y-%m-%d} "
-          f"(~{days:.1f} days at current +{delta_approved}/day rate, {remaining} more approvals needed)")
+          f"(~{days:.1f} days at current {fmt_signed(delta_approved)}/day rate, {remaining} more approvals needed)")
 
 resolution_delta = delta_approved + delta_returned + delta_rejected
 if awaiting <= 0:
@@ -110,8 +113,8 @@ elif resolution_delta <= 0:
     print(f"RESOLUTION=**Queue resolution:** 0 today; {awaiting} AWAITING REVIEW (cycle stalled)")
 else:
     days = awaiting / resolution_delta
-    print(f"RESOLUTION=**Queue resolution:** +{resolution_delta} today "
-          f"(approved +{delta_approved}, returned +{delta_returned}, rejected +{delta_rejected}); "
+    print(f"RESOLUTION=**Queue resolution:** {fmt_signed(resolution_delta)} today "
+          f"(approved {fmt_signed(delta_approved)}, returned {fmt_signed(delta_returned)}, rejected {fmt_signed(delta_rejected)}); "
           f"~{days:.1f} days to clear {awaiting} AWAITING REVIEW at this rate")
 PYEOF
   ) || FORECAST=""
@@ -828,10 +831,22 @@ else:
     print(f'  -F max_per_run=10')
     print('```')
     print('')
-    print('Default is dry-run. Skips any PID that has already moved out of AWAITING REVIEW (idempotent re-runs).')
+    print('**Live run (requires typed confirmation):**')
+    print('')
+    print('```')
+    print(f'gh workflow run bulk-reject-high-tier-no-reply.yml \\')
+    print(f'  --repo {repo} \\')
+    print(f'  -F source_run_id={run_id} \\')
+    print(f'  -F dry_run=false \\')
+    print(f'  -F confirm_reject=REJECT \\')
+    print(f'  -F max_per_run=10')
+    print('```')
+    print('')
+    print('Default is dry-run.')
+    print('Skips any PID that has already moved out of AWAITING REVIEW (idempotent re-runs).')
 print('')
 
-print(f'_Recommendations computed from `prolific-messages-inbound-csv` and `disposition-csv` artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact (7-day retention)._')
+print(f'_Recommendations computed from `prolific-messages-inbound-csv` and `disposition-csv` artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact (1-day retention)._')
 REPLIESEOF
   ); then
     REPLIES_SECTION="## 🟡 Replies to Consider
@@ -978,7 +993,7 @@ echo "$AUTO_RR_SECTION_FORMATTED $AUTO_REJECT_SECTION_FORMATTED" | grep -q "MANU
 HIGH_RISK_PREFIX=""
 HIGH_RISK_LABEL=""
 if [ "$HIGH_RISK_COUNT" -gt 0 ]; then
-  # Use the literal U+1F6A8 (rocket) character directly. bash's printf %b
+  # Use the literal U+1F6A8 (siren/police light) character directly. bash's printf %b
   # interprets \uNNNN but NOT \UNNNNNNNN, so the \U escape would have left
   # the title with a literal "\U0001F6A8" string.
   HIGH_RISK_PREFIX="🚨 HIGH RISK ($HIGH_RISK_COUNT) - "

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -119,7 +119,14 @@ else:
           f"(approved {fmt_signed(delta_approved)}, returned {fmt_signed(delta_returned)}, rejected {fmt_signed(delta_rejected)}); "
           f"~{days:.1f} days to clear {awaiting} AWAITING REVIEW at this rate")
 PYEOF
-  ) || FORECAST=""
+  ) || {
+    # Most plausible failures here: dashboard JSON missing a key (e.g.
+    # 'approvedDelta' renamed upstream) or non-numeric env var. Emit a
+    # workflow warning so the operator knows the forecast lines went blank
+    # for a real reason, not because the day is calm.
+    echo "::warning::N=500 forecast / queue resolution computation failed; check dashboard JSON schema" >&2
+    FORECAST=""
+  }
   N500_FORECAST_LINE=$(printf '%s\n' "$FORECAST" | sed -n 's/^FORECAST=//p')
   QUEUE_RESOLUTION_LINE=$(printf '%s\n' "$FORECAST" | sed -n 's/^RESOLUTION=//p')
 fi

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -77,8 +77,9 @@ if [ "$HAS_DASHBOARD" = true ]; then
              TODAY_AWAITING="$TODAY_AWAITING" DELTA_REJECTED="$DELTA_REJECTED" \
              DELTA_RETURNED="$DELTA_RETURNED" \
              python3 << 'PYEOF'
-import datetime as _dt
-import os
+ import datetime as _dt
+ import math as _math
+ import os
 
 target = int(os.environ['N500_TARGET'])
 today_approved = int(os.environ['TODAY_APPROVED'])
@@ -98,7 +99,7 @@ elif delta_approved <= 0:
 else:
     remaining = target - today_approved
     days = remaining / delta_approved
-    eta = today + _dt.timedelta(days=round(days))
+    eta = today + _dt.timedelta(days=_math.ceil(days))
     print(f"FORECAST=**N={target} ETA:** {eta:%Y-%m-%d} "
           f"(~{days:.1f} days at current +{delta_approved}/day rate, {remaining} more approvals needed)")
 
@@ -727,7 +728,7 @@ else:
     print(f'gh workflow run bulk-approve-replied.yml \\')
     print(f'  --repo {repo} \\')
     print(f'  -F source_run_id={run_id} \\')
-    print(f'  -F dry_run=false \\')
+    print(f'  -F dry_run=true \\')
     print(f'  -F max_per_run=30')
     print('```')
     print('')
@@ -824,7 +825,7 @@ else:
     print(f'  --repo {repo} \\')
     print(f'  -F source_run_id={run_id} \\')
     print(f'  -F dry_run=true \\')
-    print(f'  -F max_per_run=30')
+    print(f'  -F max_per_run=10')
     print('```')
     print('')
     print('Default is dry-run. Skips any PID that has already moved out of AWAITING REVIEW (idempotent re-runs).')

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -90,7 +90,7 @@ delta_returned = int(os.environ['DELTA_RETURNED'])
 today = _dt.date.today()
 
 if today_approved >= target:
-    print(f"FORECAST=\\U0001F389 **N={target} reached!** ({today_approved} approved)")
+    print(f"FORECAST=\U0001F389 **N={target} reached!** ({today_approved} approved)")
 elif delta_approved <= 0:
     remaining = target - today_approved
     print(f"FORECAST=**N={target} ETA:** approval rate stalled at +{delta_approved}/day; "
@@ -823,7 +823,7 @@ else:
     print(f'gh workflow run bulk-reject-high-tier-no-reply.yml \\')
     print(f'  --repo {repo} \\')
     print(f'  -F source_run_id={run_id} \\')
-    print(f'  -F dry_run=false \\')
+    print(f'  -F dry_run=true \\')
     print(f'  -F max_per_run=30')
     print('```')
     print('')

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -67,7 +67,7 @@ fi
 # --- N=500 forecast + queue resolution rate (computed from today's deltas) ---
 # Forecast: at today's net-approval rate (DELTA_APPROVED), how many days until
 # TODAY_APPROVED reaches 500? Queue clear: at today's net-resolution rate
-# (approved+returned+rejected+timed_out delta), how many days to clear the
+# (approved+returned+rejected delta), how many days to clear the
 # current AWAITING REVIEW queue? Both stay quiet (empty string) when we have
 # no signal (delta=0, no dashboard data, or already past target).
 N500_FORECAST_LINE=""
@@ -75,7 +75,7 @@ QUEUE_RESOLUTION_LINE=""
 if [ "$HAS_DASHBOARD" = true ]; then
   FORECAST=$(N500_TARGET=500 TODAY_APPROVED="$TODAY_APPROVED" DELTA_APPROVED="$DELTA_APPROVED" \
              TODAY_AWAITING="$TODAY_AWAITING" DELTA_REJECTED="$DELTA_REJECTED" \
-             DELTA_RETURNED="$DELTA_RETURNED" DELTA_TIMED="0" \
+             DELTA_RETURNED="$DELTA_RETURNED" \
              python3 << 'PYEOF'
 import datetime as _dt
 import os

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -61,7 +61,14 @@ dfmt() { if [ "$1" -gt 0 ]; then printf "+%d" "$1"; elif [ "$1" -eq 0 ]; then pr
 # --- HIGH RISK count (drives title prefix and @-mention) ---
 HIGH_RISK_COUNT=0
 if [ -f "$TODAY_FILE" ]; then
-  HIGH_RISK_COUNT=$(python3 -c "import json; d=json.load(open('$TODAY_FILE')); print(d.get('highRiskCount', 0))" 2>/dev/null || echo 0)
+  HIGH_RISK_COUNT=$(python3 -c "import json
+from pathlib import Path
+try:
+    d = json.loads(Path('$TODAY_FILE').read_text(encoding='utf-8'))
+    raw = d.get('highRiskCount', 0)
+    print(int(raw))
+except (FileNotFoundError, json.JSONDecodeError, TypeError, ValueError):
+    print(0)" 2>/dev/null || echo 0)
 fi
 
 # --- N=500 forecast + queue resolution rate (computed from today's deltas) ---

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -58,6 +58,66 @@ fi
 
 dfmt() { if [ "$1" -gt 0 ]; then printf "+%d" "$1"; elif [ "$1" -eq 0 ]; then printf "0"; else printf "%d" "$1"; fi; }
 
+# --- HIGH RISK count (drives title prefix and @-mention) ---
+HIGH_RISK_COUNT=0
+if [ -f "$TODAY_FILE" ]; then
+  HIGH_RISK_COUNT=$(python3 -c "import json; d=json.load(open('$TODAY_FILE')); print(d.get('highRiskCount', 0))" 2>/dev/null || echo 0)
+fi
+
+# --- N=500 forecast + queue resolution rate (computed from today's deltas) ---
+# Forecast: at today's net-approval rate (DELTA_APPROVED), how many days until
+# TODAY_APPROVED reaches 500? Queue clear: at today's net-resolution rate
+# (approved+returned+rejected+timed_out delta), how many days to clear the
+# current AWAITING REVIEW queue? Both stay quiet (empty string) when we have
+# no signal (delta=0, no dashboard data, or already past target).
+N500_FORECAST_LINE=""
+QUEUE_RESOLUTION_LINE=""
+if [ "$HAS_DASHBOARD" = true ]; then
+  FORECAST=$(N500_TARGET=500 TODAY_APPROVED="$TODAY_APPROVED" DELTA_APPROVED="$DELTA_APPROVED" \
+             TODAY_AWAITING="$TODAY_AWAITING" DELTA_REJECTED="$DELTA_REJECTED" \
+             DELTA_RETURNED="$DELTA_RETURNED" DELTA_TIMED="0" \
+             python3 << 'PYEOF'
+import datetime as _dt
+import os
+
+target = int(os.environ['N500_TARGET'])
+today_approved = int(os.environ['TODAY_APPROVED'])
+delta_approved = int(os.environ['DELTA_APPROVED'])
+awaiting = int(os.environ['TODAY_AWAITING'])
+delta_rejected = int(os.environ['DELTA_REJECTED'])
+delta_returned = int(os.environ['DELTA_RETURNED'])
+
+today = _dt.date.today()
+
+if today_approved >= target:
+    print(f"FORECAST=\\U0001F389 **N={target} reached!** ({today_approved} approved)")
+elif delta_approved <= 0:
+    remaining = target - today_approved
+    print(f"FORECAST=**N={target} ETA:** approval rate stalled at +{delta_approved}/day; "
+          f"{remaining} more approvals needed")
+else:
+    remaining = target - today_approved
+    days = remaining / delta_approved
+    eta = today + _dt.timedelta(days=round(days))
+    print(f"FORECAST=**N={target} ETA:** {eta:%Y-%m-%d} "
+          f"(~{days:.1f} days at current +{delta_approved}/day rate, {remaining} more approvals needed)")
+
+resolution_delta = delta_approved + delta_returned + delta_rejected
+if awaiting <= 0:
+    print("RESOLUTION=")
+elif resolution_delta <= 0:
+    print(f"RESOLUTION=**Queue resolution:** 0 today; {awaiting} AWAITING REVIEW (cycle stalled)")
+else:
+    days = awaiting / resolution_delta
+    print(f"RESOLUTION=**Queue resolution:** +{resolution_delta} today "
+          f"(approved +{delta_approved}, returned +{delta_returned}, rejected +{delta_rejected}); "
+          f"~{days:.1f} days to clear {awaiting} AWAITING REVIEW at this rate")
+PYEOF
+  ) || FORECAST=""
+  N500_FORECAST_LINE=$(printf '%s\n' "$FORECAST" | sed -n 's/^FORECAST=//p')
+  QUEUE_RESOLUTION_LINE=$(printf '%s\n' "$FORECAST" | sed -n 's/^RESOLUTION=//p')
+fi
+
 # --- Triage data ---
 # Preferred source: a triage-metrics artifact written by an upstream pipeline
 # step. Currently no step publishes this artifact, so the lookup silently
@@ -625,10 +685,14 @@ run_id = os.environ.get('RUN_ID', '<this-run-id>') or '<this-run-id>'
 repo = os.environ.get('REPO', 'clarkemoyer/technologyadoptionbarriers.org')
 
 with_replies = counts['auto_approve_eligible'] + counts['human_review_questions'] + counts['human_review_high_tier']
-no_reply = counts['no_reply']
+no_reply_total = counts.get('no_reply', 0) + counts.get('no_reply_high_tier', 0)
+multi_reply = d.get('multi_reply_count', 0)
 
 print(f'**{with_replies} of {total} awaiting-review submissions have participant replies.** '
-      f'{no_reply} have not yet replied and will continue through the auto-cycle (message > 48h > request-return > 48h > reject).')
+      f'{no_reply_total} have not yet replied and continue through the auto-cycle (message > 48h > request-return > 48h > reject).')
+if multi_reply > 0:
+    print('')
+    print(f'> ⚠ **{multi_reply} participant(s) have replied 2+ times.** Multi-reply usually means the first response did not resolve their concern. Review their threads in the `prolific-messages-inbound-csv` artifact before approving.')
 print('')
 
 # --- 1. Auto-Approve eligible ---
@@ -663,7 +727,7 @@ else:
     print(f'gh workflow run bulk-approve-replied.yml \\')
     print(f'  --repo {repo} \\')
     print(f'  -F source_run_id={run_id} \\')
-    print(f'  -F dry_run=true \\')
+    print(f'  -F dry_run=false \\')
     print(f'  -F max_per_run=30')
     print('```')
     print('')
@@ -725,6 +789,45 @@ else:
             print(f'| {disp} | {n} | {iri} | {flag_label} |')
     print('')
     print('Action paths: (a) read replies on Prolific, then approve manually, or (b) use `reject_by_pid.py` for those you decide to reject.')
+print('')
+
+# --- 4. Bulk-reject candidates (high tier, no reply) ---
+n_nr_high = counts.get('no_reply_high_tier', 0)
+print(f'### \U0001F534 Recommended for Bulk-Reject ({n_nr_high})')
+print('')
+if n_nr_high == 0:
+    print('No high-tier no-reply PIDs today. The auto-cycle (Phase 3d/3e) will handle anyone still in flight.')
+else:
+    print('High rejection tier (3+ IRI fails, or 2 IRI fails + speed/partial-straightlining) AND no reply to any TABS message. '
+          'The auto-cycle will eventually reject these after the message > 48h > RR > 48h cycle (~4 days); this lets you fast-track when the queue grows.')
+    print('')
+    bd = breakdown.get('no_reply_high_tier', {})
+    if bd.get('by_disposition'):
+        print('| Disposition | Count | IRI fails / other flags |')
+        print('|---|---:|---|')
+        from collections import Counter as _C2
+        grouped = _C2()
+        for entry in d['buckets']['no_reply_high_tier']:
+            key = (entry['disposition'], entry['iri_fail'], entry['speed_flag'], entry['partial_straightlining_flag'])
+            grouped[key] += 1
+        for (disp, iri, spd, psl), n in grouped.most_common():
+            flags = []
+            if spd: flags.append('speed')
+            if psl: flags.append('partial-straightlining')
+            flag_label = ', '.join(flags) if flags else '(IRI only)'
+            print(f'| {disp} | {n} | {iri} IRI fails / {flag_label} |')
+    print('')
+    print('**To bulk-reject these PIDs** (rejection reasons are auto-generated per PID from the disposition CSV):')
+    print('')
+    print('```')
+    print(f'gh workflow run bulk-reject-high-tier-no-reply.yml \\')
+    print(f'  --repo {repo} \\')
+    print(f'  -F source_run_id={run_id} \\')
+    print(f'  -F dry_run=false \\')
+    print(f'  -F max_per_run=30')
+    print('```')
+    print('')
+    print('Default is dry-run. Skips any PID that has already moved out of AWAITING REVIEW (idempotent re-runs).')
 print('')
 
 print(f'_Recommendations computed from `prolific-messages-inbound-csv` and `disposition-csv` artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact (7-day retention)._')
@@ -792,6 +895,10 @@ cat >> /tmp/report-body.md << STATUSEOF
 | **Rejected** | $TODAY_REJECTED | $(dfmt $DELTA_REJECTED) |
 | **Timed Out** | $TODAY_TIMED | -- |
 | **Prolific Total** | $PROLIFIC_TOTAL | -- |
+
+$N500_FORECAST_LINE
+
+$QUEUE_RESOLUTION_LINE
 
 ## Disposition Triage
 
@@ -864,8 +971,25 @@ echo "$RECOMMENDATIONS" | grep -qE "🔴|🟡|🟠" && CRITICAL_FINDINGS=true
 echo "$AUTO_RR_SECTION_FORMATTED $AUTO_REJECT_SECTION_FORMATTED" | grep -q "MANUAL INTERVENTION NEEDED" && CRITICAL_FINDINGS=true
 
 # --- Create issue ---
-TITLE="Daily Disposition Report -- $DATE"
-LABELS="documentation"
+# HIGH_RISK_COUNT > 0 means submissions are within 2 days of Prolific auto-approve.
+# Surface this via a title prefix + an @-mention prepended to the body so the
+# GitHub mobile app pushes a notification on @-mentions of the repo owner.
+HIGH_RISK_PREFIX=""
+HIGH_RISK_LABEL=""
+if [ "$HIGH_RISK_COUNT" -gt 0 ]; then
+  HIGH_RISK_PREFIX="\U0001F6A8 HIGH RISK ($HIGH_RISK_COUNT) - "
+  HIGH_RISK_LABEL=",urgent"
+  # Prepend an @-mention so GitHub Mobile fires a push notification.
+  printf '@clarkemoyer - **%d submission(s) within 2 days of Prolific 21-day auto-approve.** Action today.\n\n' "$HIGH_RISK_COUNT" \
+    | cat - /tmp/report-body.md > /tmp/report-body.md.new
+  mv /tmp/report-body.md.new /tmp/report-body.md
+fi
+
+# Decode the \U escape in the prefix (printf handles it).
+HIGH_RISK_PREFIX=$(printf '%b' "$HIGH_RISK_PREFIX")
+
+TITLE="${HIGH_RISK_PREFIX}Daily Disposition Report -- $DATE"
+LABELS="documentation${HIGH_RISK_LABEL}"
 if [ "$CRITICAL_FINDINGS" = false ]; then
   LABELS="$LABELS,auto-close-eligible"
 fi

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -61,14 +61,7 @@ dfmt() { if [ "$1" -gt 0 ]; then printf "+%d" "$1"; elif [ "$1" -eq 0 ]; then pr
 # --- HIGH RISK count (drives title prefix and @-mention) ---
 HIGH_RISK_COUNT=0
 if [ -f "$TODAY_FILE" ]; then
-  HIGH_RISK_COUNT=$(python3 -c "import json
-from pathlib import Path
-try:
-    d = json.loads(Path('$TODAY_FILE').read_text(encoding='utf-8'))
-    raw = d.get('highRiskCount', 0)
-    print(int(raw))
-except (FileNotFoundError, json.JSONDecodeError, TypeError, ValueError):
-    print(0)" 2>/dev/null || echo 0)
+  HIGH_RISK_COUNT=$(python3 -c "import json; d=json.load(open('$TODAY_FILE')); print(d.get('highRiskCount', 0))" 2>/dev/null || echo 0)
 fi
 
 # --- N=500 forecast + queue resolution rate (computed from today's deltas) ---
@@ -701,8 +694,26 @@ with_replies = counts['auto_approve_eligible'] + counts['human_review_questions'
 no_reply_total = counts.get('no_reply', 0) + counts.get('no_reply_high_tier', 0)
 multi_reply = d.get('multi_reply_count', 0)
 
+# Auto-cycle health: the no_reply bucket flows through Phase 3d/3e
+# (auto-request-return then auto-reject after the 48h+48h cycle). If
+# either phase was skipped or failed in this run, those PIDs are NOT
+# being escalated and will accumulate. Surface this so the operator
+# does not assume the auto-cycle is handling them.
+auto_rr_result = os.environ.get('AUTO_REQUEST_RETURN_RESULT', 'unknown')
+auto_rj_result = os.environ.get('AUTO_REJECT_STALE_RESULT', 'unknown')
+auto_cycle_healthy = auto_rr_result == 'success' and auto_rj_result == 'success'
+
+if auto_cycle_healthy:
+    cycle_note = ' continue through the auto-cycle (message > 48h > request-return > 48h > reject).'
+else:
+    cycle_note = (
+        f' would normally continue through the auto-cycle, but **Phase 3d auto-request-return '
+        f'({auto_rr_result})** and/or **Phase 3e auto-reject-stale ({auto_rj_result})** did not '
+        f'succeed in this run -- those PIDs are not being escalated until the auto-cycle is healthy.'
+    )
+
 print(f'**{with_replies} of {total} awaiting-review submissions have participant replies.** '
-      f'{no_reply_total} have not yet replied and continue through the auto-cycle (message > 48h > request-return > 48h > reject).')
+      f'{no_reply_total} have not yet replied and{cycle_note}')
 if multi_reply > 0:
     print('')
     print(f'> ⚠ **{multi_reply} participant(s) have replied 2+ times.** Multi-reply usually means the first response did not resolve their concern. Review their threads in the `prolific-messages-inbound-csv` artifact before approving.')
@@ -964,6 +975,7 @@ $MSG_ROWS
 | Generate Dashboard | ${DASHBOARD_RESULT:-unknown} |
 | Auto-Request-Return (3d) | ${AUTO_REQUEST_RETURN_RESULT:-unknown} |
 | Auto-Reject-Stale-RR (3e) | ${AUTO_REJECT_STALE_RESULT:-unknown} |
+| Export Prolific Messages (3f) | ${EXPORT_MESSAGES_RESULT:-unknown} |
 
 ---
 **Workflow run:** [View full logs]($RUN_URL)


### PR DESCRIPTION
Re-opens #2692 after auto-close caused by PR #2638's `--delete-branch` removing the base. Same content; targeting `main` directly now.

Full scope and the two-round review history is documented in #2692. Key features (all addressed in review):

- HIGH RISK push alert (🚨 prefix + `urgent` label + `@clarkemoyer` mention)
- N=500 ETA forecast + queue resolution rate
- `bulk-reject-high-tier-no-reply.yml` workflow + dispatch hint in daily report
- Multi-reply tracker
- Auto-cycle kill-switch surfacing (closes #2747)
- Phase 5 file-existence guard
- 31 classifier tests + 11 approve_by_pid tests (all green locally)
- PII retention 1d on all PID-bearing artifacts
- Heredoc + multiline `GITHUB_OUTPUT` for bulk workflows
- `extract.conclusion` gate on Approve/Reject steps

Conflicts vs main (the 4 parallel auto-fix commits from #2638's branch that landed via the merge) will be resolved by pushing my final file versions over — they're the same fixes applied to a different intermediate state.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
