### PR TITLE
fix: retry transient fetches in smoke redirect and infra checks

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -243,11 +243,15 @@ jobs:
           set -uo pipefail
           INFRA_FAIL=0
 
-          # Helper: check URL status with label
+          # Helper: check URL status with label (retry once, as check-url.sh does)
           check() {
             local label="$1" url="$2" expected="$3"
             local status
             status=$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 15 "$url" 2>/dev/null || echo "000")
+            if [ "$status" != "$expected" ]; then
+              sleep 3
+              status=$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 15 "$url" 2>/dev/null || echo "000")
+            fi
             if [ "$status" = "$expected" ]; then
               echo "| $label | ✅ $status |" >> /tmp/infra-results.txt
             else
@@ -318,25 +322,42 @@ jobs:
           REDIRECT_FAIL=0
 
           # Helper: verify redirect via HTTP 3xx OR static stub page (JS/link)
+          #
+          # Both fetches retry once on miss, matching check-url.sh/check-asset.sh.
+          # Without the retry a single dropped request opened a production
+          # incident (#3140) for a redirect that was never actually broken.
           check_redirect() {
             local old_url="$1" expected_path="$2" label="$3"
-            local final_url page_html
+            local final_url page_html attempt
 
-            # Try HTTP redirect first
-            final_url=$(curl -s -o /dev/null -w '%{url_effective}' -L --max-time 15 "$old_url" 2>/dev/null || echo "")
-            if echo "$final_url" | grep -F -q "$expected_path"; then
-              echo "| $label | ✅ HTTP redirect → $expected_path |" >> /tmp/redirect-results.txt
-              return
-            fi
+            for attempt in 1 2; do
+              [ "$attempt" -eq 2 ] && sleep 3
 
-            # Fall back to checking whether the stub page contains the expected path
-            page_html=$(curl -sL --max-time 15 "$old_url" 2>/dev/null || echo "")
-            if echo "$page_html" | grep -F -q -- "$expected_path"; then
-              echo "| $label | ✅ Stub page → $expected_path |" >> /tmp/redirect-results.txt
+              # Try HTTP redirect first
+              final_url=$(curl -s -o /dev/null -w '%{url_effective}' -L --max-time 15 "$old_url" 2>/dev/null || echo "")
+              if echo "$final_url" | grep -F -q "$expected_path"; then
+                echo "| $label | ✅ HTTP redirect → $expected_path |" >> /tmp/redirect-results.txt
+                return
+              fi
+
+              # Fall back to checking whether the stub page contains the expected path.
+              # ClientRedirect stubs redirect in JS, so curl never lands on the
+              # destination — in practice every entry below passes via this branch.
+              page_html=$(curl -sL --max-time 15 "$old_url" 2>/dev/null || echo "")
+              if echo "$page_html" | grep -F -q -- "$expected_path"; then
+                echo "| $label | ✅ Stub page → $expected_path |" >> /tmp/redirect-results.txt
+                return
+              fi
+            done
+
+            # Distinguish an empty fetch (transient) from a served page that is
+            # genuinely missing the path (real regression) so triage is quick.
+            if [ -z "$page_html" ]; then
+              echo "| $label | ❌ empty response after retry → ${final_url:-timeout} (expected $expected_path) |" >> /tmp/redirect-results.txt
             else
               echo "| $label | ❌ → ${final_url:-timeout} (expected $expected_path) |" >> /tmp/redirect-results.txt
-              REDIRECT_FAIL=$((REDIRECT_FAIL + 1))
             fi
+            REDIRECT_FAIL=$((REDIRECT_FAIL + 1))
           }
 
           : > /tmp/redirect-results.txt


### PR DESCRIPTION
## Summary

Fixes the false production incident in #3140.

**The redirect was never broken.** `/making-of-tabs/data-analysis` is a `ClientRedirect` stub that has served `/results/data-quality` continuously — the live HTML contains it 5 times (canonical `<link>`, visible `<a href>`, `<noscript>`, and twice in the RSC payload). Neither `src/app/making-of-tabs/data-analysis/page.tsx` nor `src/components/client-redirect.tsx` has changed since April, and the deploy that tripped the alarm (`9207d3b`) was a routine daily-pipeline data update. All 12 Post-Deploy Smoke runs since 2026-07-25 have passed.

**What actually happened:** `check_redirect` makes two un-retried `curl` calls. The stub-page fallback returned empty once, `grep` found nothing, and the check reported `❌ → <original url>` — indistinguishable from a real regression. That opened an incident issue and set a failure commit status on production.

`check-url.sh` and `check-asset.sh` already retry once after 3s "for transient CDN errors". `check_redirect` and the infra `check()` were the two helpers that didn't — so 1 unlucky request out of ~2,800 per run could open an incident.

## Changes

- `check_redirect`: both fetch strategies now run inside a 2-attempt loop (retry after 3s), matching the existing helpers.
- `check_redirect`: an empty response after retry is now reported as `❌ empty response after retry` — distinct from a page that served but genuinely lacks the path. Triage no longer requires log archaeology.
- Infrastructure `check()`: retry once, same pattern as `check-url.sh`.

No change to what is asserted — only to how many times a fetch is attempted before it counts as a failure.

## Test plan

Ran the patched step against production:

- All 5 redirects pass (`Redirects: 0 failed`), each via the stub-page branch.
- Negative test — a path that can never match still fails, taking 4s (both attempts) and reporting the original message.
- Unreachable host reports the new `empty response after retry` variant.
- `bash -n` clean on both modified `run` blocks; YAML parses; `prettier@3.9.1 --check` passes.

Closes #3140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
