### PR TITLE
fix: base Qualtrics metrics regression guard on auditable, warn not fail

### DIFF
--- a/.github/workflows/qualtrics-metrics-update.yml
+++ b/.github/workflows/qualtrics-metrics-update.yml
@@ -90,6 +90,7 @@ jobs:
           survey_name=$(jq -r '.result.name // ""' "$SURVEY_JSON")
           org_id=$(jq -r '.result.organizationId // ""' "$SURVEY_JSON")
           response_counts=$(jq -c '.result.responseCounts // {}' "$SURVEY_JSON")
+          echo "Qualtrics responseCounts: $response_counts"
 
           # Fetch question count from full survey definition endpoint
           # Note: The /questions sub-resource returns paginated { elements: [] },
@@ -157,16 +158,29 @@ jobs:
             exit 1
           fi
 
-          # 3. Check for regression (Total responses should not decrease)
+          # 3. Regression check on RECORDED responses only.
+          #
+          # Qualtrics `responseCounts` has three buckets: `auditable` (recorded /
+          # exportable responses -- the real data), `generated` (sessions started
+          # but not yet recorded, i.e. partials in flight right now), and
+          # `deleted` (responses currently in the trash). Only `auditable` is
+          # cumulative and meaningful; `generated` and `deleted` are volatile and
+          # legitimately drop to 0 between collection waves.
+          #
+          # The old guard summed all three and failed if the sum decreased. That
+          # wedged this workflow from 2026-03-30 onward: `auditable` grew
+          # (364 -> 975) while `generated`+`deleted` fell 1039 -> 0, so the sum
+          # dropped (1403 -> 975) and every run hard-failed despite zero data
+          # loss. Compare `auditable` instead, and only WARN on a decrease so a
+          # transient dip can never block the daily refresh for months again.
           if [[ -f "src/data/qualtrics-metrics.json" ]]; then
-            old_count=$(jq '.responseCounts | to_entries | map(.value) | add // 0' src/data/qualtrics-metrics.json)
-            new_count=$(jq '.responseCounts | to_entries | map(.value) | add // 0' temp-qualtrics-metrics.json)
+            old_auditable=$(jq '.responseCounts.auditable // 0' src/data/qualtrics-metrics.json)
+            new_auditable=$(jq '.responseCounts.auditable // 0' temp-qualtrics-metrics.json)
 
-            echo "Total Responses: Old=$old_count, New=$new_count"
+            echo "Auditable (recorded) responses: Old=$old_auditable, New=$new_auditable"
 
-            if [[ "$new_count" -lt "$old_count" ]]; then
-              echo "::error::Regression detected: New response count ($new_count) is lower than existing count ($old_count)."
-              exit 1
+            if [[ "$new_auditable" -lt "$old_auditable" ]]; then
+              echo "::warning::Auditable (recorded) response count decreased ($old_auditable -> $new_auditable). Publishing anyway -- verify no Qualtrics data loss."
             fi
           fi
 


### PR DESCRIPTION
## Summary

`Update Qualtrics Survey Metrics` has failed **every run since 2026-03-30** (no success in the last 40+ runs), freezing [`src/data/qualtrics-metrics.json`](src/data/qualtrics-metrics.json) — and the three raw response-count cards on the Response Funnel page — at ~3-month-old values.

### Root cause
The regression guard summed **all** of `responseCounts` and hard-failed if the sum dropped:

```
old/new = auditable + generated + deleted
```

That sum isn't a real total. Qualtrics reports three buckets:
- **`auditable`** — recorded / exportable responses (the real, cumulative data)
- **`generated`** — sessions started but not yet recorded (partials in flight *right now*)
- **`deleted`** — responses currently in the trash

`generated` and `deleted` are volatile and legitimately fall to 0 between collection waves. Confirmed live today via an instrumented read-only dispatch:

| Bucket | 2026-03-30 (stored) | 2026-07-11 (live) |
|---|---:|---:|
| auditable (recorded) | 364 | **975** |
| generated (in-flight) | 501 | 0 |
| deleted (trash) | 538 | 0 |
| **sum (old guard metric)** | **1403** | **975** |

So **recorded responses grew 364 → 975** while `generated`+`deleted` fell 1039 → 0. The sum dropped, the guard cried "regression," and every run hard-failed — **despite zero data loss**. (Cross-checked against the daily pipeline, which reads the same survey `SV_bkMopd73A8fzfwO` and reports 870 Prolific-reconciled responses today; Qualtrics `auditable` 975 is higher because it includes non-Prolific/anonymous entries.)

The homepage "march to 500 accepted" number is unaffected — it comes from Prolific `approved` in `disposition-summary.json`, a different feed.

### Fix
- Compare **`auditable`** only — the one bucket where a decrease could mean real data loss.
- **Warn instead of `exit 1`** on a decrease, so a transient dip can never wedge the daily refresh for months again.
- Log the full `responseCounts` breakdown each run for future diagnosis.

+21 / −7, one file.

## Test plan
- YAML parses; embedded bash passes `bash -n`.
- Guard control flow verified locally: decrease path emits `::warning::` and returns 0 (no hard-fail); growth path is silent.
- `jq` expressions (`.responseCounts.auditable // 0`) verified against the live API shape captured in the diagnostic run.
- **After merge:** the next scheduled run (03:17 UTC) — or a manual dispatch — will pass the guard and open a data PR refreshing `qualtrics-metrics.json` to `auditable 975 / generated 0 / deleted 0`, bringing the Response Funnel cards current.

## Follow-up (not in this PR)
With live `generated`/`deleted` now 0, the funnel's "responses started" and "deleted" cards will read 0. If we want those cards to show cumulative rather than point-in-time values, that's a display-semantics change to consider separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
