### PR TITLE
feat(prolific): BYPASS_STALE_GATE escape hatch for request_return_by_pid

### DIFF
--- a/.github/workflows/prolific-request-return-by-pid.yml
+++ b/.github/workflows/prolific-request-return-by-pid.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: string
         default: '30'
+      bypass_stale_gate:
+        description: 'Bypass the stale_no_reply_to_message bucket gate. Use only for ad-hoc operator decisions on PIDs that have replied but where the reply is insufficient.'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: 'prolific-request-return-submissions'
@@ -136,6 +141,7 @@ jobs:
           MAX_PER_RUN: ${{ inputs.max_per_run }}
           DRY_RUN: ${{ inputs.dry_run }}
           CONFIRM_REQUEST_RETURN: ${{ inputs.confirm_request_return }}
+          BYPASS_STALE_GATE: ${{ inputs.bypass_stale_gate }}
           OUTPUT_JSON_PATH: ${{ runner.temp }}/request-return-by-pid-results.json
         run: python3 scripts/analysis/request_return_by_pid.py
 

--- a/scripts/analysis/request_return_by_pid.py
+++ b/scripts/analysis/request_return_by_pid.py
@@ -21,6 +21,11 @@ Environment variables:
   DRY_RUN                     - When "false" AND CONFIRM_REQUEST_RETURN matches, live
   MAX_PER_RUN                 - Optional ceiling; abort if PID_LIST exceeds it
   OUTPUT_JSON_PATH            - Optional path for machine-readable results
+  BYPASS_STALE_GATE           - When "true", skip the stale_no_reply_to_message
+                                bucket check on live runs. Use only for ad-hoc
+                                operator decisions on PIDs that have replied
+                                but where the operator has already judged the
+                                reply insufficient. Default "false".
 
 Exit codes:
   0 - success (live or dry run completed)
@@ -216,6 +221,7 @@ def main() -> None:
     dry_run = os.environ.get("DRY_RUN", "true").strip().lower() != "false"
     confirm = os.environ.get("CONFIRM_REQUEST_RETURN", "").strip()
     output_json_path = os.environ.get("OUTPUT_JSON_PATH", "").strip()
+    bypass_stale_gate = os.environ.get("BYPASS_STALE_GATE", "false").strip().lower() == "true"
     max_per_run_raw = os.environ.get("MAX_PER_RUN", "")
     max_per_run = _parse_max_per_run(max_per_run_raw)
     stale_hours_raw = os.environ.get("STALE_HOURS", "48")
@@ -250,6 +256,8 @@ def main() -> None:
     print(f"Target PIDs: {len(target_pids)}")
     print(f"Mode: {'DRY RUN' if dry_run else 'LIVE REQUEST-RETURN'}")
     print(f"Ceiling (MAX_PER_RUN): {max_per_run if max_per_run is not None else 'unset (no limit)'}")
+    if bypass_stale_gate:
+        print("BYPASS_STALE_GATE=true - will NOT enforce stale_no_reply_to_message bucket gate")
     print()
 
     computed_at = datetime.now(timezone.utc).isoformat()
@@ -407,7 +415,7 @@ def main() -> None:
                 {"pid": r["pid"], "reason": f"revalidation failed: {e}"}
             )
             continue
-        if bucket != "stale_no_reply_to_message":
+        if bucket != "stale_no_reply_to_message" and not bypass_stale_gate:
             status_label = f"NO_LONGER_ELIGIBLE:{bucket or 'NONE'}"
             print(
                 f"  SKIPPING {r['pid']}: stale revalidation result {status_label}",
@@ -415,6 +423,11 @@ def main() -> None:
             )
             base_payload["skipped_non_awaiting"].append({"pid": r["pid"], "status": status_label})
             continue
+        if bucket != "stale_no_reply_to_message" and bypass_stale_gate:
+            print(
+                f"  BYPASS_STALE_GATE: {r['pid']} bucket={bucket or 'NONE'} - proceeding anyway",
+                file=sys.stderr,
+            )
         sub_id = pid_to_sub_id.get(r["pid"])
         if not sub_id:
             base_payload["failures"].append({"pid": r["pid"], "reason": "no submission id"})


### PR DESCRIPTION
## Summary

Adds an opt-in `BYPASS_STALE_GATE` env var to `scripts/analysis/request_return_by_pid.py` (threaded through `prolific-request-return-by-pid.yml`) that lets operators request-return on a PID that has replied to our review message but where the operator has judged the reply insufficient.

## Background

Phase 3d's auto-flow only acts on PIDs in the `stale_no_reply_to_message` bucket. The classifier returns `None` for any PID who has replied to us, which is the correct default for unattended automation. But when an operator manually decides "this 6-word non-defense is insufficient, request return with the disposition-aware reason," the previous script refused.

PR #2812 added the ad-hoc workflow but inherited this gate. This PR adds an explicit opt-in escape hatch so the workflow is actually usable for its intended ad-hoc cases.

## Safety preserved

Even with `BYPASS_STALE_GATE=true`:

- `CONFIRM_REQUEST_RETURN=REQUEST_RETURN` still required on live runs
- Status must still be `AWAITING REVIEW`
- `MAX_PER_RUN` ceiling still enforced
- Disposition-aware reason logic still gates on supported dispositions only
- Every bypassed PID gets a `BYPASS_STALE_GATE: <pid> bucket=<x> - proceeding anyway` log line for audit

Default is `false`. Phase 3d's daily-pipeline behaviour is unchanged.

## Test plan

- [ ] CI passes (format, lint, build, tests, E2E)
- [ ] After merge, re-run `prolific-request-return-by-pid.yml` for PID ****6455 with `bypass_stale_gate=true` and verify the disposition-aware reason gets posted to Prolific

🤖 Generated with [Claude Code](https://claude.com/claude-code)