### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,12 +1,12 @@
 {
-  "as_of": "2026-06-22T08:24:41Z",
-  "commit_sha": "2d7783a9974d43dde02241d1eff11d9cf067798a",
-  "commit_count": 7298,
-  "lines_of_code": 231874,
-  "comments": 13302,
-  "blanks": 26770,
-  "total_lines": 271946,
-  "tracked_files": 795,
+  "as_of": "2026-06-29T08:05:46Z",
+  "commit_sha": "e79b06fac909587d259127532464cb25aec712ac",
+  "commit_count": 7358,
+  "lines_of_code": 232106,
+  "comments": 13392,
+  "blanks": 26802,
+  "total_lines": 272300,
+  "tracked_files": 797,
   "github_workflows": 54,
   "integrations": 8,
   "development_phases": 5,
@@ -15,24 +15,24 @@
   "by_language": [
     {
       "language": "TypeScript",
-      "files": 460,
-      "code": 111962,
-      "comment": 3919,
-      "blank": 7962
+      "files": 462,
+      "code": 112082,
+      "comment": 3957,
+      "blank": 7979
     },
     {
       "language": "JSON",
       "files": 41,
-      "code": 45297,
+      "code": 45325,
       "comment": 0,
       "blank": 0
     },
     {
       "language": "Python",
       "files": 89,
-      "code": 36921,
-      "comment": 7806,
-      "blank": 7261
+      "code": 37002,
+      "comment": 7849,
+      "blank": 7276
     },
     {
       "language": "Markdown",
@@ -44,8 +44,8 @@
     {
       "language": "YAML",
       "files": 60,
-      "code": 7507,
-      "comment": 1015,
+      "code": 7510,
+      "comment": 1024,
       "blank": 1210
     },
     {

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,12 +1,12 @@
 {
-  "as_of": "2026-06-22T08:24:41Z",
-  "commit_sha": "2d7783a9974d43dde02241d1eff11d9cf067798a",
-  "commit_count": 7298,
-  "lines_of_code": 231874,
-  "comments": 13302,
-  "blanks": 26770,
-  "total_lines": 271946,
-  "tracked_files": 795,
+  "as_of": "2026-06-29T08:05:46Z",
+  "commit_sha": "e79b06fac909587d259127532464cb25aec712ac",
+  "commit_count": 7358,
+  "lines_of_code": 232106,
+  "comments": 13392,
+  "blanks": 26802,
+  "total_lines": 272300,
+  "tracked_files": 797,
   "github_workflows": 54,
   "integrations": 8,
   "development_phases": 5,
@@ -15,24 +15,24 @@
   "by_language": [
     {
       "language": "TypeScript",
-      "files": 460,
-      "code": 111962,
-      "comment": 3919,
-      "blank": 7962
+      "files": 462,
+      "code": 112082,
+      "comment": 3957,
+      "blank": 7979
     },
     {
       "language": "JSON",
       "files": 41,
-      "code": 45297,
+      "code": 45325,
       "comment": 0,
       "blank": 0
     },
     {
       "language": "Python",
       "files": 89,
-      "code": 36921,
-      "comment": 7806,
-      "blank": 7261
+      "code": 37002,
+      "comment": 7849,
+      "blank": 7276
     },
     {
       "language": "Markdown",
@@ -44,8 +44,8 @@
     {
       "language": "YAML",
       "files": 60,
-      "code": 7507,
-      "comment": 1015,
+      "code": 7510,
+      "comment": 1024,
       "blank": 1210
     },
     {


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.