### PR TITLE
fix: exclude in-window PIDs from bulk-reject recommendation (#3012)

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -958,6 +958,10 @@ jobs:
         env:
           INBOUND_CSV: ${{ runner.temp }}/artifacts/prolific-messages-inbound-csv/participant_messages.csv
           DISPOSITION_CSV: ${{ runner.temp }}/artifacts/disposition-csv/disposition.csv
+          # Optional (#3012): lets the classifier exclude high-tier no-reply
+          # PIDs still inside the message/RR window from the bulk-reject
+          # recommendation. Missing file -> legacy unsplit behavior.
+          STALE_TRIAGE_JSON: ${{ runner.temp }}/artifacts/stale-triage/stale-triage.json
           OUTPUT_JSON_PATH: ${{ runner.temp }}/reply-action-recommendations.json
 
       - uses: actions/upload-artifact@v7

--- a/scripts/analysis/classify_replies_for_action.py
+++ b/scripts/analysis/classify_replies_for_action.py
@@ -179,11 +179,14 @@ def _earliest_eligible_at(
     if stale_bucket == "in_window_rr":
         return (anchor + timedelta(hours=stale_hours)).isoformat()
     if stale_bucket == "stale_no_reply_to_message":
-        # Phase 3d sends the return request this run; the reject window
-        # starts from that RR, which we approximate as "now-ish" = anchor
-        # + message window already elapsed. Use anchor + msg + reject hours
-        # as a conservative estimate.
-        return (anchor + timedelta(hours=message_stale_hours + stale_hours)).isoformat()
+        # Phase 3d sends the return request this run; the RR anchor is
+        # approximately now (≈ anchor + age_hours).  Using message_stale_hours
+        # as the offset underestimates eligibility whenever the message is
+        # older than the message window (age_hours > message_stale_hours),
+        # which is the common case for this bucket.  age_hours reflects the
+        # actual elapsed time, so the estimate is anchor + age_hours + stale_hours.
+        age_hours = float(record.get("age_hours") or message_stale_hours)
+        return (anchor + timedelta(hours=age_hours + stale_hours)).isoformat()
     if stale_bucket == "in_window_msg":
         return (anchor + timedelta(hours=message_stale_hours + stale_hours)).isoformat()
     return None

--- a/scripts/analysis/classify_replies_for_action.py
+++ b/scripts/analysis/classify_replies_for_action.py
@@ -24,6 +24,29 @@ PIDs with no reply at all go into a `no_reply` bucket. Those continue
 through the existing auto-cycle (message > 48h > request-return > 48h >
 reject), which runs in Phases 3b/3d/3e.
 
+High-tier no-reply PIDs are split further using the Phase 3c stale-triage
+buckets (issue #3012). `reject_by_pid.py` revalidates every PID against
+live Prolific state and only rejects bucket `stale_no_reply_to_rr`, so
+recommending anything else for bulk-reject produces a guaranteed no-op
+(e.g. a PID the same pipeline run just messaged is `in_window_msg` and
+gets skipped). To keep the report's recommendation and the executor's
+guard in agreement:
+
+  no_reply_high_tier
+    High tier, no reply, AND stale-triage bucket `stale_no_reply_to_rr`.
+    These are genuinely bulk-reject-eligible right now.
+
+  no_reply_high_tier_in_window
+    High tier, no reply, but still inside the message/RR reply window
+    (or not yet messaged / not yet return-requested). NOT bulk-reject-
+    eligible; the auto-cycle is handling them. Each entry carries the
+    stale-triage bucket and an `earliest_eligible_at` estimate.
+
+When STALE_TRIAGE_JSON is not provided (or unreadable) the split cannot
+be computed and all high-tier no-reply PIDs land in `no_reply_high_tier`
+(legacy behavior); the output flags `stale_triage_available: false` so
+the report can caveat the recommendation.
+
 High rejection tier definition (operator policy):
   - iri_fail >= 3, OR
   - iri_fail == 2 AND (speed_flag == 1 OR partial_straightlining_flag == 1)
@@ -31,6 +54,7 @@ High rejection tier definition (operator policy):
 Environment variables:
   INBOUND_CSV          - participant_messages.csv (Phase 3f artifact)
   DISPOSITION_CSV      - disposition.csv (Phase 2 artifact)
+  STALE_TRIAGE_JSON    - stale-triage.json (Phase 3c artifact, optional)
   OUTPUT_JSON_PATH     - where to write the classification JSON
 
 Exit codes:
@@ -45,6 +69,7 @@ import json
 import os
 import sys
 from collections import Counter, defaultdict
+from datetime import datetime, timedelta
 from pathlib import Path
 
 
@@ -97,6 +122,73 @@ def reply_has_question(reply_records: list[dict]) -> bool:
     return False
 
 
+def load_stale_triage(path: str | None) -> dict | None:
+    """Load Phase 3c's stale-triage.json and index records by PID.
+
+    Returns None when the file is absent or unreadable — callers fall back
+    to legacy (unsplit) behavior. Returns a dict:
+      {"by_pid": {pid: (bucket_name, record)}, "stale_hours": float,
+       "message_stale_hours": float}
+    """
+    if not path:
+        return None
+    p = Path(path)
+    if not p.is_file():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        by_pid: dict[str, tuple[str, dict]] = {}
+        for bucket_name, records in (data.get("buckets") or {}).items():
+            for rec in records or []:
+                pid = (rec.get("pid") or "").strip()
+                if pid:
+                    by_pid[pid] = (bucket_name, rec)
+        return {
+            "by_pid": by_pid,
+            "stale_hours": float(data.get("stale_hours") or 48),
+            "message_stale_hours": float(
+                data.get("message_stale_hours") or data.get("stale_hours") or 48
+            ),
+        }
+    except (OSError, ValueError, TypeError) as e:
+        print(f"::warning::could not read STALE_TRIAGE_JSON at {path}: {e}", file=sys.stderr)
+        return None
+
+
+def _earliest_eligible_at(
+    stale_bucket: str | None, record: dict | None, stale_hours: float, message_stale_hours: float
+) -> str | None:
+    """Estimate when an in-window high-tier PID becomes bulk-reject-eligible.
+
+    Mirrors the auto-cycle stages in find_stale_return_requested.py:
+      in_window_rr             -> anchor + stale_hours (reject window on the RR)
+      stale_no_reply_to_message-> RR is imminent (Phase 3d), then + stale_hours
+      in_window_msg            -> anchor + message_stale_hours (msg window)
+                                  + stale_hours (subsequent RR window)
+    Unknown/absent bucket (never messaged, fetch error) -> None.
+    """
+    if not stale_bucket or record is None:
+        return None
+    anchor_raw = record.get("anchor")
+    try:
+        anchor = datetime.fromisoformat(anchor_raw) if anchor_raw else None
+    except (ValueError, TypeError):
+        anchor = None
+    if anchor is None:
+        return None
+    if stale_bucket == "in_window_rr":
+        return (anchor + timedelta(hours=stale_hours)).isoformat()
+    if stale_bucket == "stale_no_reply_to_message":
+        # Phase 3d sends the return request this run; the reject window
+        # starts from that RR, which we approximate as "now-ish" = anchor
+        # + message window already elapsed. Use anchor + msg + reject hours
+        # as a conservative estimate.
+        return (anchor + timedelta(hours=message_stale_hours + stale_hours)).isoformat()
+    if stale_bucket == "in_window_msg":
+        return (anchor + timedelta(hours=message_stale_hours + stale_hours)).isoformat()
+    return None
+
+
 def reply_theme_counts(reply_records: list[dict]) -> dict[str, int]:
     counter: Counter[str] = Counter()
     for r in reply_records:
@@ -112,6 +204,7 @@ def main() -> int:
     inbound_path = os.environ.get("INBOUND_CSV")
     disp_path = os.environ.get("DISPOSITION_CSV")
     output_path = os.environ.get("OUTPUT_JSON_PATH")
+    stale_triage = load_stale_triage(os.environ.get("STALE_TRIAGE_JSON"))
     if not inbound_path or not disp_path or not output_path:
         print(
             "Error: INBOUND_CSV, DISPOSITION_CSV, and OUTPUT_JSON_PATH are required",
@@ -182,6 +275,7 @@ def main() -> int:
         "human_review_questions": [],
         "human_review_high_tier": [],
         "no_reply_high_tier": [],
+        "no_reply_high_tier_in_window": [],
         "no_reply": [],
     }
     multi_reply_pids: list[dict] = []
@@ -201,7 +295,24 @@ def main() -> int:
             # High-tier no-reply gets a separate bucket so bulk-reject can target it
             # without affecting lower-tier PIDs still in the auto-cycle.
             if is_high_rejection_tier(row):
-                buckets["no_reply_high_tier"].append(entry)
+                if stale_triage is None:
+                    # Legacy behavior: no stale-triage data, can't split.
+                    buckets["no_reply_high_tier"].append(entry)
+                else:
+                    stale_bucket, stale_rec = stale_triage["by_pid"].get(pid, (None, None))
+                    entry["stale_bucket"] = stale_bucket or "(not classified)"
+                    if stale_bucket == "stale_no_reply_to_rr":
+                        # The only bucket reject_by_pid.py will actually
+                        # reject — genuinely bulk-reject-eligible (#3012).
+                        buckets["no_reply_high_tier"].append(entry)
+                    else:
+                        entry["earliest_eligible_at"] = _earliest_eligible_at(
+                            stale_bucket,
+                            stale_rec,
+                            stale_triage["stale_hours"],
+                            stale_triage["message_stale_hours"],
+                        )
+                        buckets["no_reply_high_tier_in_window"].append(entry)
             else:
                 buckets["no_reply"].append(entry)
         elif is_high_rejection_tier(row):
@@ -239,6 +350,7 @@ def main() -> int:
         "buckets": buckets,
         "multi_reply_count": len(multi_reply_pids),
         "multi_reply_pids": multi_reply_pids,
+        "stale_triage_available": stale_triage is not None,
     }
     Path(output_path).write_text(json.dumps(out, indent=2))
     print(f"Classified {len(awaiting_rows)} AWAITING REVIEW PIDs:")

--- a/scripts/analysis/tests/test_classify_replies_for_action.py
+++ b/scripts/analysis/tests/test_classify_replies_for_action.py
@@ -388,6 +388,35 @@ class TestStaleTriageSplit:
         # anchor + stale_hours (48) = 2026-07-03T00:00
         assert entry["earliest_eligible_at"].startswith("2026-07-03T00:00")
 
+    def test_stale_no_reply_to_message_pid_not_recommended_and_estimate_uses_age_hours(
+        self, tmp_path
+    ):
+        # Regression for the _earliest_eligible_at() underestimate bug:
+        # when age_hours (72) > message_stale_hours (48), Phase 3d sends the
+        # RR now (≈ anchor + 72h), so eligibility = anchor + 72 + 48 = anchor + 120h.
+        # The old formula (anchor + msg + reject = anchor + 96h) was 24h too early.
+        st = _write_stale_triage_json(
+            tmp_path,
+            {
+                "stale_no_reply_to_message": [
+                    {
+                        "pid": HIGH_TIER_ROW["PROLIFIC_PID"],
+                        "age_hours": 72.0,
+                        "anchor": "2026-06-29T12:00:00+00:00",
+                        "anchor_kind": "last_researcher_message",
+                    }
+                ]
+            },
+        )
+        result = _run(tmp_path, [HIGH_TIER_ROW], [], stale_triage_path=st)
+        assert result["bucket_counts"]["no_reply_high_tier"] == 0
+        assert result["bucket_counts"]["no_reply_high_tier_in_window"] == 1
+        entry = result["buckets"]["no_reply_high_tier_in_window"][0]
+        assert entry["stale_bucket"] == "stale_no_reply_to_message"
+        # anchor + age_hours (72) + stale_hours (48) = 2026-07-04T12:00
+        # (NOT anchor + message_stale_hours (48) + stale_hours (48) = 2026-07-03T12:00)
+        assert entry["earliest_eligible_at"].startswith("2026-07-04T12:00")
+
     def test_unclassified_pid_not_recommended(self, tmp_path):
         # PID absent from every stale-triage bucket (e.g. never messaged,
         # or the message fetch errored). Not provably rejectable -> in-window

--- a/scripts/analysis/tests/test_classify_replies_for_action.py
+++ b/scripts/analysis/tests/test_classify_replies_for_action.py
@@ -47,7 +47,36 @@ def _write_inbound_csv(tmp_path: Path, rows: list[dict]) -> str:
     return path
 
 
-def _run(tmp_path: Path, disp_rows: list[dict], inbound_rows: list[dict]) -> dict:
+def _write_stale_triage_json(tmp_path: Path, buckets: dict[str, list[dict]]) -> str:
+    """Write a minimal stale-triage.json matching find_stale_return_requested.py's schema."""
+    path = str(tmp_path / "stale-triage.json")
+    all_buckets = {
+        "stale_no_reply_to_rr": [],
+        "stale_no_reply_to_message": [],
+        "in_window_rr": [],
+        "in_window_msg": [],
+    }
+    all_buckets.update(buckets)
+    payload = {
+        "study_id": "test-study",
+        "computed_at": "2026-07-01T12:00:00+00:00",
+        "stale_hours": 48,
+        "message_stale_hours": 48,
+        "counts": {k: len(v) for k, v in all_buckets.items()},
+        "fetch_errors": 0,
+        "fetch_error_details": [],
+        "buckets": all_buckets,
+    }
+    Path(path).write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _run(
+    tmp_path: Path,
+    disp_rows: list[dict],
+    inbound_rows: list[dict],
+    stale_triage_path: str | None = None,
+) -> dict:
     disp = _write_disposition_csv(tmp_path, disp_rows)
     inbound = _write_inbound_csv(tmp_path, inbound_rows)
     output = str(tmp_path / "out.json")
@@ -57,6 +86,8 @@ def _run(tmp_path: Path, disp_rows: list[dict], inbound_rows: list[dict]) -> dic
         "OUTPUT_JSON_PATH": output,
         "PYTHONPATH": str(Path(__file__).parent.parent),
     }
+    if stale_triage_path is not None:
+        env["STALE_TRIAGE_JSON"] = stale_triage_path
     proc = subprocess.run(
         [sys.executable, SCRIPT],
         env=env,
@@ -283,6 +314,141 @@ class TestBucketAssignment:
             [],
         )
         assert result["total_awaiting"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Stale-triage split of high-tier no-reply PIDs (issue #3012)
+#
+# reject_by_pid.py's live revalidation only rejects bucket
+# stale_no_reply_to_rr, so the recommendation must not include PIDs the
+# same pipeline run just messaged (in_window_msg) or return-requested
+# (in_window_rr) — those produce guaranteed no-op reject dispatches.
+# ---------------------------------------------------------------------------
+
+HIGH_TIER_ROW = {
+    "PROLIFIC_PID": "MMMM000000000000000000001",
+    "IRI_Fail_Count": "3",
+    "Speed_Flag": "0",
+    "Partial_Straightlining_Flag": "0",
+    "Disposition": "AUTO-EXCLUDE",
+    "Prolific_Status": "AWAITING REVIEW",
+}
+
+
+class TestStaleTriageSplit:
+    def test_stale_rr_pid_is_bulk_reject_eligible(self, tmp_path):
+        st = _write_stale_triage_json(
+            tmp_path,
+            {
+                "stale_no_reply_to_rr": [
+                    {"pid": HIGH_TIER_ROW["PROLIFIC_PID"], "age_hours": 72.0, "anchor": "2026-06-28T10:00:00+00:00", "anchor_kind": "return_requested"}
+                ]
+            },
+        )
+        result = _run(tmp_path, [HIGH_TIER_ROW], [], stale_triage_path=st)
+        assert result["bucket_counts"]["no_reply_high_tier"] == 1
+        assert result["bucket_counts"]["no_reply_high_tier_in_window"] == 0
+        assert result["stale_triage_available"] is True
+        assert result["buckets"]["no_reply_high_tier"][0]["stale_bucket"] == "stale_no_reply_to_rr"
+
+    def test_in_window_msg_pid_not_recommended(self, tmp_path):
+        # The #3012 repro: pipeline messaged the PID hours ago, then the
+        # same run's report recommended bulk-reject. The reject script
+        # skips it (NO_LONGER_ELIGIBLE:in_window_msg); the recommendation
+        # must agree and route it to the in-window bucket instead.
+        st = _write_stale_triage_json(
+            tmp_path,
+            {
+                "in_window_msg": [
+                    {"pid": HIGH_TIER_ROW["PROLIFIC_PID"], "age_hours": 4.0, "anchor": "2026-07-01T08:00:00+00:00", "anchor_kind": "last_researcher_message"}
+                ]
+            },
+        )
+        result = _run(tmp_path, [HIGH_TIER_ROW], [], stale_triage_path=st)
+        assert result["bucket_counts"]["no_reply_high_tier"] == 0
+        assert result["bucket_counts"]["no_reply_high_tier_in_window"] == 1
+        entry = result["buckets"]["no_reply_high_tier_in_window"][0]
+        assert entry["stale_bucket"] == "in_window_msg"
+        # anchor + message_stale_hours (48) + stale_hours (48) = 2026-07-05T08:00
+        assert entry["earliest_eligible_at"].startswith("2026-07-05T08:00")
+
+    def test_in_window_rr_pid_not_recommended(self, tmp_path):
+        st = _write_stale_triage_json(
+            tmp_path,
+            {
+                "in_window_rr": [
+                    {"pid": HIGH_TIER_ROW["PROLIFIC_PID"], "age_hours": 12.0, "anchor": "2026-07-01T00:00:00+00:00", "anchor_kind": "return_requested"}
+                ]
+            },
+        )
+        result = _run(tmp_path, [HIGH_TIER_ROW], [], stale_triage_path=st)
+        assert result["bucket_counts"]["no_reply_high_tier"] == 0
+        entry = result["buckets"]["no_reply_high_tier_in_window"][0]
+        assert entry["stale_bucket"] == "in_window_rr"
+        # anchor + stale_hours (48) = 2026-07-03T00:00
+        assert entry["earliest_eligible_at"].startswith("2026-07-03T00:00")
+
+    def test_unclassified_pid_not_recommended(self, tmp_path):
+        # PID absent from every stale-triage bucket (e.g. never messaged,
+        # or the message fetch errored). Not provably rejectable -> in-window
+        # bucket with no eligibility estimate.
+        st = _write_stale_triage_json(tmp_path, {})
+        result = _run(tmp_path, [HIGH_TIER_ROW], [], stale_triage_path=st)
+        assert result["bucket_counts"]["no_reply_high_tier"] == 0
+        entry = result["buckets"]["no_reply_high_tier_in_window"][0]
+        assert entry["stale_bucket"] == "(not classified)"
+        assert entry["earliest_eligible_at"] is None
+
+    def test_missing_stale_triage_file_keeps_legacy_behavior(self, tmp_path):
+        result = _run(
+            tmp_path,
+            [HIGH_TIER_ROW],
+            [],
+            stale_triage_path=str(tmp_path / "does-not-exist.json"),
+        )
+        assert result["bucket_counts"]["no_reply_high_tier"] == 1
+        assert result["bucket_counts"]["no_reply_high_tier_in_window"] == 0
+        assert result["stale_triage_available"] is False
+
+    def test_env_var_unset_keeps_legacy_behavior(self, tmp_path):
+        result = _run(tmp_path, [HIGH_TIER_ROW], [])
+        assert result["bucket_counts"]["no_reply_high_tier"] == 1
+        assert result["stale_triage_available"] is False
+
+    def test_low_tier_no_reply_unaffected_by_stale_triage(self, tmp_path):
+        low = dict(HIGH_TIER_ROW, IRI_Fail_Count="1", Disposition="FLAG-SINGLE-IRI")
+        st = _write_stale_triage_json(
+            tmp_path,
+            {
+                "in_window_msg": [
+                    {"pid": low["PROLIFIC_PID"], "age_hours": 4.0, "anchor": "2026-07-01T08:00:00+00:00", "anchor_kind": "last_researcher_message"}
+                ]
+            },
+        )
+        result = _run(tmp_path, [low], [], stale_triage_path=st)
+        assert result["bucket_counts"]["no_reply"] == 1
+        assert result["bucket_counts"]["no_reply_high_tier_in_window"] == 0
+
+    def test_replied_pids_unaffected_by_stale_triage(self, tmp_path):
+        # A high-tier PID WITH a reply goes to human_review_high_tier
+        # regardless of its stale-triage bucket.
+        st = _write_stale_triage_json(
+            tmp_path,
+            {
+                "stale_no_reply_to_rr": [
+                    {"pid": HIGH_TIER_ROW["PROLIFIC_PID"], "age_hours": 72.0, "anchor": "2026-06-28T10:00:00+00:00", "anchor_kind": "return_requested"}
+                ]
+            },
+        )
+        result = _run(
+            tmp_path,
+            [HIGH_TIER_ROW],
+            [{"participant_id": HIGH_TIER_ROW["PROLIFIC_PID"], "body": "I was tired.", "themes": ""}],
+            stale_triage_path=st,
+        )
+        assert result["bucket_counts"]["human_review_high_tier"] == 1
+        assert result["bucket_counts"]["no_reply_high_tier"] == 0
+        assert result["bucket_counts"]["no_reply_high_tier_in_window"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -922,7 +922,12 @@ if n_nr_window > 0:
             print(f'| {disp} | {n} | {stage_label} | {est_label} |')
     print('')
 
-print(f'_Recommendations computed from `prolific-messages-inbound-csv`, `disposition-csv`, and `stale-triage` artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact (1-day retention)._')
+artifact_sources = (
+    '`prolific-messages-inbound-csv`, `disposition-csv`, and `stale-triage`'
+    if stale_triage_available
+    else '`prolific-messages-inbound-csv`, `disposition-csv`'
+)
+print(f"_Recommendations computed from {artifact_sources} artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact (1-day retention)._")
 REPLIESEOF
   ); then
     REPLIES_SECTION="## 🟡 Replies to Consider

--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -698,7 +698,11 @@ run_id = os.environ.get('RUN_ID', '<this-run-id>') or '<this-run-id>'
 repo = os.environ.get('REPO', 'clarkemoyer/technologyadoptionbarriers.org')
 
 with_replies = counts['auto_approve_eligible'] + counts['human_review_questions'] + counts['human_review_high_tier']
-no_reply_total = counts.get('no_reply', 0) + counts.get('no_reply_high_tier', 0)
+no_reply_total = (
+    counts.get('no_reply', 0)
+    + counts.get('no_reply_high_tier', 0)
+    + counts.get('no_reply_high_tier_in_window', 0)
+)
 multi_reply = d.get('multi_reply_count', 0)
 
 # Auto-cycle health: the no_reply bucket flows through Phase 3d/3e
@@ -823,15 +827,28 @@ else:
 print('')
 
 # --- 4. Bulk-reject candidates (high tier, no reply) ---
+# Split per issue #3012: only PIDs whose stale-triage bucket is
+# stale_no_reply_to_rr are recommended — that is the only bucket
+# reject_by_pid.py's live revalidation will actually reject. High-tier
+# no-reply PIDs still inside the message/RR window are shown separately
+# so the operator knows why they are not actionable yet.
 n_nr_high = counts.get('no_reply_high_tier', 0)
+n_nr_window = counts.get('no_reply_high_tier_in_window', 0)
+stale_triage_available = d.get('stale_triage_available', False)
 print(f'### \U0001F534 Recommended for Bulk-Reject ({n_nr_high})')
 print('')
 if n_nr_high == 0:
-    print('No high-tier no-reply PIDs today. The auto-cycle (Phase 3d/3e) will handle anyone still in flight.')
+    print('No bulk-reject-eligible high-tier no-reply PIDs today. The auto-cycle (Phase 3d/3e) will handle anyone still in flight.')
 else:
-    print('High rejection tier (3+ IRI fails, or 2 IRI fails + speed/partial-straightlining) AND no reply to any TABS message. '
-          'The auto-cycle will eventually reject these after the message > 48h > RR > 48h cycle (~4 days); this lets you fast-track when the queue grows.')
+    print('High rejection tier (3+ IRI fails, or 2 IRI fails + speed/partial-straightlining), no reply to any TABS message, '
+          'AND past the return-request reply window (stale-triage bucket `stale_no_reply_to_rr` — the only bucket the reject '
+          'script will action). This lets you fast-track when the queue grows.')
     print('')
+    if not stale_triage_available:
+        print('> ⚠️ Stale-triage data was unavailable for this run, so the in-window filter could not be applied. '
+              'Some of these PIDs may still be inside the 48h message/RR window; the reject script will skip those '
+              '(`NO_LONGER_ELIGIBLE`) rather than reject them.')
+        print('')
     bd = breakdown.get('no_reply_high_tier', {})
     if bd.get('by_disposition'):
         print('| Disposition | Count | IRI fails / other flags |')
@@ -873,7 +890,39 @@ else:
     print('Skips any PID that has already moved out of AWAITING REVIEW (idempotent re-runs).')
 print('')
 
-print(f'_Recommendations computed from `prolific-messages-inbound-csv` and `disposition-csv` artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact (1-day retention)._')
+# --- 4b. High-tier no-reply still inside the reply window (#3012) ---
+if n_nr_window > 0:
+    noun = 'PID is' if n_nr_window == 1 else 'PIDs are'
+    print(f'\U0001F552 **{n_nr_window} additional high-tier no-reply {noun} still inside the message/RR reply window** '
+          f'— not bulk-reject-eligible yet; the auto-cycle (Phase 3d/3e) is handling them.')
+    print('')
+    entries = d['buckets'].get('no_reply_high_tier_in_window', [])
+    if entries:
+        print('| Disposition | Count | Stage | Earliest eligible (est.) |')
+        print('|---|---:|---|---|')
+        from collections import Counter as _C3
+        grouped3 = _C3()
+        earliest_by_key = {}
+        stage_labels = {
+            'in_window_msg': 'messaged < 48h ago',
+            'in_window_rr': 'return-requested < 48h ago',
+            'stale_no_reply_to_message': 'RR being sent (Phase 3d)',
+            '(not classified)': 'not yet messaged / unclassified',
+        }
+        for entry in entries:
+            key = (entry['disposition'], entry.get('stale_bucket', '(not classified)'))
+            grouped3[key] += 1
+            est = entry.get('earliest_eligible_at')
+            if est and (key not in earliest_by_key or est < earliest_by_key[key]):
+                earliest_by_key[key] = est
+        for (disp, stage), n in grouped3.most_common():
+            stage_label = stage_labels.get(stage, stage)
+            est = earliest_by_key.get((disp, stage))
+            est_label = est[:10] if est else '—'
+            print(f'| {disp} | {n} | {stage_label} | {est_label} |')
+    print('')
+
+print(f'_Recommendations computed from `prolific-messages-inbound-csv`, `disposition-csv`, and `stale-triage` artifacts. Full PID list is in the `reply-action-recommendations` workflow artifact (1-day retention)._')
 REPLIESEOF
   ); then
     REPLIES_SECTION="## 🟡 Replies to Consider


### PR DESCRIPTION
## Summary

Fixes #3012 — the Daily Disposition Report's **Recommended for Bulk-Reject** section could recommend a PID the *same pipeline run* had just messaged. `reject_by_pid.py`'s live revalidation only rejects stale-triage bucket `stale_no_reply_to_rr`, so dispatching the recommendation was a guaranteed no-op (observed 2026-07-01: `SKIPPING ...: NO_LONGER_ELIGIBLE:in_window_msg`, run [28553312630](https://github.com/clarkemoyer/technologyadoptionbarriers.org/actions/runs/28553312630)).

## Changes

- **`classify_replies_for_action.py`**: new optional `STALE_TRIAGE_JSON` input (Phase 3c artifact). High-tier no-reply PIDs split into:
  - `no_reply_high_tier` — stale-triage bucket `stale_no_reply_to_rr` only (the one bucket the reject script actions) → still recommended
  - `no_reply_high_tier_in_window` — still inside the message/RR window (or never messaged / fetch-errored) → NOT recommended; entries carry `stale_bucket` + `earliest_eligible_at` estimate mirroring the auto-cycle stages
  - Missing/unreadable stale-triage → legacy unsplit behavior, `stale_triage_available: false`
- **`build-daily-report.sh`**: Bulk-Reject section now only recommends genuinely eligible PIDs; in-window PIDs render as a separate 🕒 table (disposition / count / stage / earliest eligible date); warning caveat when stale-triage was unavailable
- **`daily-pipeline.yml`**: Phase 5 classifier step gets `STALE_TRIAGE_JSON` pointing at the downloaded stale-triage artifact
- **Tests**: 8 new cases (split behavior, #3012 repro, legacy fallbacks, eligibility estimates, low-tier/replied PIDs unaffected)

## Test plan

- [x] `pytest scripts/analysis/tests/test_classify_replies_for_action.py` — 39 passed (31 existing + 8 new)
- [x] Full `scripts/analysis/tests/` suite — 707 passed, 10 skipped under UTF-8 (the 10 Windows-only cp1252 console failures are pre-existing and environmental)
- [x] `bash -n` on build-daily-report.sh + fixture smoke-render of the Replies section (verified new 🕒 table + reworded recommendation)
- [x] Prettier clean on the workflow YAML
- [ ] Post-merge: verify next daily run's report splits correctly

## Privacy

No PIDs in report output beyond existing patterns — the new table is aggregate (disposition × stage counts); per-PID detail stays in the 1-day `reply-action-recommendations` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)