### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,12 +1,12 @@
 {
-  "as_of": "2026-06-29T08:05:46Z",
-  "commit_sha": "e79b06fac909587d259127532464cb25aec712ac",
-  "commit_count": 7358,
-  "lines_of_code": 232106,
-  "comments": 13392,
-  "blanks": 26802,
-  "total_lines": 272300,
-  "tracked_files": 797,
+  "as_of": "2026-07-06T07:49:57Z",
+  "commit_sha": "bff09731072756ef041a90e5a0a4cc31114179b1",
+  "commit_count": 7424,
+  "lines_of_code": 232228,
+  "comments": 13393,
+  "blanks": 26818,
+  "total_lines": 272439,
+  "tracked_files": 798,
   "github_workflows": 54,
   "integrations": 8,
   "development_phases": 5,
@@ -15,15 +15,15 @@
   "by_language": [
     {
       "language": "TypeScript",
-      "files": 462,
-      "code": 112082,
-      "comment": 3957,
-      "blank": 7979
+      "files": 463,
+      "code": 112125,
+      "comment": 3958,
+      "blank": 7995
     },
     {
       "language": "JSON",
       "files": 41,
-      "code": 45325,
+      "code": 45404,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,12 +1,12 @@
 {
-  "as_of": "2026-06-29T08:05:46Z",
-  "commit_sha": "e79b06fac909587d259127532464cb25aec712ac",
-  "commit_count": 7358,
-  "lines_of_code": 232106,
-  "comments": 13392,
-  "blanks": 26802,
-  "total_lines": 272300,
-  "tracked_files": 797,
+  "as_of": "2026-07-06T07:49:57Z",
+  "commit_sha": "bff09731072756ef041a90e5a0a4cc31114179b1",
+  "commit_count": 7424,
+  "lines_of_code": 232228,
+  "comments": 13393,
+  "blanks": 26818,
+  "total_lines": 272439,
+  "tracked_files": 798,
   "github_workflows": 54,
   "integrations": 8,
   "development_phases": 5,
@@ -15,15 +15,15 @@
   "by_language": [
     {
       "language": "TypeScript",
-      "files": 462,
-      "code": 112082,
-      "comment": 3957,
-      "blank": 7979
+      "files": 463,
+      "code": 112125,
+      "comment": 3958,
+      "blank": 7995
     },
     {
       "language": "JSON",
       "files": 41,
-      "code": 45325,
+      "code": 45404,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.