### PR TITLE
feat(daily): HIGH RISK alert, N=500 forecast, bulk-reject, multi-reply, queue ETA

### DIFF
--- a/.github/workflows/bulk-reject-high-tier-no-reply.yml
+++ b/.github/workflows/bulk-reject-high-tier-no-reply.yml
@@ -1,18 +1,25 @@
-name: Bulk Approve Replied Submissions
+name: Bulk Reject High-Tier No-Reply
 
-# Approves the set of AWAITING REVIEW PIDs classified as
-# `auto_approve_eligible` by the daily-pipeline classifier
-# (scripts/analysis/classify_replies_for_action.py).
+# Rejects the AWAITING REVIEW PIDs classified as `no_reply_high_tier` by the
+# daily-pipeline classifier. These are PIDs that:
+#   1. Are in the high rejection tier (3+ IRI fails, or 2 IRI fails plus
+#      another quality factor like speed or partial straightlining), AND
+#   2. Have NOT replied to any TABS message.
 #
-# The operator never sees or types PIDs. Inputs are a source daily-pipeline
-# run ID; this workflow downloads that run's `reply-action-recommendations`
-# artifact and extracts the PID list from the appropriate bucket.
+# The auto-cycle (Phase 3d/3e) will eventually reject these after ~4 days
+# (48h to RR + 48h to auto-reject). This workflow lets you fast-track that
+# cleanup when the high-tier no-reply queue grows.
+#
+# The operator never sees or types PIDs. Input is a source daily-pipeline
+# run ID; the workflow downloads that run's `reply-action-recommendations`
+# artifact and `disposition-csv` artifact (for per-PID rejection reasons).
 #
 # Safety:
 #   - Default is dry-run. Live execution requires `dry_run: false`.
-#   - approve_by_pid.py enforces CONFIRM_APPROVE=APPROVE on live runs.
-#   - MAX_PER_RUN ceiling defaults to 30 (overridable per-run).
-#   - Skips any PID whose Prolific status is no longer AWAITING REVIEW.
+#   - Live execution also requires `confirm_reject: REJECT`.
+#   - MAX_PER_RUN ceiling defaults to 10 (overridable per-run).
+#   - reject_by_pid.py skips any PID whose status is no longer AWAITING REVIEW
+#     (so re-runs are idempotent; if Phase 3e already rejected a PID, it skips).
 
 on:
   workflow_dispatch:
@@ -22,18 +29,23 @@ on:
         required: true
         type: string
       dry_run:
-        description: 'Dry run only (no API calls). Set to false to approve live.'
+        description: 'Dry run only (no API calls). Set to false to reject live.'
         required: false
         type: boolean
         default: true
-      max_per_run:
-        description: 'Ceiling override (default 30)'
+      confirm_reject:
+        description: 'Type REJECT to allow a live run when dry_run is false'
         required: false
         type: string
-        default: '30'
+        default: ''
+      max_per_run:
+        description: 'Ceiling override (default 10)'
+        required: false
+        type: string
+        default: '10'
 
 concurrency:
-  group: bulk-approve-replied
+  group: bulk-reject-high-tier-no-reply
   cancel-in-progress: false
 
 permissions:
@@ -44,8 +56,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  approve:
-    name: Bulk Approve (auto_approve_eligible)
+  reject:
+    name: Bulk Reject (no_reply_high_tier)
     runs-on: ubuntu-latest
     environment: prolific-prod
     steps:
@@ -63,7 +75,15 @@ jobs:
           run-id: ${{ inputs.source_run_id }}
           github-token: ${{ github.token }}
 
-      - name: Extract auto_approve_eligible PIDs
+      - name: Download disposition CSV
+        uses: actions/download-artifact@v8
+        with:
+          name: disposition-csv
+          path: ${{ runner.temp }}/disp
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Extract no_reply_high_tier PIDs
         id: extract
         run: |
           set -euo pipefail
@@ -83,7 +103,7 @@ jobs:
           with open(os.environ["REC"], encoding="utf-8") as f:
               d = json.load(f)
 
-          pids = [entry["pid"] for entry in d["buckets"]["auto_approve_eligible"]]
+          pids = [entry["pid"] for entry in d["buckets"]["no_reply_high_tier"]]
           out = Path(os.environ["GITHUB_OUTPUT"])
           with out.open("a", encoding="utf-8") as fh:
               fh.write("pid_list<<EOF_PIDS\n")
@@ -93,30 +113,40 @@ jobs:
           # Diagnostic to stdout. Done inside the same Python process so
           # set -euo pipefail can't kill the Extract step from a follow-up
           # shell invocation just to compute the count.
-          print(f"Found {len(pids)} PIDs in auto_approve_eligible bucket", file=sys.stderr)
+          print(f"Found {len(pids)} PIDs in no_reply_high_tier bucket", file=sys.stderr)
           PY
 
-      - name: Approve PIDs
+      - name: Safety check for live reject
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          if [ "${{ inputs.confirm_reject }}" != "REJECT" ]; then
+            echo "::error::Live reject requires confirm_reject=REJECT."
+            exit 1
+          fi
+
+      - name: Reject PIDs
         # Guard with extract.conclusion: if Extract failed (e.g. recommendations
         # artifact missing), count is unset and "" != '0' would otherwise let
-        # Approve run with an empty PID_LIST.
+        # Reject run with an empty PID_LIST.
         if: ${{ steps.extract.conclusion == 'success' && steps.extract.outputs.count != '0' }}
-        run: python3 scripts/analysis/approve_by_pid.py
+        run: python3 scripts/analysis/reject_by_pid.py
         env:
           PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
           STUDY_ID: ${{ vars.PROLIFIC_STUDY_ID }}
+          CSV_FILE_PATH: ${{ runner.temp }}/disp/disposition.csv
           PID_LIST: ${{ steps.extract.outputs.pid_list }}
           MAX_PER_RUN: ${{ inputs.max_per_run }}
+          STRICT_AWAITING: 'false'
           DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
-          CONFIRM_APPROVE: ${{ inputs.dry_run && 'unused' || 'APPROVE' }}
-          OUTPUT_JSON_PATH: ${{ runner.temp }}/bulk-approve-results.json
+          CONFIRM_REJECT: ${{ inputs.confirm_reject }}
+          OUTPUT_JSON_PATH: ${{ runner.temp }}/bulk-reject-results.json
 
       - uses: actions/upload-artifact@v7
         if: ${{ always() && steps.extract.conclusion == 'success' && steps.extract.outputs.count != '0' }}
         with:
-          name: bulk-approve-results
-          path: ${{ runner.temp }}/bulk-approve-results.json
-          # 1-day retention: contains full PIDs (approved, deferred, failed).
+          name: bulk-reject-results
+          path: ${{ runner.temp }}/bulk-reject-results.json
+          # 1-day retention: contains full PIDs (rejected, skipped, failed).
           # Matches the privacy treatment of disposition-csv and the
           # reply-action-recommendations source artifact.
           retention-days: 1

--- a/.github/workflows/check-participant.yml
+++ b/.github/workflows/check-participant.yml
@@ -13,6 +13,7 @@ on:
           - send-thank-you
           - unreject
           - send-custom
+          - approve
           - awaiting-report
           - request-return
           - stale-return-requested
@@ -21,9 +22,23 @@ on:
           - demographics
         default: 'single'
       pid:
-        description: 'Prolific Participant ID (required for single/send-custom mode)'
+        description: 'Prolific Participant ID(s): required for single, send-custom, and approve modes. Use one PID for single/send-custom; use a comma-separated PID list for approve.'
         required: false
         type: string
+      dry_run:
+        description: 'Approve mode only: keep as true to preview AWAITING REVIEW targets without approving. Set false for a live approve run.'
+        required: false
+        type: boolean
+        default: true
+      confirm_approve:
+        description: 'Approve mode only: required for live approve runs. Type APPROVE exactly when dry_run=false.'
+        required: false
+        type: string
+      max_per_run:
+        description: 'Approve mode only: per-run ceiling override (default 30). approve_by_pid.py truncates eligible targets above this count.'
+        required: false
+        type: string
+        default: '30'
       message:
         description: 'Custom message body (required for send-custom mode)'
         required: false
@@ -183,6 +198,17 @@ jobs:
           MESSAGE: ${{ inputs.message }}
           DRY_RUN: 'false'
         run: python3 scripts/analysis/send_custom_message.py
+
+      - name: Approve PID(s)
+        if: inputs.mode == 'approve'
+        env:
+          PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
+          STUDY_ID: ${{ inputs.study_id || vars.PROLIFIC_STUDY_ID }}
+          PID_LIST: ${{ inputs.pid }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+          CONFIRM_APPROVE: ${{ inputs.confirm_approve }}
+          MAX_PER_RUN: ${{ inputs.max_per_run }}
+        run: python3 scripts/analysis/approve_by_pid.py
 
       - name: Unreject submissions
         if: inputs.mode == 'unreject'

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -807,15 +807,6 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          # Compatibility alias for existing references that used the plural form.
-          name: prolific-messages-aggregate-summary
-          path: ${{ runner.temp }}/aggregate-summary.json
-          retention-days: 7
-          if-no-files-found: warn
-
-      - uses: actions/upload-artifact@v7
-        if: always()
-        with:
           name: prolific-messages-inbound-csv
           path: ${{ runner.temp }}/participant_messages.csv
           retention-days: 1
@@ -936,11 +927,22 @@ jobs:
         continue-on-error: true
 
       # Build the reply-action recommendations JSON before the report runs.
+      # Phase 5 checks out ref:main for safety; this script lands on main only
+      # after PR #2638 + #2692 are merged. The file-existence guard handles
+      # the rollout window where one PR has merged but the other has not.
+      # Once both PRs are on main the guard is a no-op but stays as a safety
+      # check against accidental script deletion.
       # Renders nothing in the report when Phase 3f's inbound CSV is missing.
       - name: Classify replies for action
         if: always()
         continue-on-error: true
-        run: python3 scripts/analysis/classify_replies_for_action.py
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/analysis/classify_replies_for_action.py ]; then
+            echo "::warning::classify_replies_for_action.py not present on main; skipping recommendations step (likely mid-rollout of PR #2638)"
+            exit 0
+          fi
+          python3 scripts/analysis/classify_replies_for_action.py
         env:
           INBOUND_CSV: ${{ runner.temp }}/artifacts/prolific-messages-inbound-csv/participant_messages.csv
           DISPOSITION_CSV: ${{ runner.temp }}/artifacts/disposition-csv/disposition.csv
@@ -951,6 +953,11 @@ jobs:
         with:
           name: reply-action-recommendations
           path: ${{ runner.temp }}/reply-action-recommendations.json
+          # 1-day retention: this JSON contains full participant IDs from
+          # the AWAITING REVIEW queue, so it matches the privacy treatment
+          # of disposition-csv and other PID-bearing intermediate artifacts.
+          # The bulk-approve/bulk-reject dispatch workflows must run within
+          # 24h of the source daily-pipeline run.
           retention-days: 1
           if-no-files-found: warn
 
@@ -967,4 +974,5 @@ jobs:
           DASHBOARD_RESULT: ${{ needs.generate-dashboard.result }}
           AUTO_REQUEST_RETURN_RESULT: ${{ needs.auto-request-return.result }}
           AUTO_REJECT_STALE_RESULT: ${{ needs.auto-reject-stale.result }}
+          EXPORT_MESSAGES_RESULT: ${{ needs.export-messages.result }}
         run: bash scripts/build-daily-report.sh

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -154,8 +154,13 @@ This index provides a comprehensive guide to all documentation in the TABS repos
   - Qualtrics ↔ Prolific setup
   - Annual survey rollover process
   - Security and troubleshooting
+- **[docs/prolific-operations-guide.md](./docs/prolific-operations-guide.md)** - **Operations reference for participant actions**
+  - "I want to X → use workflow Y" lookup table for approve / reject / message / inspect
+  - Full inventory of every Prolific-touching workflow and script
+  - Safety conventions (dry-run defaults, CONFIRM_REJECT, MAX_PER_RUN ceilings)
+  - Tokens, environments, and kill-switch variables
 - Client Library: `src/lib/prolific-api.ts`
-- Workflow: `.github/workflows/prolific.yml`
+- Workflows: `.github/workflows/prolific.yml`, `.github/workflows/daily-pipeline.yml`, `.github/workflows/check-participant.yml`, `.github/workflows/prolific-message-flagged.yml`, `.github/workflows/prolific-reject-by-pid.yml`, `.github/workflows/bulk-approve-replied.yml`, `.github/workflows/bulk-reject-high-tier-no-reply.yml`, `.github/workflows/prolific-message-export.yml`
 
 **Google Analytics Data API v1:**
 

--- a/docs/prolific-operations-guide.md
+++ b/docs/prolific-operations-guide.md
@@ -1,0 +1,164 @@
+# Prolific Operations Guide
+
+A reference for every workflow and script that touches Prolific submissions, messages, and participant decisions. Use this when you need to act on a specific participant or batch and aren't sure which workflow to dispatch.
+
+If you're an AI agent reading this for the first time: this is the canonical "how do I X?" doc for participant operations. Search it before grepping `.github/workflows/`.
+
+## The participant lifecycle
+
+```
+Qualtrics complete  →  Prolific status: AWAITING REVIEW  →  one of:
+                                                            ├─ APPROVED  (payment released)
+                                                            ├─ RETURNED  (participant chose to return)
+                                                            ├─ REJECTED  (no payment)
+                                                            └─ TIMED-OUT (Prolific auto-action)
+```
+
+The daily pipeline (`daily-pipeline.yml`) runs at 10:30 UTC and handles the routine cycle: fetch → triage → auto-approve CLEAN → message FLAGs → auto-request-return on stale messages → auto-reject on stale return-requests → commit data → file daily report issue.
+
+Anything outside the routine cycle — single-PID approves/rejects, custom messages, ad-hoc inspection — is done with the workflows below.
+
+## Quick lookup: "I want to..."
+
+| Goal                                                      | Workflow                             | Mode / Inputs                                                                                                |
+| --------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Approve one PID                                           | `check-participant.yml`              | `mode=approve`, `pid=<id>`, `dry_run=true` (flip to `false` + `confirm_approve=APPROVE` for live)            |
+| Approve N PIDs from today's report's auto-eligible bucket | `bulk-approve-replied.yml`           | `source_run_id=<daily-pipeline run>`, `dry_run=true` (flip to `false` for live), `max_per_run=30`            |
+| Approve all CLEAN PIDs from a CSV                         | `prolific-approve-submissions.yml`   | `csv_content=<csv>` or `csv_file_path=<path>`                                                                |
+| Reject one or more PIDs                                   | `prolific-reject-by-pid.yml`         | `pid_list=<csv>`, `dry_run=false`, `confirm_reject=REJECT`                                                   |
+| Reject the daily report's high-tier-no-reply bucket       | `bulk-reject-high-tier-no-reply.yml` | `source_run_id=<run>`, `dry_run=true` (flip to `false` + `confirm_reject=REJECT` for live), `max_per_run=10` |
+| Reject all AUTO-EXCLUDE                                   | `prolific-reject-auto-exclude.yml`   | (full destructive — read inputs carefully)                                                                   |
+| Reject all failed-IRI                                     | `prolific-reject-failed-iri.yml`     | (full destructive — read inputs carefully)                                                                   |
+| Send a custom one-off message to one PID                  | `check-participant.yml`              | `mode=send-custom`, `pid=<id>`, `message=<text>`                                                             |
+| Send the standard FLAG message to one or more PIDs        | `prolific-message-flagged.yml`       | `disposition_filter=<one of the 10>`, `pid_list=<csv or empty>`, `dry_run=false`                             |
+| Send a thank-you to specific PIDs                         | `check-participant.yml`              | `mode=send-thank-you`, `pid=<id>`                                                                            |
+| Request return on one PID                                 | `check-participant.yml`              | `mode=request-return`, `pid=<id>`                                                                            |
+| Unreject one or more PIDs                                 | `check-participant.yml`              | `mode=unreject`, `pid=<comma-separated>`                                                                     |
+| Inspect one PID's submission + messages                   | `check-participant.yml`              | `mode=single`, `pid=<id>`                                                                                    |
+| List every participant who has replied                    | `check-participant.yml`              | `mode=all-replies`                                                                                           |
+| Export every Prolific message (both directions)           | `prolific-message-export.yml`        | (since: ISO date, study: optional)                                                                           |
+| Search every message body for a term                      | `check-participant.yml`              | `mode=search-messages`, `message=<term>`                                                                     |
+| Find replies that contain a URL                           | `check-participant.yml`              | `mode=find-url-replies`                                                                                      |
+| Find stale return-request candidates                      | `check-participant.yml`              | `mode=stale-return-requested`                                                                                |
+| Build the operator-style "awaiting review" report         | `check-participant.yml`              | `mode=awaiting-report`                                                                                       |
+| Verify a PID's IRI answers against Qualtrics              | `check-participant.yml`              | `mode=single`, `pid=<id>` (the verify-iri job auto-runs)                                                     |
+| Pull demographics from Prolific                           | `check-participant.yml`              | `mode=demographics`                                                                                          |
+| Smoke-test the Prolific API token                         | `prolific-api-smoke.yml`             | (no inputs)                                                                                                  |
+| Run the daily pipeline ad-hoc                             | `daily-pipeline.yml`                 | (no required inputs; runs the full chain)                                                                    |
+
+## Workflow inventory
+
+### Daily orchestration
+
+- **`daily-pipeline.yml`** — The main scheduled workflow (cron `30 10 * * *`). Six phases:
+  - Phase 1: Fetch Prolific data (auth checks, statuses)
+  - Phase 2: Export Qualtrics → enrich → disposition waterfall → unified analysis → CRP analysis
+  - Phase 3a: Auto-approve CLEAN
+  - Phase 3b: Message FLAGs (10-disposition matrix)
+  - Phase 3c: Generate dashboard + find stale submissions
+  - Phase 3d: Auto-request-return on stale-no-reply-to-message
+  - Phase 3e: Auto-reject on stale-no-reply-to-return-request
+  - Phase 3f: Export Prolific messages → recommendations classifier → upload artifact
+  - Phase 4: Commit daily data + open `chore/daily-pipeline-data` PR
+  - Phase 5: Build Daily Disposition Report issue, including a HIGH-RISK push alert when applicable
+
+  All Phase 3a/3b/3d/3e steps are kill-switch and ceiling guarded (`vars.AUTO_*_ENABLED` and `vars.AUTO_STALE_MAX_PER_RUN`).
+
+### Per-PID / per-submission actions
+
+- **`check-participant.yml`** — Swiss army knife for single-PID actions (modes listed in the table above). It includes both read-only and destructive modes; use destructive ones carefully and follow the per-mode guardrails (for example, `mode=approve` now defaults to dry-run and requires typed confirmation for live approval).
+
+- **`bulk-approve-replied.yml`** — Approves PIDs from the daily-pipeline `reply-action-recommendations` artifact's `auto_approve_eligible` bucket. Defaults to dry-run; live requires `dry_run=false`. Internally calls `approve_by_pid.py` which now does one Prolific API call per PID (partial failures don't abort).
+
+- **`bulk-reject-high-tier-no-reply.yml`** — Rejects PIDs from the same artifact's `no_reply_high_tier` bucket. Same safety pattern (dry-run default, `confirm_reject=REJECT` required for live). Uses `STRICT_AWAITING=false` so re-runs skip any PID already actioned elsewhere and remain idempotent.
+
+- **`prolific-reject-by-pid.yml`** — General single-PID-or-list rejection. Re-runs Qualtrics triage first to ensure rejection reasons are computed from current disposition data. Live requires typing "REJECT" in the confirm input.
+
+- **`prolific-approve-submissions.yml`** — Bulk-approve CLEAN-disposition PIDs from a CSV. Accept either `csv_content` (paste CSV inline) or `csv_file_path` (path inside repo). Auto-detects PID and Disposition columns.
+
+- **`prolific-reject-auto-exclude.yml`** / **`prolific-reject-failed-iri.yml`** — Older destructive batch-reject workflows. Prefer `bulk-reject-high-tier-no-reply.yml` for new operator-driven rejections since it routes through the classifier and surfaces in the daily report.
+
+- **`prolific-message-flagged.yml`** — Sends the standard FLAG template message for a single disposition type. `pid_list` filter is optional (empty = all PIDs matching the disposition). Default dry-run. Used by the daily pipeline; can be run ad-hoc to re-message a specific PID.
+
+### Message / inspection
+
+- **`prolific-message-export.yml`** — Pulls every Prolific message in the study channel (both directions) since a given ISO date. Produces:
+  - `prolific-message-aggregate-summary` (committable, 7-day retention) — totals, themes, PII risk distribution
+  - `prolific-messages-inbound-csv` (PII-bearing, 1-day retention) — full reply bodies for operator inspection
+  - `prolific-messages-raw`, `prolific-messages-transcripts`, `prolific-messages-candidates` — full audit / curation
+
+  The daily pipeline also runs this in Phase 3f; ad-hoc dispatch is for backfill or rebuild.
+
+### Health / smoke
+
+- **`prolific-api-smoke.yml`** — Verifies the `TABS_PROLIFIC_TOKEN` secret works and the study is reachable. Use after rotating tokens.
+
+- **`qualtrics-prolific-verify.yml`** — Cross-references Qualtrics responses against Prolific submissions to catch desync.
+
+- **`data-quality-check.yml`** — PII scan of `src/data/*.json`. Runs on every PR that touches data files.
+
+## Script inventory
+
+All under `scripts/analysis/`. Each is invoked by one or more workflows; check the script header docstring for env vars.
+
+### Approve / reject
+
+| Script                     | Used by                                                            | Behavior                                                                                              |
+| -------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `approve_submissions.py`   | `prolific-approve-submissions.yml`, Phase 3a                       | CSV → CLEAN rows → bulk-approve API call → thank-you per PID                                          |
+| `approve_by_pid.py`        | `bulk-approve-replied.yml`, `check-participant.yml` (mode=approve) | PID_LIST env → one bulk-approve call per PID (resilient to partial failure) → thank-you per PID       |
+| `reject_by_pid.py`         | `prolific-reject-by-pid.yml`, `bulk-reject-high-tier-no-reply.yml` | PID_LIST env + disposition CSV → per-submission rejection with auto-generated reasons per disposition |
+| `reject_auto_exclude.py`   | `prolific-reject-auto-exclude.yml`                                 | Older bulk path; superseded by `reject_by_pid.py`                                                     |
+| `reject_failed_iri.py`     | `prolific-reject-failed-iri.yml`                                   | Older bulk path; superseded                                                                           |
+| `unreject_submissions.py`  | `check-participant.yml` (mode=unreject)                            | Reverses a rejection via the transition endpoint                                                      |
+| `request_return_by_pid.py` | Phase 3d                                                           | PID_LIST env → POST /submissions/{id}/request-return/ with disposition-specific reason text           |
+
+### Messaging
+
+| Script                         | Used by                                         | Behavior                                                                                                                                                                                                         |
+| ------------------------------ | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message_flagged.py`           | Phase 3b matrix, `prolific-message-flagged.yml` | DISPOSITION_FILTER env + CSV → looks up PIDs matching that disposition (with sub-type matching for AUTO-EXCLUDE) → sends the disposition-specific template message. Dedup-aware (signature phrase per template). |
+| `send_custom_message.py`       | `check-participant.yml` (mode=send-custom)      | PID + MESSAGE env → sends a single arbitrary message. No dedup; will resend if invoked twice.                                                                                                                    |
+| `send_thank_you.py`            | `check-participant.yml` (mode=send-thank-you)   | PID_LIST env → sends the standard thank-you template, dedup-aware                                                                                                                                                |
+| `extract_prolific_messages.py` | Phase 3f, `prolific-message-export.yml`         | Pulls every message in the study channel; emits the inbound-CSV + aggregate summary + transcripts + candidates files                                                                                             |
+
+### Analysis / classification (drive the operator UI)
+
+| Script                           | Used by                                                                                                      | Behavior                                                                                                                                                                                                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `fetch_prolific_data.py`         | Phase 1                                                                                                      | Auth checks + submission statuses → CSV + JSON                                                                                                                                                                                                                           |
+| `find_stale_return_requested.py` | Phase 3c                                                                                                     | Phase 3d/3e bucket extraction (stale messages, stale return-requests)                                                                                                                                                                                                    |
+| `classify_replies_for_action.py` | Phase 5                                                                                                      | Cross-references inbound CSV with disposition CSV → 5 action buckets (`auto_approve_eligible`, `human_review_questions`, `human_review_high_tier`, `no_reply_high_tier`, `no_reply`) plus `multi_reply_count`. Uses `?` presence in reply body to detect real questions. |
+| `prolific_tools.py`              | `check-participant.yml` modes (`all-replies`, `find-url-replies`, `demographics`, `replied-pids`, `collect`) | Multi-subcommand utility for ad-hoc Prolific inspection                                                                                                                                                                                                                  |
+| `tabs_api.py`                    | All of the above                                                                                             | Low-level Prolific + Qualtrics API client. Single source of truth for endpoint URLs and request shapes.                                                                                                                                                                  |
+
+## Safety conventions
+
+Every destructive workflow follows the same pattern. If you're adding a new one, match it:
+
+1. **Default to dry-run.** `dry_run: boolean (default true)`.
+2. **Confirmation typing.** Live destructive actions require typing `REJECT` (or analogous) into a separate input. The script enforces this server-side.
+3. **`MAX_PER_RUN` ceiling.** Workflow defaults are conservative and workflow-specific (for example 30 for bulk-approve, 10 for bulk-reject). Scripts enforce the ceiling, but behavior can differ by script: `reject_by_pid.py` aborts over-ceiling lists, while `approve_by_pid.py` truncates eligible targets after status filtering and records deferred PIDs in its JSON output.
+4. **Status check before action.** Per-PID status verification — skip if no longer AWAITING REVIEW. Makes re-runs idempotent.
+5. **Audit JSON output.** Every script writes a structured results JSON listing PIDs touched and per-PID outcome. PID-bearing workflow artifacts in this area are retained for 1 day, not 7, to match the privacy policy for intermediate participant data.
+
+## Daily Disposition Report → workflow dispatch
+
+The daily report issue (filed by Phase 5) is the operator's primary UI. It includes dispatch commands per recommended action:
+
+- 🟢 **"Recommended for Auto-Approve" sub-section** quotes the exact `gh workflow run bulk-approve-replied.yml ... source_run_id=<this-run>` command
+- 🔴 **"Recommended for Bulk-Reject" sub-section** quotes the bulk-reject equivalent
+- 🟡 **"Replies to Consider — Questions" sub-section** lists reply themes; for genuine questions, use `check-participant.yml` mode=send-custom
+
+When in doubt: `gh workflow run check-participant.yml --repo clarkemoyer/technologyadoptionbarriers.org -F mode=help` — wait, that doesn't exist yet. For now, this guide is the help.
+
+## Tokens & environments
+
+Every Prolific-touching workflow runs in the `prolific-prod` environment, which holds:
+
+- `secrets.TABS_PROLIFIC_TOKEN` — Prolific API token (rotate annually; verify via `prolific-api-smoke.yml`)
+- `vars.PROLIFIC_STUDY_ID` — the TABS V2 study ID (don't hard-code)
+- `vars.AUTO_REQUEST_RETURN_ENABLED` / `vars.AUTO_REJECT_STALE_ENABLED` — Phase 3d/3e kill switches (default `'true'`)
+- `vars.AUTO_STALE_MAX_PER_RUN` — Phase 3d/3e ceiling (default `'30'`)
+
+Qualtrics workflows use the `qualtrics-prod` environment with `secrets.QUALTRICS_API_TOKEN`, `vars.QUALTRICS_BASE_URL`, and `vars.QUALTRICS_SURVEY_ID`.

--- a/scripts/analysis/approve_by_pid.py
+++ b/scripts/analysis/approve_by_pid.py
@@ -161,16 +161,16 @@ def main() -> int:
     result: dict = {
         "mode": "dry_run" if dry_run else "live",
         "input_count": len(pids),
-        "eligible_target_count": 0,
         "ceiling": max_per_run,
         "ceiling_exceeded": False,
-        "skipped_ceiling": [],
+        "deferred_over_ceiling": [],
         "approved": [],
         "skipped_non_awaiting": [],
         "thank_you_sent": [],
         "thank_you_skipped_dedup": [],
         "thank_you_failed": [],
         "bulk_approve_error": None,
+        "failures": [],
     }
 
     if not pids:
@@ -187,7 +187,6 @@ def main() -> int:
             )
             sys.exit(1)
 
-    # Resolve target PIDs (skip those not AWAITING REVIEW), including dry-run previews.
     print(f"Verifying study {study_id}...")
     study = prolific_study_info(study_id, api_token)
     print(f"  Study: {study.get('name', '?')} (status: {study.get('status', '?')})")
@@ -195,7 +194,7 @@ def main() -> int:
     print("Fetching current submission statuses...")
     statuses = prolific_submission_statuses(study_id, api_token)
 
-    targets = []
+    targets: list[str] = []
     for pid in pids:
         st = statuses.get(pid, "UNKNOWN")
         if st == "AWAITING REVIEW":
@@ -208,17 +207,19 @@ def main() -> int:
         print(f"DRY RUN - would target {len(targets)} currently AWAITING REVIEW PIDs")
     print(f"  AWAITING REVIEW (will approve): {len(targets)}")
     print(f"  Skipped (other status): {len(result['skipped_non_awaiting'])}")
-    result["eligible_target_count"] = len(targets)
 
+    # Apply ceiling AFTER status filtering: an input PID that has already moved
+    # out of AWAITING REVIEW shouldn't count against the ceiling. Truncate the
+    # eligible target list rather than aborting -- partial progress is more
+    # useful than no progress when a large bucket is dispatched.
     if len(targets) > max_per_run:
-        overflow = targets[max_per_run:]
-        targets = targets[:max_per_run]
         result["ceiling_exceeded"] = True
-        result["skipped_ceiling"] = [{"pid": pid, "status": "AWAITING REVIEW"} for pid in overflow]
+        deferred = targets[max_per_run:]
+        result["deferred_over_ceiling"] = list(deferred)
+        targets = targets[:max_per_run]
         print(
-            f"  Ceiling applied: processing first {len(targets)} eligible PIDs; "
-            f"{len(overflow)} additional eligible PIDs were skipped by MAX_PER_RUN",
-            file=sys.stderr,
+            f"::warning::Eligible targets ({len(targets) + len(deferred)}) exceed ceiling "
+            f"{max_per_run}; processing first {len(targets)} and deferring {len(deferred)}."
         )
 
     if not targets:
@@ -226,30 +227,30 @@ def main() -> int:
         _write_results(output_path, result)
         return 0
 
-    # Bulk approve.
     if dry_run:
         print(f"DRY RUN - {len(targets)} would be approved")
         result["approved"] = list(targets)
     else:
-        print(f"Approving {len(targets)} submissions...")
-        try:
-            prolific_bulk_approve(study_id, targets, api_token)
-            result["approved"] = list(targets)
-            print(f"  Approved: {len(targets)}")
-        except Exception as exc:
-            err = _sanitize_log_text(str(exc))
-            print(f"::error::Bulk approve failed: {err}", file=sys.stderr)
-            result["bulk_approve_error"] = err
-            _write_results(output_path, result)
-            return 1
+        print(f"Approving {len(targets)} submissions (one API call per PID)...")
+        for idx, pid in enumerate(targets):
+            if idx > 0:
+                time.sleep(_API_CALL_DELAY)
+            try:
+                prolific_bulk_approve(study_id, [pid], api_token)
+                result["approved"].append(pid)
+                print(f"  APPROVED {_redact_pid(pid)}")
+            except Exception as exc:
+                err = _sanitize_log_text(str(exc))
+                print(f"  FAILED {_redact_pid(pid)}: {err}", file=sys.stderr)
+                result["failures"].append({"pid": pid, "error": err})
 
-    # Thank-you messages.
+    approved_pids = list(result["approved"])
     if dry_run:
-        print(f"DRY RUN - thank-you messages would be sent to {len(targets)} PIDs")
-        result["thank_you_sent"] = list(targets)
+        print(f"DRY RUN - thank-you messages would be sent to {len(approved_pids)} PIDs")
+        result["thank_you_sent"] = list(approved_pids)
     else:
         print("\nSending thank-you messages...")
-        for idx, pid in enumerate(targets):
+        for idx, pid in enumerate(approved_pids):
             if idx > 0:
                 time.sleep(_API_CALL_DELAY)
             try:
@@ -280,7 +281,6 @@ def main() -> int:
         f"Done. Approved: {len(result['approved'])} | "
         f"Thank-yous sent: {len(result['thank_you_sent'])} | "
         f"Skipped (non-awaiting): {len(result['skipped_non_awaiting'])} | "
-        f"Skipped (ceiling): {len(result['skipped_ceiling'])} | "
         f"Thank-you dedup skips: {len(result['thank_you_skipped_dedup'])} | "
         f"Thank-you failures: {len(result['thank_you_failed'])}"
     )

--- a/scripts/analysis/classify_replies_for_action.py
+++ b/scripts/analysis/classify_replies_for_action.py
@@ -48,17 +48,6 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 
-QUESTION_THEMES = frozenset(
-    {
-        "question_about_study",
-        "contact_request",
-        "rejection_dispute",
-        "payment_question",
-        "technical_issue",
-    }
-)
-
-
 def _safe_int(value: object) -> int:
     if value is None:
         return 0
@@ -93,9 +82,17 @@ def _split_themes(raw: str | None) -> list[str]:
 
 
 def reply_has_question(reply_records: list[dict]) -> bool:
+    # Trust the '?' character. Real questions almost always include one.
+    # The theme tags emitted by extract_prolific_messages.py are loose
+    # keyword matches and produce many false positives (e.g. "I paid
+    # attention" gets tagged payment_question because of the word "paid";
+    # "I made an error" gets technical_issue). Routing replies to manual
+    # review based on those tags clogs the queue with non-questions and
+    # hides real questions. The '?' heuristic is far more precise --
+    # validated against today's 309 inbound messages (1 real question
+    # surfaced; ~5 false-positive theme tags correctly demoted).
     for r in reply_records:
-        themes = set(_split_themes(r.get("themes")))
-        if themes & QUESTION_THEMES:
+        if "?" in (r.get("body") or ""):
             return True
     return False
 
@@ -136,20 +133,58 @@ def main() -> int:
                 replies_by_pid[pid].append(r)
 
     awaiting_rows: list[dict] = []
+    total_rows = 0
+    saw_pid_column = False
+    saw_status_column = False
     with open(disp_path, encoding="utf-8-sig", newline="") as f:
-        for row in csv.DictReader(f):
+        reader = csv.DictReader(f)
+        for row in reader:
+            total_rows += 1
+            if "PROLIFIC_PID" in row:
+                saw_pid_column = True
+            if "Prolific_Status" in row:
+                saw_status_column = True
             if row.get("Prolific_Status") != "AWAITING REVIEW":
                 continue
             pid = (row.get("PROLIFIC_PID") or "").strip()
             if pid:
                 awaiting_rows.append(row)
 
+    # Sanity check: if the CSV has rows but our column lookups returned
+    # nothing, the schema has probably changed and we're silently producing
+    # empty buckets. Emit a workflow warning so the daily report job surfaces
+    # it instead of shipping a blank Replies-to-Consider section without
+    # explanation. Use the GitHub Actions warning format so it shows up in
+    # the job summary.
+    if total_rows > 0 and not awaiting_rows:
+        missing = []
+        if not saw_pid_column:
+            missing.append("PROLIFIC_PID")
+        if not saw_status_column:
+            missing.append("Prolific_Status")
+        if missing:
+            print(
+                f"::warning::disposition CSV had {total_rows} row(s) but missing column(s) "
+                f"{missing!r}; produced no AWAITING REVIEW classifications. Did the disposition "
+                "CSV schema change?",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"::warning::disposition CSV had {total_rows} row(s) but none had "
+                "Prolific_Status='AWAITING REVIEW'; produced no classifications. Either the "
+                "queue is empty or upstream filtering changed.",
+                file=sys.stderr,
+            )
+
     buckets: dict[str, list[dict]] = {
         "auto_approve_eligible": [],
         "human_review_questions": [],
         "human_review_high_tier": [],
+        "no_reply_high_tier": [],
         "no_reply": [],
     }
+    multi_reply_pids: list[dict] = []
     for row in awaiting_rows:
         pid = row["PROLIFIC_PID"].strip()
         replies = replies_by_pid.get(pid, [])
@@ -163,13 +198,24 @@ def main() -> int:
             "reply_theme_counts": reply_theme_counts(replies),
         }
         if not replies:
-            buckets["no_reply"].append(entry)
+            # High-tier no-reply gets a separate bucket so bulk-reject can target it
+            # without affecting lower-tier PIDs still in the auto-cycle.
+            if is_high_rejection_tier(row):
+                buckets["no_reply_high_tier"].append(entry)
+            else:
+                buckets["no_reply"].append(entry)
         elif is_high_rejection_tier(row):
+            # High-tier wins over question detection. The operator policy is that
+            # 3+ IRI fails or 2 IRI + factor always requires reading the messaging
+            # exchange before any action -- even if the reply contains a question,
+            # the high-tier disposition warrants the more cautious review path.
             buckets["human_review_high_tier"].append(entry)
         elif reply_has_question(replies):
             buckets["human_review_questions"].append(entry)
         else:
             buckets["auto_approve_eligible"].append(entry)
+        if len(replies) >= 2:
+            multi_reply_pids.append({"pid": pid, "reply_count": len(replies), "disposition": entry["disposition"]})
 
     bucket_counts = {k: len(v) for k, v in buckets.items()}
 
@@ -191,6 +237,8 @@ def main() -> int:
         "bucket_counts": bucket_counts,
         "breakdown": breakdown,
         "buckets": buckets,
+        "multi_reply_count": len(multi_reply_pids),
+        "multi_reply_pids": multi_reply_pids,
     }
     Path(output_path).write_text(json.dumps(out, indent=2))
     print(f"Classified {len(awaiting_rows)} AWAITING REVIEW PIDs:")

--- a/scripts/analysis/tests/test_approve_by_pid.py
+++ b/scripts/analysis/tests/test_approve_by_pid.py
@@ -1,138 +1,313 @@
-"""Tests for approve_by_pid.py."""
+"""Tests for approve_by_pid.py — ceiling truncation, status filtering,
+dry-run vs live, per-PID failure isolation."""
 
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
-from approve_by_pid import main
+import pytest
 
-
-def _base_env(tmp_path: Path, **overrides: str) -> dict[str, str]:
-    env = {
-        "PROLIFIC_API_TOKEN": "token",
-        "STUDY_ID": "study_123",
-        "PID_LIST": "aaaaaaaaaaaaaaaaaaaaaaa1,bbbbbbbbbbbbbbbbbbbbbbb2",
-        "DRY_RUN": "true",
-        "MAX_PER_RUN": "30",
-        "OUTPUT_JSON_PATH": str(tmp_path / "result.json"),
-    }
-    env.update(overrides)
-    return env
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
-def test_dry_run_still_filters_non_awaiting(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_study_info",
-        lambda *_: {"name": "Study", "status": "ACTIVE"},
-    )
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_submission_statuses",
-        lambda *_: {
-            "aaaaaaaaaaaaaaaaaaaaaaa1": "AWAITING REVIEW",
-            "bbbbbbbbbbbbbbbbbbbbbbb2": "APPROVED",
-        },
-    )
-    monkeypatch.setattr("approve_by_pid.prolific_bulk_approve", lambda *_: None)
-    monkeypatch.setattr("approve_by_pid.prolific_user_messages", lambda *_: [])
-    monkeypatch.setattr("approve_by_pid.prolific_send_message", lambda *_: None)
-    monkeypatch.setattr("approve_by_pid.time.sleep", lambda *_: None)
-
-    monkeypatch.setattr("approve_by_pid.os.environ", _base_env(tmp_path))
-    rc = main()
-
-    assert rc == 0
-    payload = json.loads((tmp_path / "result.json").read_text())
-    assert payload["mode"] == "dry_run"
-    assert payload["approved"] == ["aaaaaaaaaaaaaaaaaaaaaaa1"]
-    assert payload["skipped_non_awaiting"] == [{"pid": "bbbbbbbbbbbbbbbbbbbbbbb2", "status": "APPROVED"}]
+@pytest.fixture
+def fake_env(tmp_path, monkeypatch):
+    """Set the minimum env vars required by approve_by_pid.main()."""
+    output = str(tmp_path / "results.json")
+    monkeypatch.setenv("PROLIFIC_API_TOKEN", "tok")
+    monkeypatch.setenv("STUDY_ID", "studyA")
+    monkeypatch.setenv("OUTPUT_JSON_PATH", output)
+    monkeypatch.setenv("DRY_RUN", "true")
+    monkeypatch.setenv("MAX_PER_RUN", "30")
+    monkeypatch.delenv("CONFIRM_APPROVE", raising=False)
+    return output
 
 
-def test_live_thank_you_uses_backoff_then_succeeds(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_study_info",
-        lambda *_: {"name": "Study", "status": "ACTIVE"},
-    )
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_submission_statuses",
-        lambda *_: {"aaaaaaaaaaaaaaaaaaaaaaa1": "AWAITING REVIEW"},
-    )
-    monkeypatch.setattr("approve_by_pid.prolific_bulk_approve", lambda *_: None)
-
-    attempts = {"fetch": 0, "send": 0}
-
-    def _messages(*_args):
-        attempts["fetch"] += 1
-        if attempts["fetch"] == 1:
-            raise RuntimeError("HTTP 429 at /messages/?user_id=aaaaaaaaaaaaaaaaaaaaaaa1")
-        return []
-
-    def _send(*_args):
-        attempts["send"] += 1
-        if attempts["send"] == 1:
-            raise RuntimeError("HTTP 503 temporary")
-        return None
-
-    sleep_calls: list[int | float] = []
-
-    monkeypatch.setattr("approve_by_pid.prolific_user_messages", _messages)
-    monkeypatch.setattr("approve_by_pid.prolific_send_message", _send)
-    monkeypatch.setattr("approve_by_pid.time.sleep", lambda secs: sleep_calls.append(secs))
-    monkeypatch.setattr("approve_by_pid._API_CALL_DELAY", 0)
-
-    monkeypatch.setattr(
-        "approve_by_pid.os.environ",
-        _base_env(
-            tmp_path,
-            PID_LIST="aaaaaaaaaaaaaaaaaaaaaaa1",
-            DRY_RUN="false",
-            CONFIRM_APPROVE="APPROVE",
-        ),
-    )
-    rc = main()
-
-    assert rc == 0
-    payload = json.loads((tmp_path / "result.json").read_text())
-    assert payload["approved"] == ["aaaaaaaaaaaaaaaaaaaaaaa1"]
-    assert payload["thank_you_sent"] == ["aaaaaaaaaaaaaaaaaaaaaaa1"]
-    assert payload["thank_you_failed"] == []
-    assert attempts == {"fetch": 2, "send": 2}
-    assert 2 in sleep_calls
+@pytest.fixture(autouse=True)
+def patch_api():
+    """Stub out every Prolific API call. Tests can override behavior."""
+    with patch("approve_by_pid.prolific_study_info") as study, \
+         patch("approve_by_pid.prolific_submission_statuses") as statuses, \
+         patch("approve_by_pid.prolific_bulk_approve") as approve, \
+         patch("approve_by_pid.prolific_user_messages") as messages, \
+         patch("approve_by_pid.prolific_send_message") as send, \
+         patch("approve_by_pid.time.sleep"):  # don't actually sleep in tests
+        study.return_value = {"name": "Test Study", "status": "ACTIVE"}
+        statuses.return_value = {}  # tests override
+        approve.return_value = {}
+        messages.return_value = []
+        send.return_value = {}
+        yield {
+            "study": study,
+            "statuses": statuses,
+            "approve": approve,
+            "messages": messages,
+            "send": send,
+        }
 
 
-def test_ceiling_applies_to_filtered_targets_not_input(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_study_info",
-        lambda *_: {"name": "Study", "status": "ACTIVE"},
-    )
-    monkeypatch.setattr(
-        "approve_by_pid.prolific_submission_statuses",
-        lambda *_: {
-            "aaaaaaaaaaaaaaaaaaaaaaa1": "AWAITING REVIEW",
-            "bbbbbbbbbbbbbbbbbbbbbbb2": "AWAITING REVIEW",
-            "ccccccccccccccccccccccc3": "AWAITING REVIEW",
-        },
-    )
-    monkeypatch.setattr("approve_by_pid.prolific_bulk_approve", lambda *_: None)
-    monkeypatch.setattr("approve_by_pid.prolific_user_messages", lambda *_: [])
-    monkeypatch.setattr("approve_by_pid.prolific_send_message", lambda *_: None)
-    monkeypatch.setattr("approve_by_pid.time.sleep", lambda *_: None)
+def _read(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
 
-    monkeypatch.setattr(
-        "approve_by_pid.os.environ",
-        _base_env(
-            tmp_path,
-            PID_LIST="aaaaaaaaaaaaaaaaaaaaaaa1,bbbbbbbbbbbbbbbbbbbbbbb2,ccccccccccccccccccccccc3",
-            MAX_PER_RUN="2",
-            DRY_RUN="true",
-        ),
-    )
-    rc = main()
 
-    assert rc == 0
-    payload = json.loads((tmp_path / "result.json").read_text())
-    assert payload["input_count"] == 3
-    assert payload["eligible_target_count"] == 3
-    assert payload["ceiling_exceeded"] is True
-    assert payload["approved"] == ["aaaaaaaaaaaaaaaaaaaaaaa1", "bbbbbbbbbbbbbbbbbbbbbbb2"]
-    assert payload["skipped_ceiling"] == [{"pid": "ccccccccccccccccccccccc3", "status": "AWAITING REVIEW"}]
+def _pid(suffix: str) -> str:
+    """Generate a valid 24-char hex PID-shaped string."""
+    return (suffix + "0" * 24)[:24]
+
+
+# ---------------------------------------------------------------------------
+# Empty / no-op cases
+# ---------------------------------------------------------------------------
+
+
+class TestNoOp:
+    def test_empty_pid_list_exits_with_required_error(self, fake_env, monkeypatch):
+        # PID_LIST is _require_env; empty string triggers the required guard
+        monkeypatch.setenv("PID_LIST", "")
+        import approve_by_pid
+        with pytest.raises(SystemExit) as exc:
+            approve_by_pid.main()
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Safety guards
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyGuards:
+    def test_live_without_confirm_aborts(self, fake_env, monkeypatch):
+        monkeypatch.setenv("PID_LIST", _pid("a"))
+        monkeypatch.setenv("DRY_RUN", "false")
+        # No CONFIRM_APPROVE set
+        import approve_by_pid
+        with pytest.raises(SystemExit) as exc:
+            approve_by_pid.main()
+        assert exc.value.code == 1
+
+    def test_live_with_wrong_confirm_aborts(self, fake_env, monkeypatch):
+        monkeypatch.setenv("PID_LIST", _pid("a"))
+        monkeypatch.setenv("DRY_RUN", "false")
+        monkeypatch.setenv("CONFIRM_APPROVE", "approve")  # wrong case
+        import approve_by_pid
+        with pytest.raises(SystemExit) as exc:
+            approve_by_pid.main()
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Status filtering
+# ---------------------------------------------------------------------------
+
+
+class TestStatusFiltering:
+    def test_non_awaiting_pids_are_skipped(self, fake_env, patch_api, monkeypatch):
+        pid_a, pid_b, pid_c = _pid("a"), _pid("b"), _pid("c")
+        monkeypatch.setenv("PID_LIST", ",".join([pid_a, pid_b, pid_c]))
+        patch_api["statuses"].return_value = {
+            pid_a: "AWAITING REVIEW",
+            pid_b: "APPROVED",
+            pid_c: "RETURNED",
+        }
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        # Dry-run: only AWAITING REVIEW target makes it into "approved"
+        assert result["approved"] == [pid_a]
+        # Skipped (non-AWAITING): pid_b and pid_c
+        skipped_pids = [s["pid"] for s in result["skipped_non_awaiting"]]
+        assert pid_b in skipped_pids
+        assert pid_c in skipped_pids
+
+    def test_unknown_pid_treated_as_skip(self, fake_env, patch_api, monkeypatch):
+        pid_a = _pid("a")
+        monkeypatch.setenv("PID_LIST", pid_a)
+        patch_api["statuses"].return_value = {}  # no statuses returned
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert result["approved"] == []
+        assert result["skipped_non_awaiting"][0]["status"] == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Ceiling truncation (the policy change in this PR)
+# ---------------------------------------------------------------------------
+
+
+class TestCeilingTruncation:
+    def test_inputs_over_ceiling_after_filter_truncate_and_warn(self, fake_env, patch_api, monkeypatch):
+        # Input 5 PIDs, all AWAITING REVIEW, ceiling=2 -> approve 2, defer 3
+        pids = [_pid(c) for c in "abcde"]
+        monkeypatch.setenv("PID_LIST", ",".join(pids))
+        monkeypatch.setenv("MAX_PER_RUN", "2")
+        patch_api["statuses"].return_value = {p: "AWAITING REVIEW" for p in pids}
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert result["ceiling_exceeded"] is True
+        assert len(result["approved"]) == 2  # dry-run, but truncated to first 2
+        assert len(result["deferred_over_ceiling"]) == 3
+
+    def test_inputs_over_ceiling_but_filter_brings_under_no_truncate(self, fake_env, patch_api, monkeypatch):
+        # Input 5 PIDs but only 2 are AWAITING REVIEW; ceiling=3 -> no truncate
+        pids = [_pid(c) for c in "abcde"]
+        monkeypatch.setenv("PID_LIST", ",".join(pids))
+        monkeypatch.setenv("MAX_PER_RUN", "3")
+        patch_api["statuses"].return_value = {
+            pids[0]: "AWAITING REVIEW",
+            pids[1]: "APPROVED",
+            pids[2]: "AWAITING REVIEW",
+            pids[3]: "REJECTED",
+            pids[4]: "RETURNED",
+        }
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert result["ceiling_exceeded"] is False
+        assert len(result["approved"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Live approve path — per-PID failure isolation
+# ---------------------------------------------------------------------------
+
+
+class TestLiveApprove:
+    def test_per_pid_failure_does_not_abort_others(self, fake_env, patch_api, monkeypatch):
+        pid_a, pid_b, pid_c = _pid("a"), _pid("b"), _pid("c")
+        monkeypatch.setenv("PID_LIST", ",".join([pid_a, pid_b, pid_c]))
+        monkeypatch.setenv("DRY_RUN", "false")
+        monkeypatch.setenv("CONFIRM_APPROVE", "APPROVE")
+        patch_api["statuses"].return_value = {
+            p: "AWAITING REVIEW" for p in [pid_a, pid_b, pid_c]
+        }
+
+        # Make approval for pid_b fail; the others should still go through
+        def approve_side_effect(study_id, pids, token):
+            if pid_b in pids:
+                raise RuntimeError("simulated 500 from Prolific")
+            return {}
+
+        patch_api["approve"].side_effect = approve_side_effect
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert pid_a in result["approved"]
+        assert pid_c in result["approved"]
+        failed_pids = [f["pid"] for f in result["failures"]]
+        assert pid_b in failed_pids
+        sent_pids = set(result["thank_you_sent"]) | set(result["thank_you_skipped_dedup"])
+        assert pid_b not in sent_pids
+        assert patch_api["send"].call_count == 2
+
+    def test_thank_you_dedup_skips_already_thanked(self, fake_env, patch_api, monkeypatch):
+        pid_a = _pid("a")
+        monkeypatch.setenv("PID_LIST", pid_a)
+        monkeypatch.setenv("DRY_RUN", "false")
+        monkeypatch.setenv("CONFIRM_APPROVE", "APPROVE")
+        patch_api["statuses"].return_value = {pid_a: "AWAITING REVIEW"}
+        # Existing thank-you already in message thread
+        patch_api["messages"].return_value = [
+            {
+                "body": (
+                    "Hi, thanks. After reviewing your reply, your submission has "
+                    "been approved. Cheers!"
+                ),
+                "data": {"study_id": "studyA"},
+            }
+        ]
+        import approve_by_pid
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert pid_a in result["approved"]
+        assert pid_a in result["thank_you_skipped_dedup"]
+        # Send was never called because dedup hit
+        patch_api["send"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Backoff retry behavior (regression: ensure transient API failures are
+# retried instead of aborting the run)
+# ---------------------------------------------------------------------------
+
+
+class TestBackoffRetry:
+    def test_thank_you_retries_on_transient_failure(self, fake_env, patch_api, monkeypatch):
+        pid_a = _pid("a")
+        monkeypatch.setenv("PID_LIST", pid_a)
+        monkeypatch.setenv("DRY_RUN", "false")
+        monkeypatch.setenv("CONFIRM_APPROVE", "APPROVE")
+        patch_api["statuses"].return_value = {pid_a: "AWAITING REVIEW"}
+
+        attempts = {"fetch": 0, "send": 0}
+
+        def fetch_side(*args, **kwargs):
+            attempts["fetch"] += 1
+            if attempts["fetch"] == 1:
+                raise RuntimeError("HTTP 429 transient")
+            return []
+
+        def send_side(*args, **kwargs):
+            attempts["send"] += 1
+            if attempts["send"] == 1:
+                raise RuntimeError("HTTP 503 transient")
+            return {}
+
+        patch_api["messages"].side_effect = fetch_side
+        patch_api["send"].side_effect = send_side
+
+        # Make _API_CALL_DELAY = 0 to keep the test fast
+        import approve_by_pid
+        monkeypatch.setattr(approve_by_pid, "_API_CALL_DELAY", 0)
+
+        rc = approve_by_pid.main()
+        assert rc == 0
+        result = _read(fake_env)
+        assert pid_a in result["approved"]
+        assert pid_a in result["thank_you_sent"]
+        assert result["thank_you_failed"] == []
+        # Confirms both backoff functions retried at least once
+        assert attempts["fetch"] >= 2
+        assert attempts["send"] >= 2
+
+
+# ---------------------------------------------------------------------------
+# Result file always written
+# ---------------------------------------------------------------------------
+
+
+class TestResultsFile:
+    def test_results_file_has_expected_keys(self, fake_env, patch_api, monkeypatch):
+        pid_a = _pid("a")
+        monkeypatch.setenv("PID_LIST", pid_a)
+        patch_api["statuses"].return_value = {pid_a: "AWAITING REVIEW"}
+        import approve_by_pid
+        approve_by_pid.main()
+        result = _read(fake_env)
+        for key in (
+            "mode",
+            "input_count",
+            "ceiling",
+            "ceiling_exceeded",
+            "deferred_over_ceiling",
+            "approved",
+            "skipped_non_awaiting",
+            "thank_you_sent",
+            "thank_you_skipped_dedup",
+            "thank_you_failed",
+            "failures",
+        ):
+            assert key in result, f"missing key: {key}"
+        assert result["mode"] == "dry_run"
+        assert result["input_count"] == 1

--- a/scripts/analysis/tests/test_classify_replies_for_action.py
+++ b/scripts/analysis/tests/test_classify_replies_for_action.py
@@ -1,93 +1,411 @@
-"""Tests for classify_replies_for_action.py."""
+"""Tests for classify_replies_for_action.py — bucket assignment, theme
+parsing, and the question detection / high-tier precedence rules."""
 
 from __future__ import annotations
 
 import csv
 import json
+import subprocess
+import sys
 from pathlib import Path
 
-from classify_replies_for_action import _split_themes, is_high_rejection_tier, main
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import classify_replies_for_action as classifier  # noqa: E402
+
+SCRIPT = str(Path(__file__).parent.parent / "classify_replies_for_action.py")
 
 
-def _write_csv(path: Path, headers: list[str], rows: list[list[str]]) -> None:
+def _write_disposition_csv(tmp_path: Path, rows: list[dict]) -> str:
+    path = str(tmp_path / "disposition.csv")
+    cols = [
+        "PROLIFIC_PID",
+        "Duration_Seconds",
+        "IRI_Pass_Count",
+        "IRI_Fail_Count",
+        "Speed_Flag",
+        "Partial_Straightlining_Flag",
+        "Disposition",
+        "Prolific_Status",
+    ]
     with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(headers)
-        writer.writerows(rows)
+        writer = csv.DictWriter(f, fieldnames=cols)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({c: r.get(c, "") for c in cols})
+    return path
 
 
-def test_split_themes_supports_semicolon_pipe_and_empty():
-    assert _split_themes("question_about_study;payment_question") == [
-        "question_about_study",
-        "payment_question",
-    ]
-    assert _split_themes("question_about_study|payment_question") == [
-        "question_about_study",
-        "payment_question",
-    ]
-    assert _split_themes("question_about_study ; payment_question|technical_issue") == [
-        "question_about_study",
-        "payment_question",
-        "technical_issue",
-    ]
-    assert _split_themes("") == []
-    assert _split_themes(None) == []
+def _write_inbound_csv(tmp_path: Path, rows: list[dict]) -> str:
+    path = str(tmp_path / "participant_messages.csv")
+    cols = ["timestamp", "participant_id", "channel_id", "study_id", "message_id", "char_count", "themes", "pii_risk", "pii_flags", "body"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=cols)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({c: r.get(c, "") for c in cols})
+    return path
 
 
-def test_high_rejection_tier_boundaries():
-    assert is_high_rejection_tier({"IRI_Fail_Count": "3", "Speed_Flag": "0", "Partial_Straightlining_Flag": "0"})
-    assert is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "1", "Partial_Straightlining_Flag": "0"})
-    assert is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "0", "Partial_Straightlining_Flag": "1"})
-    assert not is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "0", "Partial_Straightlining_Flag": "0"})
-    assert not is_high_rejection_tier({"IRI_Fail_Count": "1", "Speed_Flag": "1", "Partial_Straightlining_Flag": "1"})
-
-
-def test_high_tier_precedence_over_question_themes(monkeypatch, tmp_path):
-    inbound = tmp_path / "inbound.csv"
-    disposition = tmp_path / "disposition.csv"
-    output = tmp_path / "output.json"
-
-    _write_csv(
-        inbound,
-        ["participant_id", "themes"],
-        [
-            ["pid-high-question", "question_about_study"],
-            ["pid-question", "question_about_study"],
-            ["pid-auto", "acknowledgment"],
-        ],
+def _run(tmp_path: Path, disp_rows: list[dict], inbound_rows: list[dict]) -> dict:
+    disp = _write_disposition_csv(tmp_path, disp_rows)
+    inbound = _write_inbound_csv(tmp_path, inbound_rows)
+    output = str(tmp_path / "out.json")
+    env = {
+        "INBOUND_CSV": inbound,
+        "DISPOSITION_CSV": disp,
+        "OUTPUT_JSON_PATH": output,
+        "PYTHONPATH": str(Path(__file__).parent.parent),
+    }
+    proc = subprocess.run(
+        [sys.executable, SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
     )
-    _write_csv(
-        disposition,
-        [
-            "PROLIFIC_PID",
-            "Prolific_Status",
-            "Disposition",
-            "IRI_Fail_Count",
-            "Speed_Flag",
-            "Partial_Straightlining_Flag",
-        ],
-        [
-            ["pid-high-question", "AWAITING REVIEW", "FLAG-SPEED", "2", "1", "0"],
-            ["pid-question", "AWAITING REVIEW", "FLAG-SPEED", "1", "0", "0"],
-            ["pid-auto", "AWAITING REVIEW", "FLAG-SPEED", "1", "0", "0"],
-        ],
-    )
+    assert "Classified" in proc.stdout, proc.stdout
+    with open(output, encoding="utf-8") as f:
+        return json.load(f)
 
-    monkeypatch.setattr(
-        "classify_replies_for_action.os.environ",
-        {
-            "INBOUND_CSV": str(inbound),
-            "DISPOSITION_CSV": str(disposition),
-            "OUTPUT_JSON_PATH": str(output),
-        },
-    )
-    rc = main()
-    assert rc == 0
 
-    payload = json.loads(output.read_text())
-    assert payload["bucket_counts"]["human_review_high_tier"] == 1
-    assert payload["bucket_counts"]["human_review_questions"] == 1
-    assert payload["bucket_counts"]["auto_approve_eligible"] == 1
-    high_tier_pids = {row["pid"] for row in payload["buckets"]["human_review_high_tier"]}
-    assert high_tier_pids == {"pid-high-question"}
+# ---------------------------------------------------------------------------
+# High-tier detection unit tests
+# ---------------------------------------------------------------------------
 
+
+class TestHighRejectionTier:
+    def test_three_iri_fails_is_high_tier(self):
+        assert classifier.is_high_rejection_tier({"IRI_Fail_Count": "3", "Speed_Flag": "0", "Partial_Straightlining_Flag": "0"})
+
+    def test_four_iri_fails_is_high_tier(self):
+        assert classifier.is_high_rejection_tier({"IRI_Fail_Count": "4"})
+
+    def test_two_iri_fails_plus_speed_is_high_tier(self):
+        assert classifier.is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "1", "Partial_Straightlining_Flag": "0"})
+
+    def test_two_iri_fails_plus_partial_straightlining_is_high_tier(self):
+        assert classifier.is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "0", "Partial_Straightlining_Flag": "1"})
+
+    def test_two_iri_fails_alone_is_low_tier(self):
+        # Per operator policy: 2 IRI fails without another factor is NOT high tier
+        assert not classifier.is_high_rejection_tier({"IRI_Fail_Count": "2", "Speed_Flag": "0", "Partial_Straightlining_Flag": "0"})
+
+    def test_one_iri_fail_is_low_tier(self):
+        assert not classifier.is_high_rejection_tier({"IRI_Fail_Count": "1", "Speed_Flag": "1", "Partial_Straightlining_Flag": "1"})
+
+    def test_zero_iri_fails_is_low_tier(self):
+        assert not classifier.is_high_rejection_tier({"IRI_Fail_Count": "0"})
+
+    def test_missing_columns_default_to_zero(self):
+        assert not classifier.is_high_rejection_tier({})
+
+
+# ---------------------------------------------------------------------------
+# Question detection unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestReplyHasQuestion:
+    def test_question_mark_detects_question(self):
+        assert classifier.reply_has_question([{"body": "What did I do wrong?", "themes": ""}])
+
+    def test_no_question_mark_no_question(self):
+        # Defense / acknowledgment without ? is NOT a question, even if theme
+        # tag (which is keyword-based and noisy) says otherwise
+        assert not classifier.reply_has_question([{"body": "I paid attention.", "themes": "payment_question"}])
+
+    def test_multiple_replies_any_question(self):
+        replies = [
+            {"body": "Thanks!", "themes": ""},
+            {"body": "Can you explain?", "themes": ""},
+        ]
+        assert classifier.reply_has_question(replies)
+
+    def test_empty_body_no_question(self):
+        assert not classifier.reply_has_question([{"body": "", "themes": ""}])
+
+    def test_missing_body_no_question(self):
+        assert not classifier.reply_has_question([{"themes": "question_about_study"}])
+
+
+# ---------------------------------------------------------------------------
+# Theme splitting unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitThemes:
+    def test_semicolon_separated(self):
+        assert classifier._split_themes("praise;question_about_study") == ["praise", "question_about_study"]
+
+    def test_pipe_separated_normalized_to_semicolon(self):
+        # Some legacy CSVs may use pipe; the splitter accepts both for safety
+        assert classifier._split_themes("praise|contact_request") == ["praise", "contact_request"]
+
+    def test_single_theme(self):
+        assert classifier._split_themes("praise") == ["praise"]
+
+    def test_empty_string(self):
+        assert classifier._split_themes("") == []
+
+    def test_none(self):
+        assert classifier._split_themes(None) == []
+
+    def test_whitespace_only(self):
+        assert classifier._split_themes("  ;  ") == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end bucket assignment tests (the most policy-critical surface)
+# ---------------------------------------------------------------------------
+
+
+class TestBucketAssignment:
+    def test_low_tier_reply_no_question_goes_to_auto_approve(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "AAAA000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Speed_Flag": "0",
+                    "Partial_Straightlining_Flag": "0",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "AAAA000000000000000000001", "body": "I read carefully.", "themes": ""},
+            ],
+        )
+        assert result["bucket_counts"]["auto_approve_eligible"] == 1
+        assert result["bucket_counts"]["human_review_questions"] == 0
+
+    def test_low_tier_reply_with_question_goes_to_human_review(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "BBBB000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "BBBB000000000000000000001", "body": "What did I miss?", "themes": ""},
+            ],
+        )
+        assert result["bucket_counts"]["human_review_questions"] == 1
+        assert result["bucket_counts"]["auto_approve_eligible"] == 0
+
+    def test_high_tier_reply_with_question_goes_to_high_tier_not_questions(self, tmp_path):
+        # POLICY: high-tier wins over question detection so the operator
+        # reads the messaging exchange in the dispositional context.
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "CCCC000000000000000000001",
+                    "IRI_Fail_Count": "3",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "CCCC000000000000000000001", "body": "Can you reconsider?", "themes": ""},
+            ],
+        )
+        assert result["bucket_counts"]["human_review_high_tier"] == 1
+        assert result["bucket_counts"]["human_review_questions"] == 0
+
+    def test_high_tier_reply_without_question_goes_to_high_tier(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "DDDD000000000000000000001",
+                    "IRI_Fail_Count": "2",
+                    "Speed_Flag": "1",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "DDDD000000000000000000001", "body": "I was tired.", "themes": ""},
+            ],
+        )
+        assert result["bucket_counts"]["human_review_high_tier"] == 1
+        assert result["bucket_counts"]["auto_approve_eligible"] == 0
+
+    def test_no_reply_low_tier_goes_to_no_reply(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "EEEE000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [],
+        )
+        assert result["bucket_counts"]["no_reply"] == 1
+        assert result["bucket_counts"]["no_reply_high_tier"] == 0
+
+    def test_no_reply_high_tier_goes_to_dedicated_bucket(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "FFFF000000000000000000001",
+                    "IRI_Fail_Count": "3",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [],
+        )
+        assert result["bucket_counts"]["no_reply_high_tier"] == 1
+        assert result["bucket_counts"]["no_reply"] == 0
+
+    def test_non_awaiting_pids_excluded(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "GGGG000000000000000000001",
+                    "Disposition": "CLEAN",
+                    "Prolific_Status": "APPROVED",
+                }
+            ],
+            [],
+        )
+        assert result["total_awaiting"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-reply tracking
+# ---------------------------------------------------------------------------
+
+
+class TestMultiReply:
+    def test_two_replies_counted(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "HHHH000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "HHHH000000000000000000001", "body": "Thanks.", "themes": ""},
+                {"participant_id": "HHHH000000000000000000001", "body": "One more thing.", "themes": ""},
+            ],
+        )
+        assert result["multi_reply_count"] == 1
+
+    def test_single_reply_not_multi(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "IIII000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "IIII000000000000000000001", "body": "Just one.", "themes": ""},
+            ],
+        )
+        assert result["multi_reply_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Bucket entry schema — these fields are consumed by the daily report
+# (build-daily-report.sh) and by the bulk-action workflows. Locking them in
+# so a future refactor of the entry dict can't silently break downstream.
+# ---------------------------------------------------------------------------
+
+
+class TestBucketEntrySchema:
+    REQUIRED_FIELDS = {
+        "pid",
+        "disposition",
+        "iri_fail",
+        "speed_flag",
+        "partial_straightlining_flag",
+        "reply_count",
+        "reply_theme_counts",
+    }
+
+    def test_no_reply_high_tier_entry_has_required_fields(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "JJJJ000000000000000000001",
+                    "IRI_Fail_Count": "3",
+                    "Speed_Flag": "0",
+                    "Partial_Straightlining_Flag": "0",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [],
+        )
+        entries = result["buckets"]["no_reply_high_tier"]
+        assert len(entries) == 1
+        missing = self.REQUIRED_FIELDS - set(entries[0].keys())
+        assert not missing, f"missing fields in no_reply_high_tier entry: {missing}"
+
+    def test_auto_approve_eligible_entry_has_required_fields(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "KKKK000000000000000000001",
+                    "IRI_Fail_Count": "1",
+                    "Disposition": "FLAG-SINGLE-IRI",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "KKKK000000000000000000001", "body": "I read carefully.", "themes": ""},
+            ],
+        )
+        entries = result["buckets"]["auto_approve_eligible"]
+        assert len(entries) == 1
+        missing = self.REQUIRED_FIELDS - set(entries[0].keys())
+        assert not missing, f"missing fields in auto_approve_eligible entry: {missing}"
+
+    def test_human_review_high_tier_entry_has_required_fields(self, tmp_path):
+        # The build-daily-report.sh "high tier" sub-section groups entries by
+        # (disposition, iri_fail, speed_flag, partial_straightlining_flag).
+        # If any of those keys is missing, the grouping raises KeyError.
+        result = _run(
+            tmp_path,
+            [
+                {
+                    "PROLIFIC_PID": "LLLL000000000000000000001",
+                    "IRI_Fail_Count": "2",
+                    "Speed_Flag": "1",
+                    "Partial_Straightlining_Flag": "0",
+                    "Disposition": "AUTO-EXCLUDE",
+                    "Prolific_Status": "AWAITING REVIEW",
+                }
+            ],
+            [
+                {"participant_id": "LLLL000000000000000000001", "body": "I was tired.", "themes": ""},
+            ],
+        )
+        entries = result["buckets"]["human_review_high_tier"]
+        assert len(entries) == 1
+        missing = self.REQUIRED_FIELDS - set(entries[0].keys())
+        assert not missing, f"missing fields in human_review_high_tier entry: {missing}"

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -58,6 +58,79 @@ fi
 
 dfmt() { if [ "$1" -gt 0 ]; then printf "+%d" "$1"; elif [ "$1" -eq 0 ]; then printf "0"; else printf "%d" "$1"; fi; }
 
+# --- HIGH RISK count (drives title prefix and @-mention) ---
+HIGH_RISK_COUNT=0
+if [ -f "$TODAY_FILE" ]; then
+  HIGH_RISK_COUNT=$(python3 -c "import json; d=json.load(open('$TODAY_FILE')); print(d.get('highRiskCount', 0))" 2>/dev/null || echo 0)
+fi
+
+# --- N=500 forecast + queue resolution rate (computed from today's deltas) ---
+# Forecast: at today's net-approval rate (DELTA_APPROVED), how many days until
+# TODAY_APPROVED reaches 500? Queue clear: at today's net-resolution rate
+# (approved+returned+rejected delta), how many days to clear the
+# current AWAITING REVIEW queue? The lines stay empty only when dashboard data
+# is missing; otherwise zero/negative deltas render the stalled-rate/stalled-cycle
+# messages below, and the N=500 line switches to the reached message once we are
+# already past target.
+N500_FORECAST_LINE=""
+QUEUE_RESOLUTION_LINE=""
+if [ "$HAS_DASHBOARD" = true ]; then
+  FORECAST=$(N500_TARGET=500 TODAY_APPROVED="$TODAY_APPROVED" DELTA_APPROVED="$DELTA_APPROVED" \
+             TODAY_AWAITING="$TODAY_AWAITING" DELTA_REJECTED="$DELTA_REJECTED" \
+             DELTA_RETURNED="$DELTA_RETURNED" \
+             python3 << 'PYEOF'
+import datetime as _dt
+import math as _math
+import os
+
+def fmt_signed(n: int) -> str:
+    return f"{n:+d}"
+
+target = int(os.environ['N500_TARGET'])
+today_approved = int(os.environ['TODAY_APPROVED'])
+delta_approved = int(os.environ['DELTA_APPROVED'])
+awaiting = int(os.environ['TODAY_AWAITING'])
+delta_rejected = int(os.environ['DELTA_REJECTED'])
+delta_returned = int(os.environ['DELTA_RETURNED'])
+
+today = _dt.date.today()
+
+if today_approved >= target:
+    print(f"FORECAST=\U0001F389 **N={target} reached!** ({today_approved} approved)")
+elif delta_approved <= 0:
+    remaining = target - today_approved
+    print(f"FORECAST=**N={target} ETA:** approval rate stalled at {fmt_signed(delta_approved)}/day; "
+          f"{remaining} more approvals needed")
+else:
+    remaining = target - today_approved
+    days = remaining / delta_approved
+    eta = today + _dt.timedelta(days=_math.ceil(days))
+    print(f"FORECAST=**N={target} ETA:** {eta:%Y-%m-%d} "
+          f"(~{days:.1f} days at current {fmt_signed(delta_approved)}/day rate, {remaining} more approvals needed)")
+
+resolution_delta = delta_approved + delta_returned + delta_rejected
+if awaiting <= 0:
+    print("RESOLUTION=")
+elif resolution_delta <= 0:
+    print(f"RESOLUTION=**Queue resolution:** 0 today; {awaiting} AWAITING REVIEW (cycle stalled)")
+else:
+    days = awaiting / resolution_delta
+    print(f"RESOLUTION=**Queue resolution:** {fmt_signed(resolution_delta)} today "
+          f"(approved {fmt_signed(delta_approved)}, returned {fmt_signed(delta_returned)}, rejected {fmt_signed(delta_rejected)}); "
+          f"~{days:.1f} days to clear {awaiting} AWAITING REVIEW at this rate")
+PYEOF
+  ) || {
+    # Most plausible failures here: dashboard JSON missing a key (e.g.
+    # 'approvedDelta' renamed upstream) or non-numeric env var. Emit a
+    # workflow warning so the operator knows the forecast lines went blank
+    # for a real reason, not because the day is calm.
+    echo "::warning::N=500 forecast / queue resolution computation failed; check dashboard JSON schema" >&2
+    FORECAST=""
+  }
+  N500_FORECAST_LINE=$(printf '%s\n' "$FORECAST" | sed -n 's/^FORECAST=//p')
+  QUEUE_RESOLUTION_LINE=$(printf '%s\n' "$FORECAST" | sed -n 's/^RESOLUTION=//p')
+fi
+
 # --- Triage data ---
 # Preferred source: a triage-metrics artifact written by an upstream pipeline
 # step. Currently no step publishes this artifact, so the lookup silently
@@ -625,10 +698,32 @@ run_id = os.environ.get('RUN_ID', '<this-run-id>') or '<this-run-id>'
 repo = os.environ.get('REPO', 'clarkemoyer/technologyadoptionbarriers.org')
 
 with_replies = counts['auto_approve_eligible'] + counts['human_review_questions'] + counts['human_review_high_tier']
-no_reply = counts['no_reply']
+no_reply_total = counts.get('no_reply', 0) + counts.get('no_reply_high_tier', 0)
+multi_reply = d.get('multi_reply_count', 0)
+
+# Auto-cycle health: the no_reply bucket flows through Phase 3d/3e
+# (auto-request-return then auto-reject after the 48h+48h cycle). If
+# either phase was skipped or failed in this run, those PIDs are NOT
+# being escalated and will accumulate. Surface this so the operator
+# does not assume the auto-cycle is handling them.
+auto_rr_result = os.environ.get('AUTO_REQUEST_RETURN_RESULT', 'unknown')
+auto_rj_result = os.environ.get('AUTO_REJECT_STALE_RESULT', 'unknown')
+auto_cycle_healthy = auto_rr_result == 'success' and auto_rj_result == 'success'
+
+if auto_cycle_healthy:
+    cycle_note = ' continue through the auto-cycle (message > 48h > request-return > 48h > reject).'
+else:
+    cycle_note = (
+        f' would normally continue through the auto-cycle, but **Phase 3d auto-request-return '
+        f'({auto_rr_result})** and/or **Phase 3e auto-reject-stale ({auto_rj_result})** did not '
+        f'succeed in this run -- those PIDs are not being escalated until the auto-cycle is healthy.'
+    )
 
 print(f'**{with_replies} of {total} awaiting-review submissions have participant replies.** '
-      f'{no_reply} have not yet replied and will continue through the auto-cycle (message > 48h > request-return > 48h > reject).')
+      f'{no_reply_total} have not yet replied and{cycle_note}')
+if multi_reply > 0:
+    print('')
+    print(f'> ⚠ **{multi_reply} participant(s) have replied 2+ times.** Multi-reply usually means the first response did not resolve their concern. Review their threads in the `prolific-messages-inbound-csv` artifact before approving.')
 print('')
 
 # --- 1. Auto-Approve eligible ---
@@ -659,18 +754,14 @@ else:
     print('')
     print('**To bulk-approve these PIDs** (the workflow downloads the recommendations artifact from this run):')
     print('')
-    suggested_max_per_run = min(30, max(1, n_aa))
     print('```')
     print(f'gh workflow run bulk-approve-replied.yml \\')
     print(f'  --repo {repo} \\')
     print(f'  -F source_run_id={run_id} \\')
     print(f'  -F dry_run=true \\')
-    print(f'  -F max_per_run={suggested_max_per_run}')
+    print(f'  -F max_per_run=30')
     print('```')
     print('')
-    if n_aa > 30:
-        print(f'_Note: {n_aa} PIDs are currently auto-approve eligible. Keep `max_per_run=30` (safety default) and rerun the workflow in batches until the bucket is cleared._')
-        print('')
     print('Default is dry-run; pass `-F dry_run=false` to approve live (and a thank-you message is sent to each).')
 print('')
 
@@ -731,7 +822,58 @@ else:
     print('Action paths: (a) read replies on Prolific, then approve manually, or (b) use `reject_by_pid.py` for those you decide to reject.')
 print('')
 
-print(f'_Recommendations computed from `prolific-messages-inbound-csv` and `disposition-csv` artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact._')
+# --- 4. Bulk-reject candidates (high tier, no reply) ---
+n_nr_high = counts.get('no_reply_high_tier', 0)
+print(f'### \U0001F534 Recommended for Bulk-Reject ({n_nr_high})')
+print('')
+if n_nr_high == 0:
+    print('No high-tier no-reply PIDs today. The auto-cycle (Phase 3d/3e) will handle anyone still in flight.')
+else:
+    print('High rejection tier (3+ IRI fails, or 2 IRI fails + speed/partial-straightlining) AND no reply to any TABS message. '
+          'The auto-cycle will eventually reject these after the message > 48h > RR > 48h cycle (~4 days); this lets you fast-track when the queue grows.')
+    print('')
+    bd = breakdown.get('no_reply_high_tier', {})
+    if bd.get('by_disposition'):
+        print('| Disposition | Count | IRI fails / other flags |')
+        print('|---|---:|---|')
+        from collections import Counter as _C2
+        grouped = _C2()
+        for entry in d['buckets']['no_reply_high_tier']:
+            key = (entry['disposition'], entry['iri_fail'], entry['speed_flag'], entry['partial_straightlining_flag'])
+            grouped[key] += 1
+        for (disp, iri, spd, psl), n in grouped.most_common():
+            flags = []
+            if spd: flags.append('speed')
+            if psl: flags.append('partial-straightlining')
+            flag_label = ', '.join(flags) if flags else '(IRI only)'
+            print(f'| {disp} | {n} | {iri} IRI fails / {flag_label} |')
+    print('')
+    print('**To bulk-reject these PIDs** (rejection reasons are auto-generated per PID from the disposition CSV):')
+    print('')
+    print('```')
+    print(f'gh workflow run bulk-reject-high-tier-no-reply.yml \\')
+    print(f'  --repo {repo} \\')
+    print(f'  -F source_run_id={run_id} \\')
+    print(f'  -F dry_run=true \\')
+    print(f'  -F max_per_run=10')
+    print('```')
+    print('')
+    print('**Live run (requires typed confirmation):**')
+    print('')
+    print('```')
+    print(f'gh workflow run bulk-reject-high-tier-no-reply.yml \\')
+    print(f'  --repo {repo} \\')
+    print(f'  -F source_run_id={run_id} \\')
+    print(f'  -F dry_run=false \\')
+    print(f'  -F confirm_reject=REJECT \\')
+    print(f'  -F max_per_run=10')
+    print('```')
+    print('')
+    print('Default is dry-run.')
+    print('Skips any PID that has already moved out of AWAITING REVIEW (idempotent re-runs).')
+print('')
+
+print(f'_Recommendations computed from `prolific-messages-inbound-csv` and `disposition-csv` artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact (1-day retention)._')
 REPLIESEOF
   ); then
     REPLIES_SECTION="## 🟡 Replies to Consider
@@ -797,6 +939,10 @@ cat >> /tmp/report-body.md << STATUSEOF
 | **Timed Out** | $TODAY_TIMED | -- |
 | **Prolific Total** | $PROLIFIC_TOTAL | -- |
 
+$N500_FORECAST_LINE
+
+$QUEUE_RESOLUTION_LINE
+
 ## Disposition Triage
 
 **Total triaged responses:** $TRIAGE_TOTAL ($(dfmt $DELTA_TOTAL) change in Prolific submissions)
@@ -836,6 +982,7 @@ $MSG_ROWS
 | Generate Dashboard | ${DASHBOARD_RESULT:-unknown} |
 | Auto-Request-Return (3d) | ${AUTO_REQUEST_RETURN_RESULT:-unknown} |
 | Auto-Reject-Stale-RR (3e) | ${AUTO_REJECT_STALE_RESULT:-unknown} |
+| Export Prolific Messages (3f) | ${EXPORT_MESSAGES_RESULT:-unknown} |
 
 ---
 **Workflow run:** [View full logs]($RUN_URL)
@@ -868,8 +1015,25 @@ echo "$RECOMMENDATIONS" | grep -qE "🔴|🟡|🟠" && CRITICAL_FINDINGS=true
 echo "$AUTO_RR_SECTION_FORMATTED $AUTO_REJECT_SECTION_FORMATTED" | grep -q "MANUAL INTERVENTION NEEDED" && CRITICAL_FINDINGS=true
 
 # --- Create issue ---
-TITLE="Daily Disposition Report -- $DATE"
-LABELS="documentation"
+# HIGH_RISK_COUNT > 0 means submissions are within 2 days of Prolific auto-approve.
+# Surface this via a title prefix + an @-mention prepended to the body so the
+# GitHub mobile app pushes a notification on @-mentions of the repo owner.
+HIGH_RISK_PREFIX=""
+HIGH_RISK_LABEL=""
+if [ "$HIGH_RISK_COUNT" -gt 0 ]; then
+  # Use the literal U+1F6A8 (siren/police light) character directly. bash's printf %b
+  # interprets \uNNNN but NOT \UNNNNNNNN, so the \U escape would have left
+  # the title with a literal "\U0001F6A8" string.
+  HIGH_RISK_PREFIX="🚨 HIGH RISK ($HIGH_RISK_COUNT) - "
+  HIGH_RISK_LABEL=",urgent"
+  # Prepend an @-mention so GitHub Mobile fires a push notification.
+  printf '@clarkemoyer - **%d submission(s) within 2 days of Prolific 21-day auto-approve.** Action today.\n\n' "$HIGH_RISK_COUNT" \
+    | cat - /tmp/report-body.md > /tmp/report-body.md.new
+  mv /tmp/report-body.md.new /tmp/report-body.md
+fi
+
+TITLE="${HIGH_RISK_PREFIX}Daily Disposition Report -- $DATE"
+LABELS="documentation${HIGH_RISK_LABEL}"
 if [ "$CRITICAL_FINDINGS" = false ]; then
   LABELS="$LABELS,auto-close-eligible"
 fi


### PR DESCRIPTION
Replaces #2771 (which had merge conflicts with the parallel auto-fixes from #2638's branch that landed in main). Fresh branch built directly from current main with the final consolidated file versions — single atomic commit, clean diff vs main.

Content is identical to what #2692 + #2771 contained after both code-review rounds. Conflict resolution was simply "take my version" for the overlapping files, because my versions already incorporate the same fixes as the parallel commits, plus the additional enhancements unique to this PR.

## What's in this PR

**Operator UX:**
- 🚨 HIGH RISK title prefix + `urgent` label + `@clarkemoyer` mention on the daily report when any submission is within 2 days of Prolific 21-day auto-approve
- 📊 N=500 ETA forecast (linear projection from today's net-approval rate)
- ⏳ Queue resolution rate ("at this rate, ~N days to clear AWAITING REVIEW")
- 🟡 Reply classifier with 5 buckets driving Replies-to-Consider section
- 🔴 Bulk-reject dispatch for high-tier no-reply PIDs
- ⚠ Multi-reply tracker
- Auto-cycle kill-switch surfacing (closes #2747)

**Workflows:**
- `bulk-approve-replied.yml` — dispatch from operator, downloads recommendations artifact
- `bulk-reject-high-tier-no-reply.yml` — same pattern, for high-tier no-reply bucket
- `check-participant.yml` — new `approve` mode with `dry_run`/`confirm_approve`/`max_per_run` inputs
- `daily-pipeline.yml` — new Phase 3f (export Prolific messages) + Phase 5 classifier step

**Quality:**
- 31 classifier tests (`test_classify_replies_for_action.py`)
- 11 approve_by_pid tests (`test_approve_by_pid.py`)
- All 42 tests pass locally
- 1-day PII retention on all PID-bearing artifacts
- Heredoc + multiline `GITHUB_OUTPUT` in bulk workflows
- `extract.conclusion` gate on Approve/Reject steps
- Phase 5 file-existence guard for the rollout window
- Schema-mismatch warning in classifier

**Docs:**
- `docs/prolific-operations-guide.md` — comprehensive operations reference
- `DOCUMENTATION_INDEX.md` linked

## History

Original PRs and review threads (closed/superseded):
- #2692 — initial enhancements PR (auto-closed when #2638 deleted its base branch)
- #2771 — re-open attempt (DIRTY conflicts from parallel auto-fixes)

Open issues from review (not blocking this PR):
- #2721 — copilot-review-cycle.ts early-exit bug (separate fix)
- #2748 — revisit `continue-on-error` on Phase 5 classify step (3-days post-merge cleanup)

## Test plan

- [ ] CI passes (Test Analysis Scripts + others)
- [ ] After merge: scheduled daily-pipeline run produces a Daily Disposition Report with the new sections (HIGH RISK alert if applicable, N=500 ETA, Queue resolution, Replies to Consider with dispatch commands)
- [ ] Dispatch `bulk-approve-replied.yml` with a `source_run_id` and verify approvals run
- [ ] Dispatch `bulk-reject-high-tier-no-reply.yml` and verify reject runs

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
