### PR TITLE
feat(prolific): request-return sooner via split stale windows

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -612,7 +612,14 @@ jobs:
         env:
           PROLIFIC_API_TOKEN: ${{ secrets.TABS_PROLIFIC_TOKEN }}
           STUDY_ID: ${{ vars.PROLIFIC_STUDY_ID }}
+          # Reject (return-request -> reject) window: kept at the full 48h so
+          # participants always have 48h after a formal return request.
           STALE_HOURS: '48'
+          # Request-return (message -> request-return) window: shorter so the
+          # formal request-return fires sooner. Tunable via repo variable
+          # REQUEST_RETURN_STALE_HOURS (default 24); set it to 48 to restore the
+          # original single-window cadence.
+          MESSAGE_STALE_HOURS: ${{ vars.REQUEST_RETURN_STALE_HOURS || '24' }}
           OUTPUT_JSON_PATH: ${{ runner.temp }}/stale-triage.json
 
       - uses: actions/upload-artifact@v7
@@ -623,7 +630,8 @@ jobs:
 
   # ── Phase 3d: Auto-dispatch API request-return for stale-after-message PIDs ─
   # Reads stale-triage.json's `stale_no_reply_to_message` bucket (TABS messaged
-  # > 48h ago, no participant reply, no API-level return request yet) and runs
+  # > MESSAGE_STALE_HOURS ago — default 24h via REQUEST_RETURN_STALE_HOURS — no
+  # participant reply, no API-level return request yet) and runs
   # request_return_by_pid.py to dispatch /submissions/{id}/request-return/ per
   # PID. Disposition-aware reason text per PID. Ceiling-guarded.
   #
@@ -674,6 +682,10 @@ jobs:
           CSV_FILE_PATH: ${{ runner.temp }}/disposition.csv
           PID_LIST: ${{ steps.pids.outputs.pid_list }}
           MAX_PER_RUN: ${{ vars.AUTO_STALE_MAX_PER_RUN || '30' }}
+          # Revalidation windows MUST match the stale-triage step above so a PID
+          # selected at the shorter message window is not re-skipped here.
+          STALE_HOURS: '48'
+          MESSAGE_STALE_HOURS: ${{ vars.REQUEST_RETURN_STALE_HOURS || '24' }}
           DRY_RUN: 'false'
           CONFIRM_REQUEST_RETURN: 'REQUEST_RETURN'
           OUTPUT_JSON_PATH: ${{ runner.temp }}/auto-request-return-results.json

--- a/scripts/analysis/find_stale_return_requested.py
+++ b/scripts/analysis/find_stale_return_requested.py
@@ -36,7 +36,15 @@ assumed to have no reply.
 Environment variables:
   PROLIFIC_API_TOKEN  - Prolific API token (required)
   STUDY_ID            - Prolific study ID (required)
-  STALE_HOURS         - Age threshold in hours (default: 48)
+  STALE_HOURS         - Age threshold in hours for the return-request -> reject
+                        transition, i.e. the `stale_no_reply_to_rr` bucket
+                        (default: 48).
+  MESSAGE_STALE_HOURS - Age threshold in hours for the message -> request-return
+                        transition, i.e. the `stale_no_reply_to_message` bucket.
+                        Defaults to STALE_HOURS when unset, so the single-window
+                        behaviour is preserved. The daily pipeline sets this
+                        lower than STALE_HOURS so the formal request-return fires
+                        sooner while the reject window stays a full STALE_HOURS.
   RESEARCHER_ID       - Prolific researcher user id (optional, has default)
   OUTPUT_JSON_PATH    - Optional path to write a machine-readable summary
                         that downstream workflow steps can consume.
@@ -119,6 +127,36 @@ def _parse_stale_hours() -> int:
             file=sys.stderr,
         )
         raise SystemExit(2)
+
+
+def _parse_message_stale_hours(default: int) -> int:
+    """Return the message -> request-return threshold in hours.
+
+    Defaults to ``default`` (the STALE_HOURS value) when MESSAGE_STALE_HOURS is
+    unset or blank, so leaving it unconfigured preserves the original
+    single-window behaviour where the message and return-request transitions
+    shared one cutoff.
+    """
+    raw = os.environ.get("MESSAGE_STALE_HOURS")
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError):
+        print(
+            f"Invalid MESSAGE_STALE_HOURS value: {raw!r}. "
+            "Expected an integer number of hours, e.g. 24.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if value <= 0:
+        print(
+            f"Invalid MESSAGE_STALE_HOURS value: {raw!r}. "
+            "Expected a positive integer number of hours.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return value
 
 
 def _parse_iso(ts):
@@ -242,15 +280,24 @@ def _return_request_reasons(sub):
     return [text] if text else []
 
 
-def classify_submission(sub, msgs, researcher_id, now, cutoff):
+def classify_submission(sub, msgs, researcher_id, now, cutoff, msg_cutoff=None):
     """Return (bucket_name, record_dict) or (None, None) if submission
     doesn't qualify for any bucket.
+
+    ``cutoff`` gates the return-requested -> reject transition
+    (``stale_no_reply_to_rr``). ``msg_cutoff`` gates the message ->
+    request-return transition (``stale_no_reply_to_message``); when omitted it
+    defaults to ``cutoff`` so existing callers keep their single-window
+    behaviour. The daily pipeline passes an earlier ``msg_cutoff`` so the formal
+    request-return fires sooner than the (longer) reject window.
 
     Messages with no valid timestamp are silently skipped when ordering
     against an anchor (return_requested or last researcher message). Since
     we cannot prove such a message was sent *after* our anchor, treating
     it as not-after is safe for reject/request-return classification.
     """
+    if msg_cutoff is None:
+        msg_cutoff = cutoff
     pid = sub.get("participant_id", "")
     if not pid or sub.get("status") != "AWAITING REVIEW":
         return None, None
@@ -300,7 +347,7 @@ def classify_submission(sub, msgs, researcher_id, now, cutoff):
         "researcher_messages": len(researcher_msgs),
         "reasons": _reasons_from_messages(researcher_msgs),
     }
-    if last_msg_time < cutoff:
+    if last_msg_time < msg_cutoff:
         return "stale_no_reply_to_message", record
     return "in_window_msg", record
 
@@ -346,14 +393,17 @@ def main():
     api_token = _require_env("PROLIFIC_API_TOKEN")
     study_id = _require_env("STUDY_ID")
     stale_hours = _parse_stale_hours()
+    message_stale_hours = _parse_message_stale_hours(stale_hours)
     researcher_id = os.environ.get("RESEARCHER_ID", DEFAULT_RESEARCHER_ID)
     output_json = os.environ.get("OUTPUT_JSON_PATH")
 
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(hours=stale_hours)
+    msg_cutoff = now - timedelta(hours=message_stale_hours)
 
     print(f"Study: {study_id}")
-    print(f"Stale threshold: {stale_hours}h (cutoff: {cutoff.isoformat()})")
+    print(f"Reject (RR) threshold: {stale_hours}h (cutoff: {cutoff.isoformat()})")
+    print(f"Request-return (message) threshold: {message_stale_hours}h (cutoff: {msg_cutoff.isoformat()})")
     print()
 
     subs = prolific_submissions(study_id, api_token)
@@ -399,7 +449,7 @@ def main():
             fetch_errors.append({"pid": pid, "error": err})
             continue
         try:
-            bucket, record = classify_submission(sub, msgs, researcher_id, now, cutoff)
+            bucket, record = classify_submission(sub, msgs, researcher_id, now, cutoff, msg_cutoff)
         except ValueError as exc:
             print(
                 f"  Error: classification failed for {pid}: {exc}",
@@ -415,7 +465,7 @@ def main():
         buckets["stale_no_reply_to_rr"],
     )
     _print_bucket(
-        f"STALE_NO_REPLY_TO_MESSAGE (>{stale_hours}h since last msg, no RR yet → request-return)",
+        f"STALE_NO_REPLY_TO_MESSAGE (>{message_stale_hours}h since last msg, no RR yet → request-return)",
         buckets["stale_no_reply_to_message"],
     )
     _print_bucket(
@@ -423,7 +473,7 @@ def main():
         buckets["in_window_rr"],
     )
     _print_bucket(
-        f"IN_WINDOW / MSG (≤{stale_hours}h since last msg, no RR yet)",
+        f"IN_WINDOW / MSG (≤{message_stale_hours}h since last msg, no RR yet)",
         buckets["in_window_msg"],
     )
 
@@ -452,6 +502,7 @@ def main():
             "study_id": study_id,
             "computed_at": now.isoformat(),
             "stale_hours": stale_hours,
+            "message_stale_hours": message_stale_hours,
             "counts": {k: len(v) for k, v in buckets.items()},
             "fetch_errors": len(fetch_errors),
             "fetch_error_details": fetch_errors,

--- a/scripts/analysis/request_return_by_pid.py
+++ b/scripts/analysis/request_return_by_pid.py
@@ -21,6 +21,14 @@ Environment variables:
   DRY_RUN                     - When "false" AND CONFIRM_REQUEST_RETURN matches, live
   MAX_PER_RUN                 - Optional ceiling; abort if PID_LIST exceeds it
   OUTPUT_JSON_PATH            - Optional path for machine-readable results
+  STALE_HOURS                 - Age threshold (hours) for the return-request ->
+                                reject window used during revalidation
+                                (default 48).
+  MESSAGE_STALE_HOURS         - Age threshold (hours) for the message ->
+                                request-return window used during revalidation.
+                                Defaults to STALE_HOURS. Must match the value the
+                                stale-triage step used so a PID that qualified at
+                                the shorter message window is not re-skipped here.
   BYPASS_STALE_GATE           - When "true", skip the stale_no_reply_to_message
                                 bucket check on live runs. Use only for ad-hoc
                                 operator decisions on PIDs that have replied
@@ -240,6 +248,27 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(1)
+    # Message -> request-return window for revalidation. Defaults to STALE_HOURS
+    # so unset behaviour is unchanged; the daily pipeline sets it lower to match
+    # the stale-triage step that selected these PIDs.
+    message_stale_hours_raw = os.environ.get("MESSAGE_STALE_HOURS", "").strip()
+    if message_stale_hours_raw:
+        try:
+            message_stale_hours = int(message_stale_hours_raw)
+        except ValueError:
+            print(
+                f"Error: invalid MESSAGE_STALE_HOURS={message_stale_hours_raw!r}. Expected an integer.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if message_stale_hours <= 0:
+            print(
+                f"Error: invalid MESSAGE_STALE_HOURS={message_stale_hours_raw!r}. Expected a positive integer.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        message_stale_hours = stale_hours
 
     if not dry_run and confirm != "REQUEST_RETURN":
         print("================================================================", file=sys.stderr)
@@ -373,6 +402,7 @@ def main() -> None:
     actionable: List[Dict] = []
     stale_now = datetime.now(timezone.utc)
     stale_cutoff = stale_now - timedelta(hours=stale_hours)
+    stale_msg_cutoff = stale_now - timedelta(hours=message_stale_hours)
     revalidation_idx = 0
     for r in records:
         status = status_map.get(r["pid"], "NOT FOUND")
@@ -409,6 +439,7 @@ def main() -> None:
                 researcher_id,
                 stale_now,
                 stale_cutoff,
+                stale_msg_cutoff,
             )
         except Exception as e:
             base_payload["failures"].append(

--- a/scripts/analysis/tests/test_find_stale_return_requested.py
+++ b/scripts/analysis/tests/test_find_stale_return_requested.py
@@ -244,6 +244,63 @@ class TestCustomThreshold:
         assert bucket_48 == "in_window_rr"
 
 
+# ── Split message vs reject threshold (msg_cutoff) ───────────────────────────
+
+class TestSplitMessageThreshold:
+    """The message->request-return window (msg_cutoff) is independent of the
+    return-request->reject window (cutoff)."""
+
+    def test_message_branch_uses_msg_cutoff_when_provided(self):
+        """A message 30h old is stale at a 24h msg_cutoff but in-window at 48h,
+        while the reject cutoff stays at 48h."""
+        msg_time = NOW - timedelta(hours=30)
+        sub = _sub("PID_SPLIT_1")
+        msgs = [_msg(RESEARCHER_ID, msg_time)]
+        reject_cutoff = NOW - timedelta(hours=48)
+
+        bucket_24, _ = classify_submission(
+            sub, msgs, RESEARCHER_ID, NOW, reject_cutoff, NOW - timedelta(hours=24)
+        )
+        assert bucket_24 == "stale_no_reply_to_message"
+
+        bucket_48, _ = classify_submission(
+            sub, msgs, RESEARCHER_ID, NOW, reject_cutoff, NOW - timedelta(hours=48)
+        )
+        assert bucket_48 == "in_window_msg"
+
+    def test_msg_cutoff_defaults_to_cutoff_when_omitted(self):
+        """Omitting msg_cutoff reproduces the original single-window behaviour."""
+        msg_time = NOW - timedelta(hours=30)
+        sub = _sub("PID_SPLIT_2")
+        msgs = [_msg(RESEARCHER_ID, msg_time)]
+
+        # 48h single window → in window
+        bucket_a, _ = classify_submission(sub, msgs, RESEARCHER_ID, NOW, NOW - timedelta(hours=48))
+        assert bucket_a == "in_window_msg"
+        # 24h single window → stale
+        bucket_b, _ = classify_submission(sub, msgs, RESEARCHER_ID, NOW, NOW - timedelta(hours=24))
+        assert bucket_b == "stale_no_reply_to_message"
+
+    def test_rr_branch_ignores_msg_cutoff(self):
+        """The return-requested (reject) branch keys off cutoff only; a shorter
+        msg_cutoff must never make an in-window RR look stale."""
+        rr_time = NOW - timedelta(hours=30)
+        sub = _sub("PID_SPLIT_3", rr=rr_time)
+        msgs = []
+
+        # Reject window 48h → in window even though msg_cutoff is a tight 24h.
+        bucket_a, _ = classify_submission(
+            sub, msgs, RESEARCHER_ID, NOW, NOW - timedelta(hours=48), NOW - timedelta(hours=24)
+        )
+        assert bucket_a == "in_window_rr"
+
+        # Reject window 24h → stale regardless of a longer 48h msg_cutoff.
+        bucket_b, _ = classify_submission(
+            sub, msgs, RESEARCHER_ID, NOW, NOW - timedelta(hours=24), NOW - timedelta(hours=48)
+        )
+        assert bucket_b == "stale_no_reply_to_rr"
+
+
 # ── _msg_time sentinel behaviour ─────────────────────────────────────────────
 
 class TestMsgTime:


### PR DESCRIPTION
## Summary

The auto-cycle for a flagged Prolific submission currently runs on a single 48h clock, so a clearly bad submission takes ~4 days to reach rejection:

```
Day 0  message participant
Day 2  stale_no_reply_to_message (48h) → Phase 3d request-return
Day 4  stale_no_reply_to_rr      (48h) → Phase 3e reject
```

This PR **decouples the two windows** so the formal request-return fires sooner while the (irreversible) reject step keeps its full 48h cushion:

```
Day 0    message participant
Day 1    stale_no_reply_to_message (24h) → Phase 3d request-return
Day 3    stale_no_reply_to_rr      (48h) → Phase 3e reject
```

The message→request-return window is now controlled by **`MESSAGE_STALE_HOURS`**, surfaced as the repo variable **`REQUEST_RETURN_STALE_HOURS`** (default **24**). The request-return→reject window is unchanged at `STALE_HOURS=48`.

## Changes

- **`scripts/analysis/find_stale_return_requested.py`** — `classify_submission()` gains an optional `msg_cutoff` param (defaults to `cutoff`, so existing callers/tests are unaffected). The message-anchor branch now uses `msg_cutoff`; the return-request branch still uses `cutoff`. `main()` reads `MESSAGE_STALE_HOURS` (defaults to `STALE_HOURS`) and records it in the output JSON.
- **`scripts/analysis/request_return_by_pid.py`** — revalidation reads `MESSAGE_STALE_HOURS` and passes the matching `msg_cutoff`, so a PID selected at the shorter message window in stale-triage is not re-skipped during the live request-return.
- **`.github/workflows/daily-pipeline.yml`** — the stale-triage step and Phase 3d both set `MESSAGE_STALE_HOURS: ${{ vars.REQUEST_RETURN_STALE_HOURS || '24' }}` (kept in sync so revalidation matches selection). `STALE_HOURS` stays `'48'`.
- **`scripts/analysis/tests/test_find_stale_return_requested.py`** — new `TestSplitMessageThreshold` covering: message branch honors `msg_cutoff`; omitting `msg_cutoff` reproduces single-window behavior; the reject branch ignores `msg_cutoff`.

## Safety / design notes

- **Backward compatible.** Leave `MESSAGE_STALE_HOURS` unset → behavior is identical to today (both windows = `STALE_HOURS`).
- **Reject window untouched.** The irreversible step (Phase 3e reject) still requires a full 48h with no reply *after* a formal return request. Only the gentler request-return step is accelerated.
- **Operator-tunable without code changes.** Set repo variable `REQUEST_RETURN_STALE_HOURS` to `48` to revert, or any other value to tune. Existing kill switch `AUTO_REQUEST_RETURN_ENABLED` still disables Phase 3d entirely.

## Test plan

- [x] `pytest scripts/analysis/tests/test_find_stale_return_requested.py` — 57 passed locally (54 existing + 3 new).
- [x] `python -m py_compile` on both edited scripts.
- [ ] CI: `Test` + `Build` + `Phantom Revert Guard`.
- [ ] Confirm next daily-pipeline run reports the 24h message window and Phase 3d picks up submissions ~24h after messaging.

## Related

The two high-tier AUTO-EXCLUDE submissions (`63e533…84884`, `6a18fc…cf6b2`) that motivated this were already moved forward manually via `prolific-request-return-by-pid.yml` (live, `bypass_stale_gate=true`); this change makes that acceleration the default cadence going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)