### PR TITLE
feat(prolific): add stale_hours override to reject-by-pid workflow

### DIFF
--- a/.github/workflows/prolific-reject-by-pid.yml
+++ b/.github/workflows/prolific-reject-by-pid.yml
@@ -47,8 +47,8 @@ on:
       stale_hours:
         description: 'Override the post-return-request staleness threshold in hours (default 48). Lower it for a deliberate human-decision reject of items already past the real return window but whose Prolific return_requested timestamp is recent.'
         required: false
-        type: string
-        default: '48'
+        type: number
+        default: 48
 
 concurrency:
   group: 'prolific-reject-submissions'
@@ -132,5 +132,5 @@ jobs:
           PID_LIST: ${{ inputs.pid_list }}
           DRY_RUN: ${{ inputs.dry_run }}
           CONFIRM_REJECT: ${{ inputs.confirm_reject }}
-          STALE_HOURS: ${{ inputs.stale_hours }}
+          STALE_HOURS: ${{ inputs.stale_hours || 48 }}
         run: python3 scripts/analysis/reject_by_pid.py

--- a/.github/workflows/prolific-reject-by-pid.yml
+++ b/.github/workflows/prolific-reject-by-pid.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: string
         default: ''
+      stale_hours:
+        description: 'Override the post-return-request staleness threshold in hours (default 48). Lower it for a deliberate human-decision reject of items already past the real return window but whose Prolific return_requested timestamp is recent.'
+        required: false
+        type: string
+        default: '48'
 
 concurrency:
   group: 'prolific-reject-submissions'
@@ -127,4 +132,5 @@ jobs:
           PID_LIST: ${{ inputs.pid_list }}
           DRY_RUN: ${{ inputs.dry_run }}
           CONFIRM_REJECT: ${{ inputs.confirm_reject }}
+          STALE_HOURS: ${{ inputs.stale_hours }}
         run: python3 scripts/analysis/reject_by_pid.py


### PR DESCRIPTION
Adds optional stale_hours input to prolific-reject-by-pid.yml, passed to reject_by_pid.py as STALE_HOURS (default 48, behavior unchanged). Operator escape hatch for deliberate human-decision rejects of items parked in human_review_high_tier whose Prolific return_requested timestamp is recent. Dry-run + live verified on 2 AUTO-EXCLUDE 3/3-IRI submissions.