### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,13 +1,13 @@
 {
-  "as_of": "2026-05-17T01:39:58Z",
-  "commit_sha": "b91e52eebfe1eabbab6379625fe41665344da11a",
-  "commit_count": 7038,
-  "lines_of_code": 229876,
-  "comments": 13061,
-  "blanks": 26457,
-  "total_lines": 269394,
-  "tracked_files": 789,
-  "github_workflows": 51,
+  "as_of": "2026-05-18T07:43:54Z",
+  "commit_sha": "c414a1bb3835b1cad537bec0f9ea0e7ecdd64c07",
+  "commit_count": 7050,
+  "lines_of_code": 230632,
+  "comments": 13236,
+  "blanks": 26608,
+  "total_lines": 270476,
+  "tracked_files": 791,
+  "github_workflows": 52,
   "integrations": 8,
   "development_phases": 5,
   "phases_source": "CRP §3.6 Table 8 (Five-Phase TABS Product Development Process)",
@@ -23,30 +23,30 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44914,
+      "code": 44915,
       "comment": 0,
       "blank": 0
     },
     {
       "language": "Python",
       "files": 89,
-      "code": 36536,
-      "comment": 7712,
-      "blank": 7186
+      "code": 36913,
+      "comment": 7801,
+      "blank": 7261
     },
     {
       "language": "Markdown",
-      "files": 102,
-      "code": 24049,
+      "files": 103,
+      "code": 24172,
       "comment": 39,
-      "blank": 9556
+      "blank": 9602
     },
     {
       "language": "YAML",
-      "files": 57,
-      "code": 7181,
-      "comment": 906,
-      "blank": 1170
+      "files": 58,
+      "code": 7311,
+      "comment": 966,
+      "blank": 1187
     },
     {
       "language": "CSV",
@@ -56,18 +56,18 @@
       "blank": 4
     },
     {
+      "language": "Bourne Shell",
+      "files": 4,
+      "code": 982,
+      "comment": 132,
+      "blank": 143
+    },
+    {
       "language": "Scheme",
       "files": 1,
       "code": 936,
       "comment": 0,
       "blank": 108
-    },
-    {
-      "language": "Bourne Shell",
-      "files": 4,
-      "code": 857,
-      "comment": 106,
-      "blank": 130
     },
     {
       "language": "CSS",

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,13 +1,13 @@
 {
-  "as_of": "2026-05-17T01:39:58Z",
-  "commit_sha": "b91e52eebfe1eabbab6379625fe41665344da11a",
-  "commit_count": 7038,
-  "lines_of_code": 229876,
-  "comments": 13061,
-  "blanks": 26457,
-  "total_lines": 269394,
-  "tracked_files": 789,
-  "github_workflows": 51,
+  "as_of": "2026-05-18T07:43:54Z",
+  "commit_sha": "c414a1bb3835b1cad537bec0f9ea0e7ecdd64c07",
+  "commit_count": 7050,
+  "lines_of_code": 230632,
+  "comments": 13236,
+  "blanks": 26608,
+  "total_lines": 270476,
+  "tracked_files": 791,
+  "github_workflows": 52,
   "integrations": 8,
   "development_phases": 5,
   "phases_source": "CRP §3.6 Table 8 (Five-Phase TABS Product Development Process)",
@@ -23,30 +23,30 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44914,
+      "code": 44915,
       "comment": 0,
       "blank": 0
     },
     {
       "language": "Python",
       "files": 89,
-      "code": 36536,
-      "comment": 7712,
-      "blank": 7186
+      "code": 36913,
+      "comment": 7801,
+      "blank": 7261
     },
     {
       "language": "Markdown",
-      "files": 102,
-      "code": 24049,
+      "files": 103,
+      "code": 24172,
       "comment": 39,
-      "blank": 9556
+      "blank": 9602
     },
     {
       "language": "YAML",
-      "files": 57,
-      "code": 7181,
-      "comment": 906,
-      "blank": 1170
+      "files": 58,
+      "code": 7311,
+      "comment": 966,
+      "blank": 1187
     },
     {
       "language": "CSV",
@@ -56,18 +56,18 @@
       "blank": 4
     },
     {
+      "language": "Bourne Shell",
+      "files": 4,
+      "code": 982,
+      "comment": 132,
+      "blank": 143
+    },
+    {
       "language": "Scheme",
       "files": 1,
       "code": 936,
       "comment": 0,
       "blank": 108
-    },
-    {
-      "language": "Bourne Shell",
-      "files": 4,
-      "code": 857,
-      "comment": 106,
-      "blank": 130
     },
     {
       "language": "CSS",


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.