### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-17T01:39:58Z",
-  "commit_sha": "b91e52eebfe1eabbab6379625fe41665344da11a",
-  "commit_count": 7038,
+  "as_of": "2026-05-17T01:43:47Z",
+  "commit_sha": "96d1cce44d40e0b0aca712bb0c0d1abac730e911",
+  "commit_count": 7040,
   "lines_of_code": 229876,
   "comments": 13061,
   "blanks": 26457,

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,7 +1,7 @@
 {
-  "as_of": "2026-05-17T01:39:58Z",
-  "commit_sha": "b91e52eebfe1eabbab6379625fe41665344da11a",
-  "commit_count": 7038,
+  "as_of": "2026-05-17T01:43:47Z",
+  "commit_sha": "96d1cce44d40e0b0aca712bb0c0d1abac730e911",
+  "commit_count": 7040,
   "lines_of_code": 229876,
   "comments": 13061,
   "blanks": 26457,


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.