### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,12 +1,12 @@
 {
-  "as_of": "2026-06-15T08:25:32Z",
-  "commit_sha": "c7e0f130a1942a2bb2e56cba9bc65200be6acfb2",
-  "commit_count": 7224,
-  "lines_of_code": 231023,
-  "comments": 13290,
-  "blanks": 26631,
-  "total_lines": 270944,
-  "tracked_files": 793,
+  "as_of": "2026-06-22T08:24:41Z",
+  "commit_sha": "2d7783a9974d43dde02241d1eff11d9cf067798a",
+  "commit_count": 7298,
+  "lines_of_code": 231874,
+  "comments": 13302,
+  "blanks": 26770,
+  "total_lines": 271946,
+  "tracked_files": 795,
   "github_workflows": 54,
   "integrations": 8,
   "development_phases": 5,
@@ -16,14 +16,14 @@
     {
       "language": "TypeScript",
       "files": 460,
-      "code": 111967,
+      "code": 111962,
       "comment": 3919,
       "blank": 7962
     },
     {
       "language": "JSON",
       "files": 41,
-      "code": 45108,
+      "code": 45297,
       "comment": 0,
       "blank": 0
     },
@@ -36,15 +36,15 @@
     },
     {
       "language": "Markdown",
-      "files": 103,
-      "code": 24172,
+      "files": 105,
+      "code": 24809,
       "comment": 39,
-      "blank": 9602
+      "blank": 9740
     },
     {
       "language": "YAML",
       "files": 60,
-      "code": 7501,
+      "code": 7507,
       "comment": 1015,
       "blank": 1210
     },
@@ -58,9 +58,9 @@
     {
       "language": "Bourne Shell",
       "files": 4,
-      "code": 982,
-      "comment": 132,
-      "blank": 143
+      "code": 1006,
+      "comment": 144,
+      "blank": 144
     },
     {
       "language": "Scheme",

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,12 +1,12 @@
 {
-  "as_of": "2026-06-15T08:25:32Z",
-  "commit_sha": "c7e0f130a1942a2bb2e56cba9bc65200be6acfb2",
-  "commit_count": 7224,
-  "lines_of_code": 231023,
-  "comments": 13290,
-  "blanks": 26631,
-  "total_lines": 270944,
-  "tracked_files": 793,
+  "as_of": "2026-06-22T08:24:41Z",
+  "commit_sha": "2d7783a9974d43dde02241d1eff11d9cf067798a",
+  "commit_count": 7298,
+  "lines_of_code": 231874,
+  "comments": 13302,
+  "blanks": 26770,
+  "total_lines": 271946,
+  "tracked_files": 795,
   "github_workflows": 54,
   "integrations": 8,
   "development_phases": 5,
@@ -16,14 +16,14 @@
     {
       "language": "TypeScript",
       "files": 460,
-      "code": 111967,
+      "code": 111962,
       "comment": 3919,
       "blank": 7962
     },
     {
       "language": "JSON",
       "files": 41,
-      "code": 45108,
+      "code": 45297,
       "comment": 0,
       "blank": 0
     },
@@ -36,15 +36,15 @@
     },
     {
       "language": "Markdown",
-      "files": 103,
-      "code": 24172,
+      "files": 105,
+      "code": 24809,
       "comment": 39,
-      "blank": 9602
+      "blank": 9740
     },
     {
       "language": "YAML",
       "files": 60,
-      "code": 7501,
+      "code": 7507,
       "comment": 1015,
       "blank": 1210
     },
@@ -58,9 +58,9 @@
     {
       "language": "Bourne Shell",
       "files": 4,
-      "code": 982,
-      "comment": 132,
-      "blank": 143
+      "code": 1006,
+      "comment": 144,
+      "blank": 144
     },
     {
       "language": "Scheme",


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.