### PR TITLE
fix: make daily report resilient to missing GitHub labels

### DIFF
--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -1038,10 +1038,41 @@ if [ "$CRITICAL_FINDINGS" = false ]; then
   LABELS="$LABELS,auto-close-eligible"
 fi
 
-ISSUE_URL=$(gh issue create \
+# Ensure every label we are about to apply exists. A missing label otherwise
+# makes `gh issue create --label` fail and kills the whole report job -- and it
+# fails precisely on the most important reports: the `urgent` label is only
+# applied when HIGH_RISK_COUNT > 0, so a missing `urgent` label took down the
+# high-risk report (the one that also fires the @-mention push notification).
+# Create-if-missing is idempotent and safe to run every day.
+ensure_label() {
+  local name="$1" color="$2" desc="$3"
+  if ! gh label list --limit 200 --json name --jq '.[].name' | grep -qxF "$name"; then
+    echo "Label '$name' missing; creating it."
+    gh label create "$name" --color "$color" --description "$desc" 2>/dev/null \
+      || echo "::warning::could not create label '$name'; report will fall back to no labels"
+  fi
+}
+ensure_label "documentation" "0075ca" "Daily disposition report"
+ensure_label "auto-close-eligible" "c5def5" "Report eligible for auto-close after 24h with no critical findings"
+# `auto-closed` is applied later when sweeping old eligible reports closed.
+ensure_label "auto-closed" "ededed" "Daily report auto-closed after 24h with no critical findings"
+if [ "$HIGH_RISK_COUNT" -gt 0 ]; then
+  ensure_label "urgent" "b60205" "Submissions within 2 days of Prolific 21-day auto-approve"
+fi
+
+# Create the report issue. If labeling still fails for any reason (e.g. a label
+# was deleted between the ensure step and now, or label-create was denied),
+# retry without labels so the report -- the actual deliverable -- still posts.
+if ! ISSUE_URL=$(gh issue create \
   --title "$TITLE" \
   --body-file /tmp/report-body.md \
-  --label "$LABELS")
+  --label "$LABELS" 2>/tmp/issue-create.err); then
+  echo "::warning::issue create with labels '$LABELS' failed: $(cat /tmp/issue-create.err)"
+  echo "::warning::retrying without labels so the report still posts"
+  ISSUE_URL=$(gh issue create \
+    --title "$TITLE" \
+    --body-file /tmp/report-body.md)
+fi
 
 echo "Daily report issue created: $TITLE ($ISSUE_URL)"
 

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -1044,12 +1044,18 @@ fi
 # applied when HIGH_RISK_COUNT > 0, so a missing `urgent` label took down the
 # high-risk report (the one that also fires the @-mention push notification).
 # Create-if-missing is idempotent and safe to run every day.
+# Fetch the existing labels once rather than calling the API per label, to avoid
+# redundant requests / rate-limiting (one list call instead of up to four).
+EXISTING_LABELS=$(gh label list --limit 500 --json name --jq '.[].name' 2>/dev/null || echo "")
 ensure_label() {
   local name="$1" color="$2" desc="$3"
-  if ! gh label list --limit 200 --json name --jq '.[].name' | grep -qxF "$name"; then
+  if ! printf '%s\n' "$EXISTING_LABELS" | grep -qxF "$name"; then
     echo "Label '$name' missing; creating it."
-    gh label create "$name" --color "$color" --description "$desc" 2>/dev/null \
-      || echo "::warning::could not create label '$name'; report will fall back to no labels"
+    if gh label create "$name" --color "$color" --description "$desc" 2>/dev/null; then
+      EXISTING_LABELS="$EXISTING_LABELS"$'\n'"$name"
+    else
+      echo "::warning::could not create label '$name'; report will fall back to no labels"
+    fi
   fi
 }
 ensure_label "documentation" "0075ca" "Daily disposition report"


### PR DESCRIPTION
## Problem

Phase 5 (Daily Report) of `daily-pipeline.yml` failed on 2026-06-16:

```
could not add label: 'urgent' not found
##[error]Process completed with exit code 1
```

`build-daily-report.sh` applies an `urgent` label **only when `HIGH_RISK_COUNT > 0`** (submissions within 2 days of Prolific's 21-day auto-approve). That label did not exist in the repo, so `gh issue create --label documentation,urgent` hard-failed — meaning the report died **precisely on high-risk days**, which are also the ones that prepend the `@clarkemoyer` mention to fire a GitHub Mobile push notification. The most important report was the one that never got posted.

Investigation also showed `auto-close-eligible` and `auto-closed` were missing too, leaving the auto-close sweep latently broken.

The classifier, recommendations artifact, approvals, messaging, and dashboard all succeeded — only the final issue-create step failed.

## Fix

1. **`ensure_label()`** — idempotently creates `documentation`, `auto-close-eligible`, `auto-closed` (and `urgent` when high-risk) if absent, before issue creation.
2. **Fallback on `gh issue create`** — if labeling still fails for any reason, retry without labels so the report (the actual deliverable) always posts.

The three missing labels (`urgent`, `auto-close-eligible`, `auto-closed`) were also created directly in the repo as an immediate mitigation, so the next scheduled run is unblocked regardless of when this merges.

## Testing

- `bash -n scripts/build-daily-report.sh` passes.
- Labels confirmed present in repo after manual creation.

https://claude.ai/code/session_01UChjh5ceQpEqaPT5SCx3tC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UChjh5ceQpEqaPT5SCx3tC)_