### PR TITLE
Update daily pipeline data

### DIFF
--- a/src/data/crp-sensitivity-analysis.json
+++ b/src/data/crp-sensitivity-analysis.json
@@ -2426,6 +2426,6 @@
       }
     ]
   },
-  "last_updated": "2026-07-20T11:34:53.623000Z",
-  "extended_last_updated": "2026-07-20T11:34:53.623000Z"
+  "last_updated": "2026-07-21T11:23:48.020348Z",
+  "extended_last_updated": "2026-07-21T11:23:48.020348Z"
 }

--- a/src/data/crp-validation.json
+++ b/src/data/crp-validation.json
@@ -85,7 +85,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9266,
           "bartlett_chi2": 1278.99,
-          "bartlett_p": 5.5989404416016324e-185
+          "bartlett_p": 5.598940441600992e-185
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -1366,22 +1366,22 @@
         "n_listwise": 176,
         "ecv_general": 0.784,
         "ecv_r_specific": 0.1228,
-        "ecv_m_specific": 0.0932,
+        "ecv_m_specific": 0.0933,
         "omega_t": 0.9471,
         "omega_h_general": 0.8507,
         "omega_h_r_specific": 0.0661,
         "omega_h_m_specific": 0.0303,
         "puc": 0.4533,
         "g_loadings": [
-          0.5858, 0.6297, 0.6633, 0.4459, 0.4922, 0.6563, 0.6376, 0.5369, 0.5677, 0.5953, 0.5572,
-          0.6452, 0.4902, 0.5715, 0.5345, 0.6516, 0.565, 0.5863, 0.6667, 0.5171, 0.6179, 0.5799,
+          0.5859, 0.6297, 0.6633, 0.4459, 0.4922, 0.6563, 0.6376, 0.5368, 0.5677, 0.5952, 0.5573,
+          0.6452, 0.4902, 0.5715, 0.5345, 0.6517, 0.565, 0.5863, 0.6667, 0.5171, 0.6179, 0.5799,
           0.7088, 0.6969, 0.6182
         ],
         "r_specific_loadings": [
-          0.4497, 0.2744, 0.1088, 0.4225, 0.4558, 0.2185, 0.2453, 0.3315, 0.1302, 0.1559, 0.3272,
-          -0.0104, 0.3741, 0.1612, 0.3715, 0.199, -0.0845
+          0.4496, 0.2744, 0.1087, 0.4225, 0.4559, 0.2183, 0.2453, 0.3316, 0.1302, 0.1561, 0.3271,
+          -0.0104, 0.374, 0.1611, 0.3715, 0.1989, -0.0845
         ],
-        "m_specific_loadings": [0.5244, 0.377, 0.3824, 0.3146, 0.4216, 0.3619, 0.2107, 0.2044],
+        "m_specific_loadings": [0.5244, 0.3771, 0.3826, 0.3147, 0.4216, 0.362, 0.2108, 0.2044],
         "note": "Reise/Rodriguez interpretation: ECV>.70 + omega_h>.80 + small omega_h_s implies general factor dominates; specific subscale scores are unreliable in isolation."
       },
       "second_order_barriers_cfa": {
@@ -2614,7 +2614,7 @@
           "rmsea": 0.0386,
           "latent_correlations": {
             "F1a~~F1b": 0.9468,
-            "F2~~F1a": 0.2515,
+            "F1a~~F2": 0.2515,
             "F2~~F1b": 0.4012
           }
         },
@@ -2626,7 +2626,7 @@
           "rmsea": 0.0,
           "latent_correlations": {
             "F1a~~F1b": 0.7667,
-            "F2~~F1a": 0.7336,
+            "F1a~~F2": 0.7336,
             "F2~~F1b": 0.6862
           }
         }
@@ -3303,12 +3303,12 @@
             "total_criteria": 4
           }
         },
-        "last_run_utc": "2026-07-20T11:37:32.553756+00:00"
+        "last_run_utc": "2026-07-21T11:26:54.081155+00:00"
       },
       "r_parity_tests": {
         "count": 16,
         "ci_workflow": ".github/workflows/validate-analysis.yml",
-        "last_run_utc": "2026-07-20T11:37:32.554184+00:00",
+        "last_run_utc": "2026-07-21T11:26:54.081651+00:00",
         "all_passing": null
       },
       "factor_analysis": {

--- a/src/data/disposition-summary.json
+++ b/src/data/disposition-summary.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-20T11:38:55.941999+00:00",
-  "last_updated": "2026-07-20T11:38:55.942002+00:00",
+  "updatedAt": "2026-07-21T11:28:09.895643+00:00",
+  "last_updated": "2026-07-21T11:28:09.895646+00:00",
   "study": {
     "id": "69c17630acada6abeead2da5",
     "name": "Technology Adoption Barriers Survey (2026)",
@@ -99,7 +99,7 @@
   },
   "autoApproveRunway": {
     "thresholdDays": 21,
-    "computedAt": "2026-07-20T11:38:55.941858+00:00",
+    "computedAt": "2026-07-21T11:28:09.895540+00:00",
     "totalAwaitingReview": 1,
     "evaluatedCount": 1,
     "skippedMissingCompletedAt": 0,

--- a/src/data/live-validation.json
+++ b/src/data/live-validation.json
@@ -19,7 +19,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.8604,
           "bartlett_chi2": 712.23,
-          "bartlett_p": 5.682427951602948e-73
+          "bartlett_p": 5.682427951602947e-73
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -82,7 +82,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.857,
           "bartlett_chi2": 705.77,
-          "bartlett_p": 9.232699447623405e-78
+          "bartlett_p": 9.23269944762393e-78
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -144,7 +144,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.839,
           "bartlett_chi2": 332.73,
-          "bartlett_p": 7.287269789782102e-54
+          "bartlett_p": 7.287269789782415e-54
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -1027,7 +1027,7 @@
             "alpha": 0.691,
             "kmo": 0.7729,
             "bartlett_chi2": 106.85,
-            "bartlett_p": 2.2970704112881397e-18,
+            "bartlett_p": 2.297070411288106e-18,
             "parallel_analysis_factors": 1,
             "loadings_1f": {
               "B4": -0.5813,
@@ -1354,7 +1354,7 @@
       },
       "bifactor_rm": {
         "fit": {
-          "chi2": 171.8,
+          "chi2": 171.801,
           "df": 250,
           "cfi": 1.0285,
           "tli": 1.0342,
@@ -1362,7 +1362,7 @@
         },
         "n_listwise": 131,
         "ecv_general": 0.6971,
-        "ecv_r_specific": 0.1281,
+        "ecv_r_specific": 0.128,
         "ecv_m_specific": 0.1749,
         "omega_t": 0.9134,
         "omega_h_general": 0.8185,
@@ -1370,15 +1370,15 @@
         "omega_h_m_specific": 0.0628,
         "puc": 0.4533,
         "g_loadings": [
-          0.5773, 0.5016, 0.3915, 0.4566, 0.5477, 0.4425, 0.6698, 0.6301, 0.5366, 0.5383, 0.4229,
-          0.36, 0.5199, 0.4995, 0.4647, 0.5683, 0.514, 0.5558, 0.5798, 0.3923, 0.3399, 0.2041,
+          0.5774, 0.5018, 0.3916, 0.4567, 0.5478, 0.4425, 0.6699, 0.6299, 0.5365, 0.5384, 0.4229,
+          0.3601, 0.5199, 0.4998, 0.4647, 0.5684, 0.5137, 0.5558, 0.5798, 0.3923, 0.3398, 0.2041,
           0.5568, 0.5483, 0.4733
         ],
         "r_specific_loadings": [
-          0.0071, -0.0383, -0.5151, 0.0429, 0.0032, -0.2392, -0.1209, -0.072, -0.217, 0.0011,
-          -0.6694, -0.2438, -0.3022, 0.0569, -0.1657, -0.238, 0.276
+          0.0073, -0.0375, -0.5149, 0.0433, 0.0032, -0.2394, -0.1207, -0.0737, -0.2176, 0.0019,
+          -0.6699, -0.2429, -0.3022, 0.0584, -0.166, -0.2376, 0.274
         ],
-        "m_specific_loadings": [0.3399, 0.3186, 0.4624, 0.5558, 0.588, 0.5702, 0.3279, 0.2429],
+        "m_specific_loadings": [0.3399, 0.3187, 0.4624, 0.5558, 0.588, 0.5702, 0.328, 0.2429],
         "note": "Reise/Rodriguez interpretation: ECV>.70 + omega_h>.80 + small omega_h_s implies general factor dominates; specific subscale scores are unreliable in isolation."
       },
       "second_order_barriers_cfa": {
@@ -2577,18 +2577,18 @@
       },
       "bifactor_barriers": {
         "fit": {
-          "chi2": 68.12,
+          "chi2": 68.134,
           "df": 117,
           "cfi": 1.0308,
           "tli": 1.0403,
           "rmsea": 0.0
         },
         "n_listwise": 144,
-        "ecv_general": 0.6578,
+        "ecv_general": 0.6577,
         "ecv_specifics": {
-          "F1a": 0.1106,
-          "F1b": 0.0725,
-          "F2": 0.1591
+          "F1a": 0.1104,
+          "F1b": 0.0729,
+          "F2": 0.159
         },
         "omega_h_general": 0.8101,
         "omega_h_specifics": {
@@ -2598,8 +2598,8 @@
         },
         "omega_t": 0.8879,
         "g_loadings": [
-          0.6002, 0.5133, 0.5963, 0.6869, 0.6398, 0.3413, 0.4849, 0.5636, 0.406, 0.5805, 0.5134,
-          0.4636, 0.3357, 0.3776, 0.506, 0.4737, 0.4421, 0.394
+          0.6003, 0.5133, 0.5962, 0.6869, 0.6397, 0.3415, 0.4849, 0.5637, 0.4059, 0.5806, 0.5133,
+          0.4636, 0.3357, 0.3776, 0.506, 0.4736, 0.4422, 0.394
         ]
       },
       "multigroup_3f_smb_vs_ent": {
@@ -2610,9 +2610,9 @@
           "cfi": 1.0431,
           "rmsea": 0.0,
           "latent_correlations": {
-            "F1a~~F2": 0.6621,
             "F1b~~F1a": 0.9957,
-            "F1b~~F2": 0.7986
+            "F2~~F1a": 0.6621,
+            "F2~~F1b": 0.7986
           }
         },
         "Group_0": {
@@ -2622,9 +2622,9 @@
           "cfi": 1.0249,
           "rmsea": 0.0,
           "latent_correlations": {
-            "F1a~~F2": 0.666,
             "F1b~~F1a": 0.6355,
-            "F1b~~F2": 0.6595
+            "F2~~F1a": 0.666,
+            "F2~~F1b": 0.6595
           }
         }
       },
@@ -2830,7 +2830,7 @@
             {
               "id": "R6",
               "name": "Technical Workforce",
-              "discrimination_group_1": 1.2473,
+              "discrimination_group_1": 1.2472,
               "discrimination_group_0": 0.9197,
               "delta": 0.3275,
               "flag_dif": false
@@ -3300,12 +3300,12 @@
             "total_criteria": 4
           }
         },
-        "last_run_utc": "2026-07-20T11:28:02.552976+00:00"
+        "last_run_utc": "2026-07-21T11:15:56.365899+00:00"
       },
       "r_parity_tests": {
         "count": 16,
         "ci_workflow": ".github/workflows/validate-analysis.yml",
-        "last_run_utc": "2026-07-20T11:28:02.553409+00:00",
+        "last_run_utc": "2026-07-21T11:15:56.366420+00:00",
         "all_passing": null
       },
       "factor_analysis": {
@@ -3597,7 +3597,7 @@
         "kmo_bartlett": {
           "kmo_overall": 0.9152,
           "bartlett_chi2": 1511.64,
-          "bartlett_p": 1.2104495982017037e-230
+          "bartlett_p": 1.2104495982014282e-230
         },
         "parallel_analysis": {
           "n_factors": 1,
@@ -5169,29 +5169,29 @@
       },
       "bifactor_barriers": {
         "fit": {
-          "chi2": 84.122,
+          "chi2": 84.147,
           "df": 117,
           "cfi": 1.0098,
           "tli": 1.0128,
           "rmsea": 0.0
         },
         "n_listwise": 232,
-        "ecv_general": 0.6491,
+        "ecv_general": 0.6536,
         "ecv_specifics": {
-          "F1a": 0.1158,
-          "F1b": 0.0934,
-          "F2": 0.1416
+          "F1a": 0.1174,
+          "F1b": 0.0863,
+          "F2": 0.1426
         },
-        "omega_h_general": 0.8338,
+        "omega_h_general": 0.8334,
         "omega_h_specifics": {
-          "F1a": 0.0311,
-          "F1b": 0.0146,
+          "F1a": 0.0316,
+          "F1b": 0.0139,
           "F2": 0.0297
         },
-        "omega_t": 0.9092,
+        "omega_t": 0.9086,
         "g_loadings": [
-          0.6175, 0.5069, 0.6194, 0.7315, 0.6722, 0.4644, 0.5466, 0.6055, 0.5248, 0.618, 0.5091,
-          0.515, 0.3062, 0.3576, 0.5628, 0.407, 0.5006, 0.4738
+          0.6161, 0.5056, 0.6189, 0.7327, 0.6719, 0.4642, 0.5479, 0.6057, 0.5245, 0.6174, 0.5089,
+          0.515, 0.3063, 0.3577, 0.5624, 0.407, 0.5007, 0.4739
         ]
       },
       "multigroup_3f_smb_vs_ent": {
@@ -5202,9 +5202,9 @@
           "cfi": 1.0094,
           "rmsea": 0.0,
           "latent_correlations": {
-            "F1a~~F2": 0.5996,
             "F1b~~F1a": 0.9933,
-            "F1b~~F2": 0.648
+            "F2~~F1a": 0.5996,
+            "F2~~F1b": 0.648
           }
         },
         "Group_0": {
@@ -5214,9 +5214,9 @@
           "cfi": 1.0138,
           "rmsea": 0.0,
           "latent_correlations": {
-            "F1a~~F2": 0.7572,
             "F1b~~F1a": 0.7923,
-            "F1b~~F2": 0.6855
+            "F2~~F1a": 0.7572,
+            "F2~~F1b": 0.6855
           }
         }
       },
@@ -5849,12 +5849,12 @@
             "total_criteria": 10
           }
         },
-        "last_run_utc": "2026-07-20T11:29:38.506006+00:00"
+        "last_run_utc": "2026-07-21T11:17:44.903410+00:00"
       },
       "r_parity_tests": {
         "count": 16,
         "ci_workflow": ".github/workflows/validate-analysis.yml",
-        "last_run_utc": "2026-07-20T11:29:38.506310+00:00",
+        "last_run_utc": "2026-07-21T11:17:44.903774+00:00",
         "all_passing": null
       },
       "factor_analysis": {
@@ -6425,49 +6425,49 @@
         "aic": 167.03,
         "bic": 522.5,
         "standardized_loadings": {
-          "Q10_28_Barriers_1": 0.5875,
-          "Q10_28_Barriers_2": 0.6463,
-          "Q10_28_Barriers_3": 0.6283,
+          "Q10_28_Barriers_1": 0.5876,
+          "Q10_28_Barriers_2": 0.6462,
+          "Q10_28_Barriers_3": 0.6282,
           "Q10_28_Barriers_4": 0.7015,
           "Q10_28_Barriers_5": 0.626,
-          "Q10_28_Barriers_6": 0.5133,
+          "Q10_28_Barriers_6": 0.5132,
           "Q10_28_Barriers_7": 0.607,
-          "Q10_28_Barriers_8": 0.5857,
+          "Q10_28_Barriers_8": 0.5856,
           "Q10_28_Barriers_9": 0.5528,
-          "Q10_28_Barriers_10": 0.6854,
+          "Q10_28_Barriers_10": 0.6853,
           "Q10_28_Barriers_11": 0.5618,
           "Q10_28_Barriers_12": 0.5517,
           "Q10_28_Barriers_13": 0.3487,
           "Q10_28_Barriers_14": 0.3774,
-          "Q10_28_Barriers_15": 0.5388,
+          "Q10_28_Barriers_15": 0.5387,
           "Q10_28_Barriers_16": 0.4342,
           "Q10_28_Barriers_17": 0.5295,
           "Q10_28_Barriers_18": 0.4961,
-          "Q47_64_Readiness_1": 0.6736,
-          "Q47_64_Readiness_2": 0.6132,
-          "Q47_64_Readiness_3": 0.6506,
-          "Q47_64_Readiness_4": 0.5331,
+          "Q47_64_Readiness_1": 0.6735,
+          "Q47_64_Readiness_2": 0.6133,
+          "Q47_64_Readiness_3": 0.6507,
+          "Q47_64_Readiness_4": 0.5332,
           "Q47_64_Readiness_5": 0.5547,
           "Q47_64_Readiness_6": 0.6586,
-          "Q47_64_Readiness_7": 0.6867,
-          "Q47_64_Readiness_8": 0.6653,
+          "Q47_64_Readiness_7": 0.6868,
+          "Q47_64_Readiness_8": 0.6654,
           "Q47_64_Readiness_9": 0.6071,
-          "Q47_64_Readiness_10": 0.5752,
-          "Q47_64_Readiness_11": 0.6121,
-          "Q47_64_Readiness_12": 0.5703,
-          "Q47_64_Readiness_13": 0.6197,
-          "Q47_64_Readiness_14": 0.5873,
+          "Q47_64_Readiness_10": 0.5754,
+          "Q47_64_Readiness_11": 0.6122,
+          "Q47_64_Readiness_12": 0.5704,
+          "Q47_64_Readiness_13": 0.6198,
+          "Q47_64_Readiness_14": 0.5874,
           "Q47_64_Readiness_15": 0.5864,
-          "Q47_64_Readiness_16": 0.6764,
-          "Q47_64_Readiness_17": 0.47,
+          "Q47_64_Readiness_16": 0.6765,
+          "Q47_64_Readiness_17": 0.4701,
           "Q65_73_Maturity_1": 0.743,
-          "Q65_73_Maturity_2": 0.7556,
-          "Q65_73_Maturity_3": 0.655,
+          "Q65_73_Maturity_2": 0.7555,
+          "Q65_73_Maturity_3": 0.6551,
           "Q65_73_Maturity_4": 0.6532,
-          "Q65_73_Maturity_5": 0.6315,
+          "Q65_73_Maturity_5": 0.6314,
           "Q65_73_Maturity_6": 0.7885,
           "Q65_73_Maturity_7": 0.6899,
-          "Q65_73_Maturity_8": 0.6467
+          "Q65_73_Maturity_8": 0.6466
         }
       },
       "barrier_model_comparison": {
@@ -7734,29 +7734,29 @@
       },
       "bifactor_barriers": {
         "fit": {
-          "chi2": 137.169,
+          "chi2": 137.295,
           "df": 117,
           "cfi": 0.9969,
-          "tli": 0.996,
-          "rmsea": 0.0197
+          "tli": 0.9959,
+          "rmsea": 0.0198
         },
         "n_listwise": 443,
-        "ecv_general": 0.6837,
+        "ecv_general": 0.6851,
         "ecv_specifics": {
-          "F1a": 0.0927,
-          "F1b": 0.0545,
-          "F2": 0.169
+          "F1a": 0.0929,
+          "F1b": 0.0526,
+          "F2": 0.1694
         },
         "omega_h_general": 0.8413,
         "omega_h_specifics": {
-          "F1a": 0.0205,
-          "F1b": 0.01,
+          "F1a": 0.0206,
+          "F1b": 0.0098,
           "F2": 0.0359
         },
-        "omega_t": 0.9077,
+        "omega_t": 0.9075,
         "g_loadings": [
-          0.5799, 0.5601, 0.5914, 0.7007, 0.6403, 0.4901, 0.572, 0.5821, 0.5251, 0.6371, 0.5705,
-          0.5681, 0.2893, 0.3093, 0.5382, 0.4327, 0.5603, 0.4862
+          0.5798, 0.5599, 0.5905, 0.7007, 0.6396, 0.4897, 0.5725, 0.5824, 0.5256, 0.6374, 0.5691,
+          0.5687, 0.2893, 0.3093, 0.5373, 0.4327, 0.5625, 0.4862
         ]
       },
       "multigroup_3f_smb_vs_ent": {
@@ -7767,9 +7767,9 @@
           "cfi": 0.9838,
           "rmsea": 0.0439,
           "latent_correlations": {
-            "F1a~~F2": 0.5518,
             "F1b~~F1a": 0.9666,
-            "F1b~~F2": 0.6169
+            "F2~~F1a": 0.5518,
+            "F2~~F1b": 0.6169
           }
         },
         "Group_0": {
@@ -7779,9 +7779,9 @@
           "cfi": 1.0003,
           "rmsea": 0.0,
           "latent_correlations": {
-            "F1a~~F2": 0.715,
             "F1b~~F1a": 0.8022,
-            "F1b~~F2": 0.7049
+            "F2~~F1a": 0.715,
+            "F2~~F1b": 0.7049
           }
         }
       },
@@ -8414,12 +8414,12 @@
             "total_criteria": 10
           }
         },
-        "last_run_utc": "2026-07-20T11:31:19.244719+00:00"
+        "last_run_utc": "2026-07-21T11:19:39.366691+00:00"
       },
       "r_parity_tests": {
         "count": 16,
         "ci_workflow": ".github/workflows/validate-analysis.yml",
-        "last_run_utc": "2026-07-20T11:31:19.245044+00:00",
+        "last_run_utc": "2026-07-21T11:19:39.367071+00:00",
         "all_passing": null
       },
       "factor_analysis": {
@@ -10299,29 +10299,29 @@
       },
       "bifactor_barriers": {
         "fit": {
-          "chi2": 156.674,
+          "chi2": 156.762,
           "df": 117,
-          "cfi": 0.9971,
-          "tli": 0.9962,
+          "cfi": 0.997,
+          "tli": 0.9961,
           "rmsea": 0.0221
         },
         "n_listwise": 695,
-        "ecv_general": 0.737,
+        "ecv_general": 0.7372,
         "ecv_specifics": {
-          "F1a": 0.0755,
-          "F1b": 0.0567,
-          "F2": 0.1308
+          "F1a": 0.0748,
+          "F1b": 0.0571,
+          "F2": 0.1309
         },
-        "omega_h_general": 0.8736,
+        "omega_h_general": 0.8735,
         "omega_h_specifics": {
           "F1a": 0.0158,
-          "F1b": 0.0096,
+          "F1b": 0.0097,
           "F2": 0.025
         },
         "omega_t": 0.9239,
         "g_loadings": [
-          0.616, 0.5919, 0.6082, 0.6843, 0.678, 0.5226, 0.5659, 0.6202, 0.5921, 0.6922, 0.6233,
-          0.5843, 0.4001, 0.4061, 0.6109, 0.5041, 0.6093, 0.5725
+          0.6162, 0.592, 0.6077, 0.6842, 0.6782, 0.5226, 0.5656, 0.62, 0.5923, 0.6921, 0.6234,
+          0.5842, 0.4001, 0.406, 0.6109, 0.5041, 0.609, 0.5725
         ]
       },
       "multigroup_3f_smb_vs_ent": {
@@ -10332,9 +10332,9 @@
           "cfi": 0.9882,
           "rmsea": 0.043,
           "latent_correlations": {
-            "F1a~~F2": 0.7048,
             "F1b~~F1a": 0.9262,
-            "F1b~~F2": 0.7244
+            "F2~~F1a": 0.7048,
+            "F2~~F1b": 0.7244
           }
         },
         "Group_0": {
@@ -10344,9 +10344,9 @@
           "cfi": 0.9971,
           "rmsea": 0.0198,
           "latent_correlations": {
-            "F1a~~F2": 0.7776,
             "F1b~~F1a": 0.8819,
-            "F1b~~F2": 0.7777
+            "F2~~F1a": 0.7776,
+            "F2~~F1b": 0.7777
           }
         }
       },
@@ -10979,12 +10979,12 @@
             "total_criteria": 10
           }
         },
-        "last_run_utc": "2026-07-20T11:33:03.800969+00:00"
+        "last_run_utc": "2026-07-21T11:21:39.753318+00:00"
       },
       "r_parity_tests": {
         "count": 16,
         "ci_workflow": ".github/workflows/validate-analysis.yml",
-        "last_run_utc": "2026-07-20T11:33:03.801297+00:00",
+        "last_run_utc": "2026-07-21T11:21:39.753675+00:00",
         "all_passing": null
       },
       "factor_analysis": {
@@ -12864,29 +12864,29 @@
       },
       "bifactor_barriers": {
         "fit": {
-          "chi2": 165.124,
+          "chi2": 164.895,
           "df": 117,
           "cfi": 0.9965,
           "tli": 0.9954,
           "rmsea": 0.0241
         },
         "n_listwise": 707,
-        "ecv_general": 0.7502,
+        "ecv_general": 0.749,
         "ecv_specifics": {
-          "F1a": 0.0698,
-          "F1b": 0.047,
-          "F2": 0.1329
+          "F1a": 0.0717,
+          "F1b": 0.0466,
+          "F2": 0.1327
         },
-        "omega_h_general": 0.8743,
+        "omega_h_general": 0.8739,
         "omega_h_specifics": {
-          "F1a": 0.0137,
-          "F1b": 0.0095,
+          "F1a": 0.0143,
+          "F1b": 0.0094,
           "F2": 0.0251
         },
         "omega_t": 0.9226,
         "g_loadings": [
-          0.6045, 0.5959, 0.6066, 0.6787, 0.68, 0.5229, 0.5684, 0.6174, 0.594, 0.6975, 0.6248,
-          0.5846, 0.397, 0.4093, 0.6154, 0.5027, 0.6061, 0.5714
+          0.6047, 0.5939, 0.6063, 0.6789, 0.6786, 0.5233, 0.5688, 0.6176, 0.5941, 0.6966, 0.6241,
+          0.5851, 0.3972, 0.4095, 0.6147, 0.5029, 0.6069, 0.5716
         ]
       },
       "multigroup_3f_smb_vs_ent": {
@@ -12897,9 +12897,9 @@
           "cfi": 0.9878,
           "rmsea": 0.0437,
           "latent_correlations": {
-            "F1a~~F2": 0.7037,
             "F1b~~F1a": 0.9293,
-            "F1b~~F2": 0.7278
+            "F2~~F1a": 0.7037,
+            "F2~~F1b": 0.7278
           }
         },
         "Group_0": {
@@ -12909,9 +12909,9 @@
           "cfi": 0.9962,
           "rmsea": 0.0226,
           "latent_correlations": {
-            "F1a~~F2": 0.7765,
             "F1b~~F1a": 0.8817,
-            "F1b~~F2": 0.7817
+            "F2~~F1a": 0.7765,
+            "F2~~F1b": 0.7817
           }
         }
       },
@@ -13544,12 +13544,12 @@
             "total_criteria": 10
           }
         },
-        "last_run_utc": "2026-07-20T11:34:47.898277+00:00"
+        "last_run_utc": "2026-07-21T11:23:41.111326+00:00"
       },
       "r_parity_tests": {
         "count": 16,
         "ci_workflow": ".github/workflows/validate-analysis.yml",
-        "last_run_utc": "2026-07-20T11:34:47.898586+00:00",
+        "last_run_utc": "2026-07-21T11:23:41.111700+00:00",
         "all_passing": null
       },
       "factor_analysis": {

--- a/src/data/sensitivity-analysis.json
+++ b/src/data/sensitivity-analysis.json
@@ -2444,6 +2444,6 @@
       }
     ]
   },
-  "last_updated": "2026-07-20T11:26:07.809213Z",
-  "extended_last_updated": "2026-07-20T11:26:07.809213Z"
+  "last_updated": "2026-07-21T11:13:48.279935Z",
+  "extended_last_updated": "2026-07-21T11:13:48.279935Z"
 }


### PR DESCRIPTION
Automated update from the unified daily pipeline.

**Data flow**: Qualtrics export → Prolific enrichment →
disposition waterfall → analysis suite → CRP dataset (N=200) →
approve CLEAN → dashboard summary.

All statistics computed across 5 sample definitions.
CRP dataset: N=200 tiered selection + NIST de-identification.