### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-25T07:54:16Z",
-  "commit_sha": "f6c21de784f6c65ef228e51b1a052b56bd3e73ba",
-  "commit_count": 7102,
-  "lines_of_code": 230876,
+  "as_of": "2026-06-01T08:10:25Z",
+  "commit_sha": "cdb05fdd92f0c8ff7cd285ac09bc32c10bb5adac",
+  "commit_count": 7140,
+  "lines_of_code": 230921,
   "comments": 13290,
   "blanks": 26631,
-  "total_lines": 270797,
+  "total_lines": 270842,
   "tracked_files": 793,
   "github_workflows": 54,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44961,
+      "code": 45006,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-05-25T07:54:16Z",
-  "commit_sha": "f6c21de784f6c65ef228e51b1a052b56bd3e73ba",
-  "commit_count": 7102,
-  "lines_of_code": 230876,
+  "as_of": "2026-06-01T08:10:25Z",
+  "commit_sha": "cdb05fdd92f0c8ff7cd285ac09bc32c10bb5adac",
+  "commit_count": 7140,
+  "lines_of_code": 230921,
   "comments": 13290,
   "blanks": 26631,
-  "total_lines": 270797,
+  "total_lines": 270842,
   "tracked_files": 793,
   "github_workflows": 54,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 44961,
+      "code": 45006,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.