### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-07-20T09:30:48Z",
-  "commit_sha": "70ec4625bb12c2e46c5cd3bde066bf6dfa6be799",
-  "commit_count": 7530,
-  "lines_of_code": 232324,
+  "as_of": "2026-07-27T07:24:00Z",
+  "commit_sha": "506734cc4bf73038760273b6211b2ffbb6b98d3f",
+  "commit_count": 7588,
+  "lines_of_code": 232373,
   "comments": 13407,
   "blanks": 26818,
-  "total_lines": 272549,
+  "total_lines": 272598,
   "tracked_files": 798,
   "github_workflows": 54,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 45500,
+      "code": 45549,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-07-20T09:30:48Z",
-  "commit_sha": "70ec4625bb12c2e46c5cd3bde066bf6dfa6be799",
-  "commit_count": 7530,
-  "lines_of_code": 232324,
+  "as_of": "2026-07-27T07:24:00Z",
+  "commit_sha": "506734cc4bf73038760273b6211b2ffbb6b98d3f",
+  "commit_count": 7588,
+  "lines_of_code": 232373,
   "comments": 13407,
   "blanks": 26818,
-  "total_lines": 272549,
+  "total_lines": 272598,
   "tracked_files": 798,
   "github_workflows": 54,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 45500,
+      "code": 45549,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.