### PR TITLE
fix: escape backticks in build-daily-report.sh eval blocks (Phase 5 degraded-path failure)

### DIFF
--- a/scripts/build-daily-report.sh
+++ b/scripts/build-daily-report.sh
@@ -458,12 +458,12 @@ render_auto_phase_section() {
     if [ "${DASHBOARD_RESULT:-unknown}" != "success" ]; then
       eval "$section_var=\"## $title
 
-> Skipped because upstream prerequisite was not successful (\`generate-dashboard=${DASHBOARD_RESULT:-unknown}\`).
+> Skipped because upstream prerequisite was not successful (\\\`generate-dashboard=${DASHBOARD_RESULT:-unknown}\\\`).
 \""
     else
       eval "$section_var=\"## $title
 
-> Disabled via repository variable. Run \`gh variable list\` to inspect.
+> Disabled via repository variable. Run \\\`gh variable list\\\` to inspect.
 \""
     fi
     return


### PR DESCRIPTION
## Summary

Fixes the **Phase 5: Daily Report** failure in the Daily Pipeline (run [29019031319](https://github.com/clarkemoyer/technologyadoptionbarriers.org/actions/runs/29019031319), 2026-07-09), which left the `documentation`-labeled disposition report unfiled and `src/data/disposition-summary.json` stale.

### Root cause
`render_auto_phase_section` in `scripts/build-daily-report.sh` builds its "skipped" markdown via `eval "$section_var=\"...\""`. The backticks around `generate-dashboard=...` and `gh variable list` were **single-escaped** (`` \` ``). A single-escaped backtick survives the first shell parse (the argument to `eval`) but is re-interpreted as **command substitution** when `eval` re-parses the string — so `eval` tried to execute `generate-dashboard=skipped` and died with `command not found` (exit 127).

This branch only runs when `DASHBOARD_RESULT != success` — i.e. only when the pipeline is **degraded** (an upstream phase skipped or cancelled). That is exactly the `if: always()` daily-report path. On 2026-07-09 **Phase 1 (Fetch Prolific Data) was cancelled**, all downstream phases skipped, and Phase 5 ran the degraded path straight into this latent bug. Normal runs (`DASHBOARD_RESULT=success`) never reach it — which is why 07-07 and 07-08 passed.

Note: Phase 5's other steps (`download-artifact`, `classify replies`) already have `continue-on-error: true`, so this `eval` in `build-daily-report.sh` was the **sole** cause of the job failure. Phase 1's cancellation itself was operational/transient (environment-gated job that was waiting, then cancelled), not a code defect.

### Fix
Triple-escape the backticks (`` \\` ``) so they stay literal through the `eval` re-parse — matching the already-correct pattern a few lines below (`` \\`$file\\` ``). 2 lines changed.

## Test plan
Reproduced and verified locally (git-bash):

- **Before:** the skipped branch with `DASHBOARD_RESULT=skipped` → `generate-dashboard=skipped: command not found`, exit 127. ✅ reproduced
- **After:** both branches render correct literal-backtick markdown, exit 0, no command substitution:
  - `> Skipped because upstream prerequisite was not successful (` `` `generate-dashboard=skipped` `` `).`
  - `> Disabled via repository variable. Run ` `` `gh variable list` `` ` to inspect.`
- `bash -n scripts/build-daily-report.sh` → syntax OK.

CI Test + Build gate this PR. After merge, the next scheduled Daily Pipeline (or a manual `workflow_dispatch`) will exercise Phase 5 normally; the degraded path is now safe if any phase skips/cancels again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
