### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-17T01:28:37Z",
-  "commit_sha": "5ff4b81cdcb691d57e4d1269c357fb44af7dc506",
-  "commit_count": 7032,
+  "as_of": "2026-05-17T01:31:58Z",
+  "commit_sha": "e03be7877138a0927d2b82486cb051c0b4f2a5c9",
+  "commit_count": 7034,
   "lines_of_code": 229876,
   "comments": 13061,
   "blanks": 26457,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-17T01:28:37Z",
-  "commit_sha": "5ff4b81cdcb691d57e4d1269c357fb44af7dc506",
-  "commit_count": 7032,
+  "as_of": "2026-05-17T01:31:58Z",
+  "commit_sha": "e03be7877138a0927d2b82486cb051c0b4f2a5c9",
+  "commit_count": 7034,
   "lines_of_code": 229876,
   "comments": 13061,
   "blanks": 26457,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.