### PR TITLE
chore: refresh platform-stats.json

### DIFF
--- a/public/data/platform-stats.json
+++ b/public/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-08-03T07:22:33Z",
-  "commit_sha": "9c5e0abad974fffcc5d6f7a3aa68b47a0958b110",
-  "commit_count": 7648,
-  "lines_of_code": 232424,
+  "as_of": "2026-08-10T06:40:00Z",
+  "commit_sha": "b3d608bfabdd50571f48f5911811aac8e746572a",
+  "commit_count": 7706,
+  "lines_of_code": 232476,
   "comments": 13415,
   "blanks": 26820,
-  "total_lines": 272659,
+  "total_lines": 272711,
   "tracked_files": 798,
   "github_workflows": 54,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 45589,
+      "code": 45641,
       "comment": 0,
       "blank": 0
     },

--- a/src/data/platform-stats.json
+++ b/src/data/platform-stats.json
@@ -1,11 +1,11 @@
 {
-  "as_of": "2026-08-03T07:22:33Z",
-  "commit_sha": "9c5e0abad974fffcc5d6f7a3aa68b47a0958b110",
-  "commit_count": 7648,
-  "lines_of_code": 232424,
+  "as_of": "2026-08-10T06:40:00Z",
+  "commit_sha": "b3d608bfabdd50571f48f5911811aac8e746572a",
+  "commit_count": 7706,
+  "lines_of_code": 232476,
   "comments": 13415,
   "blanks": 26820,
-  "total_lines": 272659,
+  "total_lines": 272711,
   "tracked_files": 798,
   "github_workflows": 54,
   "integrations": 8,
@@ -23,7 +23,7 @@
     {
       "language": "JSON",
       "files": 41,
-      "code": 45589,
+      "code": 45641,
       "comment": 0,
       "blank": 0
     },


### PR DESCRIPTION
Auto-generated by [.github/workflows/platform-stats.yml](.github/workflows/platform-stats.yml).

Refreshes `src/data/platform-stats.json` and the public mirror at
`public/data/platform-stats.json` from the current `main` HEAD. See #1900
for the canonical-numbers rationale. Methodology: cloc with the same
exclusion list used by the workflow.

Reviewers: spot-check that `commit_count`, `lines_of_code`,
`github_workflows`, and `integrations` look directionally right
for what landed since the last refresh. Sudden 10x jumps or drops
are usually a sign of a new vendored dir slipping past the
exclusion list — investigate before merging.