### PR TITLE
fix(platform-stats): remove push:main trigger to break self-feeding loop

### DIFF
--- a/.github/workflows/platform-stats.yml
+++ b/.github/workflows/platform-stats.yml
@@ -15,8 +15,16 @@ name: Platform stats
 # website, the slides, the CRP, future README badges) honest. See #1900.
 
 on:
-  push:
-    branches: [main]
+  # push: main trigger removed 2026-05-17 — it created a self-feeding loop.
+  # The workflow writes three monotonically/always-changing fields to the
+  # output JSON (commit_count, commit_sha, as_of). Each push to main fired
+  # the workflow, which opened an auto-merging PR with those changes, which
+  # was itself a push to main, which fired the workflow again. ~80 chore PRs
+  # per day at steady state, ~360/day under recent merge activity, with all
+  # of them effectively no-ops apart from the timestamp/SHA/count fields.
+  # The weekly cron below keeps the figure honest; operators can also
+  # dispatch on demand after a meaningful code change.
+  # See issue #1900 for the original rationale.
   schedule:
     # Weekly Monday 06:00 UTC keeps the figure fresh even if no main commit
     # happens for a week. Off-minute scheduling avoids GHA's :00 quota crunch.


### PR DESCRIPTION
## Problem

`.github/workflows/platform-stats.yml` writes three always-changing fields to its output JSON on every run:

- `commit_count` — `git rev-list --count HEAD`, monotonically increasing
- `commit_sha` — always the current HEAD
- `as_of` — current timestamp

The workflow triggered on `push: branches: [main]`. Each push fired the workflow, which opened an auto-merging PR with those three fields changing, which was itself a new push to main, which fired the workflow again. The loop has run continuously since the workflow was first committed on **2026-05-06** (commit `8a045e6`, [issue #1900](https://github.com/clarkemoyer/technologyadoptionbarriers.org/issues/1900)).

## Volume of the loop

- **799+ `chore: refresh platform-stats.json` PRs** merged in 10 days
- **~2,400 runner-minutes** (~40 hours of CI compute) spent on these no-ops
- Current cadence: **~4 minutes per cycle** under recent push activity
- All those PRs are effectively no-ops apart from the three always-changing fields

The loop also blocks normal merges in the meantime: any PR requiring "branch up-to-date with main" must update against main, run CI for ~5-10 min, but main has typically moved twice in that window — so the PR can never catch up without an admin override.

## Fix

Remove `push: branches: [main]`. Keep:
- **Weekly cron** (`'7 6 * * 1'`) — Monday 06:07 UTC keeps the figure honest
- **`workflow_dispatch`** — operators can refresh on demand after a meaningful code change

## Trade-off

The numbers on the website / slides / CRP will trail main by up to a week. That's acceptable for a documentation-accuracy metric — the original drift problem from #1900 ("574K LOC" vs the real 149K) was about figures being **stale by months**, not minutes.

If real-time-ness is ever needed for a specific metric, the right fix is a `paths-ignore` exclusion for the workflow's own output files, not the broad `push` trigger this PR removes.

## Test plan

- [ ] Merge this PR
- [ ] Observe: no new `chore: refresh platform-stats.json` PRs are opened after merge
- [ ] Monday 06:07 UTC: weekly cron fires and opens at most one fresh PR (verify it's the only one of the week)
- [ ] After a substantive change (e.g. a new workflow lands), manually dispatch this workflow and confirm the JSON updates correctly

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
