### PR TITLE
feat: add GitHub issues link to footer

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -25,7 +25,7 @@ const Footer: React.FC = () => {
     },
   ]
 
-  const policyLinks: { name: string; href: string; external?: boolean }[] = [
+  const policyLinks: { name: string; href: string; isExternal?: boolean }[] = [
     { name: 'Cookie Policy', href: '/cookie-policy' },
     { name: 'Privacy Policy', href: '/privacy-policy' },
     { name: 'Terms of Service', href: '/terms-of-service' },
@@ -35,7 +35,7 @@ const Footer: React.FC = () => {
     {
       name: 'Report an Issue',
       href: 'https://github.com/clarkemoyer/technologyadoptionbarriers.org/issues',
-      external: true,
+      isExternal: true,
     },
   ]
 
@@ -293,11 +293,12 @@ const Footer: React.FC = () => {
                 <li key={link.name}>
                   <Link
                     href={link.href}
-                    target={link.external ? '_blank' : undefined}
-                    rel={link.external ? 'noopener noreferrer' : undefined}
+                    target={link.isExternal ? '_blank' : undefined}
+                    rel={link.isExternal ? 'noopener noreferrer' : undefined}
                     className="text-gray-400 hover:text-tabs-teal-bright transition-colors"
                   >
                     {link.name}
+                    {link.isExternal && <span className="ml-1 text-[10px]">↗</span>}
                   </Link>
                 </li>
               ))}

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -298,7 +298,11 @@ const Footer: React.FC = () => {
                     className="text-gray-400 hover:text-tabs-teal-bright transition-colors"
                   >
                     {link.name}
-                    {link.isExternal && <span className="ml-1 text-[10px]">↗</span>}
+                    {link.isExternal && (
+                      <span aria-hidden="true" className="ml-1 text-[10px]">
+                        ↗
+                      </span>
+                    )}
                   </Link>
                 </li>
               ))}

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -25,13 +25,18 @@ const Footer: React.FC = () => {
     },
   ]
 
-  const policyLinks = [
+  const policyLinks: { name: string; href: string; external?: boolean }[] = [
     { name: 'Cookie Policy', href: '/cookie-policy' },
     { name: 'Privacy Policy', href: '/privacy-policy' },
     { name: 'Terms of Service', href: '/terms-of-service' },
     { name: 'Contribution Policy', href: '/contribution-policy' },
     { name: 'Vulnerability Disclosure', href: '/vulnerability-disclosure-policy' },
     { name: 'Security Acknowledgements', href: '/security-acknowledgements' },
+    {
+      name: 'Report an Issue',
+      href: 'https://github.com/clarkemoyer/technologyadoptionbarriers.org/issues',
+      external: true,
+    },
   ]
 
   return (
@@ -288,6 +293,8 @@ const Footer: React.FC = () => {
                 <li key={link.name}>
                   <Link
                     href={link.href}
+                    target={link.external ? '_blank' : undefined}
+                    rel={link.external ? 'noopener noreferrer' : undefined}
                     className="text-gray-400 hover:text-tabs-teal-bright transition-colors"
                   >
                     {link.name}


### PR DESCRIPTION
## Description

Adds a "Report an Issue" link to the site footer that points to the repository's GitHub issues page, so admins and users can submit issues for the site.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issue(s)

<!-- No tracking issue -->

## Changes Made

- Added a "Report an Issue" entry to the footer policy links (`src/components/footer/index.tsx`) linking to `https://github.com/clarkemoyer/technologyadoptionbarriers.org/issues`.
- Extended the policy-link rendering to support external links (`target="_blank"` + `rel="noopener noreferrer"`), and typed the `policyLinks` array with an optional `external` flag.
- Left the existing GitHub social icon (repo home) unchanged.

## Screenshots (if applicable)

N/A — text link rendered in the existing footer policy-link row.

## Testing Performed

### Automated Testing

- [x] `npm test` — Footer unit + accessibility tests pass (9/9)
- [x] `npm run lint` — no new errors (only pre-existing acceptable warnings)
- [x] `npx tsc --noEmit` — footer change compiles cleanly

### Accessibility

- [x] Link is keyboard-navigable and uses descriptive text ("Report an Issue"); jest-axe reports no violations.

## Documentation

- [x] Code is self-documenting

## Breaking Changes

None / N/A

## Additional Notes

The new link opens in a new tab with `rel="noopener noreferrer"`, matching the other external links in the footer.

---
_Generated by [Claude Code](https://claude.ai/code/session_016gwEBMKCBJ33N84u6qH8bG)_